### PR TITLE
fix: refresh avatar filenames with photo ids

### DIFF
--- a/src/avatar_utils.py
+++ b/src/avatar_utils.py
@@ -1,0 +1,37 @@
+import os
+import logging
+from typing import Optional, Tuple
+
+from telethon.tl.types import User, ChatPhotoEmpty, UserProfilePhotoEmpty
+
+logger = logging.getLogger(__name__)
+
+
+def _get_avatar_dir(media_path: str, entity) -> str:
+    """Return avatar directory for given entity and ensure it exists."""
+    folder = "users" if isinstance(entity, User) else "chats"
+    base_dir = os.path.join(media_path, "avatars", folder)
+    os.makedirs(base_dir, exist_ok=True)
+    return base_dir
+
+
+def get_avatar_paths(media_path: str, entity, chat_id: int) -> Tuple[Optional[str], str]:
+    """
+    Build target and legacy avatar file paths.
+
+    Returns:
+        (target_path, legacy_path)
+        - target_path is None when entity has no avatar
+        - legacy_path is the old `<chat_id>.jpg` name used in past versions
+    """
+    base_dir = _get_avatar_dir(media_path, entity)
+    legacy_path = os.path.join(base_dir, f"{chat_id}.jpg")
+
+    photo = getattr(entity, "photo", None)
+    if photo is None or isinstance(photo, (ChatPhotoEmpty, UserProfilePhotoEmpty)):
+        return None, legacy_path
+
+    photo_id = getattr(photo, "photo_id", None) or getattr(photo, "id", None)
+    suffix = f"_{photo_id}" if photo_id is not None else "_current"
+    file_name = f"{chat_id}{suffix}.jpg"
+    return os.path.join(base_dir, file_name), legacy_path

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -972,6 +972,11 @@ class DatabaseAdapter:
             for avatar_type in ['chats', 'users']:
                 avatar_pattern = os.path.join(media_base_path, 'avatars', avatar_type, f'{chat_id}_*.jpg')
                 avatar_files = glob.glob(avatar_pattern)
+
+                # Legacy fallback: remove old <chat_id>.jpg files as well
+                legacy_avatar = os.path.join(media_base_path, 'avatars', avatar_type, f'{chat_id}.jpg')
+                if os.path.exists(legacy_avatar):
+                    avatar_files.append(legacy_avatar)
                 for avatar_file in avatar_files:
                     try:
                         os.remove(avatar_file)
@@ -1282,4 +1287,3 @@ class DatabaseAdapter:
     async def close(self) -> None:
         """Close database connections."""
         await self.db_manager.close()
-


### PR DESCRIPTION
Continuing the discussion of issue #35 

Avatars were disappearing because we saved them as `<chat_id>.jpg`, while the viewer looked for `<chat_id>_<photo_id>.jpg` and didn’t fall back to the old name.

The commit fixes it like this:

- Added a shared helper `avatar_utils.py`: builds `<chat_id>_<photo_id>.jpg` and knows about legacy `<chat_id>.jpg`.
- `telegram_backup.py`, `listener.py`: save avatars via the helper in the new format and skip re-downloading if the file is already present.
- `main.py`: looks for both avatar formats and lazily imports the push manager so it won’t crash without crypto dependencies.
- `adapter.py`: when deleting a chat, it removes both file variants.
- `test_database_viewer.py`: checks that the viewer prefers the new file and falls back to legacy if missing; tests run in a temporary backup path.

P.S. It might seem like a bit much, but it works in my case.