### PR TITLE
fix: listener media deduplication

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,11 @@ For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
 ## [Unreleased]
 
+## [5.3.3] - 2026-01-20
+
+### Fixed
+- **Listener media deduplication** - Real-time listener now uses the same deduplication logic as scheduled backups, creating symlinks to `_shared` directory instead of downloading duplicates
+
 ## [5.3.2] - 2026-01-20
 
 ### Added


### PR DESCRIPTION
## Problem

The real-time listener (`LISTEN_NEW_MESSAGES_MEDIA=true`) was downloading media directly to chat folders, bypassing the `_shared` directory deduplication.

When the same image was sent to multiple chats:
- Scheduled backup: ✅ Downloaded once to `_shared`, symlinked to chat folders
- Real-time listener: ❌ Downloaded separately to each chat folder

## Fix

Added the same deduplication logic to `listener.py`'s `_download_media` method:
1. Check if file exists in `_shared` → create symlink
2. If not, download to `_shared` → create symlink to chat folder

## Testing

Send the same image to multiple chats and verify:
- First download goes to `media/_shared/`
- Subsequent appearances are symlinks