### PR TITLE
fix: resolve chat search returning no results due to limit mismatch

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,13 @@ For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
 ## [Unreleased]
 
+## [6.2.15] - 2026-02-15
+
+### Fixed
+
+- **Chat search broken (silent 422 error)** — The search bar sent `limit=1000` but the API enforced `le=500`, causing FastAPI to reject every search request with a 422 validation error. The frontend silently swallowed the error, making search appear to return no results. Raised the API limit to 1000 to match the frontend.
+- **Chat search ignored in DISPLAY_CHAT_IDS mode** — When `DISPLAY_CHAT_IDS` was configured, the search query was never passed to the database, so typing in the search bar had no effect on the displayed chats.
+
 ## [6.2.14] - 2026-02-13
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "6.2.14"
+version = "6.2.15"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -531,7 +531,7 @@ def _get_cached_avatar_path(chat_id: int, chat_type: str) -> str | None:
 
 @app.get("/api/chats", dependencies=[Depends(require_auth)])
 async def get_chats(
-    limit: int = Query(50, ge=1, le=500, description="Number of chats to return"),
+    limit: int = Query(50, ge=1, le=1000, description="Number of chats to return"),
     offset: int = Query(0, ge=0, description="Offset for pagination"),
     search: str = Query(None, description="Search query for chat names/usernames"),
     archived: bool | None = Query(None, description="Filter by archived status"),
@@ -548,7 +548,7 @@ async def get_chats(
         # If display_chat_ids is configured, we need to load all matching chats
         # Otherwise, use pagination
         if config.display_chat_ids:
-            chats = await db.get_all_chats(archived=archived, folder_id=folder_id)
+            chats = await db.get_all_chats(search=search, archived=archived, folder_id=folder_id)
             chats = [c for c in chats if c["id"] in config.display_chat_ids]
             total = len(chats)
             # Apply pagination after filtering


### PR DESCRIPTION
## Summary

- **Bug 1**: The search bar sent `limit=1000` but the `/api/chats` endpoint enforced `le=500`, causing FastAPI to reject every search request with a silent 422 error. Raised the API limit to `le=1000`.
- **Bug 2**: When `DISPLAY_CHAT_IDS` was configured, the `search` parameter was never passed to the database query, making search non-functional for restricted viewers. Now passes `search=` to the DB call.

## Test plan

- [ ] Type a chat name in the search bar — results should appear
- [ ] Search for a chat that would be on page 2+ of the paginated list — it should be found
- [ ] If using `DISPLAY_CHAT_IDS`, verify search filters within the allowed chats