### PR TITLE
docs: consolidate env var documentation into unified reference table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,14 +1,27 @@
-# Required Telegram API credentials
+# ==============================================================================
+# Telegram Archive — Environment Variables
+# ==============================================================================
+# Copy this file to .env and fill in your values:
+#   cp .env.example .env
+#
+# For the full reference table, see the README:
+#   https://github.com/GeiserX/Telegram-Archive#environment-variables
+# ==============================================================================
+
+# ==============================================================================
+# TELEGRAM CREDENTIALS (required for backup)
+# ==============================================================================
 # Get these from https://my.telegram.org/apps
 TELEGRAM_API_ID=your_api_id_here
 TELEGRAM_API_HASH=your_api_hash_here
 TELEGRAM_PHONE=+1234567890
 
-# Backup schedule (cron format: minute hour day month weekday)
-# Examples:
-#   0 */6 * * *    = Every 6 hours
-#   0 0 * * *      = Daily at midnight
-#   0 */1 * * *    = Every hour
+# ==============================================================================
+# BACKUP SCHEDULE & STORAGE
+# ==============================================================================
+
+# Cron schedule (minute hour day month weekday)
+# Examples: 0 */6 * * * (every 6h), 0 0 * * * (daily), 0 */1 * * * (hourly)
 SCHEDULE=0 */6 * * *
 
 # Backup destination path (inside container)
@@ -22,52 +35,48 @@ DOWNLOAD_MEDIA=true
 # Files larger than this will be skipped
 MAX_MEDIA_SIZE_MB=4096
 
-# Batch size for database insertions and progress logging
+# Messages processed per database batch
 # Higher values = faster but more memory usage
-# Default: 100
-# Batch size for database insertions and progress logging
-# Higher values = faster but more memory usage
-# Default: 100
 BATCH_SIZE=100
 
-# Sync deletions and edits (Optional)
-# Set to true to mirror deletions and edits from Telegram
-# WARNING: This is expensive and slow as it checks every message
-# Default: false
-SYNC_DELETIONS_EDITS=false
+# Use symlinks to deduplicate identical media files across chats
+# DEDUPLICATE_MEDIA=true
 
-# Media verification mode (Optional)
-# When enabled, checks all media files on disk after each backup
-# Re-downloads any missing or corrupted files from Telegram
-# Useful for recovering from interrupted backups or accidentally deleted media
-# Default: false
-VERIFY_MEDIA=false
+# Comma-separated chat IDs to process FIRST in all operations
+# PRIORITY_CHAT_IDS=
+
+# Hour (0-23) to recalculate backup statistics daily
+# STATS_CALCULATION_HOUR=3
+
+# Logging level: DEBUG, INFO, WARNING, ERROR
+LOG_LEVEL=INFO
+
+# Session name (use different names for multiple accounts)
+SESSION_NAME=telegram_backup
+
+# Session directory (defaults to /data/session)
+# SESSION_DIR=/data/session
 
 # ==============================================================================
-# CHAT FILTERING - Choose ONE mode
+# CHAT FILTERING — Choose ONE mode
 # ==============================================================================
 
-# -----------------------------------------------------------------------------
-# MODE 1: WHITELIST (Simple) - Set CHAT_IDS to backup ONLY specific chats
-# -----------------------------------------------------------------------------
-# When set, ONLY these chats are backed up. All other settings are ignored.
+# MODE 1: WHITELIST (Simple) — Set CHAT_IDS to backup ONLY specific chats
+# When set, ONLY these chats are backed up. All other filtering is ignored.
 # Example: CHAT_IDS=-1001234567890,-1009876543210
 CHAT_IDS=
 
-# -----------------------------------------------------------------------------
-# MODE 2: TYPE-BASED (Default) - Use CHAT_TYPES to backup by type
-# -----------------------------------------------------------------------------
+# MODE 2: TYPE-BASED (Default) — Use CHAT_TYPES to backup by type
 # Options: private, groups, channels (comma-separated)
