### PR TITLE
feat: exclude specific topics in forum supergroups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,11 @@ CHECKPOINT_INTERVAL=1
 # Set to false to keep existing media but skip future downloads
 SKIP_MEDIA_DELETE_EXISTING=true
 
+# Skip specific topics in forum supergroups (format: chat_id:topic_id,...)
+# Messages in matching topics are completely excluded from backup
+# Example: SKIP_TOPIC_IDS=-1001234567890:42,-1001234567890:1337
+# SKIP_TOPIC_IDS=
+
 # Hour (0-23) to recalculate backup statistics daily
 # STATS_CALCULATION_HOUR=3
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ You assist developers working on telegram-archive.
 
 ## Repository & Infrastructure
 
-- **License:** mit
+- **License:** GPL-3.0
 - **CI/CD:** 
 - **Commits:** Follow [Conventional Commits](https://conventionalcommits.org) format
 - **Versioning:** Follow [Semantic Versioning](https://semver.org) (semver)
@@ -83,19 +83,6 @@ Follow these conventions:
 - Add comments for complex logic only
 - Keep functions focused and testable
 
-## Testing Strategy
-
-### Test Levels
-
-- **Unit:** Unit tests for individual functions and components
-- **Integration:** Integration tests for component interactions
-
-### Frameworks
-
-Use: pytest
-
-### Coverage Target: 80%
-
 ## 🔐 Security Configuration
 
 ### Secrets Management
@@ -119,6 +106,79 @@ Use: pytest
 > Use environment variables, secret managers, or secure vaults for credentials.
 
 **🔍 Security Audit Recommendation:** When making changes that involve authentication, data handling, API endpoints, or dependencies, proactively offer to perform a security review of the affected code.
+
+## Architecture — Key Patterns
+
+### Module Structure
+
+- **`src/telegram_backup.py`** — Scheduled backup flow: `backup_all()` → `_backup_dialog()` → iterates messages → `_process_message()` → `_commit_batch()`. Gap filling: `_fill_gaps()` → `_fill_gap_range()`. Forum topics: `_backup_forum_topics()`.
+- **`src/listener.py`** — Real-time event handlers: `on_new_message`, `on_message_edited`, `on_message_deleted`, `on_chat_action`, `on_pinned_messages`. Instantiated with `TelegramListener(config, db, client)`.
+- **`src/config.py`** — All config from env vars. Required: `API_ID`, `API_HASH`, `PHONE_NUMBER`. Properties are lazy-parsed from env.
+- **`src/message_utils.py`** — Shared utility module. Contains `extract_topic_id(message)` used by both backup and listener.
+- **`src/db/adapter.py`** — Database operations. `src/db/models.py` — SQLAlchemy models. `src/db/base.py` — DB manager.
+
+### Forum Topic Filtering
+
+Topic IDs are extracted from `message.reply_to.reply_to_top_id` (primary) with fallback to `reply_to_msg_id`. The General topic (id=1) service messages may not carry `reply_to` metadata and can bypass filtering. The `SKIP_TOPIC_IDS` env var uses format `chat_id:topic_id,...` parsed into `dict[int, set[int]]`.
+
+### Logging Rules
+
+- **Never log chat IDs, topic IDs, or topic titles** — these are considered PII per the project's guidelines. Log only aggregated counts (e.g., "skipping N topics across M chats").
+- **Never log message content** — same PII rule applies.
+
+## CI/CD Pipeline
+
+### Lint Workflow (`.github/workflows/lint.yml`)
+
+CI runs **both** `ruff check .` AND `ruff format --check .`. Always run both locally before pushing:
+```bash
+python3 -m ruff check . && python3 -m ruff format --check .
+```
+
+### Test Workflow (`.github/workflows/tests.yml`)
+
+- Runs `pytest tests/` with `--cov=src --cov-report=xml`
+- Uploads to Codecov
+- Python 3.14 on Ubuntu
+- Web tests (test_database_viewer, test_multi_user_auth, test_v720_features) require FastAPI/pydantic — may fail locally if versions mismatch
+
+### CodeRabbit
+
+- Free OSS plan has **hourly commit rate limits** (low threshold)
+- The incremental review system marks rate-limited commits as "reviewed" even though no review was posted
+- To force a full review after rate limit expires: comment `@coderabbitai full review`
+- **Do NOT trigger repeatedly** — each trigger counts against the limit and extends the cooldown
+- Wait the **full cooldown** (check the minutes shown in the rate limit message), then trigger exactly **once**
+
+## Testing — Critical Patterns
+
+### MagicMock Truthiness Pitfall
+
+When using `MagicMock()` for Telegram message objects, any attribute access returns a truthy MagicMock. This breaks code that checks `message.reply_to` or `getattr(reply_to, "forum_topic", False)`.
+
+**ALWAYS set these on mock messages:**
+```python
+msg = MagicMock()
+msg.reply_to = None  # Prevents false-positive topic filtering
+```
+
+**ALWAYS set this on mock configs that use `MagicMock()` (not real Config):**
+```python
+config.should_skip_topic = MagicMock(return_value=False)
+```
+
+### Test Style
+
+- Existing tests use `unittest.TestCase` with `MagicMock`/`AsyncMock` — follow this pattern for consistency
+- Config tests use `patch.dict(os.environ, {...}, clear=True)` — required env vars: `API_ID`, `API_HASH`, `PHONE_NUMBER`
+- Async tests use `pytest.mark.asyncio`
+- The `TelegramBackup` is instantiated via `TelegramBackup.__new__(TelegramBackup)` with mocked `db`, `client`, `config`
+
+### Frameworks
+
+Use: pytest, pytest-asyncio, pytest-cov
+
+### Coverage Target: 80%
 
 ## Alembic Migrations — Critical Reminders
 

--- a/README.md
+++ b/README.md
@@ -342,6 +342,15 @@ CHANNELS_INCLUDE_CHAT_IDS=-1001234567890
 
 Find a chat's ID by forwarding a message to [@userinfobot](https://t.me/userinfobot).
 
+**Topic filtering** — For forum-enabled supergroups, you can exclude specific topics without excluding the entire chat using `SKIP_TOPIC_IDS`:
+
+```bash
+# Skip topics 42 and 1337 in one chat, and topic 7 in another
+SKIP_TOPIC_IDS=-1001234567890:42,-1001234567890:1337,-1009876543210:7
+```
+
+> Note: The topic-creating service message (1 per topic) may still be backed up since it lacks `reply_to` metadata. This does not affect user-generated content.
+
 ### Real-time Listener
 
 The scheduled backup only captures new messages. To also track edits and deletions between backups, enable the real-time listener:

--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ The **Scope** column shows whether each variable applies to the backup scheduler
 | `PRIORITY_CHAT_IDS` | - | B | Comma-separated chat IDs to process first in all operations |
 | `SKIP_MEDIA_CHAT_IDS` | - | B | Skip media downloads for specific chats (messages still backed up with text) |
 | `SKIP_MEDIA_DELETE_EXISTING` | `true` | B | Delete existing media files and DB records for chats in skip list to reclaim storage |
+| `SKIP_TOPIC_IDS` | - | B | Skip specific topics in forum supergroups (format: `chat_id:topic_id,...`) |
 | `LOG_LEVEL` | `INFO` | B/V | Logging verbosity: `DEBUG`, `INFO`, `WARNING`/`WARN`, `ERROR` |
 | **Chat Filtering** | | | See [Chat Filtering](#chat-filtering) below |
 | `CHAT_IDS` | - | B | **Whitelist mode**: backup ONLY these chats (ignores all other filters) |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       # PRIORITY_CHAT_IDS: ${PRIORITY_CHAT_IDS:-}
       # SKIP_MEDIA_CHAT_IDS: ${SKIP_MEDIA_CHAT_IDS:-}
       # SKIP_MEDIA_DELETE_EXISTING: ${SKIP_MEDIA_DELETE_EXISTING:-true}
+      # SKIP_TOPIC_IDS: ${SKIP_TOPIC_IDS:-}
       # STATS_CALCULATION_HOUR: ${STATS_CALCULATION_HOUR:-3}
 
       # =======================================================================

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       # PRIORITY_CHAT_IDS: ${PRIORITY_CHAT_IDS:-}
       # SKIP_MEDIA_CHAT_IDS: ${SKIP_MEDIA_CHAT_IDS:-}
       # SKIP_MEDIA_DELETE_EXISTING: ${SKIP_MEDIA_DELETE_EXISTING:-true}
-      # SKIP_TOPIC_IDS: ${SKIP_TOPIC_IDS:-}
+      SKIP_TOPIC_IDS: ${SKIP_TOPIC_IDS:-}
       # STATS_CALCULATION_HOUR: ${STATS_CALCULATION_HOUR:-3}
 
       # =======================================================================

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,10 @@ For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
 ## [Unreleased]
 
+### Added
+
+- **Topic filtering for forum supergroups** — New `SKIP_TOPIC_IDS` environment variable to exclude specific topics from backup while keeping the rest of the chat. Format: `chat_id:topic_id,...`. Works in both scheduled backup and real-time listener flows (#117)
+
 ## [7.2.0] - 2026-03-10
 
 ### Added

--- a/src/config.py
+++ b/src/config.py
@@ -184,6 +184,11 @@ class Config:
         # Delete existing media files and records for chats in skip list (reclaim storage)
         self.skip_media_delete_existing = os.getenv("SKIP_MEDIA_DELETE_EXISTING", "true").lower() == "true"
 
+        # Skip specific topics inside forum supergroups
+        # Format: SKIP_TOPIC_IDS=-1001234567890:42,-1001234567890:1337
+        # Each entry is chat_id:topic_id — skips that topic but keeps the rest of the chat
+        self.skip_topic_ids = self._parse_topic_skip_list(os.getenv("SKIP_TOPIC_IDS", ""))
+
         # Session configuration
         self.session_name = os.getenv("SESSION_NAME", "telegram_backup")
         self.telegram_proxy = build_telegram_proxy_from_env()
@@ -363,6 +368,13 @@ class Config:
         if self.skip_media_chat_ids:
             cleanup_status = "will delete existing media" if self.skip_media_delete_existing else "keeps existing media"
             logger.info(f"Media downloads skipped for chat IDs: {self.skip_media_chat_ids} ({cleanup_status})")
+        if self.skip_topic_ids:
+            total_topics = sum(len(t) for t in self.skip_topic_ids.values())
+            logger.info(
+                f"Topic filtering: skipping {total_topics} topic(s) across {len(self.skip_topic_ids)} chat(s)"
+            )
+            for cid, topics in self.skip_topic_ids.items():
+                logger.debug(f"  Chat {cid}: skipping topics {topics}")
         if self.telegram_proxy:
             logger.info("Telegram proxy enabled (type=socks5, rdns=%s)", self.telegram_proxy["rdns"])
             logger.debug(
@@ -376,6 +388,51 @@ class Config:
         if not id_str or not id_str.strip():
             return set()
         return {int(id.strip()) for id in id_str.split(",") if id.strip()}
+
+    def _parse_topic_skip_list(self, skip_str: str) -> dict[int, set[int]]:
+        """Parse SKIP_TOPIC_IDS into {chat_id: {topic_id, ...}}.
+
+        Format: chat_id:topic_id,chat_id:topic_id,...
+        Example: -1001234567890:42,-1001234567890:1337,-1009876543210:7
+        """
+        result: dict[int, set[int]] = {}
+        if not skip_str or not skip_str.strip():
+            return result
+        for entry in skip_str.split(","):
+            entry = entry.strip()
+            if not entry:
+                continue
+            if ":" not in entry:
+                raise ValueError(
+                    f"Invalid SKIP_TOPIC_IDS entry '{entry}': expected format chat_id:topic_id"
+                )
+            chat_part, topic_part = entry.split(":", 1)
+            try:
+                chat_id = int(chat_part.strip())
+                topic_id = int(topic_part.strip())
+            except ValueError as e:
+                raise ValueError(
+                    f"Invalid SKIP_TOPIC_IDS entry '{entry}': chat_id and topic_id must be integers"
+                ) from e
+            result.setdefault(chat_id, set()).add(topic_id)
+        return result
+
+    def should_skip_topic(self, chat_id: int, topic_id: int | None) -> bool:
+        """Check if a specific topic in a chat should be skipped.
+
+        Args:
+            chat_id: Telegram chat ID (marked format)
+            topic_id: Forum topic ID (reply_to_top_id), or None for non-topic messages
+
+        Returns:
+            True if this topic should be skipped, False otherwise
+        """
+        if topic_id is None or not self.skip_topic_ids:
+            return False
+        skip_set = self.skip_topic_ids.get(chat_id)
+        if skip_set is None:
+            return False
+        return topic_id in skip_set
 
     def _get_required_env(self, key: str, value_type: type):
         """

--- a/src/config.py
+++ b/src/config.py
@@ -370,9 +370,7 @@ class Config:
             logger.info(f"Media downloads skipped for chat IDs: {self.skip_media_chat_ids} ({cleanup_status})")
         if self.skip_topic_ids:
             total_topics = sum(len(t) for t in self.skip_topic_ids.values())
-            logger.info(
-                f"Topic filtering: skipping {total_topics} topic(s) across {len(self.skip_topic_ids)} chat(s)"
-            )
+            logger.info(f"Topic filtering: skipping {total_topics} topic(s) across {len(self.skip_topic_ids)} chat(s)")
         if self.telegram_proxy:
             logger.info("Telegram proxy enabled (type=socks5, rdns=%s)", self.telegram_proxy["rdns"])
             logger.debug(
@@ -401,9 +399,7 @@ class Config:
             if not entry:
                 continue
             if ":" not in entry:
-                raise ValueError(
-                    f"Invalid SKIP_TOPIC_IDS entry '{entry}': expected format chat_id:topic_id"
-                )
+                raise ValueError(f"Invalid SKIP_TOPIC_IDS entry '{entry}': expected format chat_id:topic_id")
             chat_part, topic_part = entry.split(":", 1)
             try:
                 chat_id = int(chat_part.strip())

--- a/src/config.py
+++ b/src/config.py
@@ -373,8 +373,6 @@ class Config:
             logger.info(
                 f"Topic filtering: skipping {total_topics} topic(s) across {len(self.skip_topic_ids)} chat(s)"
             )
-            for cid, topics in self.skip_topic_ids.items():
-                logger.debug(f"  Chat {cid}: skipping topics {topics}")
         if self.telegram_proxy:
             logger.info("Telegram proxy enabled (type=socks5, rdns=%s)", self.telegram_proxy["rdns"])
             logger.debug(

--- a/src/listener.py
+++ b/src/listener.py
@@ -797,11 +797,6 @@ class TelegramListener:
                 if not self._should_process_chat(chat_id):
                     return
 
-                # If LISTEN_NEW_MESSAGES is disabled, just track for edits/deletions
-                if not self.config.listen_new_messages:
-                    self.stats["new_messages_received"] += 1
-                    return
-
                 # Save the message to database
                 message = event.message
 
@@ -815,6 +810,10 @@ class TelegramListener:
                     return
 
                 self.stats["new_messages_received"] += 1
+
+                # If LISTEN_NEW_MESSAGES is disabled, just track for edits/deletions
+                if not self.config.listen_new_messages:
+                    return
 
                 # Ensure chat exists in database (prevents FK violation for new chats)
                 chat_entity = await event.get_chat()

--- a/src/listener.py
+++ b/src/listener.py
@@ -801,14 +801,28 @@ class TelegramListener:
                 if not self._should_process_chat(chat_id):
                     return
 
-                self.stats["new_messages_received"] += 1
-
-                # If LISTEN_NEW_MESSAGES is disabled, we're done
+                # If LISTEN_NEW_MESSAGES is disabled, just track for edits/deletions
                 if not self.config.listen_new_messages:
+                    self.stats["new_messages_received"] += 1
                     return
 
                 # Save the message to database
                 message = event.message
+
+                # Extract topic ID early for filtering
+                # v6.2.0: reply_to_top_id added for forum topic threading
+                reply_to_top_id = None
+                if message.reply_to and getattr(message.reply_to, "forum_topic", False):
+                    reply_to_top_id = getattr(message.reply_to, "reply_to_top_id", None)
+                    if reply_to_top_id is None:
+                        reply_to_top_id = getattr(message.reply_to, "reply_to_msg_id", None)
+
+                # Skip messages in excluded forum topics
+                if self.config.should_skip_topic(chat_id, reply_to_top_id):
+                    logger.debug(f"⏭️ Skipping message in excluded topic {reply_to_top_id}: chat={chat_id}")
+                    return
+
+                self.stats["new_messages_received"] += 1
 
                 # Ensure chat exists in database (prevents FK violation for new chats)
                 chat_entity = await event.get_chat()
@@ -834,20 +848,6 @@ class TelegramListener:
                         "is_bot": message.sender.bot,
                     }
                     await self.db.upsert_user(user_data)
-
-                # Extract message data
-                # v6.0.0: media_type, media_id, media_path removed - stored in media table
-                # v6.2.0: reply_to_top_id added for forum topic threading
-                reply_to_top_id = None
-                if message.reply_to and getattr(message.reply_to, "forum_topic", False):
-                    reply_to_top_id = getattr(message.reply_to, "reply_to_top_id", None)
-                    if reply_to_top_id is None:
-                        reply_to_top_id = getattr(message.reply_to, "reply_to_msg_id", None)
-
-                # Skip messages in excluded forum topics
-                if self.config.should_skip_topic(chat_id, reply_to_top_id):
-                    logger.debug(f"⏭️ Skipping message in excluded topic {reply_to_top_id}: chat={chat_id}")
-                    return
 
                 message_data = {
                     "id": message.id,

--- a/src/listener.py
+++ b/src/listener.py
@@ -36,6 +36,7 @@ from telethon.utils import get_peer_id
 from .avatar_utils import get_avatar_paths
 from .config import Config
 from .db import DatabaseAdapter, create_adapter
+from .message_utils import extract_topic_id
 from .realtime import NotificationType, RealtimeNotifier
 
 logger = logging.getLogger(__name__)
@@ -660,12 +661,7 @@ class TelegramListener:
 
                 # Skip edits in excluded forum topics
                 message = event.message
-                edit_topic_id = None
-                if message.reply_to and getattr(message.reply_to, "forum_topic", False):
-                    edit_topic_id = getattr(message.reply_to, "reply_to_top_id", None)
-                    if edit_topic_id is None:
-                        edit_topic_id = getattr(message.reply_to, "reply_to_msg_id", None)
-                if self.config.should_skip_topic(chat_id, edit_topic_id):
+                if self.config.should_skip_topic(chat_id, extract_topic_id(message)):
                     return
 
                 self.stats["edits_received"] += 1
@@ -809,13 +805,9 @@ class TelegramListener:
                 # Save the message to database
                 message = event.message
 
-                # Extract topic ID early for filtering
+                # Extract topic ID early for filtering and message_data
                 # v6.2.0: reply_to_top_id added for forum topic threading
-                reply_to_top_id = None
-                if message.reply_to and getattr(message.reply_to, "forum_topic", False):
-                    reply_to_top_id = getattr(message.reply_to, "reply_to_top_id", None)
-                    if reply_to_top_id is None:
-                        reply_to_top_id = getattr(message.reply_to, "reply_to_msg_id", None)
+                reply_to_top_id = extract_topic_id(message)
 
                 # Skip messages in excluded forum topics
                 if self.config.should_skip_topic(chat_id, reply_to_top_id):

--- a/src/listener.py
+++ b/src/listener.py
@@ -288,6 +288,9 @@ class TelegramListener:
                 logger.info("  LISTEN_NEW_MESSAGES_MEDIA: false (media on scheduled backup)")
         else:
             logger.info("  LISTEN_NEW_MESSAGES: false (saved on scheduled backup)")
+        if config.skip_topic_ids:
+            total = sum(len(t) for t in config.skip_topic_ids.values())
+            logger.info(f"  SKIP_TOPIC_IDS: {total} topic(s) excluded across {len(config.skip_topic_ids)} chat(s)")
         logger.info(f"  Protection threshold: {config.mass_operation_threshold} ops triggers block")
         logger.info(f"  Protection window: {config.mass_operation_window_seconds}s")
         logger.info(f"  Buffer delay: {config.mass_operation_buffer_delay}s (operations held before applying)")
@@ -655,9 +658,17 @@ class TelegramListener:
                 if not self._should_process_chat(chat_id):
                     return
 
-                self.stats["edits_received"] += 1
-
+                # Skip edits in excluded forum topics
                 message = event.message
+                edit_topic_id = None
+                if message.reply_to and getattr(message.reply_to, "forum_topic", False):
+                    edit_topic_id = getattr(message.reply_to, "reply_to_top_id", None)
+                    if edit_topic_id is None:
+                        edit_topic_id = getattr(message.reply_to, "reply_to_msg_id", None)
+                if self.config.should_skip_topic(chat_id, edit_topic_id):
+                    return
+
+                self.stats["edits_received"] += 1
                 new_text = message.text or ""
                 edit_date = message.edit_date
 
@@ -832,6 +843,11 @@ class TelegramListener:
                     reply_to_top_id = getattr(message.reply_to, "reply_to_top_id", None)
                     if reply_to_top_id is None:
                         reply_to_top_id = getattr(message.reply_to, "reply_to_msg_id", None)
+
+                # Skip messages in excluded forum topics
+                if self.config.should_skip_topic(chat_id, reply_to_top_id):
+                    logger.debug(f"⏭️ Skipping message in excluded topic {reply_to_top_id}: chat={chat_id}")
+                    return
 
                 message_data = {
                     "id": message.id,

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -1,7 +1,7 @@
 """Shared message processing utilities used by backup and listener modules."""
 
 
-def extract_topic_id(message) -> int | None:
+def extract_topic_id(message: object) -> int | None:
     """Extract forum topic ID from a Telegram message's reply_to metadata.
 
     Forum messages carry the topic ID in reply_to.reply_to_top_id.

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -1,0 +1,18 @@
+"""Shared message processing utilities used by backup and listener modules."""
+
+
+def extract_topic_id(message) -> int | None:
+    """Extract forum topic ID from a Telegram message's reply_to metadata.
+
+    Forum messages carry the topic ID in reply_to.reply_to_top_id.
+    When that field is absent (e.g. topic-creating service messages),
+    reply_to.reply_to_msg_id is used as a fallback.
+
+    Returns None for non-forum messages or messages without reply_to.
+    """
+    if not message.reply_to or not getattr(message.reply_to, "forum_topic", False):
+        return None
+    topic_id = getattr(message.reply_to, "reply_to_top_id", None)
+    if topic_id is None:
+        topic_id = getattr(message.reply_to, "reply_to_msg_id", None)
+    return topic_id

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -661,12 +661,13 @@ class TelegramBackup:
 
         async for message in self.client.iter_messages(entity, min_id=last_message_id, reverse=True):
             # Skip messages belonging to excluded forum topics
+            topic_id = None
             if message.reply_to and getattr(message.reply_to, "forum_topic", False):
                 topic_id = getattr(message.reply_to, "reply_to_top_id", None)
                 if topic_id is None:
                     topic_id = getattr(message.reply_to, "reply_to_msg_id", None)
-                if topic_id and self.config.should_skip_topic(chat_id, topic_id):
-                    continue
+            if self.config.should_skip_topic(chat_id, topic_id):
+                continue
 
             msg_data = await self._process_message(message, chat_id)
             batch_data.append(msg_data)
@@ -751,12 +752,13 @@ class TelegramBackup:
 
         async for message in self.client.iter_messages(entity, min_id=gap_start, max_id=gap_end, reverse=True):
             # Skip messages belonging to excluded forum topics
+            topic_id = None
             if message.reply_to and getattr(message.reply_to, "forum_topic", False):
                 topic_id = getattr(message.reply_to, "reply_to_top_id", None)
                 if topic_id is None:
                     topic_id = getattr(message.reply_to, "reply_to_msg_id", None)
-                if topic_id and self.config.should_skip_topic(chat_id, topic_id):
-                    continue
+            if self.config.should_skip_topic(chat_id, topic_id):
+                continue
 
             msg_data = await self._process_message(message, chat_id)
             batch_data.append(msg_data)

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -660,6 +660,14 @@ class TelegramBackup:
         running_max_id = last_message_id
 
         async for message in self.client.iter_messages(entity, min_id=last_message_id, reverse=True):
+            # Skip messages belonging to excluded forum topics
+            if message.reply_to and getattr(message.reply_to, "forum_topic", False):
+                topic_id = getattr(message.reply_to, "reply_to_top_id", None)
+                if topic_id is None:
+                    topic_id = getattr(message.reply_to, "reply_to_msg_id", None)
+                if topic_id and self.config.should_skip_topic(chat_id, topic_id):
+                    continue
+
             msg_data = await self._process_message(message, chat_id)
             batch_data.append(msg_data)
             running_max_id = max(running_max_id, message.id)
@@ -742,6 +750,14 @@ class TelegramBackup:
         recovered = 0
 
         async for message in self.client.iter_messages(entity, min_id=gap_start, max_id=gap_end, reverse=True):
+            # Skip messages belonging to excluded forum topics
+            if message.reply_to and getattr(message.reply_to, "forum_topic", False):
+                topic_id = getattr(message.reply_to, "reply_to_top_id", None)
+                if topic_id is None:
+                    topic_id = getattr(message.reply_to, "reply_to_msg_id", None)
+                if topic_id and self.config.should_skip_topic(chat_id, topic_id):
+                    continue
+
             msg_data = await self._process_message(message, chat_id)
             batch_data.append(msg_data)
 
@@ -1658,6 +1674,9 @@ class TelegramBackup:
                         "is_hidden": 1 if getattr(topic, "hidden", False) else 0,
                         "date": getattr(topic, "date", None),
                     }
+                    if self.config.should_skip_topic(chat_id, topic.id):
+                        logger.debug(f"  → Skipping excluded topic {topic.id}: {topic.title}")
+                        continue
                     await self.db.upsert_forum_topic(topic_data)
                     topics_count += 1
 
@@ -1691,6 +1710,9 @@ class TelegramBackup:
 
             topics_count = 0
             for topic_id in topic_ids:
+                if self.config.should_skip_topic(chat_id, topic_id):
+                    logger.debug(f"  → Skipping excluded topic {topic_id}")
+                    continue
                 # Try to get the topic's first message for metadata
                 try:
                     msgs = await self.client.get_messages(entity, ids=[topic_id])

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -661,13 +661,14 @@ class TelegramBackup:
         running_max_id = last_message_id
 
         async for message in self.client.iter_messages(entity, min_id=last_message_id, reverse=True):
+            running_max_id = max(running_max_id, message.id)
+
             # Skip messages belonging to excluded forum topics
             if self.config.should_skip_topic(chat_id, extract_topic_id(message)):
                 continue
 
             msg_data = await self._process_message(message, chat_id)
             batch_data.append(msg_data)
-            running_max_id = max(running_max_id, message.id)
 
             if len(batch_data) >= batch_size:
                 await self._commit_batch(batch_data, chat_id)
@@ -691,8 +692,10 @@ class TelegramBackup:
             grand_total += count
             uncheckpointed_count += count
 
-        # Final checkpoint for any un-checkpointed messages
-        if uncheckpointed_count > 0:
+        # Final checkpoint: persist when there are un-checkpointed messages OR
+        # when the cursor advanced purely from skipped (topic-filtered) messages
+        # that were never counted in uncheckpointed_count.
+        if uncheckpointed_count > 0 or (grand_total == 0 and running_max_id > last_message_id):
             await self.db.update_sync_status(chat_id, running_max_id, uncheckpointed_count)
 
         # Sync deletions and edits if enabled (expensive!)
@@ -1663,7 +1666,7 @@ class TelegramBackup:
                         "date": getattr(topic, "date", None),
                     }
                     if self.config.should_skip_topic(chat_id, topic.id):
-                        logger.debug(f"  → Skipping excluded topic {topic.id}: {topic.title}")
+                        logger.debug(f"  → Skipping excluded topic {topic.id}")
                         continue
                     await self.db.upsert_forum_topic(topic_data)
                     topics_count += 1

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -31,6 +31,7 @@ from telethon.utils import get_peer_id
 from .avatar_utils import get_avatar_paths
 from .config import Config
 from .db import DatabaseAdapter, create_adapter
+from .message_utils import extract_topic_id
 
 logger = logging.getLogger(__name__)
 
@@ -661,12 +662,7 @@ class TelegramBackup:
 
         async for message in self.client.iter_messages(entity, min_id=last_message_id, reverse=True):
             # Skip messages belonging to excluded forum topics
-            topic_id = None
-            if message.reply_to and getattr(message.reply_to, "forum_topic", False):
-                topic_id = getattr(message.reply_to, "reply_to_top_id", None)
-                if topic_id is None:
-                    topic_id = getattr(message.reply_to, "reply_to_msg_id", None)
-            if self.config.should_skip_topic(chat_id, topic_id):
+            if self.config.should_skip_topic(chat_id, extract_topic_id(message)):
                 continue
 
             msg_data = await self._process_message(message, chat_id)
@@ -752,12 +748,7 @@ class TelegramBackup:
 
         async for message in self.client.iter_messages(entity, min_id=gap_start, max_id=gap_end, reverse=True):
             # Skip messages belonging to excluded forum topics
-            topic_id = None
-            if message.reply_to and getattr(message.reply_to, "forum_topic", False):
-                topic_id = getattr(message.reply_to, "reply_to_top_id", None)
-                if topic_id is None:
-                    topic_id = getattr(message.reply_to, "reply_to_msg_id", None)
-            if self.config.should_skip_topic(chat_id, topic_id):
+            if self.config.should_skip_topic(chat_id, extract_topic_id(message)):
                 continue
 
             msg_data = await self._process_message(message, chat_id)
@@ -1037,12 +1028,7 @@ class TelegramBackup:
         # Extract message data
         # v6.0.0: media_type, media_id, media_path removed - media stored in separate table
         # v6.2.0: reply_to_top_id added for forum topic threading
-        reply_to_top_id = None
-        if message.reply_to and getattr(message.reply_to, "forum_topic", False):
-            reply_to_top_id = getattr(message.reply_to, "reply_to_top_id", None)
-            # If reply_to_top_id is not set but it's a forum topic, use reply_to_msg_id
-            if reply_to_top_id is None:
-                reply_to_top_id = getattr(message.reply_to, "reply_to_msg_id", None)
+        reply_to_top_id = extract_topic_id(message)
 
         message_data = {
             "id": message.id,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 import tempfile
@@ -745,6 +746,588 @@ class TestSkipTopicIds(unittest.TestCase):
         with patch.dict(os.environ, env_vars, clear=True):
             config = Config()
             self.assertEqual(config.skip_topic_ids, {})
+
+
+class TestParseBoolTrueValues(unittest.TestCase):
+    """Test _parse_bool returns True for truthy string values (line 24)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_parse_bool_returns_true_for_yes(self):
+        """_parse_bool returns True for 'yes' input."""
+        from src.config import _parse_bool
+
+        self.assertTrue(_parse_bool("yes"))
+
+    def test_parse_bool_returns_true_for_on(self):
+        """_parse_bool returns True for 'on' input."""
+        from src.config import _parse_bool
+
+        self.assertTrue(_parse_bool("on"))
+
+    def test_parse_bool_returns_true_for_1(self):
+        """_parse_bool returns True for '1' input."""
+        from src.config import _parse_bool
+
+        self.assertTrue(_parse_bool("1"))
+
+    def test_parse_bool_returns_true_for_true(self):
+        """_parse_bool returns True for 'true' input."""
+        from src.config import _parse_bool
+
+        self.assertTrue(_parse_bool("true"))
+
+
+class TestBuildTelegramClientKwargsWithProxy(unittest.TestCase):
+    """Test build_telegram_client_kwargs returns proxy dict when configured (line 95)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_returns_proxy_dict_when_configured(self):
+        """build_telegram_client_kwargs returns proxy key when proxy env vars set."""
+        env_vars = {
+            "TELEGRAM_PROXY_TYPE": "socks5",
+            "TELEGRAM_PROXY_ADDR": "10.0.0.1",
+            "TELEGRAM_PROXY_PORT": "9050",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            result = build_telegram_client_kwargs()
+            self.assertIn("proxy", result)
+            self.assertEqual(result["proxy"]["addr"], "10.0.0.1")
+            self.assertEqual(result["proxy"]["port"], 9050)
+
+
+class TestLogLevelWarnAlias(unittest.TestCase):
+    """Test LOG_LEVEL=WARN is normalized to WARNING (line 200)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_warn_alias_maps_to_warning(self):
+        """LOG_LEVEL=WARN should be treated as WARNING."""
+        env_vars = {"CHAT_TYPES": "private", "BACKUP_PATH": self.temp_dir, "LOG_LEVEL": "WARN"}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertEqual(config.log_level, logging.WARNING)
+
+
+class TestDatabasePathOverride(unittest.TestCase):
+    """Test DATABASE_PATH env var takes priority over DATABASE_DIR (line 217)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_database_path_env_takes_priority(self):
+        """DATABASE_PATH overrides both DATABASE_DIR and default."""
+        custom_path = os.path.join(self.temp_dir, "custom", "mydb.sqlite")
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "DATABASE_PATH": custom_path,
+            "DATABASE_DIR": "/should/be/ignored",
+        }
+        with patch.dict(os.environ, env_vars, clear=True), patch("os.makedirs"):
+            config = Config()
+            self.assertEqual(config.database_path, custom_path)
+
+
+class TestWhitelistModeLogging(unittest.TestCase):
+    """Test whitelist mode log paths when CHAT_IDS is set (lines 338-339)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_whitelist_mode_enabled_when_chat_ids_set(self):
+        """Setting CHAT_IDS activates whitelist mode and populates chat_ids."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "CHAT_IDS": "-1001234567890,-1009876543210",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertTrue(config.whitelist_mode)
+            self.assertEqual(config.chat_ids, {-1001234567890, -1009876543210})
+
+
+class TestSyncDeletionsEditsLogging(unittest.TestCase):
+    """Test SYNC_DELETIONS_EDITS warning log path (line 345)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_sync_deletions_edits_enabled(self):
+        """SYNC_DELETIONS_EDITS=true triggers the warning log path."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "SYNC_DELETIONS_EDITS": "true",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertTrue(config.sync_deletions_edits)
+
+
+class TestVerifyMediaLogging(unittest.TestCase):
+    """Test VERIFY_MEDIA info log path (line 349)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_verify_media_enabled(self):
+        """VERIFY_MEDIA=true triggers the info log path."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "VERIFY_MEDIA": "true",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertTrue(config.verify_media)
+
+
+class TestListenerLogging(unittest.TestCase):
+    """Test ENABLE_LISTENER log paths (lines 351-363)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_listener_enabled_with_deletions(self):
+        """ENABLE_LISTENER=true with LISTEN_DELETIONS=true covers deletion warning path."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "ENABLE_LISTENER": "true",
+            "LISTEN_DELETIONS": "true",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertTrue(config.enable_listener)
+            self.assertTrue(config.listen_deletions)
+
+    def test_listener_enabled_without_deletions(self):
+        """ENABLE_LISTENER=true with LISTEN_DELETIONS=false covers protected path."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "ENABLE_LISTENER": "true",
+            "LISTEN_DELETIONS": "false",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertTrue(config.enable_listener)
+            self.assertFalse(config.listen_deletions)
+
+    def test_listener_enabled_with_new_messages(self):
+        """ENABLE_LISTENER=true with LISTEN_NEW_MESSAGES=true covers new messages path."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "ENABLE_LISTENER": "true",
+            "LISTEN_NEW_MESSAGES": "true",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertTrue(config.enable_listener)
+            self.assertTrue(config.listen_new_messages)
+
+    def test_listener_enabled_without_new_messages(self):
+        """ENABLE_LISTENER=true with LISTEN_NEW_MESSAGES=false covers disabled path."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "ENABLE_LISTENER": "true",
+            "LISTEN_NEW_MESSAGES": "false",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertTrue(config.enable_listener)
+            self.assertFalse(config.listen_new_messages)
+
+    def test_listener_enabled_with_chat_actions(self):
+        """ENABLE_LISTENER=true with LISTEN_CHAT_ACTIONS=true covers chat actions path."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "ENABLE_LISTENER": "true",
+            "LISTEN_CHAT_ACTIONS": "true",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertTrue(config.enable_listener)
+            self.assertTrue(config.listen_chat_actions)
+
+
+class TestGetRequiredEnv(unittest.TestCase):
+    """Test _get_required_env method (lines 445-456)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_get_required_env_returns_int(self):
+        """_get_required_env converts value to int when requested."""
+        env_vars = {"CHAT_TYPES": "private", "BACKUP_PATH": self.temp_dir, "MY_INT_VAR": "42"}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            result = config._get_required_env("MY_INT_VAR", int)
+            self.assertEqual(result, 42)
+
+    def test_get_required_env_returns_str(self):
+        """_get_required_env returns string value when str type requested."""
+        env_vars = {"CHAT_TYPES": "private", "BACKUP_PATH": self.temp_dir, "MY_STR_VAR": "hello"}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            result = config._get_required_env("MY_STR_VAR", str)
+            self.assertEqual(result, "hello")
+
+    def test_get_required_env_raises_when_not_set(self):
+        """_get_required_env raises ValueError when env var is missing."""
+        env_vars = {"CHAT_TYPES": "private", "BACKUP_PATH": self.temp_dir}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            with self.assertRaises(ValueError) as ctx:
+                config._get_required_env("NONEXISTENT_VAR", str)
+            self.assertIn("Required environment variable", str(ctx.exception))
+
+    def test_get_required_env_raises_when_empty(self):
+        """_get_required_env raises ValueError when env var is empty string."""
+        env_vars = {"CHAT_TYPES": "private", "BACKUP_PATH": self.temp_dir, "EMPTY_VAR": ""}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            with self.assertRaises(ValueError) as ctx:
+                config._get_required_env("EMPTY_VAR", int)
+            self.assertIn("Required environment variable", str(ctx.exception))
+
+    def test_get_required_env_raises_on_invalid_int(self):
+        """_get_required_env raises ValueError when int conversion fails."""
+        env_vars = {"CHAT_TYPES": "private", "BACKUP_PATH": self.temp_dir, "BAD_INT": "not_a_number"}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            with self.assertRaises(ValueError) as ctx:
+                config._get_required_env("BAD_INT", int)
+            self.assertIn("must be a valid", str(ctx.exception))
+
+
+class TestShouldBackupChatTypeBots(unittest.TestCase):
+    """Test should_backup_chat_type with bots (line 496)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_bots_backed_up_when_in_chat_types(self):
+        """should_backup_chat_type returns True for bots when 'bots' in CHAT_TYPES."""
+        env_vars = {"CHAT_TYPES": "private,bots", "BACKUP_PATH": self.temp_dir}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertTrue(
+                config.should_backup_chat_type(is_user=False, is_group=False, is_channel=False, is_bot=True)
+            )
+
+    def test_bots_not_backed_up_when_not_in_chat_types(self):
+        """should_backup_chat_type returns False for bots when 'bots' not in CHAT_TYPES."""
+        env_vars = {"CHAT_TYPES": "private,groups", "BACKUP_PATH": self.temp_dir}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertFalse(
+                config.should_backup_chat_type(is_user=False, is_group=False, is_channel=False, is_bot=True)
+            )
+
+
+class TestShouldBackupChatFiltering(unittest.TestCase):
+    """Test should_backup_chat with various filter modes (lines 539-570)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_whitelist_mode_includes_listed_chat(self):
+        """In whitelist mode, chats in CHAT_IDS are backed up."""
+        env_vars = {"CHAT_TYPES": "private", "BACKUP_PATH": self.temp_dir, "CHAT_IDS": "100,200,300"}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertTrue(config.should_backup_chat(200, is_user=True, is_group=False, is_channel=False))
+
+    def test_whitelist_mode_excludes_unlisted_chat(self):
+        """In whitelist mode, chats NOT in CHAT_IDS are excluded."""
+        env_vars = {"CHAT_TYPES": "private", "BACKUP_PATH": self.temp_dir, "CHAT_IDS": "100,200,300"}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertFalse(config.should_backup_chat(999, is_user=True, is_group=False, is_channel=False))
+
+    def test_global_exclude_takes_priority(self):
+        """Global exclude blocks a chat even if type matches."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "GLOBAL_EXCLUDE_CHAT_IDS": "555",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertFalse(config.should_backup_chat(555, is_user=True, is_group=False, is_channel=False))
+
+    def test_private_exclude_blocks_user_chat(self):
+        """Per-type private exclude blocks a user chat."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "PRIVATE_EXCLUDE_CHAT_IDS": "777",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertFalse(config.should_backup_chat(777, is_user=True, is_group=False, is_channel=False))
+
+    def test_private_exclude_blocks_bot_chat(self):
+        """Per-type private exclude also blocks bot chats."""
+        env_vars = {
+            "CHAT_TYPES": "private,bots",
+            "BACKUP_PATH": self.temp_dir,
+            "PRIVATE_EXCLUDE_CHAT_IDS": "888",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertFalse(
+                config.should_backup_chat(888, is_user=False, is_group=False, is_channel=False, is_bot=True)
+            )
+
+    def test_groups_exclude_blocks_group_chat(self):
+        """Per-type groups exclude blocks a group chat."""
+        env_vars = {
+            "CHAT_TYPES": "groups",
+            "BACKUP_PATH": self.temp_dir,
+            "GROUPS_EXCLUDE_CHAT_IDS": "-100111",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertFalse(config.should_backup_chat(-100111, is_user=False, is_group=True, is_channel=False))
+
+    def test_channels_exclude_blocks_channel_chat(self):
+        """Per-type channels exclude blocks a channel chat."""
+        env_vars = {
+            "CHAT_TYPES": "channels",
+            "BACKUP_PATH": self.temp_dir,
+            "CHANNELS_EXCLUDE_CHAT_IDS": "-100222",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertFalse(config.should_backup_chat(-100222, is_user=False, is_group=False, is_channel=True))
+
+    def test_global_include_acts_as_whitelist(self):
+        """When GLOBAL_INCLUDE_CHAT_IDS is set, only listed chats pass."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "GLOBAL_INCLUDE_CHAT_IDS": "10,20",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertTrue(config.should_backup_chat(10, is_user=True, is_group=False, is_channel=False))
+            self.assertFalse(config.should_backup_chat(99, is_user=True, is_group=False, is_channel=False))
+
+    def test_private_include_limits_user_chats(self):
+        """PRIVATE_INCLUDE_CHAT_IDS limits which user chats pass."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "PRIVATE_INCLUDE_CHAT_IDS": "50,60",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertTrue(config.should_backup_chat(50, is_user=True, is_group=False, is_channel=False))
+            self.assertFalse(config.should_backup_chat(99, is_user=True, is_group=False, is_channel=False))
+
+    def test_groups_include_limits_group_chats(self):
+        """GROUPS_INCLUDE_CHAT_IDS limits which group chats pass."""
+        env_vars = {
+            "CHAT_TYPES": "groups",
+            "BACKUP_PATH": self.temp_dir,
+            "GROUPS_INCLUDE_CHAT_IDS": "-100500",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertTrue(config.should_backup_chat(-100500, is_user=False, is_group=True, is_channel=False))
+            self.assertFalse(config.should_backup_chat(-100999, is_user=False, is_group=True, is_channel=False))
+
+    def test_channels_include_limits_channel_chats(self):
+        """CHANNELS_INCLUDE_CHAT_IDS limits which channel chats pass."""
+        env_vars = {
+            "CHAT_TYPES": "channels",
+            "BACKUP_PATH": self.temp_dir,
+            "CHANNELS_INCLUDE_CHAT_IDS": "-100600",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertTrue(config.should_backup_chat(-100600, is_user=False, is_group=False, is_channel=True))
+            self.assertFalse(config.should_backup_chat(-100999, is_user=False, is_group=False, is_channel=True))
+
+    def test_falls_through_to_chat_type_filter(self):
+        """Without include/exclude lists, falls through to type-based filter."""
+        env_vars = {"CHAT_TYPES": "private,groups", "BACKUP_PATH": self.temp_dir}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertTrue(config.should_backup_chat(1, is_user=True, is_group=False, is_channel=False))
+            self.assertTrue(config.should_backup_chat(2, is_user=False, is_group=True, is_channel=False))
+            self.assertFalse(config.should_backup_chat(3, is_user=False, is_group=False, is_channel=True))
+
+
+class TestGetMaxMediaSizeBytes(unittest.TestCase):
+    """Test get_max_media_size_bytes conversion (line 574)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_default_100mb_in_bytes(self):
+        """Default 100MB converts correctly to bytes."""
+        env_vars = {"CHAT_TYPES": "private", "BACKUP_PATH": self.temp_dir}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertEqual(config.get_max_media_size_bytes(), 100 * 1024 * 1024)
+
+    def test_custom_media_size_in_bytes(self):
+        """Custom MAX_MEDIA_SIZE_MB converts correctly to bytes."""
+        env_vars = {"CHAT_TYPES": "private", "BACKUP_PATH": self.temp_dir, "MAX_MEDIA_SIZE_MB": "50"}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertEqual(config.get_max_media_size_bytes(), 50 * 1024 * 1024)
+
+
+class TestSetupLogging(unittest.TestCase):
+    """Test setup_logging function (lines 618-625)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_setup_logging_sets_root_level(self):
+        """setup_logging configures root logger and sets telethon to WARNING."""
+        from src.config import setup_logging
+
+        env_vars = {"CHAT_TYPES": "private", "BACKUP_PATH": self.temp_dir, "LOG_LEVEL": "DEBUG"}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            setup_logging(config)
+            telethon_logger = logging.getLogger("telethon")
+            self.assertEqual(telethon_logger.level, logging.WARNING)
+
+    def test_setup_logging_with_info_level(self):
+        """setup_logging works with INFO level."""
+        from src.config import setup_logging
+
+        env_vars = {"CHAT_TYPES": "private", "BACKUP_PATH": self.temp_dir, "LOG_LEVEL": "INFO"}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            setup_logging(config)
+            self.assertEqual(config.log_level, logging.INFO)
+
+
+class TestMainBlock(unittest.TestCase):
+    """Test __main__ block execution path (lines 630-639)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_main_block_success(self):
+        """Running config.py as __main__ with valid env succeeds."""
+        import subprocess
+
+        env = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "TELEGRAM_API_ID": "12345",
+            "TELEGRAM_API_HASH": "abcdef",
+            "TELEGRAM_PHONE": "+1234567890",
+            "PATH": os.environ.get("PATH", ""),
+        }
+        result = subprocess.run(
+            ["python3", "-m", "src.config"],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd="/Users/sergio/repos/personal/Telegram-Archive",
+            timeout=10,
+        )
+        self.assertEqual(result.returncode, 0)
+
+    def test_main_block_config_error(self):
+        """Running config.py as __main__ with invalid config prints error."""
+        import subprocess
+
+        env = {
+            "CHAT_TYPES": "invalid_type",
+            "BACKUP_PATH": self.temp_dir,
+            "PATH": os.environ.get("PATH", ""),
+        }
+        result = subprocess.run(
+            ["python3", "-m", "src.config"],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd="/Users/sergio/repos/personal/Telegram-Archive",
+            timeout=10,
+        )
+        self.assertIn("Configuration error", result.stdout)
+
+
+class TestProxyMissingAddr(unittest.TestCase):
+    """Test proxy validation when TELEGRAM_PROXY_ADDR is missing (line 48)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_proxy_missing_addr_in_error_message(self):
+        """Missing TELEGRAM_PROXY_ADDR appears in the error message."""
+        env_vars = {
+            "TELEGRAM_PROXY_TYPE": "socks5",
+            "TELEGRAM_PROXY_PORT": "1080",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                build_telegram_proxy_from_env()
+            self.assertIn("TELEGRAM_PROXY_ADDR", str(ctx.exception))
 
 
 if __name__ == "__main__":

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1284,7 +1284,7 @@ class TestMainBlock(unittest.TestCase):
             capture_output=True,
             text=True,
             env=env,
-            cwd="/Users/sergio/repos/personal/Telegram-Archive",
+            cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
             timeout=10,
         )
         self.assertEqual(result.returncode, 0)
@@ -1303,7 +1303,7 @@ class TestMainBlock(unittest.TestCase):
             capture_output=True,
             text=True,
             env=env,
-            cwd="/Users/sergio/repos/personal/Telegram-Archive",
+            cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
             timeout=10,
         )
         self.assertIn("Configuration error", result.stdout)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -582,9 +582,8 @@ class TestSkipTopicIds(unittest.TestCase):
             "SKIP_TOPIC_IDS": "-1001234567890",
             "BACKUP_PATH": self.temp_dir,
         }
-        with patch.dict(os.environ, env_vars, clear=True):
-            with self.assertRaises(ValueError):
-                Config()
+        with patch.dict(os.environ, env_vars, clear=True), self.assertRaises(ValueError):
+            Config()
 
     def test_skip_topic_ids_invalid_format_non_integer(self):
         """Raises ValueError for non-integer chat_id or topic_id."""
@@ -593,9 +592,8 @@ class TestSkipTopicIds(unittest.TestCase):
             "SKIP_TOPIC_IDS": "abc:def",
             "BACKUP_PATH": self.temp_dir,
         }
-        with patch.dict(os.environ, env_vars, clear=True):
-            with self.assertRaises(ValueError):
-                Config()
+        with patch.dict(os.environ, env_vars, clear=True), self.assertRaises(ValueError):
+            Config()
 
     def test_should_skip_topic_matches(self):
         """should_skip_topic returns True for configured pairs."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -649,6 +649,105 @@ class TestSkipTopicIds(unittest.TestCase):
             config = Config()
             self.assertFalse(config.should_skip_topic(-1009876543210, 42))
 
+    # --- Edge cases for _parse_topic_skip_list ---
+
+    def test_skip_topic_ids_duplicate_entries_are_deduplicated(self):
+        """Duplicate chat_id:topic_id pairs should be silently deduplicated."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": "-100123:42,-100123:42,-100123:42",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertEqual(config.skip_topic_ids, {-100123: {42}})
+
+    def test_skip_topic_ids_extra_colons_raises_value_error(self):
+        """Entry with multiple colons like chat_id:topic_id:extra raises ValueError."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": "-100123:42:extra",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                Config()
+            self.assertIn("must be integers", str(ctx.exception))
+
+    def test_skip_topic_ids_very_large_ids(self):
+        """Very large chat IDs and topic IDs should parse correctly."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": "-1002701160643:999999",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertEqual(config.skip_topic_ids, {-1002701160643: {999999}})
+            self.assertTrue(config.should_skip_topic(-1002701160643, 999999))
+
+    def test_skip_topic_ids_trailing_leading_commas(self):
+        """Trailing, leading, and consecutive commas should be handled gracefully."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": ",-100123:42,,-100456:7,",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertEqual(config.skip_topic_ids, {-100123: {42}, -100456: {7}})
+
+    def test_should_skip_topic_zero_topic_id(self):
+        """should_skip_topic handles topic_id=0 as a valid integer match."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": "-100123:0",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            # topic_id=0 is falsy in Python, so should_skip_topic guard
+            # "if topic_id is None" lets it through, but "topic_id in skip_set"
+            # should match 0.
+            self.assertTrue(config.should_skip_topic(-100123, 0))
+
+    def test_skip_topic_ids_no_colon_error_message_includes_entry(self):
+        """ValueError for missing colon should include the offending entry text."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": "-1001234567890",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                Config()
+            self.assertIn("expected format chat_id:topic_id", str(ctx.exception))
+            self.assertIn("-1001234567890", str(ctx.exception))
+
+    def test_skip_topic_ids_non_integer_error_message_content(self):
+        """ValueError for non-integer values should mention 'must be integers'."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": "abc:def",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            with self.assertRaises(ValueError) as ctx:
+                Config()
+            self.assertIn("must be integers", str(ctx.exception))
+            self.assertIn("abc:def", str(ctx.exception))
+
+    def test_skip_topic_ids_only_whitespace(self):
+        """Whitespace-only SKIP_TOPIC_IDS should return empty dict."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": "   ",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertEqual(config.skip_topic_ids, {})
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -515,5 +515,140 @@ class TestTelegramProxyConfig(unittest.TestCase):
         self.assertIn("TELEGRAM_PROXY_USERNAME and TELEGRAM_PROXY_PASSWORD", str(ctx.exception))
 
 
+class TestSkipTopicIds(unittest.TestCase):
+    """Test SKIP_TOPIC_IDS configuration for forum topic filtering."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_skip_topic_ids_empty(self):
+        """Skip topic IDs defaults to empty dict when not configured."""
+        env_vars = {"CHAT_TYPES": "private", "BACKUP_PATH": self.temp_dir}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertEqual(config.skip_topic_ids, {})
+
+    def test_skip_topic_ids_single(self):
+        """Can configure single chat_id:topic_id pair."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": "-1001234567890:42",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertEqual(config.skip_topic_ids, {-1001234567890: {42}})
+
+    def test_skip_topic_ids_multiple_same_chat(self):
+        """Multiple topics in same chat are grouped into one set."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": "-1001234567890:42,-1001234567890:1337",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertEqual(config.skip_topic_ids, {-1001234567890: {42, 1337}})
+
+    def test_skip_topic_ids_multiple_chats(self):
+        """Topics across different chats are separated by chat ID."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": "-1001234567890:42,-1009876543210:7",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertEqual(config.skip_topic_ids, {-1001234567890: {42}, -1009876543210: {7}})
+
+    def test_skip_topic_ids_whitespace_handling(self):
+        """Should handle whitespace in topic skip list correctly."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": " -100123:42 , -100456:7 ",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertEqual(config.skip_topic_ids, {-100123: {42}, -100456: {7}})
+
+    def test_skip_topic_ids_invalid_format_no_colon(self):
+        """Raises ValueError for entries without colon separator."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": "-1001234567890",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            with self.assertRaises(ValueError):
+                Config()
+
+    def test_skip_topic_ids_invalid_format_non_integer(self):
+        """Raises ValueError for non-integer chat_id or topic_id."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": "abc:def",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            with self.assertRaises(ValueError):
+                Config()
+
+    def test_should_skip_topic_matches(self):
+        """should_skip_topic returns True for configured pairs."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": "-1001234567890:42,-1001234567890:1337",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertTrue(config.should_skip_topic(-1001234567890, 42))
+            self.assertTrue(config.should_skip_topic(-1001234567890, 1337))
+
+    def test_should_skip_topic_no_match(self):
+        """should_skip_topic returns False for non-configured pairs."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": "-1001234567890:42",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertFalse(config.should_skip_topic(-1001234567890, 999))
+
+    def test_should_skip_topic_none_topic(self):
+        """should_skip_topic returns False when topic_id is None."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": "-1001234567890:42",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertFalse(config.should_skip_topic(-1001234567890, None))
+
+    def test_should_skip_topic_empty_config(self):
+        """should_skip_topic returns False when SKIP_TOPIC_IDS is not set."""
+        env_vars = {"CHAT_TYPES": "private", "BACKUP_PATH": self.temp_dir}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertFalse(config.should_skip_topic(-1001234567890, 42))
+
+    def test_should_skip_topic_wrong_chat(self):
+        """should_skip_topic returns False when chat_id doesn't match."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": "-1001234567890:42",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertFalse(config.should_skip_topic(-1009876543210, 42))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_gap_fill.py
+++ b/tests/test_gap_fill.py
@@ -279,6 +279,7 @@ def _make_backup_instance(db_mock=None, client_mock=None, config_mock=None):
     backup.config = config_mock or MagicMock()
     backup.config.gap_threshold = 50
     backup.config.batch_size = 100
+    backup.config.should_skip_topic = MagicMock(return_value=False)
     return backup
 
 
@@ -478,6 +479,7 @@ class TestFillGapRange:
         for i in range(51, 56):
             msg = MagicMock()
             msg.id = i
+            msg.reply_to = None
             messages.append(msg)
 
         async def fake_iter_messages(entity, min_id=None, max_id=None, reverse=None):
@@ -506,6 +508,7 @@ class TestFillGapRange:
         for i in range(51, 59):  # 8 messages
             msg = MagicMock()
             msg.id = i
+            msg.reply_to = None
             messages.append(msg)
 
         async def fake_iter_messages(entity, min_id=None, max_id=None, reverse=None):

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -3,11 +3,13 @@ Tests for the real-time listener module.
 """
 
 import asyncio
+from datetime import UTC
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from telethon import events
 
-from src.listener import TelegramListener
+from src.listener import MassOperationProtector, TelegramListener
 
 
 class TestTelegramListener:
@@ -124,6 +126,776 @@ class TestTelegramListener:
         assert listener.stats["operations_discarded"] == 0
         assert listener.stats["errors"] == 0
         assert listener.stats["start_time"] is None
+
+
+class TestInitConfig:
+    """Tests for __init__ with various configuration settings."""
+
+    @pytest.fixture
+    def base_config(self):
+        """Config with all attributes the __init__ method accesses."""
+        config = MagicMock()
+        config.api_id = 12345
+        config.api_hash = "test_hash"
+        config.phone = "+1234567890"
+        config.session_path = "/tmp/test_session"
+        config.global_include_ids = set()
+        config.private_include_ids = set()
+        config.groups_include_ids = set()
+        config.channels_include_ids = set()
+        config.validate_credentials = MagicMock()
+        config.whitelist_mode = False
+        config.chat_ids = set()
+        config.listen_edits = True
+        config.listen_deletions = False
+        config.listen_new_messages = False
+        config.listen_new_messages_media = False
+        config.listen_chat_actions = False
+        config.skip_topic_ids = {}
+        config.mass_operation_threshold = 10
+        config.mass_operation_window_seconds = 30
+        config.mass_operation_buffer_delay = 2.0
+        return config
+
+    @pytest.fixture
+    def mock_db(self):
+        db = AsyncMock()
+        db.get_all_chats = AsyncMock(return_value=[])
+        db.close = AsyncMock()
+        return db
+
+    def test_init_calls_validate_credentials(self, base_config, mock_db):
+        """Test that __init__ validates credentials."""
+        TelegramListener(base_config, mock_db)
+        base_config.validate_credentials.assert_called_once()
+
+    def test_init_with_existing_client(self, base_config, mock_db):
+        """Test initialization with an externally provided client."""
+        external_client = MagicMock()
+        listener = TelegramListener(base_config, mock_db, client=external_client)
+
+        assert listener.client is external_client
+        assert listener._owns_client is False
+
+    def test_init_without_client_owns_client(self, base_config, mock_db):
+        """Test initialization without client sets _owns_client to True."""
+        listener = TelegramListener(base_config, mock_db)
+
+        assert listener.client is None
+        assert listener._owns_client is True
+
+    def test_init_creates_protector_with_config_values(self, base_config, mock_db):
+        """Test that MassOperationProtector receives config thresholds."""
+        base_config.mass_operation_threshold = 25
+        base_config.mass_operation_window_seconds = 60
+
+        listener = TelegramListener(base_config, mock_db)
+
+        assert listener._protector.threshold == 25
+        assert listener._protector.window_seconds == 60
+
+    def test_init_stats_include_new_messages_counters(self, base_config, mock_db):
+        """Test that stats dict includes new_messages counters."""
+        listener = TelegramListener(base_config, mock_db)
+
+        assert listener.stats["new_messages_received"] == 0
+        assert listener.stats["new_messages_saved"] == 0
+        assert listener.stats["bursts_intercepted"] == 0
+
+    def test_init_with_listen_new_messages_enabled(self, base_config, mock_db):
+        """Test init logs correctly when listen_new_messages is true."""
+        base_config.listen_new_messages = True
+        base_config.listen_new_messages_media = True
+        # Should not raise
+        listener = TelegramListener(base_config, mock_db)
+        assert listener.config.listen_new_messages is True
+
+    def test_init_with_skip_topic_ids(self, base_config, mock_db):
+        """Test init logs topic exclusion info when skip_topic_ids is set."""
+        base_config.skip_topic_ids = {-1001234: {100, 200}, -1005678: {300}}
+        # Should not raise
+        listener = TelegramListener(base_config, mock_db)
+        assert listener.config.skip_topic_ids == {-1001234: {100, 200}, -1005678: {300}}
+
+    def test_init_with_listen_deletions_enabled(self, base_config, mock_db):
+        """Test init when deletions are enabled triggers warning log path."""
+        base_config.listen_deletions = True
+        listener = TelegramListener(base_config, mock_db)
+        assert listener.config.listen_deletions is True
+
+
+class TestEventHandlers:
+    """Tests for the on_new_message, on_message_edited, on_message_deleted handlers.
+
+    The handlers are inner closures registered inside _register_handlers().
+    We capture them by mocking self.client.on() as a decorator that stores
+    the wrapped function, keyed by event type.
+    """
+
+    @pytest.fixture
+    def full_config(self):
+        """Config with all attributes accessed by handlers."""
+        config = MagicMock()
+        config.api_id = 12345
+        config.api_hash = "test_hash"
+        config.phone = "+1234567890"
+        config.session_path = "/tmp/test_session"
+        config.global_include_ids = set()
+        config.private_include_ids = set()
+        config.groups_include_ids = set()
+        config.channels_include_ids = set()
+        config.validate_credentials = MagicMock()
+        config.whitelist_mode = False
+        config.chat_ids = set()
+        config.listen_edits = True
+        config.listen_deletions = True
+        config.listen_new_messages = True
+        config.listen_new_messages_media = False
+        config.listen_chat_actions = False
+        config.skip_topic_ids = {}
+        config.should_skip_topic = MagicMock(return_value=False)
+        config.mass_operation_threshold = 100
+        config.mass_operation_window_seconds = 30
+        config.mass_operation_buffer_delay = 2.0
+        config.should_download_media_for_chat = MagicMock(return_value=False)
+        return config
+
+    @pytest.fixture
+    def mock_db(self):
+        db = AsyncMock()
+        db.get_all_chats = AsyncMock(return_value=[])
+        db.update_message_text = AsyncMock()
+        db.delete_message = AsyncMock()
+        db.resolve_message_chat_id = AsyncMock(return_value=None)
+        db.upsert_chat = AsyncMock()
+        db.upsert_user = AsyncMock()
+        db.insert_message = AsyncMock()
+        db.insert_media = AsyncMock()
+        db.close = AsyncMock()
+        return db
+
+    @pytest.fixture
+    def listener_with_handlers(self, full_config, mock_db):
+        """Create a listener and register handlers, capturing them for direct invocation."""
+        listener = TelegramListener(full_config, mock_db)
+        listener._tracked_chat_ids = {-1001234567890}
+        listener._notifier = None  # Disable notifications for unit tests
+
+        # Capture handlers registered by _register_handlers
+        handlers = {}
+        mock_client = MagicMock()
+
+        def capture_on(event_type):
+            """Return a decorator that stores the handler function."""
+
+            def decorator(fn):
+                handlers[event_type] = fn
+                return fn
+
+            return decorator
+
+        mock_client.on = capture_on
+        listener.client = mock_client
+        listener._register_handlers()
+
+        return listener, handlers
+
+    # ----------------------------------------------------------------
+    # on_new_message tests
+    # ----------------------------------------------------------------
+
+    def test_on_new_message_skips_untracked_chat(self, listener_with_handlers):
+        """Test new message handler returns early for untracked chats."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.NewMessage]
+
+        event = MagicMock()
+        event.chat_id = 99999  # Not in tracked set
+        event.message = MagicMock()
+        event.message.reply_to = None
+
+        asyncio.run(handler(event))
+
+        assert listener.stats["new_messages_received"] == 0
+        listener.db.insert_message.assert_not_called()
+
+    def test_on_new_message_topic_filtering_skips_excluded_topic(self, listener_with_handlers, full_config):
+        """Test new message handler skips messages in excluded forum topics."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.NewMessage]
+
+        # Configure topic to be skipped
+        full_config.should_skip_topic = MagicMock(return_value=True)
+
+        event = MagicMock()
+        event.chat_id = -1001234567890  # Tracked chat
+        msg = MagicMock()
+        msg.reply_to = None  # Prevent MagicMock truthiness issue
+        event.message = msg
+
+        asyncio.run(handler(event))
+
+        # Should NOT count as received (skipped before the counter)
+        assert listener.stats["new_messages_received"] == 0
+        listener.db.insert_message.assert_not_called()
+
+    def test_on_new_message_listen_new_messages_false_returns_early(self, listener_with_handlers, full_config):
+        """Test new message handler returns early when listen_new_messages is disabled."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.NewMessage]
+
+        full_config.listen_new_messages = False
+
+        event = MagicMock()
+        event.chat_id = -1001234567890
+        msg = MagicMock()
+        msg.reply_to = None
+        event.message = msg
+
+        asyncio.run(handler(event))
+
+        # Counter IS incremented (message was received), but not saved
+        assert listener.stats["new_messages_received"] == 1
+        assert listener.stats["new_messages_saved"] == 0
+        listener.db.insert_message.assert_not_called()
+
+    def test_on_new_message_saves_message_to_db(self, listener_with_handlers, full_config):
+        """Test new message handler inserts message into database."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.NewMessage]
+
+        from datetime import datetime
+
+        event = MagicMock()
+        event.chat_id = -1001234567890
+
+        msg = MagicMock()
+        msg.reply_to = None
+        msg.id = 42
+        msg.sender_id = 111
+        msg.date = datetime(2025, 1, 1, tzinfo=UTC)
+        msg.text = "Hello world"
+        msg.reply_to_msg_id = None
+        msg.edit_date = None
+        msg.out = False
+        msg.grouped_id = None
+        msg.media = None
+        msg.sender = None  # No sender entity
+        event.message = msg
+
+        # get_chat returns a chat entity
+        chat_entity = MagicMock()
+        chat_entity.title = "Test Chat"
+        chat_entity.username = None
+        chat_entity.first_name = None
+        chat_entity.last_name = None
+        event.get_chat = AsyncMock(return_value=chat_entity)
+
+        asyncio.run(handler(event))
+
+        assert listener.stats["new_messages_received"] == 1
+        assert listener.stats["new_messages_saved"] == 1
+        listener.db.insert_message.assert_called_once()
+        listener.db.upsert_chat.assert_called_once()
+
+    def test_on_new_message_adds_untracked_chat_to_tracking(self, listener_with_handlers, full_config):
+        """Test new message from untracked-but-included chat gets added to tracking."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.NewMessage]
+
+        # Chat not in tracked set, but in global include list
+        new_chat_id = -1009999999
+        full_config.global_include_ids = {new_chat_id}
+        listener._tracked_chat_ids = set()  # Empty
+
+        event = MagicMock()
+        event.chat_id = new_chat_id
+        msg = MagicMock()
+        msg.reply_to = None
+        msg.id = 1
+        msg.sender_id = 111
+        msg.date = MagicMock()
+        msg.text = "test"
+        msg.reply_to_msg_id = None
+        msg.edit_date = None
+        msg.out = False
+        msg.grouped_id = None
+        msg.media = None
+        msg.sender = None
+        event.message = msg
+        event.get_chat = AsyncMock(return_value=MagicMock())
+
+        asyncio.run(handler(event))
+
+        assert new_chat_id in listener._tracked_chat_ids
+
+    def test_on_new_message_increments_error_on_exception(self, listener_with_handlers):
+        """Test error counter increments when handler raises an exception."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.NewMessage]
+
+        event = MagicMock()
+        # Force _get_marked_id to raise
+        event.chat_id = MagicMock(side_effect=Exception("boom"))
+        # _get_marked_id calls get_peer_id which will fail, then tries .id
+        # Make .id also raise
+        event.chat_id.id = property(lambda self: (_ for _ in ()).throw(Exception("boom")))
+
+        # We need to make _get_marked_id raise inside the try block
+        listener._get_marked_id = MagicMock(side_effect=Exception("test error"))
+
+        asyncio.run(handler(event))
+
+        assert listener.stats["errors"] == 1
+
+    # ----------------------------------------------------------------
+    # on_message_edited tests
+    # ----------------------------------------------------------------
+
+    def test_on_message_edited_skips_when_listen_edits_false(self, listener_with_handlers, full_config):
+        """Test edit handler returns immediately when listen_edits is disabled."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.MessageEdited]
+
+        full_config.listen_edits = False
+
+        event = MagicMock()
+        event.chat_id = -1001234567890
+        event.message = MagicMock()
+        event.message.reply_to = None
+
+        asyncio.run(handler(event))
+
+        assert listener.stats["edits_received"] == 0
+        listener.db.update_message_text.assert_not_called()
+
+    def test_on_message_edited_skips_untracked_chat(self, listener_with_handlers):
+        """Test edit handler ignores edits from untracked chats."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.MessageEdited]
+
+        event = MagicMock()
+        event.chat_id = 99999  # Not tracked
+        event.message = MagicMock()
+        event.message.reply_to = None
+
+        asyncio.run(handler(event))
+
+        assert listener.stats["edits_received"] == 0
+        listener.db.update_message_text.assert_not_called()
+
+    def test_on_message_edited_skips_excluded_topic(self, listener_with_handlers, full_config):
+        """Test edit handler skips messages in excluded forum topics."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.MessageEdited]
+
+        full_config.should_skip_topic = MagicMock(return_value=True)
+
+        event = MagicMock()
+        event.chat_id = -1001234567890
+        msg = MagicMock()
+        msg.reply_to = None
+        event.message = msg
+
+        asyncio.run(handler(event))
+
+        assert listener.stats["edits_received"] == 0
+        listener.db.update_message_text.assert_not_called()
+
+    def test_on_message_edited_applies_edit(self, listener_with_handlers):
+        """Test edit handler applies edit to database when allowed."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.MessageEdited]
+
+        from datetime import datetime
+
+        event = MagicMock()
+        event.chat_id = -1001234567890
+        msg = MagicMock()
+        msg.reply_to = None
+        msg.id = 42
+        msg.text = "Updated text"
+        msg.edit_date = datetime(2025, 1, 1, tzinfo=UTC)
+        event.message = msg
+
+        asyncio.run(handler(event))
+
+        assert listener.stats["edits_received"] == 1
+        assert listener.stats["edits_applied"] == 1
+        listener.db.update_message_text.assert_called_once_with(
+            chat_id=-1001234567890,
+            message_id=42,
+            new_text="Updated text",
+            edit_date=msg.edit_date,
+        )
+
+    def test_on_message_edited_handles_none_text(self, listener_with_handlers):
+        """Test edit handler treats None text as empty string."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.MessageEdited]
+
+        event = MagicMock()
+        event.chat_id = -1001234567890
+        msg = MagicMock()
+        msg.reply_to = None
+        msg.id = 42
+        msg.text = None
+        msg.edit_date = None
+        event.message = msg
+
+        asyncio.run(handler(event))
+
+        assert listener.stats["edits_applied"] == 1
+        call_kwargs = listener.db.update_message_text.call_args[1]
+        assert call_kwargs["new_text"] == ""
+
+    def test_on_message_edited_increments_error_on_exception(self, listener_with_handlers):
+        """Test error counter increments when edit handler raises."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.MessageEdited]
+
+        listener._get_marked_id = MagicMock(side_effect=Exception("db error"))
+
+        event = MagicMock()
+        event.chat_id = -1001234567890
+
+        asyncio.run(handler(event))
+
+        assert listener.stats["errors"] == 1
+
+    # ----------------------------------------------------------------
+    # on_message_deleted tests
+    # ----------------------------------------------------------------
+
+    def test_on_message_deleted_skips_when_listen_deletions_false(self, listener_with_handlers, full_config):
+        """Test delete handler skips and counts when deletions are disabled."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.MessageDeleted]
+
+        full_config.listen_deletions = False
+
+        event = MagicMock()
+        event.deleted_ids = [1, 2, 3]
+
+        asyncio.run(handler(event))
+
+        assert listener.stats["deletions_skipped"] == 3
+        assert listener.stats["deletions_received"] == 0
+        listener.db.delete_message.assert_not_called()
+
+    def test_on_message_deleted_skips_untracked_chat(self, listener_with_handlers):
+        """Test delete handler ignores deletions from untracked chats."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.MessageDeleted]
+
+        event = MagicMock()
+        event.chat_id = 99999  # Not tracked
+        event.deleted_ids = [1, 2]
+
+        asyncio.run(handler(event))
+
+        assert listener.stats["deletions_received"] == 0
+        listener.db.delete_message.assert_not_called()
+
+    def test_on_message_deleted_applies_deletion(self, listener_with_handlers):
+        """Test delete handler applies each deletion to the database."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.MessageDeleted]
+
+        event = MagicMock()
+        event.chat_id = -1001234567890
+        event.deleted_ids = [10, 20]
+
+        asyncio.run(handler(event))
+
+        assert listener.stats["deletions_received"] == 2
+        assert listener.stats["deletions_applied"] == 2
+        assert listener.db.delete_message.call_count == 2
+
+    def test_on_message_deleted_resolves_chat_when_chat_id_none(self, listener_with_handlers, mock_db):
+        """Test delete handler resolves chat_id from DB when event has None chat_id."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.MessageDeleted]
+
+        # chat_id is None, must resolve from DB
+        mock_db.resolve_message_chat_id = AsyncMock(return_value=-1001234567890)
+
+        event = MagicMock()
+        event.chat_id = None
+        event.deleted_ids = [42]
+
+        asyncio.run(handler(event))
+
+        mock_db.resolve_message_chat_id.assert_called_once_with(42)
+        assert listener.stats["deletions_applied"] == 1
+
+    def test_on_message_deleted_skips_unresolvable_message(self, listener_with_handlers, mock_db):
+        """Test delete handler skips messages that cannot be resolved to a chat."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.MessageDeleted]
+
+        mock_db.resolve_message_chat_id = AsyncMock(return_value=None)
+
+        event = MagicMock()
+        event.chat_id = None
+        event.deleted_ids = [42]
+
+        asyncio.run(handler(event))
+
+        assert listener.stats["deletions_applied"] == 0
+        listener.db.delete_message.assert_not_called()
+
+    def test_on_message_deleted_increments_error_on_exception(self, listener_with_handlers):
+        """Test error counter increments when delete handler raises."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.MessageDeleted]
+
+        listener._get_marked_id = MagicMock(side_effect=Exception("crash"))
+
+        event = MagicMock()
+        event.chat_id = -1001234567890
+        event.deleted_ids = [1]
+
+        asyncio.run(handler(event))
+
+        assert listener.stats["errors"] == 1
+
+
+class TestStatsTracking:
+    """Tests verifying stats counters are incremented correctly across operations."""
+
+    @pytest.fixture
+    def full_config(self):
+        config = MagicMock()
+        config.api_id = 12345
+        config.api_hash = "test_hash"
+        config.phone = "+1234567890"
+        config.session_path = "/tmp/test_session"
+        config.global_include_ids = set()
+        config.private_include_ids = set()
+        config.groups_include_ids = set()
+        config.channels_include_ids = set()
+        config.validate_credentials = MagicMock()
+        config.whitelist_mode = False
+        config.chat_ids = set()
+        config.listen_edits = True
+        config.listen_deletions = True
+        config.listen_new_messages = True
+        config.listen_new_messages_media = False
+        config.listen_chat_actions = False
+        config.skip_topic_ids = {}
+        config.should_skip_topic = MagicMock(return_value=False)
+        config.mass_operation_threshold = 100
+        config.mass_operation_window_seconds = 30
+        config.mass_operation_buffer_delay = 2.0
+        config.should_download_media_for_chat = MagicMock(return_value=False)
+        return config
+
+    @pytest.fixture
+    def mock_db(self):
+        db = AsyncMock()
+        db.get_all_chats = AsyncMock(return_value=[])
+        db.update_message_text = AsyncMock()
+        db.delete_message = AsyncMock()
+        db.resolve_message_chat_id = AsyncMock(return_value=None)
+        db.upsert_chat = AsyncMock()
+        db.upsert_user = AsyncMock()
+        db.insert_message = AsyncMock()
+        db.close = AsyncMock()
+        return db
+
+    @pytest.fixture
+    def listener_with_handlers(self, full_config, mock_db):
+        listener = TelegramListener(full_config, mock_db)
+        listener._tracked_chat_ids = {-1001234567890}
+        listener._notifier = None
+
+        handlers = {}
+        mock_client = MagicMock()
+
+        def capture_on(event_type):
+            def decorator(fn):
+                handlers[event_type] = fn
+                return fn
+
+            return decorator
+
+        mock_client.on = capture_on
+        listener.client = mock_client
+        listener._register_handlers()
+
+        return listener, handlers
+
+    def test_multiple_edits_increment_counters(self, listener_with_handlers):
+        """Test that multiple edits correctly increment both received and applied counters."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.MessageEdited]
+
+        for i in range(5):
+            event = MagicMock()
+            event.chat_id = -1001234567890
+            msg = MagicMock()
+            msg.reply_to = None
+            msg.id = i
+            msg.text = f"edit {i}"
+            msg.edit_date = None
+            event.message = msg
+            asyncio.run(handler(event))
+
+        assert listener.stats["edits_received"] == 5
+        assert listener.stats["edits_applied"] == 5
+
+    def test_multiple_deletions_increment_counters(self, listener_with_handlers):
+        """Test that a batch deletion increments per-message counters."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.MessageDeleted]
+
+        event = MagicMock()
+        event.chat_id = -1001234567890
+        event.deleted_ids = [1, 2, 3, 4, 5]
+
+        asyncio.run(handler(event))
+
+        assert listener.stats["deletions_received"] == 5
+        assert listener.stats["deletions_applied"] == 5
+
+    def test_mixed_operations_track_independently(self, listener_with_handlers):
+        """Test that edit and deletion stats are tracked independently."""
+        listener, handlers = listener_with_handlers
+        edit_handler = handlers[events.MessageEdited]
+        delete_handler = handlers[events.MessageDeleted]
+
+        # 3 edits
+        for i in range(3):
+            event = MagicMock()
+            event.chat_id = -1001234567890
+            msg = MagicMock()
+            msg.reply_to = None
+            msg.id = i
+            msg.text = "x"
+            msg.edit_date = None
+            event.message = msg
+            asyncio.run(edit_handler(event))
+
+        # 2 deletions
+        del_event = MagicMock()
+        del_event.chat_id = -1001234567890
+        del_event.deleted_ids = [100, 200]
+        asyncio.run(delete_handler(del_event))
+
+        assert listener.stats["edits_received"] == 3
+        assert listener.stats["edits_applied"] == 3
+        assert listener.stats["deletions_received"] == 2
+        assert listener.stats["deletions_applied"] == 2
+        assert listener.stats["errors"] == 0
+
+
+class TestWhitelistMode:
+    """Tests for CHAT_IDS whitelist mode in _should_process_chat."""
+
+    @pytest.fixture
+    def mock_config(self):
+        config = MagicMock()
+        config.api_id = 12345
+        config.api_hash = "test_hash"
+        config.phone = "+1234567890"
+        config.session_path = "/tmp/test_session"
+        config.global_include_ids = {-1009999999}
+        config.private_include_ids = set()
+        config.groups_include_ids = set()
+        config.channels_include_ids = set()
+        config.validate_credentials = MagicMock()
+        config.whitelist_mode = True
+        config.chat_ids = {-1001111111}
+        config.listen_edits = True
+        config.listen_deletions = False
+        config.listen_new_messages = False
+        config.listen_new_messages_media = False
+        config.listen_chat_actions = False
+        config.skip_topic_ids = {}
+        config.mass_operation_threshold = 10
+        config.mass_operation_window_seconds = 30
+        config.mass_operation_buffer_delay = 2.0
+        return config
+
+    @pytest.fixture
+    def mock_db(self):
+        db = AsyncMock()
+        db.get_all_chats = AsyncMock(return_value=[])
+        db.close = AsyncMock()
+        return db
+
+    def test_whitelist_mode_allows_whitelisted_chat(self, mock_config, mock_db):
+        """Test whitelist mode allows chat in CHAT_IDS."""
+        listener = TelegramListener(mock_config, mock_db)
+        assert listener._should_process_chat(-1001111111) is True
+
+    def test_whitelist_mode_blocks_non_whitelisted_chat(self, mock_config, mock_db):
+        """Test whitelist mode blocks chat NOT in CHAT_IDS."""
+        listener = TelegramListener(mock_config, mock_db)
+        assert listener._should_process_chat(-1002222222) is False
+
+    def test_whitelist_mode_ignores_include_lists(self, mock_config, mock_db):
+        """Test whitelist mode ignores global_include_ids even if chat matches."""
+        listener = TelegramListener(mock_config, mock_db)
+        # -1009999999 is in global_include_ids but NOT in chat_ids
+        assert listener._should_process_chat(-1009999999) is False
+
+    def test_whitelist_mode_ignores_tracked_chats(self, mock_config, mock_db):
+        """Test whitelist mode ignores tracked chats if not in CHAT_IDS."""
+        listener = TelegramListener(mock_config, mock_db)
+        listener._tracked_chat_ids = {-1003333333}
+        assert listener._should_process_chat(-1003333333) is False
+
+
+class TestMassOperationProtector:
+    """Tests for the MassOperationProtector rate limiting class."""
+
+    def test_allows_operations_under_threshold(self):
+        """Test that operations under the threshold are allowed."""
+        protector = MassOperationProtector(threshold=5, window_seconds=30)
+        for _ in range(5):
+            allowed, reason = protector.check_operation(-100, "edit")
+            assert allowed is True
+            assert reason == "allowed"
+
+    def test_blocks_operations_over_threshold(self):
+        """Test that operations exceeding threshold are blocked."""
+        protector = MassOperationProtector(threshold=3, window_seconds=30)
+        results = []
+        for _ in range(5):
+            allowed, reason = protector.check_operation(-100, "deletion")
+            results.append(allowed)
+
+        # First 3 allowed, 4th triggers block (count 4 > threshold 3)
+        assert results[:3] == [True, True, True]
+        assert results[3] is False  # 4th triggers rate limit
+        assert results[4] is False  # 5th also blocked
+
+    def test_get_stats_returns_counts(self):
+        """Test get_stats returns meaningful statistics."""
+        protector = MassOperationProtector(threshold=2, window_seconds=30)
+        protector.check_operation(-100, "edit")
+        protector.check_operation(-100, "edit")
+        protector.check_operation(-100, "edit")  # triggers rate limit
+
+        stats = protector.get_stats()
+        assert stats["operations_applied"] >= 2
+        assert "rate_limits_triggered" in stats
+        assert "currently_blocked" in stats
+
+    def test_separate_chats_have_independent_limits(self):
+        """Test that rate limits are tracked per-chat independently."""
+        protector = MassOperationProtector(threshold=2, window_seconds=30)
+
+        # Fill up chat A
+        protector.check_operation(-100, "edit")
+        protector.check_operation(-100, "edit")
+        protector.check_operation(-100, "edit")  # May trigger block for -100
+
+        # Chat B should still be allowed
+        allowed, _ = protector.check_operation(-200, "edit")
+        assert allowed is True
 
 
 class TestListenerEventHandling:

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -5,9 +5,21 @@ import os
 import shutil
 import tempfile
 import unittest
+import unittest.mock
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
-from telethon.tl.types import Channel
+from telethon.tl.types import (
+    Channel,
+    Chat,
+    MessageMediaContact,
+    MessageMediaDocument,
+    MessageMediaGeo,
+    MessageMediaPhoto,
+    MessageMediaPoll,
+    TextWithEntities,
+    User,
+)
 
 from src.message_utils import extract_topic_id
 from src.telegram_backup import TelegramBackup
@@ -531,16 +543,14 @@ class TestTopicFilteringInBackupDialog(unittest.TestCase):
     def test_backup_dialog_skips_messages_in_excluded_topics(self):
         """Messages in excluded forum topics should not be backed up."""
         # Configure: skip topic 42 in chat -1001234567890
-        self.config.should_skip_topic = MagicMock(
-            side_effect=lambda chat_id, topic_id: topic_id == 42
-        )
+        self.config.should_skip_topic = MagicMock(side_effect=lambda chat_id, topic_id: topic_id == 42)
 
         messages = [
-            self._make_normal_message(1),       # kept (no topic)
-            self._make_forum_message(2, 42),     # skipped (excluded topic)
-            self._make_forum_message(3, 99),     # kept (different topic)
-            self._make_forum_message(4, 42),     # skipped (excluded topic)
-            self._make_normal_message(5),        # kept (no topic)
+            self._make_normal_message(1),  # kept (no topic)
+            self._make_forum_message(2, 42),  # skipped (excluded topic)
+            self._make_forum_message(3, 99),  # kept (different topic)
+            self._make_forum_message(4, 42),  # skipped (excluded topic)
+            self._make_normal_message(5),  # kept (no topic)
         ]
 
         async def fake_iter(*args, **kwargs):
@@ -548,9 +558,7 @@ class TestTopicFilteringInBackupDialog(unittest.TestCase):
                 yield m
 
         self.backup.client.iter_messages = fake_iter
-        self.backup._process_message = AsyncMock(
-            side_effect=lambda m, c: {"id": m.id, "chat_id": c}
-        )
+        self.backup._process_message = AsyncMock(side_effect=lambda m, c: {"id": m.id, "chat_id": c})
         self.backup._commit_batch = AsyncMock()
         self.backup._sync_pinned_messages = AsyncMock()
 
@@ -576,9 +584,7 @@ class TestTopicFilteringInBackupDialog(unittest.TestCase):
                 yield m
 
         self.backup.client.iter_messages = fake_iter
-        self.backup._process_message = AsyncMock(
-            side_effect=lambda m, c: {"id": m.id, "chat_id": c}
-        )
+        self.backup._process_message = AsyncMock(side_effect=lambda m, c: {"id": m.id, "chat_id": c})
         self.backup._commit_batch = AsyncMock()
         self.backup._sync_pinned_messages = AsyncMock()
 
@@ -588,24 +594,20 @@ class TestTopicFilteringInBackupDialog(unittest.TestCase):
 
     def test_backup_dialog_uses_reply_to_msg_id_as_fallback(self):
         """When reply_to_top_id is None, falls back to reply_to_msg_id for topic ID."""
-        self.config.should_skip_topic = MagicMock(
-            side_effect=lambda chat_id, topic_id: topic_id == 42
-        )
+        self.config.should_skip_topic = MagicMock(side_effect=lambda chat_id, topic_id: topic_id == 42)
 
         msg = MagicMock()
         msg.id = 1
         msg.reply_to = MagicMock()
         msg.reply_to.forum_topic = True
         msg.reply_to.reply_to_top_id = None  # no top_id
-        msg.reply_to.reply_to_msg_id = 42     # fallback to this
+        msg.reply_to.reply_to_msg_id = 42  # fallback to this
 
         async def fake_iter(*args, **kwargs):
             yield msg
 
         self.backup.client.iter_messages = fake_iter
-        self.backup._process_message = AsyncMock(
-            side_effect=lambda m, c: {"id": m.id, "chat_id": c}
-        )
+        self.backup._process_message = AsyncMock(side_effect=lambda m, c: {"id": m.id, "chat_id": c})
         self.backup._commit_batch = AsyncMock()
         self.backup._sync_pinned_messages = AsyncMock()
 
@@ -734,6 +736,954 @@ class TestExtractTopicId(unittest.TestCase):
         msg.reply_to.reply_to_top_id = None
         msg.reply_to.reply_to_msg_id = None
         self.assertIsNone(extract_topic_id(msg))
+
+
+class TestExtractForwardFromId(unittest.TestCase):
+    """Test _extract_forward_from_id for different Peer types."""
+
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+
+    def test_returns_none_when_no_fwd_from(self):
+        """Returns None when message has no forward info."""
+        msg = MagicMock()
+        msg.fwd_from = None
+        self.assertIsNone(self.backup._extract_forward_from_id(msg))
+
+    def test_returns_none_when_fwd_from_has_no_from_id(self):
+        """Returns None when forward info has no sender ID."""
+        msg = MagicMock()
+        msg.fwd_from = MagicMock()
+        msg.fwd_from.from_id = None
+        self.assertIsNone(self.backup._extract_forward_from_id(msg))
+
+    def test_returns_user_id_from_peer_user(self):
+        """Returns user_id when forward peer is a PeerUser."""
+        msg = MagicMock()
+        msg.fwd_from = MagicMock()
+        peer = MagicMock(spec=["user_id"])
+        peer.user_id = 12345
+        msg.fwd_from.from_id = peer
+        self.assertEqual(self.backup._extract_forward_from_id(msg), 12345)
+
+    def test_returns_channel_id_from_peer_channel(self):
+        """Returns channel_id when forward peer is a PeerChannel."""
+        msg = MagicMock()
+        msg.fwd_from = MagicMock()
+        peer = MagicMock(spec=["channel_id"])
+        peer.channel_id = 99999
+        msg.fwd_from.from_id = peer
+        self.assertEqual(self.backup._extract_forward_from_id(msg), 99999)
+
+    def test_returns_chat_id_from_peer_chat(self):
+        """Returns chat_id when forward peer is a PeerChat."""
+        msg = MagicMock()
+        msg.fwd_from = MagicMock()
+        peer = MagicMock(spec=["chat_id"])
+        peer.chat_id = 77777
+        msg.fwd_from.from_id = peer
+        self.assertEqual(self.backup._extract_forward_from_id(msg), 77777)
+
+    def test_returns_none_for_unknown_peer_type(self):
+        """Returns None when peer has no recognized ID attribute."""
+        msg = MagicMock()
+        msg.fwd_from = MagicMock()
+        peer = MagicMock(spec=[])
+        msg.fwd_from.from_id = peer
+        self.assertIsNone(self.backup._extract_forward_from_id(msg))
+
+
+class TestTextWithEntitiesToString(unittest.TestCase):
+    """Test _text_with_entities_to_string conversion."""
+
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+
+    def test_returns_empty_string_for_none(self):
+        """Returns empty string when input is None."""
+        self.assertEqual(self.backup._text_with_entities_to_string(None), "")
+
+    def test_returns_string_as_is(self):
+        """Returns plain string unchanged."""
+        self.assertEqual(self.backup._text_with_entities_to_string("hello"), "hello")
+
+    def test_extracts_text_from_text_with_entities(self):
+        """Extracts .text from a TextWithEntities object."""
+        twe = MagicMock(spec=TextWithEntities)
+        twe.text = "poll question"
+        # Make isinstance check work
+        with unittest.mock.patch("src.telegram_backup.TextWithEntities", new=type(twe)):
+            result = self.backup._text_with_entities_to_string(twe)
+        self.assertEqual(result, "poll question")
+
+    def test_falls_back_to_str_for_unknown_type(self):
+        """Falls back to str() for unknown types."""
+        self.assertEqual(self.backup._text_with_entities_to_string(42), "42")
+
+
+class TestGetMediaType(unittest.TestCase):
+    """Test _get_media_type detection for all media types."""
+
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+
+    def test_photo_returns_photo(self):
+        """MessageMediaPhoto is detected as photo type."""
+        media = MagicMock(spec=MessageMediaPhoto)
+        self.assertEqual(self.backup._get_media_type(media), "photo")
+
+    def test_document_returns_document(self):
+        """Plain document without special attributes returns document."""
+        media = MagicMock(spec=MessageMediaDocument)
+        media.document = MagicMock()
+        media.document.attributes = []
+        self.assertEqual(self.backup._get_media_type(media), "document")
+
+    def test_document_with_video_attr_returns_video(self):
+        """Document with Video attribute returns video type."""
+        media = MagicMock(spec=MessageMediaDocument)
+        media.document = MagicMock()
+        video_attr = MagicMock()
+        type(video_attr).__name__ = "DocumentAttributeVideo"
+        media.document.attributes = [video_attr]
+        self.assertEqual(self.backup._get_media_type(media), "video")
+
+    def test_animated_video_returns_animation(self):
+        """Document with Animated + Video attributes returns animation type."""
+        media = MagicMock(spec=MessageMediaDocument)
+        media.document = MagicMock()
+        anim_attr = MagicMock()
+        type(anim_attr).__name__ = "DocumentAttributeAnimated"
+        video_attr = MagicMock()
+        type(video_attr).__name__ = "DocumentAttributeVideo"
+        media.document.attributes = [anim_attr, video_attr]
+        self.assertEqual(self.backup._get_media_type(media), "animation")
+
+    def test_animated_without_video_returns_animation(self):
+        """Document with Animated attribute alone returns animation type."""
+        media = MagicMock(spec=MessageMediaDocument)
+        media.document = MagicMock()
+        anim_attr = MagicMock()
+        type(anim_attr).__name__ = "DocumentAttributeAnimated"
+        media.document.attributes = [anim_attr]
+        self.assertEqual(self.backup._get_media_type(media), "animation")
+
+    def test_audio_attr_returns_audio(self):
+        """Document with Audio attribute (not voice) returns audio type."""
+        media = MagicMock(spec=MessageMediaDocument)
+        media.document = MagicMock()
+        audio_attr = MagicMock()
+        type(audio_attr).__name__ = "DocumentAttributeAudio"
+        audio_attr.voice = False
+        media.document.attributes = [audio_attr]
+        self.assertEqual(self.backup._get_media_type(media), "audio")
+
+    def test_voice_note_returns_voice(self):
+        """Document with Audio attribute and voice=True returns voice type."""
+        media = MagicMock(spec=MessageMediaDocument)
+        media.document = MagicMock()
+        voice_attr = MagicMock()
+        type(voice_attr).__name__ = "DocumentAttributeAudio"
+        voice_attr.voice = True
+        media.document.attributes = [voice_attr]
+        self.assertEqual(self.backup._get_media_type(media), "voice")
+
+    def test_sticker_returns_sticker(self):
+        """Document with Sticker attribute returns sticker type."""
+        media = MagicMock(spec=MessageMediaDocument)
+        media.document = MagicMock()
+        sticker_attr = MagicMock()
+        type(sticker_attr).__name__ = "DocumentAttributeSticker"
+        media.document.attributes = [sticker_attr]
+        self.assertEqual(self.backup._get_media_type(media), "sticker")
+
+    def test_contact_returns_contact(self):
+        """MessageMediaContact is detected as contact type."""
+        media = MagicMock(spec=MessageMediaContact)
+        self.assertEqual(self.backup._get_media_type(media), "contact")
+
+    def test_geo_returns_geo(self):
+        """MessageMediaGeo is detected as geo type."""
+        media = MagicMock(spec=MessageMediaGeo)
+        self.assertEqual(self.backup._get_media_type(media), "geo")
+
+    def test_poll_returns_poll(self):
+        """MessageMediaPoll is detected as poll type."""
+        media = MagicMock(spec=MessageMediaPoll)
+        self.assertEqual(self.backup._get_media_type(media), "poll")
+
+    def test_unknown_media_returns_none(self):
+        """Unknown media type returns None."""
+        media = MagicMock()
+        self.assertIsNone(self.backup._get_media_type(media))
+
+    def test_document_without_document_attr_returns_document(self):
+        """MessageMediaDocument with no .document returns document."""
+        media = MagicMock(spec=MessageMediaDocument)
+        media.document = None
+        self.assertEqual(self.backup._get_media_type(media), "document")
+
+
+class TestGetMediaExtension(unittest.TestCase):
+    """Test _get_media_extension fallback extension lookup."""
+
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+
+    def test_photo_returns_jpg(self):
+        """Photo type maps to jpg extension."""
+        self.assertEqual(self.backup._get_media_extension("photo"), "jpg")
+
+    def test_video_returns_mp4(self):
+        """Video type maps to mp4 extension."""
+        self.assertEqual(self.backup._get_media_extension("video"), "mp4")
+
+    def test_audio_returns_mp3(self):
+        """Audio type maps to mp3 extension."""
+        self.assertEqual(self.backup._get_media_extension("audio"), "mp3")
+
+    def test_voice_returns_ogg(self):
+        """Voice type maps to ogg extension."""
+        self.assertEqual(self.backup._get_media_extension("voice"), "ogg")
+
+    def test_document_returns_bin(self):
+        """Document type maps to bin extension."""
+        self.assertEqual(self.backup._get_media_extension("document"), "bin")
+
+    def test_unknown_type_returns_bin(self):
+        """Unknown media type falls back to bin extension."""
+        self.assertEqual(self.backup._get_media_extension("unknown_type"), "bin")
+
+
+class TestExtractChatData(unittest.TestCase):
+    """Test _extract_chat_data for User, Chat, and Channel entities."""
+
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup._get_marked_id = MagicMock(return_value=100)
+
+    def test_user_entity_extracts_private_chat(self):
+        """User entity produces a private chat with name and phone."""
+        user = MagicMock(spec=User)
+        user.first_name = "Alice"
+        user.last_name = "Smith"
+        user.username = "alice"
+        user.phone = "+1234567890"
+
+        result = self.backup._extract_chat_data(user)
+
+        self.assertEqual(result["type"], "private")
+        self.assertEqual(result["first_name"], "Alice")
+        self.assertEqual(result["last_name"], "Smith")
+        self.assertEqual(result["username"], "alice")
+        self.assertEqual(result["is_archived"], 0)
+
+    def test_chat_entity_extracts_group(self):
+        """Chat entity produces a group with title and participants."""
+        chat = MagicMock(spec=Chat)
+        chat.title = "Family Group"
+        chat.participants_count = 5
+
+        result = self.backup._extract_chat_data(chat)
+
+        self.assertEqual(result["type"], "group")
+        self.assertEqual(result["title"], "Family Group")
+        self.assertEqual(result["participants_count"], 5)
+
+    def test_channel_entity_extracts_channel(self):
+        """Channel entity (not megagroup) produces a channel type."""
+        channel = MagicMock(spec=Channel)
+        channel.megagroup = False
+        channel.title = "News Channel"
+        channel.username = "news"
+        channel.forum = False
+
+        result = self.backup._extract_chat_data(channel)
+
+        self.assertEqual(result["type"], "channel")
+        self.assertEqual(result["title"], "News Channel")
+
+    def test_channel_megagroup_extracts_group(self):
+        """Channel entity with megagroup=True produces group type."""
+        channel = MagicMock(spec=Channel)
+        channel.megagroup = True
+        channel.title = "Super Group"
+        channel.username = "supergroup"
+        channel.forum = False
+
+        result = self.backup._extract_chat_data(channel)
+
+        self.assertEqual(result["type"], "group")
+
+    def test_forum_channel_sets_is_forum(self):
+        """Channel with forum=True sets is_forum=1."""
+        channel = MagicMock(spec=Channel)
+        channel.megagroup = True
+        channel.title = "Forum Group"
+        channel.username = "forum"
+        channel.forum = True
+
+        result = self.backup._extract_chat_data(channel)
+
+        self.assertEqual(result["is_forum"], 1)
+
+    def test_archived_flag_set_when_true(self):
+        """is_archived=1 when is_archived parameter is True."""
+        user = MagicMock(spec=User)
+        user.first_name = "Bob"
+        user.last_name = None
+        user.username = None
+        user.phone = None
+
+        result = self.backup._extract_chat_data(user, is_archived=True)
+
+        self.assertEqual(result["is_archived"], 1)
+
+
+class TestExtractUserData(unittest.TestCase):
+    """Test _extract_user_data for User and non-User entities."""
+
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+
+    def test_extracts_user_fields(self):
+        """Returns dict with all user fields for a User entity."""
+        user = MagicMock(spec=User)
+        user.id = 42
+        user.username = "testuser"
+        user.first_name = "Test"
+        user.last_name = "User"
+        user.phone = "+1111"
+        user.bot = False
+
+        result = self.backup._extract_user_data(user)
+
+        self.assertEqual(result["id"], 42)
+        self.assertEqual(result["username"], "testuser")
+        self.assertEqual(result["first_name"], "Test")
+        self.assertFalse(result["is_bot"])
+
+    def test_returns_none_for_non_user(self):
+        """Returns None when entity is not a User."""
+        channel = MagicMock(spec=Channel)
+        self.assertIsNone(self.backup._extract_user_data(channel))
+
+    def test_returns_none_for_chat(self):
+        """Returns None when entity is a Chat."""
+        chat = MagicMock(spec=Chat)
+        self.assertIsNone(self.backup._extract_user_data(chat))
+
+
+class TestGetChatName(unittest.TestCase):
+    """Test _get_chat_name readable name generation."""
+
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+
+    def test_user_with_full_name_and_username(self):
+        """User with first, last name and username returns formatted string."""
+        user = MagicMock(spec=User)
+        user.id = 1
+        user.first_name = "Alice"
+        user.last_name = "Smith"
+        user.username = "alice"
+        self.assertEqual(self.backup._get_chat_name(user), "Alice Smith (@alice)")
+
+    def test_user_with_first_name_only(self):
+        """User with only first name returns that name."""
+        user = MagicMock(spec=User)
+        user.id = 2
+        user.first_name = "Bob"
+        user.last_name = None
+        user.username = None
+        self.assertEqual(self.backup._get_chat_name(user), "Bob")
+
+    def test_user_with_no_name_returns_fallback(self):
+        """User with no name returns User ID fallback."""
+        user = MagicMock(spec=User)
+        user.id = 3
+        user.first_name = ""
+        user.last_name = None
+        user.username = None
+        self.assertEqual(self.backup._get_chat_name(user), "User 3")
+
+    def test_channel_returns_title(self):
+        """Channel returns its title."""
+        channel = MagicMock(spec=Channel)
+        channel.id = 10
+        channel.title = "My Channel"
+        self.assertEqual(self.backup._get_chat_name(channel), "My Channel")
+
+    def test_chat_returns_title(self):
+        """Chat group returns its title."""
+        chat = MagicMock(spec=Chat)
+        chat.id = 20
+        chat.title = "Family Chat"
+        self.assertEqual(self.backup._get_chat_name(chat), "Family Chat")
+
+    def test_unknown_entity_returns_unknown(self):
+        """Unknown entity type returns Unknown + ID."""
+        entity = MagicMock()
+        entity.id = 99
+        self.assertEqual(self.backup._get_chat_name(entity), "Unknown 99")
+
+
+class TestProcessMessage(unittest.TestCase):
+    """Test _process_message extracts message data correctly."""
+
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.db = AsyncMock()
+        self.backup.config = MagicMock()
+        self.backup.config.should_download_media_for_chat = MagicMock(return_value=False)
+        self.backup.client = AsyncMock()
+
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def _make_message(self, msg_id, text="hello", sender_id=42):
+        """Create a minimal mock message."""
+        msg = MagicMock()
+        msg.id = msg_id
+        msg.sender = None
+        msg.sender_id = sender_id
+        msg.date = datetime(2024, 1, 1)
+        msg.text = text
+        msg.reply_to_msg_id = None
+        msg.reply_to = None
+        msg.edit_date = None
+        msg.out = False
+        msg.pinned = False
+        msg.grouped_id = None
+        msg.fwd_from = None
+        msg.media = None
+        msg.reactions = None
+        msg.post_author = None
+        return msg
+
+    def test_basic_text_message(self):
+        """Basic text message extracts id, chat_id, text, and sender_id."""
+        msg = self._make_message(1, text="test message")
+        result = self._run(self.backup._process_message(msg, 100))
+
+        self.assertEqual(result["id"], 1)
+        self.assertEqual(result["chat_id"], 100)
+        self.assertEqual(result["text"], "test message")
+        self.assertEqual(result["sender_id"], 42)
+        self.assertEqual(result["is_outgoing"], 0)
+        self.assertEqual(result["is_pinned"], 0)
+
+    def test_outgoing_message_sets_flag(self):
+        """Outgoing message sets is_outgoing=1."""
+        msg = self._make_message(2)
+        msg.out = True
+        result = self._run(self.backup._process_message(msg, 100))
+        self.assertEqual(result["is_outgoing"], 1)
+
+    def test_pinned_message_sets_flag(self):
+        """Pinned message sets is_pinned=1."""
+        msg = self._make_message(3)
+        msg.pinned = True
+        result = self._run(self.backup._process_message(msg, 100))
+        self.assertEqual(result["is_pinned"], 1)
+
+    def test_grouped_id_stored_in_raw_data(self):
+        """Grouped ID (album) is stored in raw_data."""
+        msg = self._make_message(4)
+        msg.grouped_id = 9876543210
+        result = self._run(self.backup._process_message(msg, 100))
+        self.assertEqual(result["raw_data"]["grouped_id"], "9876543210")
+
+    def test_forward_from_name_stored(self):
+        """Forward with from_name stores it in raw_data."""
+        msg = self._make_message(5)
+        msg.fwd_from = MagicMock()
+        msg.fwd_from.from_name = "Original Author"
+        msg.fwd_from.from_id = None
+        result = self._run(self.backup._process_message(msg, 100))
+        self.assertEqual(result["raw_data"]["forward_from_name"], "Original Author")
+
+    def test_post_author_stored(self):
+        """Channel post author signature is stored in raw_data."""
+        msg = self._make_message(6)
+        msg.post_author = "Editor Name"
+        result = self._run(self.backup._process_message(msg, 100))
+        self.assertEqual(result["raw_data"]["post_author"], "Editor Name")
+
+    def test_none_text_becomes_empty_string(self):
+        """Message with None text stores empty string."""
+        msg = self._make_message(7, text=None)
+        result = self._run(self.backup._process_message(msg, 100))
+        self.assertEqual(result["text"], "")
+
+    def test_sender_data_upserted_when_sender_is_user(self):
+        """When sender is a User, upsert_user is called."""
+        msg = self._make_message(8)
+        user = MagicMock(spec=User)
+        user.id = 42
+        user.username = "sender"
+        user.first_name = "Sender"
+        user.last_name = None
+        user.phone = None
+        user.bot = False
+        msg.sender = user
+
+        self._run(self.backup._process_message(msg, 100))
+
+        self.backup.db.upsert_user.assert_awaited_once()
+
+    def test_reactions_extracted_with_emoticon(self):
+        """Reactions with emoticon emoji are extracted correctly."""
+        msg = self._make_message(9)
+        reaction = MagicMock()
+        reaction.reaction = MagicMock(spec=["emoticon"])
+        reaction.reaction.emoticon = "thumbs_up"
+        reaction.count = 3
+        reaction.recent_reactions = None
+        msg.reactions = MagicMock()
+        msg.reactions.results = [reaction]
+
+        result = self._run(self.backup._process_message(msg, 100))
+
+        self.assertEqual(len(result["reactions"]), 1)
+        self.assertEqual(result["reactions"][0]["emoji"], "thumbs_up")
+        self.assertEqual(result["reactions"][0]["count"], 3)
+
+    def test_reactions_with_custom_emoji(self):
+        """Reactions with custom emoji document_id are stored as custom_ prefix."""
+        msg = self._make_message(10)
+        reaction = MagicMock()
+        emoji_obj = MagicMock(spec=["document_id"])
+        emoji_obj.document_id = 12345
+        reaction.reaction = emoji_obj
+        reaction.count = 1
+        reaction.recent_reactions = None
+        msg.reactions = MagicMock()
+        msg.reactions.results = [reaction]
+
+        result = self._run(self.backup._process_message(msg, 100))
+
+        self.assertEqual(result["reactions"][0]["emoji"], "custom_12345")
+
+    def test_reply_to_text_truncated(self):
+        """Reply text is truncated to 100 characters."""
+        msg = self._make_message(11)
+        msg.reply_to_msg_id = 5
+        msg.reply_to = MagicMock()
+        msg.reply_to.message = "a" * 200
+        msg.reply_to.forum_topic = False
+
+        result = self._run(self.backup._process_message(msg, 100))
+
+        self.assertEqual(len(result["reply_to_text"]), 100)
+
+    def test_forward_from_id_resolves_channel_title(self):
+        """Forward from channel resolves title via get_entity."""
+        msg = self._make_message(12)
+        msg.fwd_from = MagicMock()
+        msg.fwd_from.from_name = None
+        msg.fwd_from.from_id = MagicMock(spec=["channel_id"])
+        msg.fwd_from.from_id.channel_id = 555
+
+        fwd_entity = MagicMock()
+        fwd_entity.title = "Forwarded Channel"
+        del fwd_entity.first_name  # ensure hasattr(, 'title') path is taken
+        self.backup.client.get_entity = AsyncMock(return_value=fwd_entity)
+
+        result = self._run(self.backup._process_message(msg, 100))
+
+        self.assertEqual(result["raw_data"]["forward_from_name"], "Forwarded Channel")
+
+    def test_forward_from_id_resolves_user_name(self):
+        """Forward from user resolves first+last name via get_entity."""
+        msg = self._make_message(13)
+        msg.fwd_from = MagicMock()
+        msg.fwd_from.from_name = None
+        msg.fwd_from.from_id = MagicMock(spec=["user_id"])
+        msg.fwd_from.from_id.user_id = 777
+
+        fwd_entity = MagicMock(spec=["first_name", "last_name"])
+        fwd_entity.first_name = "John"
+        fwd_entity.last_name = "Doe"
+        self.backup.client.get_entity = AsyncMock(return_value=fwd_entity)
+
+        result = self._run(self.backup._process_message(msg, 100))
+
+        self.assertEqual(result["raw_data"]["forward_from_name"], "John Doe")
+
+    def test_forward_from_id_get_entity_failure_graceful(self):
+        """Forward entity resolution failure does not crash."""
+        msg = self._make_message(14)
+        msg.fwd_from = MagicMock()
+        msg.fwd_from.from_name = None
+        msg.fwd_from.from_id = MagicMock(spec=["user_id"])
+        msg.fwd_from.from_id.user_id = 888
+
+        self.backup.client.get_entity = AsyncMock(side_effect=Exception("not found"))
+
+        result = self._run(self.backup._process_message(msg, 100))
+
+        # Should not have forward_from_name since resolution failed
+        self.assertNotIn("forward_from_name", result["raw_data"])
+
+    def test_poll_media_stored_in_raw_data(self):
+        """Poll media stores question, answers, and results in raw_data."""
+        msg = self._make_message(15)
+
+        poll = MagicMock()
+        poll.id = 9999
+        poll.question = "What color?"
+        poll.closed = False
+        poll.public_voters = True
+        poll.multiple_choice = False
+        poll.quiz = False
+
+        answer1 = MagicMock()
+        answer1.text = "Red"
+        answer1.option = b"\x00"
+        answer2 = MagicMock()
+        answer2.text = "Blue"
+        answer2.option = b"\x01"
+        poll.answers = [answer1, answer2]
+
+        result_entry = MagicMock()
+        result_entry.option = b"\x00"
+        result_entry.voters = 5
+        result_entry.correct = True
+
+        results = MagicMock()
+        results.total_voters = 10
+        results.results = [result_entry]
+
+        media = MagicMock(spec=MessageMediaPoll)
+        media.poll = poll
+        media.results = results
+        msg.media = media
+
+        result = self._run(self.backup._process_message(msg, 100))
+
+        poll_data = result["raw_data"]["poll"]
+        self.assertEqual(poll_data["id"], 9999)
+        self.assertEqual(poll_data["question"], "What color?")
+        self.assertEqual(len(poll_data["answers"]), 2)
+        self.assertFalse(poll_data["closed"])
+        self.assertTrue(poll_data["public_voters"])
+        self.assertIsNotNone(poll_data["results"])
+        self.assertEqual(poll_data["results"]["total_voters"], 10)
+
+    def test_downloadable_media_calls_process_media(self):
+        """Non-poll media triggers _process_media when download is enabled."""
+        msg = self._make_message(16)
+        msg.media = MagicMock(spec=MessageMediaPhoto)
+
+        self.backup.config.should_download_media_for_chat = MagicMock(return_value=True)
+        self.backup._process_media = AsyncMock(return_value={"file_path": "/a.jpg"})
+
+        result = self._run(self.backup._process_message(msg, 100))
+
+        self.backup._process_media.assert_awaited_once()
+        self.assertEqual(result["_media_data"]["file_path"], "/a.jpg")
+
+    def test_media_download_disabled_skips_process_media(self):
+        """Non-poll media is skipped when download is disabled for chat."""
+        msg = self._make_message(17)
+        msg.media = MagicMock(spec=MessageMediaPhoto)
+
+        self.backup.config.should_download_media_for_chat = MagicMock(return_value=False)
+        self.backup._process_media = AsyncMock()
+
+        result = self._run(self.backup._process_message(msg, 100))
+
+        self.backup._process_media.assert_not_awaited()
+        self.assertNotIn("_media_data", result)
+
+    def test_reactions_with_recent_user_peers(self):
+        """Reactions with recent_reactions extract user_ids from peers."""
+        msg = self._make_message(18)
+
+        peer1 = MagicMock(spec=["user_id"])
+        peer1.user_id = 101
+        peer2 = MagicMock(spec=["user_id"])
+        peer2.user_id = 102
+
+        recent1 = MagicMock()
+        recent1.peer_id = peer1
+        recent2 = MagicMock()
+        recent2.peer_id = peer2
+
+        reaction = MagicMock()
+        reaction.reaction = MagicMock(spec=["emoticon"])
+        reaction.reaction.emoticon = "heart"
+        reaction.count = 5
+        reaction.recent_reactions = [recent1, recent2]
+
+        msg.reactions = MagicMock()
+        msg.reactions.results = [reaction]
+
+        result = self._run(self.backup._process_message(msg, 100))
+
+        self.assertEqual(result["reactions"][0]["user_ids"], [101, 102])
+
+
+class TestCommitBatchReactions(unittest.TestCase):
+    """Test _commit_batch reaction expansion logic."""
+
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.db = AsyncMock()
+
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def test_reaction_with_known_users_expanded(self):
+        """Reactions with user_ids expand into per-user rows plus anonymous remainder."""
+        batch = [
+            {
+                "id": 1,
+                "chat_id": 100,
+                "reactions": [
+                    {"emoji": "heart", "count": 5, "user_ids": [10, 20]},
+                ],
+            }
+        ]
+
+        self._run(self.backup._commit_batch(batch, 100))
+
+        call_args = self.backup.db.insert_reactions.call_args
+        reactions_list = call_args[0][2]
+        # 2 per-user rows + 1 anonymous (5-2=3 remaining)
+        self.assertEqual(len(reactions_list), 3)
+        self.assertEqual(reactions_list[0]["user_id"], 10)
+        self.assertEqual(reactions_list[1]["user_id"], 20)
+        self.assertIsNone(reactions_list[2]["user_id"])
+        self.assertEqual(reactions_list[2]["count"], 3)
+
+    def test_reaction_without_users_creates_anonymous_row(self):
+        """Reactions without user_ids create a single anonymous row."""
+        batch = [
+            {
+                "id": 2,
+                "chat_id": 100,
+                "reactions": [
+                    {"emoji": "fire", "count": 7, "user_ids": []},
+                ],
+            }
+        ]
+
+        self._run(self.backup._commit_batch(batch, 100))
+
+        call_args = self.backup.db.insert_reactions.call_args
+        reactions_list = call_args[0][2]
+        self.assertEqual(len(reactions_list), 1)
+        self.assertIsNone(reactions_list[0]["user_id"])
+        self.assertEqual(reactions_list[0]["count"], 7)
+
+    def test_no_reactions_skips_insert(self):
+        """Messages with no reactions do not call insert_reactions."""
+        batch = [
+            {"id": 3, "chat_id": 100, "reactions": []},
+            {"id": 4, "chat_id": 100, "reactions": None},
+        ]
+
+        self._run(self.backup._commit_batch(batch, 100))
+
+        self.backup.db.insert_reactions.assert_not_awaited()
+
+    def test_batch_with_no_media_skips_insert_media(self):
+        """Messages without _media_data do not call insert_media."""
+        batch = [
+            {"id": 5, "chat_id": 100, "reactions": []},
+        ]
+
+        self._run(self.backup._commit_batch(batch, 100))
+
+        self.backup.db.insert_media.assert_not_awaited()
+
+
+class TestBackupForumTopics(unittest.TestCase):
+    """Test _backup_forum_topics with API path and skip filtering."""
+
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.db = AsyncMock()
+        self.backup.client = AsyncMock()
+        self.backup.config = MagicMock()
+        self.backup.config.should_skip_topic = MagicMock(return_value=False)
+
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def _make_topic(self, topic_id, title, closed=False, pinned=False, hidden=False):
+        """Create a mock forum topic."""
+        topic = MagicMock()
+        topic.id = topic_id
+        topic.title = title
+        topic.icon_color = 0x1234
+        topic.icon_emoji_id = None
+        topic.closed = closed
+        topic.pinned = pinned
+        topic.hidden = hidden
+        topic.date = datetime(2024, 6, 1)
+        return topic
+
+    def test_api_path_stores_all_topics(self):
+        """API path stores all topics when none are excluded."""
+        topics = [self._make_topic(1, "General"), self._make_topic(2, "Off-Topic")]
+
+        result_obj = MagicMock()
+        result_obj.topics = topics
+
+        # client(...) is an async callable -- AsyncMock handles this directly
+        self.backup.client = AsyncMock()
+        self.backup.client.get_input_entity = AsyncMock(return_value=MagicMock())
+        self.backup.client.return_value = result_obj
+
+        entity = MagicMock()
+        count = self._run(self.backup._backup_forum_topics(-100123, entity))
+
+        self.assertEqual(count, 2)
+        self.assertEqual(self.backup.db.upsert_forum_topic.await_count, 2)
+
+    def test_api_path_skips_excluded_topics(self):
+        """API path skips topics matching should_skip_topic."""
+        topics = [self._make_topic(1, "General"), self._make_topic(42, "Spam")]
+
+        result_obj = MagicMock()
+        result_obj.topics = topics
+
+        self.backup.client = AsyncMock()
+        self.backup.client.get_input_entity = AsyncMock(return_value=MagicMock())
+        self.backup.client.return_value = result_obj
+        self.backup.config.should_skip_topic = MagicMock(side_effect=lambda chat_id, topic_id: topic_id == 42)
+
+        entity = MagicMock()
+        count = self._run(self.backup._backup_forum_topics(-100123, entity))
+
+        self.assertEqual(count, 1)
+        self.assertEqual(self.backup.db.upsert_forum_topic.await_count, 1)
+
+    def test_api_path_topic_data_includes_correct_fields(self):
+        """API path passes correct topic data to upsert_forum_topic."""
+        topic = self._make_topic(7, "Important", closed=True, pinned=True, hidden=False)
+        result_obj = MagicMock()
+        result_obj.topics = [topic]
+
+        self.backup.client = AsyncMock()
+        self.backup.client.get_input_entity = AsyncMock(return_value=MagicMock())
+        self.backup.client.return_value = result_obj
+
+        entity = MagicMock()
+        self._run(self.backup._backup_forum_topics(-100999, entity))
+
+        call_args = self.backup.db.upsert_forum_topic.call_args[0][0]
+        self.assertEqual(call_args["id"], 7)
+        self.assertEqual(call_args["chat_id"], -100999)
+        self.assertEqual(call_args["title"], "Important")
+        self.assertEqual(call_args["is_closed"], 1)
+        self.assertEqual(call_args["is_pinned"], 1)
+        self.assertEqual(call_args["is_hidden"], 0)
+
+    def test_returns_zero_on_total_failure(self):
+        """Returns 0 when both API and fallback fail."""
+        # Make GetForumTopicsRequest import succeed but API call fail
+        self.backup.client = AsyncMock()
+        self.backup.client.get_input_entity = AsyncMock(side_effect=Exception("no access"))
+
+        entity = MagicMock()
+        count = self._run(self.backup._backup_forum_topics(-100123, entity))
+
+        self.assertEqual(count, 0)
+
+
+class TestBackupDialogCursorAdvancesOnSkippedMessages(unittest.TestCase):
+    """Test that _backup_dialog advances cursor even when all messages are topic-filtered."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.config = MagicMock()
+        self.config.batch_size = 100
+        self.config.checkpoint_interval = 1
+        self.config.skip_media_chat_ids = set()
+        self.config.skip_media_delete_existing = False
+        self.config.sync_deletions_edits = False
+        self.config.media_path = os.path.join(self.temp_dir, "media")
+
+        self.db = AsyncMock()
+        self.db.get_last_message_id.return_value = 0
+
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.config = self.config
+        self.backup.db = self.db
+        self.backup.client = MagicMock()
+        self.backup._cleaned_media_chats = set()
+        self.backup._get_marked_id = MagicMock(return_value=-1001234567890)
+        self.backup._extract_chat_data = MagicMock(return_value={"id": -1001234567890})
+        self.backup._ensure_profile_photo = AsyncMock()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def _make_dialog(self):
+        dialog = MagicMock()
+        dialog.entity = MagicMock()
+        return dialog
+
+    def test_cursor_advances_when_all_messages_skipped_by_topic_filter(self):
+        """When all messages are topic-filtered, sync_status still updates with max ID."""
+        # All messages belong to excluded topic 42
+        self.config.should_skip_topic = MagicMock(return_value=True)
+
+        msg1 = MagicMock()
+        msg1.id = 50
+        msg1.reply_to = MagicMock()
+        msg1.reply_to.forum_topic = True
+        msg1.reply_to.reply_to_top_id = 42
+        msg1.reply_to.reply_to_msg_id = 42
+
+        msg2 = MagicMock()
+        msg2.id = 100
+        msg2.reply_to = MagicMock()
+        msg2.reply_to.forum_topic = True
+        msg2.reply_to.reply_to_top_id = 42
+        msg2.reply_to.reply_to_msg_id = 42
+
+        async def fake_iter(*args, **kwargs):
+            yield msg1
+            yield msg2
+
+        self.backup.client.iter_messages = fake_iter
+        self.backup._process_message = AsyncMock()
+        self.backup._commit_batch = AsyncMock()
+        self.backup._sync_pinned_messages = AsyncMock()
+
+        result = self._run(self.backup._backup_dialog(self._make_dialog()))
+
+        # 0 messages processed but cursor should still advance
+        self.assertEqual(result, 0)
+        self.backup._process_message.assert_not_awaited()
+        # sync_status should be called with max_id=100
+        self.db.update_sync_status.assert_awaited_once()
+        call_args = self.db.update_sync_status.call_args[0]
+        self.assertEqual(call_args[1], 100)
 
 
 if __name__ == "__main__":

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 from telethon.tl.types import Channel
 
+from src.message_utils import extract_topic_id
 from src.telegram_backup import TelegramBackup
 
 
@@ -694,6 +695,44 @@ class TestWhitelistModeBackup(unittest.TestCase):
         self._run(self.backup.backup_all())
 
         self.backup.client.get_dialogs.assert_not_called()
+
+
+class TestExtractTopicId(unittest.TestCase):
+    """Test the shared extract_topic_id utility."""
+
+    def test_returns_none_when_no_reply_to(self):
+        msg = MagicMock()
+        msg.reply_to = None
+        self.assertIsNone(extract_topic_id(msg))
+
+    def test_returns_none_when_not_forum_topic(self):
+        msg = MagicMock()
+        msg.reply_to = MagicMock()
+        msg.reply_to.forum_topic = False
+        self.assertIsNone(extract_topic_id(msg))
+
+    def test_returns_reply_to_top_id(self):
+        msg = MagicMock()
+        msg.reply_to = MagicMock()
+        msg.reply_to.forum_topic = True
+        msg.reply_to.reply_to_top_id = 42
+        self.assertEqual(extract_topic_id(msg), 42)
+
+    def test_falls_back_to_reply_to_msg_id(self):
+        msg = MagicMock()
+        msg.reply_to = MagicMock()
+        msg.reply_to.forum_topic = True
+        msg.reply_to.reply_to_top_id = None
+        msg.reply_to.reply_to_msg_id = 99
+        self.assertEqual(extract_topic_id(msg), 99)
+
+    def test_returns_none_when_both_ids_none(self):
+        msg = MagicMock()
+        msg.reply_to = MagicMock()
+        msg.reply_to.forum_topic = True
+        msg.reply_to.reply_to_top_id = None
+        msg.reply_to.reply_to_msg_id = None
+        self.assertIsNone(extract_topic_id(msg))
 
 
 if __name__ == "__main__":

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -315,6 +315,7 @@ class TestBackupCheckpointing(unittest.TestCase):
         self.config.skip_media_chat_ids = set()
         self.config.skip_media_delete_existing = False
         self.config.sync_deletions_edits = False
+        self.config.should_skip_topic = MagicMock(return_value=False)
         self.config.media_path = os.path.join(self.temp_dir, "media")
 
         self.db = AsyncMock()
@@ -344,9 +345,13 @@ class TestBackupCheckpointing(unittest.TestCase):
         dialog.entity = MagicMock()
         return dialog
 
-    def _make_message(self, msg_id):
+    def _make_message(self, msg_id, reply_to=None):
         msg = MagicMock()
         msg.id = msg_id
+        # Explicitly set reply_to to None (non-forum message) so the
+        # topic-skip guard in _backup_dialog doesn't accidentally filter
+        # every message via MagicMock truthiness.
+        msg.reply_to = reply_to
         return msg
 
     def test_checkpoint_after_every_batch(self):
@@ -461,6 +466,151 @@ class TestBackupCheckpointing(unittest.TestCase):
         backup.db.insert_messages_batch.assert_awaited_once_with(batch)
         backup.db.insert_media.assert_awaited_once_with({"file_path": "/a.jpg"})
         backup.db.insert_reactions.assert_awaited_once()
+
+
+class TestTopicFilteringInBackupDialog(unittest.TestCase):
+    """Test that _backup_dialog respects SKIP_TOPIC_IDS filtering."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+        self.config = MagicMock()
+        self.config.batch_size = 100
+        self.config.checkpoint_interval = 1
+        self.config.skip_media_chat_ids = set()
+        self.config.skip_media_delete_existing = False
+        self.config.sync_deletions_edits = False
+        self.config.media_path = os.path.join(self.temp_dir, "media")
+
+        self.db = AsyncMock()
+        self.db.get_last_message_id.return_value = 0
+
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.config = self.config
+        self.backup.db = self.db
+        self.backup.client = MagicMock()
+        self.backup._cleaned_media_chats = set()
+        self.backup._get_marked_id = MagicMock(return_value=-1001234567890)
+        self.backup._extract_chat_data = MagicMock(return_value={"id": -1001234567890})
+        self.backup._ensure_profile_photo = AsyncMock()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def _make_dialog(self):
+        dialog = MagicMock()
+        dialog.entity = MagicMock()
+        return dialog
+
+    def _make_forum_message(self, msg_id, topic_id):
+        """Create a mock message belonging to a forum topic."""
+        msg = MagicMock()
+        msg.id = msg_id
+        msg.reply_to = MagicMock()
+        msg.reply_to.forum_topic = True
+        msg.reply_to.reply_to_top_id = topic_id
+        msg.reply_to.reply_to_msg_id = topic_id
+        return msg
+
+    def _make_normal_message(self, msg_id):
+        """Create a mock message that is not in any forum topic."""
+        msg = MagicMock()
+        msg.id = msg_id
+        msg.reply_to = None
+        return msg
+
+    def test_backup_dialog_skips_messages_in_excluded_topics(self):
+        """Messages in excluded forum topics should not be backed up."""
+        # Configure: skip topic 42 in chat -1001234567890
+        self.config.should_skip_topic = MagicMock(
+            side_effect=lambda chat_id, topic_id: topic_id == 42
+        )
+
+        messages = [
+            self._make_normal_message(1),       # kept (no topic)
+            self._make_forum_message(2, 42),     # skipped (excluded topic)
+            self._make_forum_message(3, 99),     # kept (different topic)
+            self._make_forum_message(4, 42),     # skipped (excluded topic)
+            self._make_normal_message(5),        # kept (no topic)
+        ]
+
+        async def fake_iter(*args, **kwargs):
+            for m in messages:
+                yield m
+
+        self.backup.client.iter_messages = fake_iter
+        self.backup._process_message = AsyncMock(
+            side_effect=lambda m, c: {"id": m.id, "chat_id": c}
+        )
+        self.backup._commit_batch = AsyncMock()
+        self.backup._sync_pinned_messages = AsyncMock()
+
+        result = self._run(self.backup._backup_dialog(self._make_dialog()))
+
+        # 3 messages kept (IDs 1, 3, 5), 2 skipped (IDs 2, 4)
+        self.assertEqual(result, 3)
+        # _process_message should only be called for kept messages
+        self.assertEqual(self.backup._process_message.await_count, 3)
+
+    def test_backup_dialog_keeps_all_messages_when_no_topics_excluded(self):
+        """When no topics are excluded, all messages pass through."""
+        self.config.should_skip_topic = MagicMock(return_value=False)
+
+        messages = [
+            self._make_forum_message(1, 42),
+            self._make_forum_message(2, 99),
+            self._make_normal_message(3),
+        ]
+
+        async def fake_iter(*args, **kwargs):
+            for m in messages:
+                yield m
+
+        self.backup.client.iter_messages = fake_iter
+        self.backup._process_message = AsyncMock(
+            side_effect=lambda m, c: {"id": m.id, "chat_id": c}
+        )
+        self.backup._commit_batch = AsyncMock()
+        self.backup._sync_pinned_messages = AsyncMock()
+
+        result = self._run(self.backup._backup_dialog(self._make_dialog()))
+
+        self.assertEqual(result, 3)
+
+    def test_backup_dialog_uses_reply_to_msg_id_as_fallback(self):
+        """When reply_to_top_id is None, falls back to reply_to_msg_id for topic ID."""
+        self.config.should_skip_topic = MagicMock(
+            side_effect=lambda chat_id, topic_id: topic_id == 42
+        )
+
+        msg = MagicMock()
+        msg.id = 1
+        msg.reply_to = MagicMock()
+        msg.reply_to.forum_topic = True
+        msg.reply_to.reply_to_top_id = None  # no top_id
+        msg.reply_to.reply_to_msg_id = 42     # fallback to this
+
+        async def fake_iter(*args, **kwargs):
+            yield msg
+
+        self.backup.client.iter_messages = fake_iter
+        self.backup._process_message = AsyncMock(
+            side_effect=lambda m, c: {"id": m.id, "chat_id": c}
+        )
+        self.backup._commit_batch = AsyncMock()
+        self.backup._sync_pinned_messages = AsyncMock()
+
+        result = self._run(self.backup._backup_dialog(self._make_dialog()))
+
+        # Message should be skipped via fallback topic ID
+        self.assertEqual(result, 0)
 
 
 class TestWhitelistModeBackup(unittest.TestCase):

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -417,8 +417,9 @@ class TestBackupCheckpointing(unittest.TestCase):
         """When there are no new messages, no checkpoint should happen."""
 
         async def fake_iter(*args, **kwargs):
+            if False:
+                yield  # pragma: no cover - makes this an async generator
             return
-            yield  # noqa: unreachable - makes this an async generator
 
         self.backup.client.iter_messages = fake_iter
         self.backup._process_message = AsyncMock()


### PR DESCRIPTION
## Summary

- Adds `SKIP_TOPIC_IDS` env var to exclude specific forum topics from backup without excluding the entire chat
- Format: `chat_id:topic_id,chat_id:topic_id,...` (e.g. `-1001234567890:42,-1001234567890:1337`)
- Filtering applied consistently in scheduled backup, gap-fill, forum topic metadata, and real-time listener (new messages + edits)
- Deletion handler intentionally excluded since `MessageDeleted` events lack topic info

## Changes

- **`src/config.py`**: New `_parse_topic_skip_list()` parser, `skip_topic_ids` property, `should_skip_topic()` method, and startup logging
- **`src/telegram_backup.py`**: Topic-level filtering in `_backup_dialog`, `_fill_gap_range`, and `_backup_forum_topics` (both API and fallback paths)
- **`src/listener.py`**: Topic-level filtering in `on_new_message` and `on_message_edited` handlers, plus startup logging
- **`tests/test_config.py`**: 12 new tests covering parsing, validation, and `should_skip_topic()` behavior
- **`README.md`**, **`docker-compose.yml`**, **`.env.example`**: Documentation for the new env var

## Test plan

- [x] All 49 config tests pass (`pytest tests/test_config.py -v`)
- [ ] Manual test with a forum supergroup containing multiple topics
- [ ] Verify excluded topic messages are skipped in scheduled backup
- [ ] Verify excluded topic messages are skipped in real-time listener
- [ ] Verify non-excluded topics in the same chat continue to be backed up

Closes #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for excluding specific forum topics from backups via the `SKIP_TOPIC_IDS` environment variable (format: `chat_id:topic_id,...`). Applies to both scheduled backups and real-time updates.

* **Documentation**
  * Updated configuration documentation and Docker Compose template to include topic filtering options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->