### PR TITLE
Fix VERIFY_MEDIA redownload failures on dangling dedup symlinks

### DIFF
--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -464,6 +464,70 @@ class TelegramBackup:
             dialogs = await self.client.get_dialogs(folder=0)
         return dialogs
 
+    def _resolve_shared_media_path(self, shared_dir: str, file_name: str) -> str | None:
+        """Resolve actual shared media path, handling extension/suffix variants.
+
+        Telethon may append an extension or collision suffix (e.g. `` (1)``)
+        to the requested filename. This helper finds the best on-disk match
+        for a logical dedup filename.
+        """
+        expected_path = os.path.join(shared_dir, file_name)
+        if os.path.exists(expected_path):
+            return expected_path
+
+        try:
+            entries = os.listdir(shared_dir)
+        except OSError:
+            return None
+
+        prefix_with_ext = f"{file_name}."
+        prefix_with_suffix = f"{file_name} ("
+
+        candidates: list[str] = []
+        for entry in entries:
+            if not (entry.startswith(prefix_with_ext) or entry.startswith(prefix_with_suffix)):
+                continue
+            candidate_path = os.path.join(shared_dir, entry)
+            if os.path.isfile(candidate_path):
+                candidates.append(candidate_path)
+
+        if not candidates:
+            return None
+
+        # Prefer files without collision suffix, then latest modified.
+        without_collision_suffix = [p for p in candidates if " (" not in os.path.basename(p)]
+        preferred = without_collision_suffix if without_collision_suffix else candidates
+        return max(preferred, key=os.path.getmtime)
+
+    def _ensure_symlink(self, target_path: str, link_path: str) -> None:
+        """Create/update symlink, safely handling existing dangling links."""
+        rel_target = os.path.relpath(target_path, os.path.dirname(link_path))
+
+        try:
+            os.symlink(rel_target, link_path)
+            return
+        except FileExistsError:
+            pass
+
+        # Existing path may be dangling symlink, stale symlink, or regular file.
+        if not os.path.lexists(link_path):
+            os.symlink(rel_target, link_path)
+            return
+
+        if not os.path.islink(link_path):
+            raise FileExistsError(f"Path exists and is not a symlink: {link_path}")
+
+        current_target = os.readlink(link_path)
+        current_abs = os.path.normpath(os.path.join(os.path.dirname(link_path), current_target))
+        desired_abs = os.path.normpath(target_path)
+
+        if current_abs == desired_abs and os.path.exists(current_abs):
+            # Correct and healthy symlink already in place.
+            return
+
+        os.unlink(link_path)
+        os.symlink(rel_target, link_path)
+
     async def _verify_and_redownload_media(self) -> None:
         """
         Verify all media files on disk and re-download missing/corrupted ones.
@@ -579,9 +643,9 @@ class TelegramBackup:
                         continue
 
                     try:
-                        # Delete corrupted file if exists
+                        # Delete existing path if present (including dangling symlink)
                         file_path = record.get("file_path")
-                        if file_path and os.path.exists(file_path):
+                        if file_path and os.path.lexists(file_path):
                             os.remove(file_path)
 
                         # Re-download using existing method
@@ -1337,38 +1401,57 @@ class TelegramBackup:
                 shared_dir = os.path.join(self.config.media_path, "_shared")
                 os.makedirs(shared_dir, exist_ok=True)
                 shared_file_path = os.path.join(shared_dir, file_name)
+                resolved_shared_path = self._resolve_shared_media_path(shared_dir, file_name)
 
                 # Check if file already exists (either directly or in shared)
                 if not os.path.exists(file_path):
-                    if os.path.exists(shared_file_path):
-                        # File exists in shared - create symlink
+                    if resolved_shared_path:
+                        # File exists in shared - create/repair symlink
                         try:
-                            # Use relative symlink for portability
-                            rel_path = os.path.relpath(shared_file_path, chat_media_dir)
-                            os.symlink(rel_path, file_path)
+                            self._ensure_symlink(resolved_shared_path, file_path)
                             logger.debug(f"Created symlink for deduplicated media: {file_name}")
                         except OSError as e:
-                            # Symlink failed (e.g., Windows), copy reference instead
+                            # Symlink failed (e.g., Windows), download direct copy
                             logger.warning(f"Symlink failed, downloading copy: {e}")
-                            await self.client.download_media(message, file_path)
+                            direct_path = await self.client.download_media(message, file_path)
+                            if isinstance(direct_path, str) and direct_path:
+                                file_path = direct_path
+                                file_name = os.path.basename(direct_path)
                     else:
                         # First time seeing this file - download to shared and create symlink
-                        await self.client.download_media(message, shared_file_path)
-                        logger.debug(f"Downloaded media to shared: {file_name}")
+                        downloaded_shared_path = await self.client.download_media(message, shared_file_path)
+                        if isinstance(downloaded_shared_path, str) and downloaded_shared_path:
+                            resolved_shared_path = downloaded_shared_path
+                        else:
+                            resolved_shared_path = self._resolve_shared_media_path(shared_dir, file_name) or shared_file_path
+
+                        logger.debug(f"Downloaded media to shared: {os.path.basename(resolved_shared_path)}")
 
                         # Create symlink in chat directory
                         try:
-                            rel_path = os.path.relpath(shared_file_path, chat_media_dir)
-                            os.symlink(rel_path, file_path)
+                            self._ensure_symlink(resolved_shared_path, file_path)
                         except OSError as e:
-                            # Symlink failed - move file to chat dir instead
+                            # Symlink failed - move/copy file to chat dir instead
                             logger.warning(f"Symlink failed, using direct path: {e}")
                             import shutil
 
-                            shutil.move(shared_file_path, file_path)
+                            source_path = resolved_shared_path
+                            if source_path and os.path.exists(source_path):
+                                if os.path.lexists(file_path):
+                                    os.remove(file_path)
+                                shutil.move(source_path, file_path)
+                            else:
+                                direct_path = await self.client.download_media(message, file_path)
+                                if isinstance(direct_path, str) and direct_path:
+                                    file_path = direct_path
+                                    file_name = os.path.basename(direct_path)
 
                 # Update file_size with actual size from disk (follow symlinks)
-                actual_path = shared_file_path if os.path.exists(shared_file_path) else file_path
+                actual_path = (
+                    resolved_shared_path
+                    if resolved_shared_path and os.path.exists(resolved_shared_path)
+                    else file_path
+                )
                 if os.path.exists(actual_path):
                     file_size = os.path.getsize(actual_path)
             else:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -528,6 +528,30 @@ class TelegramBackup:
         os.unlink(link_path)
         os.symlink(rel_target, link_path)
 
+    @staticmethod
+    def _is_missing_or_dangling_path(path: str) -> bool:
+        """Return True when path is absent or points to a missing target."""
+        return not os.path.lexists(path) or not os.path.exists(path)
+
+    def _resolve_canonical_media_path(self, file_path: str, shared_path: str | None = None) -> str:
+        """Resolve canonical on-disk media path for DB persistence."""
+        if os.path.lexists(file_path) and os.path.islink(file_path):
+            try:
+                link_target = os.readlink(file_path)
+                link_target_abs = os.path.normpath(os.path.join(os.path.dirname(file_path), link_target))
+                if os.path.exists(link_target_abs):
+                    return link_target_abs
+            except OSError:
+                pass
+
+        if os.path.exists(file_path):
+            return os.path.normpath(file_path)
+
+        if shared_path and os.path.exists(shared_path):
+            return os.path.normpath(shared_path)
+
+        return os.path.normpath(file_path)
+
     async def _verify_and_redownload_media(self) -> None:
         """
         Verify all media files on disk and re-download missing/corrupted ones.
