### PR TITLE
fix: show General forum topic messages (coalesce NULL reply_to_top_id)

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1098,9 +1098,10 @@ class DatabaseAdapter:
                 .where(Message.chat_id == chat_id)
             )
 
-            # v6.2.0: Filter by forum topic
+            # v6.2.0: Filter by forum topic. NULL reply_to_top_id == General (id=1),
+            # matching the coalesce in get_forum_topics counts.
             if topic_id is not None:
-                stmt = stmt.where(Message.reply_to_top_id == topic_id)
+                stmt = stmt.where(func.coalesce(Message.reply_to_top_id, 1) == topic_id)
 
             if search:
                 escaped = search.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")

--- a/tests/test_general_topic_messages.py
+++ b/tests/test_general_topic_messages.py
@@ -53,6 +53,9 @@ async def _make_adapter_with_messages():
             (3, datetime(2024, 3, 1, 10), "sexy topic msg", 47),
             (4, datetime(2024, 3, 2, 10), "another sexy msg", 47),
             (5, datetime(2024, 4, 1, 10), "photos topic", 144),
+            # Post-forum-enable: Telegram sets reply_to_top_id=1 explicitly on
+            # new General messages. Must appear alongside NULL rows under topic_id=1.
+            (6, datetime(2024, 5, 1, 10), "post-forum general (explicit 1)", 1),
         ]
         for mid, dt, body, top in rows:
             session.add(Message(id=mid, chat_id=chat_id, date=dt, text=body, reply_to_top_id=top))
@@ -62,13 +65,14 @@ async def _make_adapter_with_messages():
 
 
 @pytest.mark.asyncio
-async def test_general_topic_includes_null_reply_to_top_id():
-    """topic_id=1 (General) must match messages whose reply_to_top_id IS NULL."""
+async def test_general_topic_includes_null_and_explicit_one():
+    """topic_id=1 (General) must match both NULL reply_to_top_id (pre-forum) and
+    explicit reply_to_top_id=1 (post-forum-enable) messages."""
     adapter, engine, chat_id = await _make_adapter_with_messages()
     try:
         messages = await adapter.get_messages_paginated(chat_id=chat_id, topic_id=1)
         ids = sorted(m["id"] for m in messages)
-        assert ids == [1, 2], f"General (topic_id=1) must return the 2 NULL-top messages, got {ids}"
+        assert ids == [1, 2, 6], f"General (topic_id=1) must return NULL and explicit-1 messages, got {ids}"
     finally:
         await engine.dispose()
 
@@ -93,6 +97,6 @@ async def test_no_topic_filter_returns_all():
     adapter, engine, chat_id = await _make_adapter_with_messages()
     try:
         all_msgs = await adapter.get_messages_paginated(chat_id=chat_id)
-        assert sorted(m["id"] for m in all_msgs) == [1, 2, 3, 4, 5]
+        assert sorted(m["id"] for m in all_msgs) == [1, 2, 3, 4, 5, 6]
     finally:
         await engine.dispose()

