### PR TITLE
fix: show empty state when chat has no backed up messages

### DIFF
--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1057,6 +1057,13 @@
                             Beginning of chat history
                         </div>
 
+                        <div v-if="!loading && !hasMore && messages.length === 0 && selectedChat" class="flex flex-col items-center justify-center py-16 text-tg-muted">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="w-12 h-12 mb-3 opacity-30" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.5">
+                                <path stroke-linecap="round" stroke-linejoin="round" d="M20 13V6a2 2 0 00-2-2H6a2 2 0 00-2 2v7m16 0v5a2 2 0 01-2 2H6a2 2 0 01-2-2v-5m16 0h-2.586a1 1 0 00-.707.293l-2.414 2.414a1 1 0 01-.707.293h-3.172a1 1 0 01-.707-.293l-2.414-2.414A1 1 0 006.586 13H4" />
+                            </svg>
+                            <p class="text-sm">No messages backed up for this chat yet</p>
+                        </div>
+
                         <div ref="scrollAnchor"></div>
                     </div>
 


### PR DESCRIPTION
## Summary
- Adds an empty state message ("No messages backed up for this chat yet") when a chat exists in the database but has zero messages
- Previously, clicking such a chat showed a blank screen with no feedback

Closes #78

## Test plan
- [ ] Open a chat that has been partially backed up (chat metadata saved but no messages fetched)
- [ ] Verify the empty state with icon and message appears instead of blank screen
- [ ] Verify chats with at least 1 message still render normally