### PR TITLE
feat: LISTEN_NEW_MESSAGES for real-time message sync

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -131,6 +131,11 @@ class Config:
         # Only enable if you explicitly want to mirror Telegram exactly
         self.listen_deletions = os.getenv('LISTEN_DELETIONS', 'false').lower() == 'true'
         
+        # LISTEN_NEW_MESSAGES: Save new messages to backup in real-time
+        # When enabled, new messages are saved immediately instead of waiting for scheduled backup
+        # This provides true real-time backup but may increase API usage
+        self.listen_new_messages = os.getenv('LISTEN_NEW_MESSAGES', 'false').lower() == 'true'
+        
         # =====================================================================
         # ZERO-FOOTPRINT MASS OPERATION PROTECTION
         # =====================================================================
@@ -174,6 +179,10 @@ class Config:
                 logger.warning("  ⚠️ LISTEN_DELETIONS: true - Messages will be DELETED from backup!")
             else:
                 logger.info("  LISTEN_DELETIONS: false (backup protected)")
+            if self.listen_new_messages:
+                logger.info("  LISTEN_NEW_MESSAGES: true - New messages saved in real-time!")
+            else:
+                logger.info("  LISTEN_NEW_MESSAGES: false (messages saved on scheduled backup)")
             logger.info(f"  Mass operation protection: block if >{self.mass_operation_threshold} ops in {self.mass_operation_window_seconds}s")
         if self.display_chat_ids:
             logger.info(f"Display mode: Viewer restricted to chat IDs {self.display_chat_ids}")

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -291,6 +291,22 @@
                     </div>
                 </div>
 
+                <!-- Notification Permission Banner -->
+                <div v-if="notificationsEnabled && notificationsSupported && notificationPermission === 'default'" 
+                    class="px-3 py-2 bg-blue-900/80 border-b border-blue-700">
+                    <div class="flex items-center gap-2 text-blue-200 text-sm">
+                        <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"></path>
+                        </svg>
+                        <span>Enable notifications for new messages</span>
+                        <button @click="requestNotificationPermission()" 
+                            class="ml-auto px-2 py-1 bg-blue-600 hover:bg-blue-500 text-white text-xs rounded transition">
+                            Enable
+                        </button>
+                    </div>
+                </div>
+
                 <!-- Chat List -->
                 <div class="flex-1 overflow-y-auto">
                     <div v-for="chat in filteredChats" :key="chat.id" @click="selectChat(chat)"


### PR DESCRIPTION
## Summary
Adds LISTEN_NEW_MESSAGES env var for true real-time backup of new messages.

## Changes
- New `LISTEN_NEW_MESSAGES` env var (default: false)
- When enabled, new messages are saved to database immediately
- Added notification permission banner in viewer UI (shows when notifications enabled but permission not granted)
- Stats tracking for new messages received/saved
- Media handled by scheduled backup (only text saved instantly)

## New Environment Variables
| Variable | Default | Description |
|----------|---------|-------------|
| LISTEN_NEW_MESSAGES | false | Save new messages to backup in real-time |

## Testing
- Enable `LISTEN_NEW_MESSAGES=true` along with `ENABLE_LISTENER=true`
- Send a message to a tracked chat
- Message should appear in viewer immediately (without waiting for next backup)