--- a/tests/test_general_topic_messages.py
+++ b/tests/test_general_topic_messages.py
@@ -1,0 +1,98 @@
+"""Regression test: forum-topic message filter must include General (topic_id=1).
+
+Bug: get_forum_topics() coalesces NULL reply_to_top_id to 1 when counting
+General messages (pre-v6.2.0 messages and pre-forum messages all have NULL),
+but get_messages_paginated() used a strict equality filter
+(``reply_to_top_id == topic_id``), so ``?topic_id=1`` returned zero rows
+even when the sidebar showed "67 messages".
+
+Fix: apply the same ``coalesce(reply_to_top_id, 1) == topic_id`` in the
+messages query so General sees its NULL messages while non-General topics
+still filter strictly.
+"""
+
+import os
+import sys
+from datetime import datetime
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Base, Chat, Message
+
+
+async def _make_adapter_with_messages():
+    """Spin up an in-memory SQLite DB seeded with a forum chat + mixed-topic messages."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db_manager = DatabaseManager.__new__(DatabaseManager)
+    db_manager.engine = engine
+    db_manager.database_url = "sqlite+aiosqlite://"
+    db_manager._is_sqlite = True
+    db_manager.async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    chat_id = -1002010842190
+    async with db_manager.async_session_factory() as session:
+        session.add(Chat(id=chat_id, type="group", title="Forum Chat", is_forum=1))
+        rows = [
+            # (id, date, text, reply_to_top_id)
+            (1, datetime(2024, 1, 1, 10), "pre-forum general #1", None),
+            (2, datetime(2024, 1, 2, 10), "pre-forum general #2", None),
+            (3, datetime(2024, 3, 1, 10), "sexy topic msg", 47),
+            (4, datetime(2024, 3, 2, 10), "another sexy msg", 47),
+            (5, datetime(2024, 4, 1, 10), "photos topic", 144),
+        ]
+        for mid, dt, body, top in rows:
+            session.add(Message(id=mid, chat_id=chat_id, date=dt, text=body, reply_to_top_id=top))
+        await session.commit()
+
+    return DatabaseAdapter(db_manager), engine, chat_id
+
+
+@pytest.mark.asyncio
+async def test_general_topic_includes_null_reply_to_top_id():
+    """topic_id=1 (General) must match messages whose reply_to_top_id IS NULL."""
+    adapter, engine, chat_id = await _make_adapter_with_messages()
+    try:
+        messages = await adapter.get_messages_paginated(chat_id=chat_id, topic_id=1)
+        ids = sorted(m["id"] for m in messages)
+        assert ids == [1, 2], f"General (topic_id=1) must return the 2 NULL-top messages, got {ids}"
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_non_general_topic_filters_strictly():
+    """Non-General topic IDs must still filter by strict equality on reply_to_top_id."""
+    adapter, engine, chat_id = await _make_adapter_with_messages()
+    try:
+        sexy = await adapter.get_messages_paginated(chat_id=chat_id, topic_id=47)
+        assert sorted(m["id"] for m in sexy) == [3, 4]
+
+        photos = await adapter.get_messages_paginated(chat_id=chat_id, topic_id=144)
+        assert sorted(m["id"] for m in photos) == [5]
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_no_topic_filter_returns_all():
+    """Without topic_id, all messages in the chat must be returned regardless of reply_to_top_id."""
+    adapter, engine, chat_id = await _make_adapter_with_messages()
+    try:
+        all_msgs = await adapter.get_messages_paginated(chat_id=chat_id)
+        assert sorted(m["id"] for m in all_msgs) == [1, 2, 3, 4, 5]
+    finally:
+        await engine.dispose()


### PR DESCRIPTION
## Summary

- Apply the same `coalesce(reply_to_top_id, 1) == topic_id` predicate in `get_messages_paginated()` that `get_forum_topics()` already uses for counting, so the General topic pane stops returning empty when its messages have NULL `reply_to_top_id` (pre-v6.2.0 / pre-forum) or explicit `reply_to_top_id=1` (post-forum-enable).
- Three regression tests covering NULL+explicit-1 General messages, strict filtering for non-General topics, and unfiltered no-topic queries.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change

## Database Changes

- [ ] Schema changes (Alembic migration required)
- [ ] Data migration script added in `scripts/`
- [x] No database changes

## Data Consistency Checklist

<!-- Change is a SELECT predicate adjustment — no chat_id construction, datetime handling, or INSERT/UPDATE paths touched. -->

- [ ] All `chat_id` values use marked format (via `_get_marked_id()`) — N/A, no chat_id construction
- [ ] All datetime values pass through `_strip_tz()` before DB operations — N/A, no datetime handling
- [ ] INSERT and UPDATE operations handle the same fields identically — N/A, change is read-side only

## Testing

- [x] Tests pass locally (`python -m pytest tests/ -v`)
- [x] Linting passes (`ruff check .`)
- [x] Formatting passes (`ruff format --check .`)
- [x] Manually tested in development environment

## Security Checklist

- [x] No secrets or credentials committed
- [x] User input properly validated/sanitized — `topic_id` flows through SQLAlchemy bound parameters
- [x] Authentication/authorization properly checked — same auth path as other paginated reads

## Deployment Notes

- No image rebuild needed beyond a normal release; the change is a query predicate and takes effect immediately on rolled code.

---

## The bug

In the web viewer, a forum chat's topic list correctly shows the **General** topic with its true message count (e.g. "67 messages"), but clicking the General tab renders an empty message pane.

Reproduce:
1. Enable a forum on a group chat that has pre-existing (pre-forum) messages, or keep using a forum chat whose early messages predate v6.2.0.
2. Run the archiver + viewer.
3. Open the chat → **General** topic.

Sidebar shows the correct count; main pane is empty.

## Root cause

`get_forum_topics()` in `src/db/adapter.py` already handles this correctly when *counting* General messages:

```python
effective_topic_id = func.coalesce(Message.reply_to_top_id, 1).label("effective_topic_id")
```

…with a comment that explains: *"Messages with `reply_to_top_id=NULL` are treated as General topic (id=1), since pre-v6.2.0 messages and pre-forum messages lack topic assignment and Telegram's client displays them under General."*

But `get_messages_paginated()` uses a strict equality filter:

```python
if topic_id is not None:
    stmt = stmt.where(Message.reply_to_top_id == topic_id)
```

So `?topic_id=1` never matches the NULL-top rows, and the General pane is empty despite the sidebar claim.

## The fix

Apply the same `coalesce(reply_to_top_id, 1) == topic_id` filter in `get_messages_paginated()`. General sees its NULL-top messages; non-General topics still filter strictly.

One-line change + three regression tests (`tests/test_general_topic_messages.py`) covering:

- `topic_id=1` returns NULL-top **and** explicit `reply_to_top_id=1` messages (post-review fix-up)
- non-General topic IDs still filter strictly
- no `topic_id` returns everything regardless of `reply_to_top_id`

Tests use `Base.metadata.create_all` on an in-memory SQLite engine so column drift can't silently break them.

## Verification against a real DB

On the affected forum chat (pre-forum + forum messages mixed):
- `GET /api/chats/<id>/messages?topic_id=1` — before: `[]`; after: returns the General messages.
- `GET /api/chats/<id>/messages?topic_id=<other>` — still returns only rows matching that exact topic.

## Test plan
- [x] `pytest tests/test_general_topic_messages.py` — 3/3 pass
- [x] Manually verified General tab now renders messages in the viewer
- [x] Manually verified non-General topics still filter strictly
