### PR TITLE
feat(backup): gap-fill — detect and recover skipped messages

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -144,6 +144,25 @@ For more information, visit: https://github.com/GeiserX/Telegram-Archive
         "--merge", action="store_true", help="Allow importing into a chat that already has messages"
     )
 
+    # Fill gaps command
+    fill_gaps_parser = subparsers.add_parser(
+        "fill-gaps",
+        help="Detect and fill message gaps from failed backups",
+        description=(
+            "Scans backed-up chats for gaps in message ID sequences "
+            "and recovers skipped messages from Telegram. "
+            "Gaps are caused by API errors, rate limits, or interruptions "
+            "during previous backup runs."
+        ),
+    )
+    fill_gaps_parser.add_argument(
+        "-c", "--chat-id", type=int, help="Fill gaps only for this specific chat ID"
+    )
+    fill_gaps_parser.add_argument(
+        "-t", "--threshold", type=int, default=None,
+        help="Minimum gap size to investigate (overrides GAP_THRESHOLD env var)",
+    )
+
     return parser
 
 
@@ -243,6 +262,35 @@ async def run_import(args) -> int:
         return 1
 
 
+async def run_fill_gaps_cmd(args) -> int:
+    """Run fill-gaps command."""
+    from .config import Config, setup_logging
+    from .telegram_backup import run_fill_gaps
+
+    try:
+        config = Config()
+        if args.threshold is not None:
+            config.gap_threshold = args.threshold
+        setup_logging(config)
+
+        summary = await run_fill_gaps(config, chat_id=args.chat_id)
+        print("\nGap-fill complete:")
+        print(f"  Chats scanned: {summary['chats_scanned']}")
+        print(f"  Chats with gaps: {summary['chats_with_gaps']}")
+        print(f"  Total gaps found: {summary['total_gaps']}")
+        print(f"  Messages recovered: {summary['total_recovered']}")
+        if summary["details"]:
+            for detail in summary["details"]:
+                print(
+                    f"  - {detail['chat_name']} (ID {detail['chat_id']}): "
+                    f"{detail['gaps']} gaps, {detail['recovered']} recovered"
+                )
+        return 0
+    except Exception as e:
+        print(f"Gap-fill failed: {e}", file=sys.stderr)
+        return 1
+
+
 def run_auth(args) -> int:
     """Run authentication setup."""
     from .setup_auth import main as auth_main
@@ -304,6 +352,8 @@ def main() -> int:
         return asyncio.run(run_list_chats(args))
     elif args.command == "import":
         return asyncio.run(run_import(args))
+    elif args.command == "fill-gaps":
+        return asyncio.run(run_fill_gaps_cmd(args))
     else:
         parser.print_help()
         return 0

--- a/src/config.py
+++ b/src/config.py
@@ -147,6 +147,12 @@ class Config:
         # Useful for recovering from interrupted backups or deleted media files
         self.verify_media = os.getenv("VERIFY_MEDIA", "false").lower() == "true"
 
+        # Gap-fill mode: detect and recover skipped messages
+        # When enabled, runs after each scheduled backup to find and fill gaps
+        # in message ID sequences caused by API errors or interruptions
+        self.fill_gaps = os.getenv("FILL_GAPS", "false").lower() == "true"
+        self.gap_threshold = int(os.getenv("GAP_THRESHOLD", "50"))
+
         # Real-time listener mode
         # When enabled, runs a background listener that catches message edits and deletions
         # in real-time instead of batch-checking on each backup run

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -890,6 +890,42 @@ class DatabaseAdapter:
             await session.execute(stmt)
             await session.commit()
 