-# Example: CHAT_TYPES=private,groups (everything except channels)
 CHAT_TYPES=private,groups,channels
 
-# EXCLUDE specific chats (blacklist - takes priority)
+# EXCLUDE specific chats (blacklist — takes priority)
 GLOBAL_EXCLUDE_CHAT_IDS=
 PRIVATE_EXCLUDE_CHAT_IDS=
 GROUPS_EXCLUDE_CHAT_IDS=
 CHANNELS_EXCLUDE_CHAT_IDS=
 
-# INCLUDE additional chats (additive - adds to what CHAT_TYPES already includes)
+# INCLUDE additional chats (additive — adds to what CHAT_TYPES selects)
 # Note: These ADD to the selection, they don't restrict it.
 # For exclusive selection, use CHAT_IDS mode instead.
 GLOBAL_INCLUDE_CHAT_IDS=
@@ -75,63 +84,45 @@ PRIVATE_INCLUDE_CHAT_IDS=
 GROUPS_INCLUDE_CHAT_IDS=
 CHANNELS_INCLUDE_CHAT_IDS=
 
-# Examples:
-# 1. Backup ONLY these 2 channels (nothing else):
-#    CHAT_IDS=-1001234567890,-1009876543210
-#
-# 2. Backup all groups except one:
-#    CHAT_TYPES=groups
-#    GROUPS_EXCLUDE_CHAT_IDS=-123456789
-#
-# 3. Backup all groups PLUS one specific channel:
-#    CHAT_TYPES=groups
-#    CHANNELS_INCLUDE_CHAT_IDS=-1001234567890
+# ==============================================================================
+# REAL-TIME LISTENER
+# ==============================================================================
+# ENABLE_LISTENER is the master switch. When false (default), all LISTEN_*
+# and MASS_OPERATION_* variables below have no effect.
 
+ENABLE_LISTENER=false
 
-# Logging level
-# Options: DEBUG, INFO, WARNING, ERROR
-LOG_LEVEL=INFO
+# Granular listener controls (only apply when ENABLE_LISTENER=true):
+# LISTEN_EDITS=true
+# LISTEN_DELETIONS=true
+# LISTEN_NEW_MESSAGES=true
+# LISTEN_NEW_MESSAGES_MEDIA=false
+# LISTEN_CHAT_ACTIONS=true
 
-# Session name (for multiple accounts, use different names)
-SESSION_NAME=telegram_backup
+# Mass operation protection (only applies when ENABLE_LISTENER=true)
+# MASS_OPERATION_THRESHOLD=10
+# MASS_OPERATION_WINDOW_SECONDS=30
+# MASS_OPERATION_BUFFER_DELAY=2.0
 
-# Session directory (defaults to /data/session)
-# The session file is stored separately from backup data for better organization
-# SESSION_DIR=/data/session
+# Batch sync alternative (expensive — prefer ENABLE_LISTENER instead)
+SYNC_DELETIONS_EDITS=false
 
-# Database directory (optional)
-# Store the SQLite database in a separate location (e.g., on SSD)
-# Default: same as BACKUP_PATH
-# DATABASE_DIR=/data/database
+# Re-download missing or corrupted media files
+VERIFY_MEDIA=false
 
-# ================================
-# Display Chat IDs (Viewer Restriction)
-# ================================
-# Restrict the web viewer to show only specific chats
-# Useful for sharing public channel viewers without exposing other chats
-# Comma-separated list of chat IDs (e.g., 224091347,-100123456789)
-# DISPLAY_CHAT_IDS=
+# ==============================================================================
+# DATABASE CONFIGURATION (v3.0+)
+# ==============================================================================
+# Supports SQLite (default) and PostgreSQL.
+# Both backup and viewer containers MUST use the same database settings.
 
