### PR TITLE
fix: add migration 006 detection to pre-Alembic stamping

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "6.2.1"
+version = "6.2.2"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -81,6 +81,15 @@ if has_tables and not has_alembic:
             CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
         );
     \"\"\")
+    # Check if forum_topics table exists (added in migration 006)
+    cur.execute(\"\"\"
+        SELECT EXISTS (
+            SELECT FROM information_schema.tables
+            WHERE table_name = 'forum_topics'
+        );
+    \"\"\")
+    has_006_table = cur.fetchone()[0]
+
     # Check if idx_messages_reply_to index exists (added in migration 005)
     cur.execute(\"\"\"
         SELECT EXISTS (
@@ -109,7 +118,9 @@ if has_tables and not has_alembic:
     has_push_subs = cur.fetchone()[0]
     
     # Determine which version to stamp based on existing schema
-    if has_005_index:
+    if has_006_table:
+        stamp_version = '006'
+    elif has_005_index:
         stamp_version = '005'
     elif has_is_pinned:
         stamp_version = '004'
@@ -168,6 +179,10 @@ if has_tables and not has_alembic:
         )
     ''')
 
+    # Check if forum_topics table exists (added in migration 006)
+    cur.execute(\"SELECT name FROM sqlite_master WHERE type='table' AND name='forum_topics'\")
+    has_006_table = cur.fetchone() is not None
+
     # Check for idx_messages_reply_to index (added in migration 005)
     cur.execute(\"SELECT name FROM sqlite_master WHERE type='index' AND name='idx_messages_reply_to'\")
     has_005_index = cur.fetchone() is not None
@@ -182,7 +197,9 @@ if has_tables and not has_alembic:
     has_push_subs = cur.fetchone() is not None
 
     # Determine which version to stamp based on existing schema
-    if has_005_index:
+    if has_006_table:
+        stamp_version = '006'
+    elif has_005_index:
         stamp_version = '005'
     elif has_is_pinned:
         stamp_version = '004'


### PR DESCRIPTION
## Summary

- Databases created by `create_all()` (SQLite path) include all v6.2.0 schema but no `alembic_version`. The stamping logic only detected up to 005, causing migration 006 to fail with `duplicate column name: is_forum` on restart.
- Adds `forum_topics` table detection for migration 006 in both SQLite and PostgreSQL stamping paths.

Follow-up to #61

## Test plan

- [ ] Fresh SQLite database: first run creates via `create_all()`, restart stamps at 006 and runs cleanly
- [ ] Existing pre-006 SQLite database: stamps correctly and upgrades to 006