### PR TITLE
fix: add pre-Alembic stamping for SQLite databases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "6.2.0"
+version = "6.2.1"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- Existing SQLite databases created before Alembic was introduced had no `alembic_version` table. On upgrade to v6.2.0, the entrypoint ran all migrations from 001, causing `table chats already exists` error.
- The PostgreSQL path already had this stamping logic but SQLite did not.
- Also adds migration 005 detection to PostgreSQL stamping (previously only went up to 004).

Closes #61

## Test plan

- [ ] Start v6.2.1 with an existing pre-Alembic SQLite database -- should stamp and migrate cleanly
- [ ] Start v6.2.1 with a fresh SQLite database -- should create from scratch normally
- [ ] Start v6.2.1 with an already-migrated database -- should be a no-op