### PR TITLE
chore: standardize on docker compose (v2) syntax

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -78,7 +78,7 @@ body:
       description: Please paste any relevant logs or error messages.
       render: shell
       placeholder: |
-        Paste logs here (run: docker-compose logs telegram-backup)
+        Paste logs here (run: docker compose logs telegram-backup)
 
   - type: textarea
     id: environment

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Project description: Own your Telegram history. Automated, incremental backups w
 - **PRs build `:dev` tag** via `docker-publish-dev.yml` workflow
 - **Tags build semver** via `docker-publish.yml` workflow
 - Always test on dev environment before releasing to prod
-- See gitea docker-compose for environment assignments
+- See gitea docker compose for environment assignments
 
 ## Release Guidelines
 

--- a/README.md
+++ b/README.md
@@ -135,10 +135,10 @@ docker run -it --rm \
   python -m src.setup_auth
 ```
 
-**Example for docker-compose deployment:**
+**Example for docker compose deployment:**
 
 ```bash
-# If using docker-compose with a session volume
+# If using docker compose with a session volume
 docker run -it --rm \
   --env-file .env \
   -v telegram-archive_session:/data/session \
@@ -146,7 +146,7 @@ docker run -it --rm \
   python -m src.setup_auth
 
 # Then restart the backup container
-docker-compose restart telegram-backup
+docker compose restart telegram-backup
 ```
 
 **What happens during authentication:**
@@ -159,7 +159,7 @@ docker-compose restart telegram-backup
 ### 4. Start Services
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 **View your backup** at http://localhost:8000
@@ -445,7 +445,7 @@ Telegram Archive supports both SQLite and PostgreSQL.
 2. Set `POSTGRES_PASSWORD` in your `.env`
 3. Set `DB_TYPE=postgresql` in your `.env`
 4. Uncomment `depends_on` in backup and viewer services
-5. Run `docker-compose up -d`
+5. Run `docker compose up -d`
 
 ## Updating to Latest Version
 
@@ -497,19 +497,19 @@ For major version upgrades with breaking changes and migration scripts, see **[d
 
 ```bash
 # View statistics
-docker-compose exec telegram-backup python -m src.export_backup stats
+docker compose exec telegram-backup python -m src.export_backup stats
 
 # List chats
-docker-compose exec telegram-backup python -m src.export_backup list-chats
+docker compose exec telegram-backup python -m src.export_backup list-chats
 
 # Export to JSON
-docker-compose exec telegram-backup python -m src.export_backup export -o backup.json
+docker compose exec telegram-backup python -m src.export_backup export -o backup.json
 
 # Export date range
-docker-compose exec telegram-backup python -m src.export_backup export -o backup.json -s 2024-01-01 -e 2024-12-31
+docker compose exec telegram-backup python -m src.export_backup export -o backup.json -s 2024-01-01 -e 2024-12-31
 
 # Manual backup run
-docker-compose exec telegram-backup python -m src.telegram_backup
+docker compose exec telegram-backup python -m src.telegram_backup
 ```
 
 ## Data Storage

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -556,12 +556,12 @@ v5.0.0 changes media folder naming to use marked IDs consistently. While the bac
 
 1. **Stop your backup container:**
    ```bash
-   docker-compose stop telegram-backup
+   docker compose stop telegram-backup
    ```
 
 2. **Pull the new image:**
    ```bash
-   docker-compose pull
+   docker compose pull
    ```
 
 3. **Run migration scripts** (one at a time, wait for each to finish):
@@ -631,7 +631,7 @@ v5.0.0 changes media folder naming to use marked IDs consistently. While the bac
 
 5. **Start the new version:**
    ```bash
-   docker-compose up -d
+   docker compose up -d
    ```
 
 **If starting fresh:** No migration needed, just use the new image.
@@ -648,7 +648,7 @@ v4.0.5 had a bug where chats were stored with positive IDs while messages used n
 
 1. **Stop your backup container:**
    ```bash
-   docker-compose stop telegram-backup
+   docker compose stop telegram-backup
    ```
 
 2. **Run the migration script:**
@@ -667,8 +667,8 @@ v4.0.5 had a bug where chats were stored with positive IDs while messages used n
 
 3. **Pull and restart:**
    ```bash
-   docker-compose pull
-   docker-compose up -d
+   docker compose pull
+   docker compose up -d
    ```
 
 **If upgrading from v4.0.4 or earlier:** No migration needed.
@@ -702,8 +702,8 @@ telegram-viewer:
 
 Then:
 ```bash
-docker-compose pull
-docker-compose up -d
+docker compose pull
+docker compose up -d
 ```
 
 **Your data is safe** - no database migration needed.
@@ -714,8 +714,8 @@ docker-compose up -d
 
 Transparent upgrade - just pull and restart:
 ```bash
-docker-compose pull
-docker-compose up -d
+docker compose pull
+docker compose up -d
 ```
 
 Your existing SQLite data works automatically. v3 detects v2 environment variables for backward compatibility.

--- a/init_auth.bat
+++ b/init_auth.bat
@@ -19,12 +19,12 @@ echo Starting interactive authentication container...
 echo You will be asked for your Telegram verification code.
 echo.
 
-docker-compose run --rm telegram-backup python -m src.setup_auth
+docker compose run --rm telegram-backup python -m src.setup_auth
 
 echo.
 if %ERRORLEVEL% EQU 0 (
     echo [SUCCESS] Authentication completed!
-    echo You can now run 'docker-compose up -d' to start the backup service.
+    echo You can now run 'docker compose up -d' to start the backup service.
 ) else (
     echo [ERROR] Authentication failed.
 )

--- a/init_auth.sh
+++ b/init_auth.sh
@@ -17,12 +17,12 @@ echo "Starting interactive authentication container..."
 echo "You will be asked for your Telegram verification code."
 echo
 
-docker-compose run --rm telegram-backup python -m src.setup_auth
+docker compose run --rm telegram-backup python -m src.setup_auth
 
 if [ $? -eq 0 ]; then
     echo
     echo "[SUCCESS] Authentication completed!"
-    echo "You can now run 'docker-compose up -d' to start the backup service."
+    echo "You can now run 'docker compose up -d' to start the backup service."
 else
     echo
     echo "[ERROR] Authentication failed."


### PR DESCRIPTION
Previously the codebase inconsistently used both "docker-compose" (v1 CLI) and "docker compose" (v2 built-in) commands. This commit uniformly adopts the modern "docker compose" syntax.

Docker Compose v2 is built into Docker CLI (docker compose) and has been the recommended approach since mid-2021. The standalone docker-compose v1 tool is deprecated and no longer maintained as of July 2023.

Changes:
- Replaced all instances of "docker-compose " with "docker compose "
- Affected files: README.md, CHANGELOG.md, AGENTS.md, init_auth scripts, and issue templates