-# ================================
-# Database Configuration (v3.0+)
-# ================================
-# Telegram Archive supports multiple database backends:
-# - SQLite (default): Simple, no setup required
-# - PostgreSQL: Better for high-traffic deployments
+# Option 1: Full DATABASE_URL (takes priority over all below)
+# SQLite:     DATABASE_URL=sqlite:///data/telegram_backup.db
+# PostgreSQL: DATABASE_URL=postgresql://user:password@localhost:5432/telegram_backup
 
-# Option 1: Use DATABASE_URL (takes priority)
-# SQLite example:
-# DATABASE_URL=sqlite:///data/telegram_backup.db
-# PostgreSQL example:
-# DATABASE_URL=postgresql://user:password@localhost:5432/telegram_backup
-
-# Option 2: Use individual settings (v2 DATABASE_PATH/DATABASE_DIR also supported)
-# DB_TYPE: sqlite (default) or postgresql
+# Option 2: Individual settings
 DB_TYPE=sqlite
-
-# SQLite settings (when DB_TYPE=sqlite)
-# DB_PATH: Path to SQLite database file
-DB_PATH=data/telegram_backup.db
+DB_PATH=/data/backups/telegram_backup.db
 
 # PostgreSQL settings (when DB_TYPE=postgresql)
 # POSTGRES_HOST=localhost
@@ -140,5 +131,48 @@ DB_PATH=data/telegram_backup.db
 # POSTGRES_PASSWORD=your_secure_password
 # POSTGRES_DB=telegram_backup
 
-# Enable SQL query logging (for debugging)
-# DB_ECHO=false
+# ==============================================================================
+# VIEWER & AUTHENTICATION
+# ==============================================================================
+# These apply to the telegram-archive-viewer container.
+
+# Basic auth — set BOTH to enable authentication (recommended)
+# VIEWER_USERNAME=admin
+# VIEWER_PASSWORD=your_secure_password
+# AUTH_SESSION_DAYS=30
+
+# Timezone for displayed timestamps (tz database name)
+# VIEWER_TIMEZONE=Europe/Madrid
+
+# Show backup statistics dropdown in viewer header
+# SHOW_STATS=true
+
+# Restrict viewer to specific chats (comma-separated IDs)
+# Useful for sharing public channel viewers without exposing other chats
+# DISPLAY_CHAT_IDS=
+
+# ==============================================================================
+# SECURITY
+# ==============================================================================
+
+# Allowed CORS origins (comma-separated)
+# Default: * (allow all origins, credentials auto-disabled)
+# Example: CORS_ORIGINS=https://my.domain.com,https://other.domain.com
+# CORS_ORIGINS=*
+
+# Set Secure flag on auth cookies
+# Disable (false) only when developing locally over HTTP
+# SECURE_COOKIES=true
+
+# ==============================================================================
+# NOTIFICATIONS
+# ==============================================================================
+
+# Push notification mode: off, basic (in-browser only), full (Web Push)
+# PUSH_NOTIFICATIONS=basic
+
+# Custom VAPID keys for Web Push (auto-generated if empty)
+# Generate with: npx web-push generate-vapid-keys
+# VAPID_PRIVATE_KEY=
+# VAPID_PUBLIC_KEY=
+# VAPID_CONTACT=mailto:admin@example.com

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     command: ["python", "-m", "src", "schedule"]
 
     environment:
-      # Authentication & Connection
+      # Telegram Credentials (required)
       TELEGRAM_API_ID: ${TELEGRAM_API_ID}
       TELEGRAM_API_HASH: ${TELEGRAM_API_HASH}
       TELEGRAM_PHONE: ${TELEGRAM_PHONE}
@@ -20,7 +20,10 @@ services:
       DOWNLOAD_MEDIA: ${DOWNLOAD_MEDIA:-true}
       MAX_MEDIA_SIZE_MB: ${MAX_MEDIA_SIZE_MB:-100}
       BATCH_SIZE: ${BATCH_SIZE:-100}