+    # ========== Gap Detection ==========
+
+    async def detect_message_gaps(self, chat_id: int, threshold: int = 50) -> list[tuple[int, int, int]]:
+        """Detect gaps in message ID sequences for a chat.
+
+        Finds consecutive message IDs where the jump between them exceeds
+        the threshold. Small gaps are normal (deleted/service messages) —
+        large gaps indicate backup failures.
+
+        Returns list of (gap_start_id, gap_end_id, gap_size) tuples.
+        """
+        async with self.db_manager.async_session_factory() as session:
+            query = text("""
+                WITH ordered AS (
+                    SELECT id, LAG(id) OVER (ORDER BY id) AS prev_id
+                    FROM messages
+                    WHERE chat_id = :chat_id
+                )
+                SELECT prev_id AS gap_start,
+                       id AS gap_end,
+                       id - prev_id AS gap_size
+                FROM ordered
+                WHERE prev_id IS NOT NULL
+                  AND id - prev_id > :threshold
+                ORDER BY gap_start
+            """)
+            result = await session.execute(query, {"chat_id": chat_id, "threshold": threshold})
+            return [(row.gap_start, row.gap_end, row.gap_size) for row in result]
+
+    async def get_chats_with_messages(self) -> list[int]:
+        """Get all chat IDs that have at least one message."""
+        async with self.db_manager.async_session_factory() as session:
+            stmt = select(Message.chat_id).distinct()
+            result = await session.execute(stmt)
+            return [row[0] for row in result]
+
     # ========== Statistics ==========
 
     async def get_statistics(self) -> dict[str, Any]:

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -76,6 +76,15 @@ class BackupScheduler:
             # Run backup using shared client
             await run_backup(self.config, client=client)
 
+            # Run gap-fill if enabled
+            if self.config.fill_gaps:
+                try:
+                    from .telegram_backup import run_fill_gaps
+                    logger.info("Running gap-fill after backup...")
+                    await run_fill_gaps(self.config, client=client)
+                except Exception as e:
+                    logger.error(f"Gap-fill failed: {e}", exc_info=True)
+
             # Reload tracked chats in listener after backup
             # (new chats may have been added)
             if self._listener:
@@ -213,6 +222,15 @@ class BackupScheduler:
         try:
             await run_backup(self.config, client=self._connection.client)
             logger.info("Initial backup completed")
+
+            # Run gap-fill after initial backup if enabled
+            if self.config.fill_gaps:
+                try:
+                    from .telegram_backup import run_fill_gaps
+                    logger.info("Running initial gap-fill...")
+                    await run_fill_gaps(self.config, client=self._connection.client)
+                except Exception as e:
+                    logger.error(f"Initial gap-fill failed: {e}", exc_info=True)
 
             # Reload tracked chats in listener after initial backup
             if self._listener:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -692,6 +692,117 @@ class TelegramBackup:
                 if reactions_list:
                     await self.db.insert_reactions(msg["id"], chat_id, reactions_list)
 