@@ -561,8 +585,8 @@ class TelegramBackup:
             if not file_path:
                 continue
 
-            # Check if file exists
-            if not os.path.exists(file_path):
+            # Check if file is missing or a dangling symlink
+            if self._is_missing_or_dangling_path(file_path):
                 missing_files.append(record)
                 continue
 
@@ -1300,25 +1324,51 @@ class TelegramBackup:
             deleted_records = 0
             freed_bytes = 0
 
+            shared_media_dir = os.path.abspath(os.path.join(self.config.media_path, "_shared"))
+            chat_media_dir = os.path.join(self.config.media_path, str(chat_id))
+
             for record in media_records:
                 file_path = record.get("file_path")
-                if file_path and os.path.exists(file_path):
+                if not file_path or not os.path.exists(file_path):
+                    continue
+
+                file_path_abs = os.path.abspath(file_path)
+                if file_path_abs.startswith(f"{shared_media_dir}{os.sep}"):
+                    # Canonical dedup target; never delete shared files during per-chat cleanup.
+                    continue
+
+                try:
+                    if os.path.islink(file_path):
+                        os.unlink(file_path)
+                        deleted_symlinks += 1
+                    else:
+                        freed_bytes += os.path.getsize(file_path)
+                        os.remove(file_path)
+                        deleted_files += 1
+                except Exception as e:
+                    logger.warning(f"Failed to delete media file {file_path}: {e}")
+
+            # Remove any remaining files/symlinks in this chat directory.
+            if os.path.isdir(chat_media_dir):
+                for entry in os.listdir(chat_media_dir):
+                    entry_path = os.path.join(chat_media_dir, entry)
+                    if not os.path.lexists(entry_path):
+                        continue
                     try:
-                        if os.path.islink(file_path):
-                            os.unlink(file_path)
+                        if os.path.islink(entry_path):
+                            os.unlink(entry_path)
                             deleted_symlinks += 1
-                        else:
-                            freed_bytes += os.path.getsize(file_path)
-                            os.remove(file_path)
+                        elif os.path.isfile(entry_path):
+                            freed_bytes += os.path.getsize(entry_path)
+                            os.remove(entry_path)
                             deleted_files += 1
                     except Exception as e:
-                        logger.warning(f"Failed to delete media file {file_path}: {e}")
+                        logger.warning(f"Failed to delete media file {entry_path}: {e}")
 
             # Delete all media records from database for this chat
             deleted_records = await self.db.delete_media_for_chat(chat_id)
 
             # Clean up empty chat media directory
-            chat_media_dir = os.path.join(self.config.media_path, str(chat_id))
             if os.path.isdir(chat_media_dir):
                 try:
                     remaining = os.listdir(chat_media_dir)
@@ -1394,6 +1444,7 @@ class TelegramBackup:
             # Generate filename using file_id for automatic deduplication
             file_name = self._get_media_filename(message, media_type, telegram_file_id)
             file_path = os.path.join(chat_media_dir, file_name)
+            resolved_shared_path: str | None = None
 
             # Check if deduplication is enabled
             if getattr(self.config, "deduplicate_media", True):
@@ -1404,7 +1455,7 @@ class TelegramBackup:
                 resolved_shared_path = self._resolve_shared_media_path(shared_dir, file_name)
 
                 # Check if file already exists (either directly or in shared)
-                if not os.path.exists(file_path):
+                if self._is_missing_or_dangling_path(file_path):
                     if resolved_shared_path:
                         # File exists in shared - create/repair symlink
                         try:
@@ -1446,23 +1497,19 @@ class TelegramBackup:
                                     file_path = direct_path
                                     file_name = os.path.basename(direct_path)
 
-                # Update file_size with actual size from disk (follow symlinks)
-                actual_path = (
-                    resolved_shared_path
-                    if resolved_shared_path and os.path.exists(resolved_shared_path)
-                    else file_path
-                )
-                if os.path.exists(actual_path):
-                    file_size = os.path.getsize(actual_path)
             else:
                 # No deduplication - download directly to chat directory
-                if not os.path.exists(file_path):
+                if self._is_missing_or_dangling_path(file_path):
                     await self.client.download_media(message, file_path)
                     logger.debug(f"Downloaded media: {file_name}")
 
-                # Update file_size with actual size from disk
-                if os.path.exists(file_path):
-                    file_size = os.path.getsize(file_path)
+            # Persist canonical final path/name for strict DB metadata consistency
+            file_path = self._resolve_canonical_media_path(file_path, resolved_shared_path)
+            file_name = os.path.basename(file_path)
+
+            # Update file_size with actual size from canonical path
+            if os.path.exists(file_path):
+                file_size = os.path.getsize(file_path)
 
             # Extract media metadata
             media_data = {


### PR DESCRIPTION
## Summary
This PR fixes a failure mode in media verification/redownload when deduplicated chat paths are dangling symlinks and Telethon has written  files using extension/suffix-adjusted filenames.

## Root cause
During  re-download:
- dangling symlinks were treated as missing paths () but not removed before reprocessing,
-  attempted to create a symlink on an already-existing path (raising ),
- fallback logic assumed  exists, but Telethon may have written  or , leading to .

## Changes
- Add  to resolve canonical  targets including extension/suffix variants.
- Add  to safely create/repair symlinks and recover from stale/dangling links.
- In , use  cleanup so dangling symlinks are removed before re-download.
- In , use resolved canonical shared path and use returned path from  when Telethon rewrites names.
- Keep behavior compatible with non-symlink fallback paths.

## Validation
- 
- Note: full unit test execution in this environment is blocked by missing test dependency () for local runner.

Closes #115

Context: https://app.warp.dev/conversation/8dc039d9-6c7e-47a6-9814-e790a9181c24

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved backup reliability for shared and duplicate media by better detecting actual file locations when filenames are altered.
  * Enhanced file verification and cleanup processes for corrupted or invalid files.
  * More robust symlink creation and repair for deduplicated media storage, with improved handling of edge cases and stale links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->