-      
+      # DEDUPLICATE_MEDIA: ${DEDUPLICATE_MEDIA:-true}
+      # PRIORITY_CHAT_IDS: ${PRIORITY_CHAT_IDS:-}
+      # STATS_CALCULATION_HOUR: ${STATS_CALCULATION_HOUR:-3}
+
       # =======================================================================
       # CHAT FILTERING - Choose ONE mode:
       # =======================================================================
@@ -32,6 +35,16 @@ services:
       # =======================================================================
       CHAT_IDS: ${CHAT_IDS:-}
       CHAT_TYPES: ${CHAT_TYPES-private,groups,channels}
+
+      # Granular Filtering (only used in type-based mode)
+      GLOBAL_INCLUDE_CHAT_IDS: ${GLOBAL_INCLUDE_CHAT_IDS:-}
+      GLOBAL_EXCLUDE_CHAT_IDS: ${GLOBAL_EXCLUDE_CHAT_IDS:-}
+      PRIVATE_INCLUDE_CHAT_IDS: ${PRIVATE_INCLUDE_CHAT_IDS:-}
+      PRIVATE_EXCLUDE_CHAT_IDS: ${PRIVATE_EXCLUDE_CHAT_IDS:-}
+      GROUPS_INCLUDE_CHAT_IDS: ${GROUPS_INCLUDE_CHAT_IDS:-}
+      GROUPS_EXCLUDE_CHAT_IDS: ${GROUPS_EXCLUDE_CHAT_IDS:-}
+      CHANNELS_INCLUDE_CHAT_IDS: ${CHANNELS_INCLUDE_CHAT_IDS:-}
+      CHANNELS_EXCLUDE_CHAT_IDS: ${CHANNELS_EXCLUDE_CHAT_IDS:-}
 
       # Database Configuration (v3.0+)
       # Option 1: DATABASE_URL (takes priority)
@@ -46,25 +59,23 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-telegram_backup}
 
-      # Granular Filtering
-      GLOBAL_INCLUDE_CHAT_IDS: ${GLOBAL_INCLUDE_CHAT_IDS:-}
-      GLOBAL_EXCLUDE_CHAT_IDS: ${GLOBAL_EXCLUDE_CHAT_IDS:-}
-
-      PRIVATE_INCLUDE_CHAT_IDS: ${PRIVATE_INCLUDE_CHAT_IDS:-}
-      PRIVATE_EXCLUDE_CHAT_IDS: ${PRIVATE_EXCLUDE_CHAT_IDS:-}
-
-      GROUPS_INCLUDE_CHAT_IDS: ${GROUPS_INCLUDE_CHAT_IDS:-}
-      GROUPS_EXCLUDE_CHAT_IDS: ${GROUPS_EXCLUDE_CHAT_IDS:-}
-
-      CHANNELS_INCLUDE_CHAT_IDS: ${CHANNELS_INCLUDE_CHAT_IDS:-}
-      CHANNELS_EXCLUDE_CHAT_IDS: ${CHANNELS_EXCLUDE_CHAT_IDS:-}
-
-      # Real-time Sync Options
-      # ENABLE_LISTENER: Catches edits/deletions in real-time (recommended)
+      # Real-time Listener
+      # ENABLE_LISTENER is the master switch — when false, all LISTEN_* vars are ignored
       ENABLE_LISTENER: ${ENABLE_LISTENER:-false}
-      # SYNC_DELETIONS_EDITS: Batch-check ALL messages for edits/deletions (expensive!)
+      # Granular listener controls (only apply when ENABLE_LISTENER=true):
+      # LISTEN_EDITS: ${LISTEN_EDITS:-true}
+      # LISTEN_DELETIONS: ${LISTEN_DELETIONS:-true}
+      # LISTEN_NEW_MESSAGES: ${LISTEN_NEW_MESSAGES:-true}
+      # LISTEN_NEW_MESSAGES_MEDIA: ${LISTEN_NEW_MESSAGES_MEDIA:-false}
+      # LISTEN_CHAT_ACTIONS: ${LISTEN_CHAT_ACTIONS:-true}
+
+      # Mass operation protection (only applies when ENABLE_LISTENER=true)
+      # MASS_OPERATION_THRESHOLD: ${MASS_OPERATION_THRESHOLD:-10}
+      # MASS_OPERATION_WINDOW_SECONDS: ${MASS_OPERATION_WINDOW_SECONDS:-30}
+      # MASS_OPERATION_BUFFER_DELAY: ${MASS_OPERATION_BUFFER_DELAY:-2.0}
+
+      # Batch sync alternative (expensive — prefer ENABLE_LISTENER instead)
       SYNC_DELETIONS_EDITS: ${SYNC_DELETIONS_EDITS:-false}