+    async def _fill_gap_range(self, entity, chat_id: int, gap_start: int, gap_end: int) -> int:
+        """Fetch messages for a single gap range and insert them.
+
+        Args:
+            entity: Telegram entity for the chat.
+            chat_id: Marked chat ID.
+            gap_start: Last message ID before the gap (exclusive lower bound).
+            gap_end: First message ID after the gap (exclusive upper bound).
+
+        Returns:
+            Number of messages recovered.
+        """
+        batch_data: list[dict] = []
+        batch_size = self.config.batch_size
+        total = 0
+
+        async for message in self.client.iter_messages(
+            entity, min_id=gap_start, max_id=gap_end, reverse=True
+        ):
+            msg_data = await self._process_message(message, chat_id)
+            batch_data.append(msg_data)
+
+            if len(batch_data) >= batch_size:
+                await self._commit_batch(batch_data, chat_id)
+                total += len(batch_data)
+                batch_data = []
+
+        if batch_data:
+            await self._commit_batch(batch_data, chat_id)
+            total += len(batch_data)
+
+        return total
+
+    async def _fill_gaps(self, chat_id: int | None = None) -> dict:
+        """Detect and fill message gaps for backed-up chats.
+
+        Args:
+            chat_id: If provided, scan only this chat. Otherwise scan all.
+
+        Returns:
+            Summary dict with total_gaps, total_recovered, per_chat details.
+        """
+        threshold = self.config.gap_threshold
+
+        if chat_id:
+            chat_ids = [chat_id]
+        else:
+            chat_ids = await self.db.get_chats_with_messages()
+
+        total_gaps = 0
+        total_recovered = 0
+        per_chat: list[dict] = []
+
+        for cid in chat_ids:
+            gaps = await self.db.detect_message_gaps(cid, threshold)
+            if not gaps:
+                continue
+
+            total_gaps += len(gaps)
+            chat_recovered = 0
+
+            try:
+                entity = await self.client.get_entity(cid)
+            except (ChannelPrivateError, ChatForbiddenError, UserBannedInChannelError):
+                logger.warning(f"Gap-fill: skipping chat {cid} (no access)")
+                continue
+            except Exception as e:
+                logger.error(f"Gap-fill: cannot get entity for chat {cid}: {e}")
+                continue
+
+            chat_name = self._get_chat_name(entity)
+            logger.info(f"Gap-fill: {chat_name} (ID: {cid}) — {len(gaps)} gap(s) detected")
+
+            for gap_start, gap_end, gap_size in gaps:
+                logger.info(f"  → Gap [{gap_start}..{gap_end}] (~{gap_size} IDs missing)")
+                try:
+                    recovered = await self._fill_gap_range(entity, cid, gap_start, gap_end)
+                    chat_recovered += recovered
+                    if recovered > 0:
+                        logger.info(f"    Recovered {recovered} messages")
+                    else:
+                        logger.info("    No messages found (likely deleted)")
+                except Exception as e:
+                    logger.error(f"    Error filling gap: {e}", exc_info=True)
+
+            total_recovered += chat_recovered
+            per_chat.append({
+                "chat_id": cid,
+                "chat_name": chat_name,
+                "gaps": len(gaps),
+                "recovered": chat_recovered,
+            })
+
+        summary = {
+            "chats_scanned": len(chat_ids),
+            "chats_with_gaps": len(per_chat),
+            "total_gaps": total_gaps,
+            "total_recovered": total_recovered,
+            "details": per_chat,
+        }
+
+        logger.info("=" * 60)
+        logger.info("Gap-fill completed!")
+        logger.info(f"Chats scanned: {summary['chats_scanned']}")
+        logger.info(f"Chats with gaps: {summary['chats_with_gaps']}")
+        logger.info(f"Total gaps: {summary['total_gaps']}")
+        logger.info(f"Messages recovered: {summary['total_recovered']}")
+        logger.info("=" * 60)
+
+        return summary
+
     async def _sync_deletions_and_edits(self, chat_id: int, entity):
         """
         Sync deletions and edits for existing messages in the database.
@@ -1635,6 +1746,25 @@ async def run_backup(config: Config, client: TelegramClient | None = None):
     try:
         await backup.connect()
         await backup.backup_all()
+    finally:
+        await backup.disconnect()
+        await backup.db.close()
+
+
+async def run_fill_gaps(
+    config: Config, client: TelegramClient | None = None, chat_id: int | None = None
+) -> dict:
+    """Run gap-fill operation.
+
+    Args:
+        config: Configuration object.
+        client: Optional shared TelegramClient.
+        chat_id: If provided, fill gaps only for this chat.
+    """
+    backup = await TelegramBackup.create(config, client=client)
+    try:
+        await backup.connect()
+        return await backup._fill_gaps(chat_id=chat_id)
     finally:
         await backup.disconnect()
         await backup.db.close()

--- a/tests/test_gap_fill.py
+++ b/tests/test_gap_fill.py
@@ -1,0 +1,231 @@
+"""Tests for gap-fill backup feature (phases 1-4)."""
+
+from unittest.mock import patch
+
+import pytest
+
+
+class TestGapDetectionQuery:
+    """Phase 1: detect_message_gaps and get_chats_with_messages on adapter."""
+
+    def test_adapter_has_detect_message_gaps(self):
+        from src.db.adapter import DatabaseAdapter
+
+        assert hasattr(DatabaseAdapter, "detect_message_gaps")
+
+    def test_adapter_has_get_chats_with_messages(self):
+        from src.db.adapter import DatabaseAdapter
+
+        assert hasattr(DatabaseAdapter, "get_chats_with_messages")
+
+    def test_detect_message_gaps_signature(self):
+        """detect_message_gaps accepts chat_id and threshold."""
+        import inspect
+
+        from src.db.adapter import DatabaseAdapter
+
+        sig = inspect.signature(DatabaseAdapter.detect_message_gaps)
+        params = list(sig.parameters.keys())
+        assert "chat_id" in params
+        assert "threshold" in params
+
+
+class TestGapFillMethods:
+    """Phase 2: _fill_gap_range, _fill_gaps, run_fill_gaps on TelegramBackup."""
+
+    def test_backup_has_fill_gap_range(self):
+        from src.telegram_backup import TelegramBackup
+
+        assert hasattr(TelegramBackup, "_fill_gap_range")
+
+    def test_backup_has_fill_gaps(self):
+        from src.telegram_backup import TelegramBackup
+
+        assert hasattr(TelegramBackup, "_fill_gaps")
+
+    def test_run_fill_gaps_exists(self):
+        from src.telegram_backup import run_fill_gaps
+
+        assert callable(run_fill_gaps)
+
+    def test_run_fill_gaps_is_coroutine(self):
+        import inspect
+
+        from src.telegram_backup import run_fill_gaps
+
+        assert inspect.iscoroutinefunction(run_fill_gaps)
+
+
+class TestConfigGapFill:
+    """Phase 3: Config env vars for gap-fill."""
+
+    def test_config_has_fill_gaps(self):
+        import inspect
+
+        from src.config import Config
+
+        source = inspect.getsource(Config.__init__)
+        assert "fill_gaps" in source
+
+    def test_config_has_gap_threshold(self):
+        import inspect
+
+        from src.config import Config
+
+        source = inspect.getsource(Config.__init__)
+        assert "gap_threshold" in source
+
+    @patch.dict("os.environ", {"FILL_GAPS": "true"}, clear=False)
+    def test_fill_gaps_enabled(self):
+        """FILL_GAPS=true should set fill_gaps to True."""
+        # Need to patch all required env vars for Config
+        required = {
+            "API_ID": "12345",
+            "API_HASH": "abc123",
+            "FILL_GAPS": "true",
+        }
+        with patch.dict("os.environ", required, clear=False):
+            try:
+                from src.config import Config
+
+                config = Config()
+                assert config.fill_gaps is True
+            except Exception:
+                # Config may fail on other missing envs; just verify the attribute
+                pytest.skip("Config requires additional env vars")
+
+    @patch.dict("os.environ", {"FILL_GAPS": "false"}, clear=False)
+    def test_fill_gaps_disabled_by_default(self):
+        """Default FILL_GAPS should be false."""
+        required = {
+            "API_ID": "12345",
+            "API_HASH": "abc123",
+        }
+        with patch.dict("os.environ", required, clear=False):
+            try:
+                from src.config import Config
+
+                config = Config()
+                assert config.fill_gaps is False
+            except Exception:
+                pytest.skip("Config requires additional env vars")
+
+
+class TestSchedulerGapFill:
+    """Phase 3: Scheduler integrates gap-fill after backup."""
+
+    def test_scheduler_run_backup_job_calls_gap_fill(self):
+        """_run_backup_job source references fill_gaps."""
+        from pathlib import Path
+
+        source = Path("src/scheduler.py").read_text()
+        assert "fill_gaps" in source
+        assert "run_fill_gaps" in source
+
+    def test_scheduler_run_forever_calls_gap_fill(self):
+        """run_forever source references fill_gaps for initial backup."""
+        from pathlib import Path
+
+        source = Path("src/scheduler.py").read_text()
+        assert "Initial gap-fill" in source
+
+
+class TestCLIFillGaps:
+    """Phase 3: fill-gaps CLI subcommand."""
+
+    def test_fill_gaps_subcommand_exists(self):
+        from src.__main__ import create_parser
+
+        parser = create_parser()
+        # Parse fill-gaps without args to verify it's registered
+        args = parser.parse_args(["fill-gaps"])
+        assert args.command == "fill-gaps"
+
+    def test_fill_gaps_chat_id_arg(self):
+        from src.__main__ import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["fill-gaps", "--chat-id", "-1001234567890"])
+        assert args.chat_id == -1001234567890
+
+    def test_fill_gaps_threshold_arg(self):
+        from src.__main__ import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["fill-gaps", "--threshold", "100"])
+        assert args.threshold == 100
+
+    def test_fill_gaps_threshold_default_none(self):
+        from src.__main__ import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["fill-gaps"])
+        assert args.threshold is None
+
+    def test_fill_gaps_short_flags(self):
+        from src.__main__ import create_parser
+
+        parser = create_parser()
+        args = parser.parse_args(["fill-gaps", "-c", "123", "-t", "200"])
+        assert args.chat_id == 123
+        assert args.threshold == 200
+
+    def test_run_fill_gaps_cmd_exists(self):
+        from src.__main__ import run_fill_gaps_cmd
+
+        assert callable(run_fill_gaps_cmd)
+
+    def test_dispatch_handles_fill_gaps(self):
+        """main() dispatch includes fill-gaps case."""
+        import inspect
+
+        from src.__main__ import main
+
+        source = inspect.getsource(main)
+        assert '"fill-gaps"' in source
+
+
+class TestFillGapRangeLogic:
+    """Phase 2: _fill_gap_range uses correct iter_messages params."""
+
+    def test_fill_gap_range_source_uses_min_max_id(self):
+        """_fill_gap_range should use min_id and max_id for bounded fetching."""
+        import inspect
+
+        from src.telegram_backup import TelegramBackup
+
+        source = inspect.getsource(TelegramBackup._fill_gap_range)
+        assert "min_id" in source
+        assert "max_id" in source
+
+    def test_fill_gap_range_commits_batches(self):
+        """_fill_gap_range should call _commit_batch."""
+        import inspect
+
+        from src.telegram_backup import TelegramBackup
+
+        source = inspect.getsource(TelegramBackup._fill_gap_range)
+        assert "_commit_batch" in source
+
+    def test_fill_gaps_handles_inaccessible_chats(self):
+        """_fill_gaps should catch ChannelPrivateError etc."""
+        import inspect
+
+        from src.telegram_backup import TelegramBackup
+
+        source = inspect.getsource(TelegramBackup._fill_gaps)
+        assert "ChannelPrivateError" in source
+
+
+class TestFillGapsSummary:
+    """Phase 2: _fill_gaps returns correct summary structure."""
+
+    def test_fill_gaps_returns_summary_keys(self):
+        """_fill_gaps source builds summary with expected keys."""
+        import inspect
+
+        from src.telegram_backup import TelegramBackup
+
+        source = inspect.getsource(TelegramBackup._fill_gaps)
+        for key in ["chats_scanned", "chats_with_gaps", "total_gaps", "total_recovered", "details"]:
+            assert key in source, f"Missing key '{key}' in _fill_gaps summary"


### PR DESCRIPTION
## Summary

Adds a gap-fill feature that detects and recovers messages skipped during previous backup runs due to API errors, rate limits, or interruptions.

**Rebased onto v7.2.0** — removed all previous UI/viewer changes since you properly implemented those in v7.2.0. This PR now focuses solely on the gap-fill feature.

### What it does

- **Gap detection**: SQL `LAG()` window function finds jumps in message ID sequences exceeding a configurable threshold (default: 50 IDs)
- **Gap recovery**: Uses `iter_messages(min_id, max_id)` to fetch missing messages within detected gaps
- **Scheduler integration**: Runs automatically after each scheduled backup when `FILL_GAPS=true`
- **CLI command**: `telegram-archive fill-gaps [--chat-id ID] [--threshold N]` for manual runs

### Files changed

| File | Change |
|------|--------|
| `src/db/adapter.py` | `detect_message_gaps()` + `get_chats_with_messages()` |
| `src/telegram_backup.py` | `_fill_gap_range()`, `_fill_gaps()`, `run_fill_gaps()` |
| `src/config.py` | `FILL_GAPS` + `GAP_THRESHOLD` env vars |
| `src/scheduler.py` | Post-backup gap-fill integration |
| `src/__main__.py` | `fill-gaps` CLI subcommand |
| `tests/test_gap_fill.py` | 24 tests covering all phases |

### Configuration

```env
FILL_GAPS=true          # Enable gap-fill after each backup (default: false)
GAP_THRESHOLD=50        # Minimum gap size to investigate (default: 50)
```

### Previous review feedback

All issues from the v7.2.0-conflicting changes have been removed by rebasing. This PR contains only new, non-overlapping code.

## Test plan

- [ ] Run `telegram-archive fill-gaps` against a database with known gaps
- [ ] Enable `FILL_GAPS=true` and verify it runs after scheduled backup
- [ ] Verify gap detection query returns correct results for various gap sizes
- [ ] Run `pytest tests/test_gap_fill.py` — 24 tests pass