### PR TITLE
fix: disable WebSocket, use polling

### DIFF
--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -796,49 +796,11 @@
                     initWebSocket()
                 })
 
-                // WebSocket initialization
+                // WebSocket initialization (disabled - using polling instead)
                 const initWebSocket = () => {
-                    if (ws) {
-                        ws.close()
-                    }
-                    
-                    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:'
-                    const wsUrl = `${protocol}//${window.location.host}/ws/updates`
-                    
-                    try {
-                        ws = new WebSocket(wsUrl)
-                        
-                        ws.onopen = () => {
-                            console.log('[WS] Connected to real-time updates')
-                            // Subscribe to current chat if selected
-                            if (selectedChat.value) {
-                                ws.send(JSON.stringify({
-                                    action: 'subscribe',
-                                    chat_id: selectedChat.value.id
-                                }))
-                            }
-                        }
-                        
-                        ws.onmessage = (event) => {
-                            try {
-                                const data = JSON.parse(event.data)
-                                handleWebSocketMessage(data)
-                            } catch (e) {
-                                console.error('[WS] Parse error:', e)
-                            }
-                        }
-                        
-                        ws.onclose = () => {
-                            console.log('[WS] Connection closed, reconnecting in 5s...')
-                            wsReconnectTimer = setTimeout(initWebSocket, 5000)
-                        }
-                        
-                        ws.onerror = (e) => {
-                            console.error('[WS] Error:', e)
-                        }
-                    } catch (e) {
-                        console.error('[WS] Failed to connect:', e)
-                    }
+                    // WebSocket disabled - auto-refresh polling handles new messages
+                    // WebSocket would require Caddy config changes to proxy /ws/updates
+                    console.log('[WS] WebSocket disabled, using polling for real-time updates')
                 }
                 
                 const handleWebSocketMessage = (data) => {


### PR DESCRIPTION
Disables WebSocket to avoid Caddy configuration changes. Polling every 3 seconds handles real-time updates fine.