-      # VERIFY_MEDIA: Re-download missing/corrupted media files
       VERIFY_MEDIA: ${VERIFY_MEDIA:-false}
 
       # Logging
@@ -105,12 +116,31 @@ services:
       - "8000:8000"
     environment:
       BACKUP_PATH: /data/backups
-      # Optional basic auth for the viewer (recommended)
+
+      # Authentication (recommended — set both to enable)
       VIEWER_USERNAME: ${VIEWER_USERNAME:-}
       VIEWER_PASSWORD: ${VIEWER_PASSWORD:-}
-      # Timezone for displaying last backup time
+      AUTH_SESSION_DAYS: ${AUTH_SESSION_DAYS:-30}
+
+      # Display
       VIEWER_TIMEZONE: ${VIEWER_TIMEZONE:-Europe/Madrid}
-      # Database Configuration - MUST MATCH telegram-backup service!
+      SHOW_STATS: ${SHOW_STATS:-true}
+      # Restrict viewer to specific chats (optional)
+      # DISPLAY_CHAT_IDS: ${DISPLAY_CHAT_IDS:-}
+
+      # Security
+      # CORS_ORIGINS: comma-separated allowed origins (default: * = allow all)
+      # CORS_ORIGINS: ${CORS_ORIGINS:-*}
+      # SECURE_COOKIES: set Secure flag on auth cookies (disable for local HTTP dev)
+      # SECURE_COOKIES: ${SECURE_COOKIES:-true}
+
+      # Notifications
+      # PUSH_NOTIFICATIONS: ${PUSH_NOTIFICATIONS:-basic}
+      # VAPID_PRIVATE_KEY: ${VAPID_PRIVATE_KEY:-}
+      # VAPID_PUBLIC_KEY: ${VAPID_PUBLIC_KEY:-}
+      # VAPID_CONTACT: ${VAPID_CONTACT:-mailto:admin@example.com}
+
+      # Database Configuration — MUST MATCH telegram-backup service!
       # If viewer shows no data, ensure these match the backup container
       DATABASE_URL: ${DATABASE_URL:-}
       DB_TYPE: ${DB_TYPE:-sqlite}
@@ -120,6 +150,10 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-telegram}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
       POSTGRES_DB: ${POSTGRES_DB:-telegram_backup}
+
+      # Logging
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+
     volumes:
       - ./data:/data:ro
     networks:


### PR DESCRIPTION
## Summary

- Replaces 8+ scattered env var subsections in README with **one unified reference table** grouped by category, with a Scope column (B=backup, V=viewer, B/V=both)
- Documents previously undocumented `CORS_ORIGINS`, `SECURE_COOKIES`, and `MASS_OPERATION_BUFFER_DELAY` environment variables
- Clearly explains that `ENABLE_LISTENER` is a **master switch** — when `false`, all `LISTEN_*` and `MASS_OPERATION_*` variables have no effect
- Updates `docker-compose.yml` with all missing env vars for both backup and viewer services (listener sub-settings, mass operation protection, CORS, secure cookies, notifications, etc.)
- Rewrites `.env.example` with complete variable coverage including viewer, security, listener, and notification sections

## Test plan

- [ ] Verify README renders correctly on GitHub (table formatting, links, anchors)
- [ ] Validate `docker compose config` passes without errors
- [ ] Confirm all env vars in the table match actual code defaults in `src/config.py` and `src/web/main.py`