### PR TITLE
update specific channels example in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -74,7 +74,7 @@ CHANNELS_EXCLUDE_CHAT_IDS=
 #    PRIVATE_EXCLUDE_CHAT_IDS=123456789
 #
 # 2. Backup only specific channels (Whitelist):
-#    CHAT_TYPES=
+#    CHAT_TYPES=,,
 #    CHANNELS_INCLUDE_CHAT_IDS=100123456789,100987654321
 #
 # 3. Backup all groups but force include one specific channel:


### PR DESCRIPTION
Currently the example for backing up specific channels provides a strange result: all chats are backed up. Tested in the Portainer's web interface. Switching CHAT_TYPES from empty to ",," fixes the behavior.