### PR TITLE
feat: make Telethon flood-waits visible in the log

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -89,10 +89,11 @@ def build_telegram_proxy_from_env() -> dict | None:
 
 def build_telegram_client_kwargs() -> dict:
     """Build common Telethon client keyword arguments from environment configuration."""
+    kwargs: dict = {"flood_sleep_threshold": 0}
     proxy = build_telegram_proxy_from_env()
-    if proxy is None:
-        return {}
-    return {"proxy": dict(proxy)}
+    if proxy is not None:
+        kwargs["proxy"] = dict(proxy)
+    return kwargs
 
 
 class Config:
@@ -602,10 +603,16 @@ class Config:
             )
 
     def get_telegram_client_kwargs(self) -> dict:
-        """Get shared TelegramClient keyword arguments."""
-        if self.telegram_proxy is None:
-            return {}
-        return {"proxy": dict(self.telegram_proxy)}
+        """Get shared TelegramClient keyword arguments.
+
+        ``flood_sleep_threshold=0`` forces Telethon to raise FloodWaitError
+        instead of silently sleeping, so long waits become visible in the log
+        via ``iter_messages_with_flood_retry``.
+        """
+        kwargs: dict = {"flood_sleep_threshold": 0}
+        if self.telegram_proxy is not None:
+            kwargs["proxy"] = dict(self.telegram_proxy)
+        return kwargs
 
 
 def setup_logging(config: Config):

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -38,28 +38,60 @@ from .message_utils import extract_topic_id
 logger = logging.getLogger(__name__)
 
 
+MAX_FLOOD_RETRIES = 5
+MAX_FLOOD_WAIT_SECONDS = 600
+
+
 async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
     """Wrap ``client.iter_messages`` so FloodWaitError is logged and retried.
 
     With ``flood_sleep_threshold=0`` on the client, every flood-wait bubbles up
     as an exception. We log the wait and resume iteration from the last yielded
     message id so progress isn't lost.
+
+    Bounded retries: the inner ``while`` is capped at ``MAX_FLOOD_RETRIES``
+    *consecutive* flood-waits without progress, and the counter resets every
+    time iteration yields a message. Without the cap, an account-restricted
+    Telegram session would loop forever on one chat and block every later one.
+
+    Bounded sleep: ``e.seconds`` is clamped at ``MAX_FLOOD_WAIT_SECONDS`` so a
+    pathologically large value (buggy or malicious server response) cannot
+    hang the process for hours.
+
+    The ``FLOOD_WAIT_LOG_THRESHOLD`` env var (default 10) suppresses log
+    output for short waits — those are routine and noisy in healthy backfills.
+    Set to 0 to log every wait.
     """
+    log_threshold_seconds = int(os.getenv("FLOOD_WAIT_LOG_THRESHOLD", "10"))
     resume_from = min_id
+    retries = 0
     while True:
         try:
             async for msg in client.iter_messages(entity, min_id=resume_from, **kwargs):
                 yield msg
                 if getattr(msg, "id", None) is not None:
                     resume_from = max(resume_from, msg.id)
+                retries = 0
             return
         except FloodWaitError as e:
-            logger.warning(
-                "FloodWait: sleeping %ss before resuming (last_msg_id=%s)",
-                e.seconds,
-                resume_from,
-            )
-            await asyncio.sleep(e.seconds + 1)
+            retries += 1
+            if retries > MAX_FLOOD_RETRIES:
+                logger.error(
+                    "FloodWait: exceeded %d retries without progress, giving up (last_msg_id=%s)",
+                    MAX_FLOOD_RETRIES,
+                    resume_from,
+                )
+                raise
+            wait_seconds = min(e.seconds, MAX_FLOOD_WAIT_SECONDS)
+            if e.seconds >= log_threshold_seconds:
+                logger.warning(
+                    "FloodWait: sleeping %ss before resuming (last_msg_id=%s, retry=%d/%d)",
+                    wait_seconds,
+                    resume_from,
+                    retries,
+                    MAX_FLOOD_RETRIES,
+                )
+            await asyncio.sleep(wait_seconds + 1)
 
 
 class TelegramBackup:
@@ -695,7 +727,6 @@ class TelegramBackup:
             if self.config.should_skip_topic(chat_id, extract_topic_id(message)):
                 continue
 
-
             msg_data = await self._process_message(message, chat_id)
             batch_data.append(msg_data)
 
@@ -784,7 +815,6 @@ class TelegramBackup:
             # Skip messages belonging to excluded forum topics
             if self.config.should_skip_topic(chat_id, extract_topic_id(message)):
                 continue
-
 
             msg_data = await self._process_message(message, chat_id)
             batch_data.append(msg_data)

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -3,6 +3,7 @@ Main Telegram backup module.
 Handles Telegram client connection, message fetching, and incremental backup logic.
 """
 
+import asyncio
 import base64
 import logging
 import os
@@ -12,6 +13,7 @@ from telethon import TelegramClient
 from telethon.errors import (
     ChannelPrivateError,
     ChatForbiddenError,
+    FloodWaitError,
     UserBannedInChannelError,
 )
 from telethon.tl.types import (
@@ -34,6 +36,30 @@ from .db import DatabaseAdapter, create_adapter
 from .message_utils import extract_topic_id
 
 logger = logging.getLogger(__name__)
+
+
+async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
+    """Wrap ``client.iter_messages`` so FloodWaitError is logged and retried.
+
+    With ``flood_sleep_threshold=0`` on the client, every flood-wait bubbles up
+    as an exception. We log the wait and resume iteration from the last yielded
+    message id so progress isn't lost.
+    """
+    resume_from = min_id
+    while True:
+        try:
+            async for msg in client.iter_messages(entity, min_id=resume_from, **kwargs):
+                yield msg
+                if getattr(msg, "id", None) is not None:
+                    resume_from = max(resume_from, msg.id)
+            return
+        except FloodWaitError as e:
+            logger.warning(
+                "FloodWait: sleeping %ss before resuming (last_msg_id=%s)",
+                e.seconds,
+                resume_from,
+            )
+            await asyncio.sleep(e.seconds + 1)
 
 
 class TelegramBackup:
@@ -660,12 +686,15 @@ class TelegramBackup:
         batches_since_checkpoint = 0
         running_max_id = last_message_id
 
-        async for message in self.client.iter_messages(entity, min_id=last_message_id, reverse=True):
+        async for message in iter_messages_with_flood_retry(
+            self.client, entity, min_id=last_message_id, reverse=True
+        ):
             running_max_id = max(running_max_id, message.id)
 
             # Skip messages belonging to excluded forum topics
             if self.config.should_skip_topic(chat_id, extract_topic_id(message)):
                 continue
+
 
             msg_data = await self._process_message(message, chat_id)
             batch_data.append(msg_data)
@@ -749,10 +778,13 @@ class TelegramBackup:
         batch_size = self.config.batch_size
         recovered = 0
 
-        async for message in self.client.iter_messages(entity, min_id=gap_start, max_id=gap_end, reverse=True):
+        async for message in iter_messages_with_flood_retry(
+            self.client, entity, min_id=gap_start, max_id=gap_end, reverse=True
+        ):
             # Skip messages belonging to excluded forum topics
             if self.config.should_skip_topic(chat_id, extract_topic_id(message)):
                 continue
+
 
             msg_data = await self._process_message(message, chat_id)
             batch_data.append(msg_data)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -356,8 +356,8 @@ class TestTelegramProxyConfig(unittest.TestCase):
         with patch.dict(os.environ, env_vars, clear=True):
             config = Config()
             self.assertIsNone(config.telegram_proxy)
-            self.assertEqual(config.get_telegram_client_kwargs(), {})
-            self.assertEqual(build_telegram_client_kwargs(), {})
+            self.assertEqual(config.get_telegram_client_kwargs(), {"flood_sleep_threshold": 0})
+            self.assertEqual(build_telegram_client_kwargs(), {"flood_sleep_threshold": 0})
 
     def test_proxy_parses_complete_socks5_config(self):
         """Complete SOCKS5 env vars produce a Telethon proxy dict."""
@@ -385,7 +385,10 @@ class TestTelegramProxyConfig(unittest.TestCase):
                 "rdns": False,
             },
         )
-        self.assertEqual(config.get_telegram_client_kwargs(), {"proxy": config.telegram_proxy})
+        self.assertEqual(
+            config.get_telegram_client_kwargs(),
+            {"flood_sleep_threshold": 0, "proxy": config.telegram_proxy},
+        )
 
     def test_proxy_requires_required_fields(self):
         """Partial proxy configuration should fail fast."""

--- a/tests/test_flood_wait_visibility.py
+++ b/tests/test_flood_wait_visibility.py
@@ -1,13 +1,17 @@
-"""Flood-wait visibility (yrru-mix3).
+"""Flood-wait visibility (upstream PR #124).
 
 Goal: make Telethon flood-waits visible in the scheduler log so a long silent
 pause during backfill can be diagnosed instead of mistaken for a hang.
 
-Two things under test:
+Three things under test:
 1. Config exposes ``flood_sleep_threshold=0`` in the shared client kwargs so
    Telethon always raises ``FloodWaitError`` instead of sleeping silently.
 2. A thin retry wrapper around ``client.iter_messages`` catches the error,
-   logs the wait, and resumes iteration from the last yielded message id.
+   logs the wait (above ``FLOOD_WAIT_LOG_THRESHOLD``), resumes iteration from
+   the last yielded message id, and gives up after ``MAX_FLOOD_RETRIES``
+   consecutive flood-waits without progress.
+3. ``e.seconds`` is clamped at ``MAX_FLOOD_WAIT_SECONDS`` so a pathologically
+   large value cannot hang the process for hours.
 """
 
 import importlib
@@ -23,8 +27,13 @@ import pytest
 from telethon.errors import FloodWaitError
 
 
-@pytest.fixture(autouse=True)
-def _fake_db(monkeypatch):
+def _patch_db_module(monkeypatch):
+    """Stub ``src.db`` so we can import telegram_backup without a real adapter.
+
+    Reloads ``src.connection`` and ``src.telegram_backup`` against the stub so
+    they pick up the fake module. Tests that don't import telegram_backup
+    don't need this — see ``test_config_kwargs_include_flood_sleep_threshold_zero``.
+    """
     fake_db_module = types.ModuleType("src.db")
     fake_db_module.DatabaseAdapter = object
     fake_db_module.create_adapter = AsyncMock()
@@ -37,9 +46,16 @@ def _fake_db(monkeypatch):
     importlib.reload(src.connection)
     importlib.reload(src.telegram_backup)
 
-    yield
 
+@pytest.fixture
+def fake_db(monkeypatch):
+    """Opt-in fixture for tests that import src.telegram_backup."""
+    _patch_db_module(monkeypatch)
+    yield
     if "src.db" in sys.modules:
+        import src.connection
+        import src.telegram_backup
+
         importlib.reload(src.connection)
         importlib.reload(src.telegram_backup)
 
@@ -62,7 +78,7 @@ def test_config_kwargs_include_flood_sleep_threshold_zero():
 
 
 @pytest.mark.asyncio
-async def test_connection_passes_flood_sleep_threshold_to_client():
+async def test_connection_passes_flood_sleep_threshold_to_client(fake_db):
     from src.connection import TelegramConnection
 
     config = MagicMock()
@@ -90,23 +106,22 @@ async def test_connection_passes_flood_sleep_threshold_to_client():
 
 
 @pytest.mark.asyncio
-async def test_iter_with_flood_retry_logs_and_resumes(caplog):
+async def test_iter_with_flood_retry_logs_and_resumes_after_partial_progress(caplog, fake_db):
+    """First call yields id=1 then raises; second call resumes at min_id=1."""
     from src import telegram_backup
 
     calls = {"n": 0}
 
-    async def fake_iter(entity, min_id=0, reverse=True, **_):
+    async def seeded_iter(entity, min_id=0, reverse=True, **_):
         calls["n"] += 1
         if calls["n"] == 1:
-            assert min_id == 0
-            raise FloodWaitError(request=None, capture=7)
-        # Second call: resume from last yielded id (1) then yield 2, 3
+            yield SimpleNamespace(id=1)
+            raise FloodWaitError(request=None, capture=15)
         assert min_id == 1
         for i in (2, 3):
             yield SimpleNamespace(id=i)
 
-    fake_client = SimpleNamespace(iter_messages=fake_iter)
-
+    fake_client = SimpleNamespace(iter_messages=seeded_iter)
     collected: list[int] = []
 
     async def fast_sleep(_):
@@ -116,19 +131,6 @@ async def test_iter_with_flood_retry_logs_and_resumes(caplog):
         caplog.at_level(logging.WARNING, logger="src.telegram_backup"),
         patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
     ):
-        # Simulate: first fetch yields id=1, then FloodWait, then retry yields 2,3.
-        # We need an additional pre-yielded message to seed last-id tracking.
-        async def seeded_iter(entity, min_id=0, reverse=True, **_):
-            calls["n"] += 1
-            if calls["n"] == 1:
-                yield SimpleNamespace(id=1)
-                raise FloodWaitError(request=None, capture=7)
-            assert min_id == 1
-            for i in (2, 3):
-                yield SimpleNamespace(id=i)
-
-        fake_client.iter_messages = seeded_iter
-        calls["n"] = 0
         async for msg in telegram_backup.iter_messages_with_flood_retry(
             fake_client, "chat", min_id=0, reverse=True
         ):
@@ -136,7 +138,238 @@ async def test_iter_with_flood_retry_logs_and_resumes(caplog):
 
     assert collected == [1, 2, 3]
     assert calls["n"] == 2
-    assert any(
-        "FloodWait" in r.getMessage() and "7" in r.getMessage()
-        for r in caplog.records
-    )
+    assert any("FloodWait" in r.getMessage() and "15" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_iter_with_flood_retry_handles_flood_before_any_yield(caplog, fake_db):
+    """FloodWait on the very first call (no progress) — resume_from must stay
+    at the original min_id and iteration must continue once the wait clears."""
+    from src import telegram_backup
+
+    calls = {"n": 0}
+
+    async def first_call_floods(entity, min_id=0, **_):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            assert min_id == 100
+            raise FloodWaitError(request=None, capture=15)
+            yield  # unreachable; satisfies async-generator contract
+        assert min_id == 100  # still the original min_id, not advanced
+        for i in (101, 102):
+            yield SimpleNamespace(id=i)
+
+    fake_client = SimpleNamespace(iter_messages=first_call_floods)
+    collected: list[int] = []
+
+    async def fast_sleep(_):
+        return None
+
+    with (
+        caplog.at_level(logging.WARNING, logger="src.telegram_backup"),
+        patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
+    ):
+        async for msg in telegram_backup.iter_messages_with_flood_retry(
+            fake_client, "chat", min_id=100
+        ):
+            collected.append(msg.id)
+
+    assert collected == [101, 102]
+    assert calls["n"] == 2
+
+
+@pytest.mark.asyncio
+async def test_iter_with_flood_retry_survives_consecutive_floods(caplog, fake_db):
+    """Three consecutive FloodWaitErrors before success — common in production."""
+    from src import telegram_backup
+
+    calls = {"n": 0}
+
+    async def thrice_floods(entity, min_id=0, **_):
+        calls["n"] += 1
+        if calls["n"] <= 3:
+            raise FloodWaitError(request=None, capture=15)
+            yield  # unreachable
+        for i in (1, 2):
+            yield SimpleNamespace(id=i)
+
+    fake_client = SimpleNamespace(iter_messages=thrice_floods)
+    collected: list[int] = []
+
+    async def fast_sleep(_):
+        return None
+
+    with (
+        caplog.at_level(logging.WARNING, logger="src.telegram_backup"),
+        patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
+    ):
+        async for msg in telegram_backup.iter_messages_with_flood_retry(
+            fake_client, "chat", min_id=0
+        ):
+            collected.append(msg.id)
+
+    assert collected == [1, 2]
+    assert calls["n"] == 4
+
+
+@pytest.mark.asyncio
+async def test_iter_with_flood_retry_resets_counter_on_progress(caplog, fake_db):
+    """Each successful yield must reset the retry counter so a long backfill
+    that hits one flood-wait per chunk doesn't trip the cap."""
+    from src import telegram_backup
+
+    calls = {"n": 0}
+
+    async def alternating(entity, min_id=0, **_):
+        calls["n"] += 1
+        # Yield one message, then flood. Repeat enough times that without a
+        # counter reset, MAX_FLOOD_RETRIES (5) would be exceeded.
+        if calls["n"] <= 7:
+            yield SimpleNamespace(id=calls["n"])
+            raise FloodWaitError(request=None, capture=15)
+        # Final call: drain to completion
+        yield SimpleNamespace(id=99)
+
+    fake_client = SimpleNamespace(iter_messages=alternating)
+    collected: list[int] = []
+
+    async def fast_sleep(_):
+        return None
+
+    with (
+        caplog.at_level(logging.WARNING, logger="src.telegram_backup"),
+        patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
+    ):
+        async for msg in telegram_backup.iter_messages_with_flood_retry(
+            fake_client, "chat", min_id=0
+        ):
+            collected.append(msg.id)
+
+    assert collected == [1, 2, 3, 4, 5, 6, 7, 99]
+
+
+@pytest.mark.asyncio
+async def test_iter_with_flood_retry_gives_up_after_max_retries(caplog, fake_db):
+    """Flood-wait without progress past MAX_FLOOD_RETRIES must raise."""
+    from src import telegram_backup
+
+    calls = {"n": 0}
+
+    async def always_floods(entity, min_id=0, **_):
+        calls["n"] += 1
+        raise FloodWaitError(request=None, capture=15)
+        yield  # unreachable
+
+    fake_client = SimpleNamespace(iter_messages=always_floods)
+
+    async def fast_sleep(_):
+        return None
+
+    with (
+        caplog.at_level(logging.ERROR, logger="src.telegram_backup"),
+        patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
+        pytest.raises(FloodWaitError),
+    ):
+        async for _msg in telegram_backup.iter_messages_with_flood_retry(
+            fake_client, "chat", min_id=0
+        ):
+            pass
+
+    assert calls["n"] == telegram_backup.MAX_FLOOD_RETRIES + 1
+    assert any("exceeded" in r.getMessage().lower() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_iter_with_flood_retry_caps_sleep_seconds(fake_db):
+    """An e.seconds value above MAX_FLOOD_WAIT_SECONDS must be clamped."""
+    from src import telegram_backup
+
+    calls = {"n": 0}
+
+    async def one_huge_flood(entity, min_id=0, **_):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise FloodWaitError(request=None, capture=86400)  # 1 day
+            yield
+        yield SimpleNamespace(id=1)
+
+    fake_client = SimpleNamespace(iter_messages=one_huge_flood)
+    sleeps: list[float] = []
+
+    async def record_sleep(seconds):
+        sleeps.append(seconds)
+
+    with patch.object(telegram_backup.asyncio, "sleep", record_sleep):
+        async for _msg in telegram_backup.iter_messages_with_flood_retry(
+            fake_client, "chat", min_id=0
+        ):
+            pass
+
+    assert sleeps == [telegram_backup.MAX_FLOOD_WAIT_SECONDS + 1]
+
+
+@pytest.mark.asyncio
+async def test_iter_with_flood_retry_preserves_max_id_kwarg(fake_db):
+    """Gap-fill call sites pass ``max_id`` via **kwargs; it must be forwarded
+    on the post-flood retry too, otherwise the gap fetch turns into a full scan."""
+    from src import telegram_backup
+
+    seen_kwargs: list[dict] = []
+    calls = {"n": 0}
+
+    async def capture_kwargs(entity, min_id=0, **kwargs):
+        calls["n"] += 1
+        seen_kwargs.append({"min_id": min_id, **kwargs})
+        if calls["n"] == 1:
+            raise FloodWaitError(request=None, capture=15)
+            yield
+        yield SimpleNamespace(id=42)
+
+    fake_client = SimpleNamespace(iter_messages=capture_kwargs)
+
+    async def fast_sleep(_):
+        return None
+
+    with patch.object(telegram_backup.asyncio, "sleep", fast_sleep):
+        async for _msg in telegram_backup.iter_messages_with_flood_retry(
+            fake_client, "chat", min_id=10, max_id=100, reverse=True
+        ):
+            pass
+
+    assert len(seen_kwargs) == 2
+    for kw in seen_kwargs:
+        assert kw["max_id"] == 100
+        assert kw["reverse"] is True
+
+
+@pytest.mark.asyncio
+async def test_iter_with_flood_retry_suppresses_short_wait_logs(caplog, fake_db):
+    """FLOOD_WAIT_LOG_THRESHOLD must silence routine short waits."""
+    from src import telegram_backup
+
+    calls = {"n": 0}
+
+    async def short_then_done(entity, min_id=0, **_):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise FloodWaitError(request=None, capture=3)
+            yield
+        yield SimpleNamespace(id=1)
+
+    fake_client = SimpleNamespace(iter_messages=short_then_done)
+
+    async def fast_sleep(_):
+        return None
+
+    with (
+        caplog.at_level(logging.WARNING, logger="src.telegram_backup"),
+        patch.dict(os.environ, {"FLOOD_WAIT_LOG_THRESHOLD": "10"}),
+        patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
+    ):
+        async for _msg in telegram_backup.iter_messages_with_flood_retry(
+            fake_client, "chat", min_id=0
+        ):
+            pass
+
+    flood_logs = [r for r in caplog.records if "FloodWait" in r.getMessage()]
+    assert flood_logs == [], f"Short wait should be silent, got {[r.getMessage() for r in flood_logs]}"

--- a/tests/test_flood_wait_visibility.py
+++ b/tests/test_flood_wait_visibility.py
@@ -1,0 +1,142 @@
+"""Flood-wait visibility (yrru-mix3).
+
+Goal: make Telethon flood-waits visible in the scheduler log so a long silent
+pause during backfill can be diagnosed instead of mistaken for a hang.
+
+Two things under test:
+1. Config exposes ``flood_sleep_threshold=0`` in the shared client kwargs so
+   Telethon always raises ``FloodWaitError`` instead of sleeping silently.
+2. A thin retry wrapper around ``client.iter_messages`` catches the error,
+   logs the wait, and resumes iteration from the last yielded message id.
+"""
+
+import importlib
+import logging
+import os
+import sys
+import tempfile
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from telethon.errors import FloodWaitError
+
+
+@pytest.fixture(autouse=True)
+def _fake_db(monkeypatch):
+    fake_db_module = types.ModuleType("src.db")
+    fake_db_module.DatabaseAdapter = object
+    fake_db_module.create_adapter = AsyncMock()
+    fake_db_module.get_db_manager = AsyncMock()
+    monkeypatch.setitem(sys.modules, "src.db", fake_db_module)
+
+    import src.connection
+    import src.telegram_backup
+
+    importlib.reload(src.connection)
+    importlib.reload(src.telegram_backup)
+
+    yield
+
+    if "src.db" in sys.modules:
+        importlib.reload(src.connection)
+        importlib.reload(src.telegram_backup)
+
+
+def test_config_kwargs_include_flood_sleep_threshold_zero():
+    from src.config import Config
+
+    env = {
+        "CHAT_TYPES": "private",
+        "BACKUP_PATH": tempfile.mkdtemp(),
+        "TELEGRAM_API_ID": "1",
+        "TELEGRAM_API_HASH": "x",
+        "TELEGRAM_PHONE": "+1",
+    }
+    with patch.dict(os.environ, env, clear=True):
+        config = Config()
+
+    kwargs = config.get_telegram_client_kwargs()
+    assert kwargs.get("flood_sleep_threshold") == 0
+
+
+@pytest.mark.asyncio
+async def test_connection_passes_flood_sleep_threshold_to_client():
+    from src.connection import TelegramConnection
+
+    config = MagicMock()
+    config.validate_credentials = MagicMock()
+    config.session_path = "/tmp/test-session"
+    config.api_id = 12345
+    config.api_hash = "hash"
+    config.get_telegram_client_kwargs.return_value = {"flood_sleep_threshold": 0}
+
+    client = AsyncMock()
+    client.session = SimpleNamespace(_conn=None)
+    client.is_user_authorized.return_value = True
+    client.get_me.return_value = SimpleNamespace(first_name="Test", phone="123")
+
+    with (
+        patch("src.connection.TelegramClient", return_value=client) as client_cls,
+        patch.object(TelegramConnection, "_session_has_auth", return_value=False),
+        patch("src.connection.shutil.copy2"),
+    ):
+        connection = TelegramConnection(config)
+        await connection.connect()
+
+    _, kwargs = client_cls.call_args
+    assert kwargs.get("flood_sleep_threshold") == 0
+
+
+@pytest.mark.asyncio
+async def test_iter_with_flood_retry_logs_and_resumes(caplog):
+    from src import telegram_backup
+
+    calls = {"n": 0}
+
+    async def fake_iter(entity, min_id=0, reverse=True, **_):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            assert min_id == 0
+            raise FloodWaitError(request=None, capture=7)
+        # Second call: resume from last yielded id (1) then yield 2, 3
+        assert min_id == 1
+        for i in (2, 3):
+            yield SimpleNamespace(id=i)
+
+    fake_client = SimpleNamespace(iter_messages=fake_iter)
+
+    collected: list[int] = []
+
+    async def fast_sleep(_):
+        return None
+
+    with (
+        caplog.at_level(logging.WARNING, logger="src.telegram_backup"),
+        patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
+    ):
+        # Simulate: first fetch yields id=1, then FloodWait, then retry yields 2,3.
+        # We need an additional pre-yielded message to seed last-id tracking.
+        async def seeded_iter(entity, min_id=0, reverse=True, **_):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                yield SimpleNamespace(id=1)
+                raise FloodWaitError(request=None, capture=7)
+            assert min_id == 1
+            for i in (2, 3):
+                yield SimpleNamespace(id=i)
+
+        fake_client.iter_messages = seeded_iter
+        calls["n"] = 0
+        async for msg in telegram_backup.iter_messages_with_flood_retry(
+            fake_client, "chat", min_id=0, reverse=True
+        ):
+            collected.append(msg.id)
+
+    assert collected == [1, 2, 3]
+    assert calls["n"] == 2
+    assert any(
+        "FloodWait" in r.getMessage() and "7" in r.getMessage()
+        for r in caplog.records
+    )


### PR DESCRIPTION
## Summary

- Set `flood_sleep_threshold=0` on the shared `TelegramClient` so every `FloodWaitError` surfaces, then wrap `client.iter_messages` at the two bulk call-sites in `src/telegram_backup.py` with `iter_messages_with_flood_retry`, which logs the wait, sleeps, and resumes from the last yielded id.
- Bound the wrapper: `MAX_FLOOD_RETRIES=5` consecutive flood-waits without progress (counter resets on each yield) before the wrapper gives up and re-raises; `MAX_FLOOD_WAIT_SECONDS=600` clamp on `e.seconds` to defend against pathological values.
- New `FLOOD_WAIT_LOG_THRESHOLD` env var (default 10s) suppresses noisy short-wait log lines while keeping the operator-visible long ones.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change

<!-- Visible-flood-wait surface is genuinely new functionality. The bounded retry + sleep clamp added in review are defensive improvements on that surface, not separate bug fixes. -->

## Database Changes

- [ ] Schema changes (Alembic migration required)
- [ ] Data migration script added in `scripts/`
- [x] No database changes

## Data Consistency Checklist

<!-- N/A — no database code modified in this PR. -->

- [ ] All `chat_id` values use marked format (via `_get_marked_id()`)
- [ ] All datetime values pass through `_strip_tz()` before DB operations
- [ ] INSERT and UPDATE operations handle the same fields identically

## Testing

- [x] Tests pass locally (`python -m pytest tests/ -v`)
- [x] Linting passes (`ruff check .`)
- [x] Formatting passes (`ruff format --check .`)
- [x] Manually tested in development environment

## Security Checklist

- [x] No secrets or credentials committed
- [x] User input properly validated/sanitized — `e.seconds` is integer from Telethon and is clamped before use
- [x] Authentication/authorization properly checked — change is internal to the backup pipeline; no auth surface modified

## Deployment Notes

- New optional env var: `FLOOD_WAIT_LOG_THRESHOLD` (default `10`, set to `0` to log every wait). No-op for existing deployments — the defaults match the prior log-everything behavior except for sub-10-second waits which are now silent.

---

## The problem

Telethon's `TelegramClient` silently sleeps through any `FloodWaitError` whose wait is ≤ `flood_sleep_threshold` (default 60 s). On a large `iter_messages` pass — e.g. initial backup of a 100 k-message chat — Telegram often hands back much longer waits, and the operator can't tell "crashed" from "rate-limited":

- No log lines
- No DB writes
- Realtime listener is still firing
- `systemctl status` still shows the service as active

## The fix

1. Set `flood_sleep_threshold=0` on the shared `TelegramClient` so every `FloodWaitError` bubbles up as an exception rather than a silent sleep.
2. Add `iter_messages_with_flood_retry(client, entity, **kwargs)` — a thin async generator that wraps `client.iter_messages`, logs `FloodWait: sleeping Ns before resuming (last_msg_id=M, retry=N/MAX)`, sleeps, then resumes iteration from the last-seen message id.
3. Bound the wrapper after the original review: `MAX_FLOOD_RETRIES=5` consecutive flood-waits without progress before re-raising (the counter resets every time iteration yields a message, so a long backfill that hits one wait per chunk doesn't trip the cap), and `MAX_FLOOD_WAIT_SECONDS=600` clamp on the sleep so a buggy/malicious server can't hang the process for hours.
4. Use that wrapper at the two bulk-iteration call-sites in `src/telegram_backup.py` (full chat backup and gap-fill).

`FLOOD_WAIT_LOG_THRESHOLD` (default 10 s) controls the minimum wait to log, so trivial 1-2 s floods don't spam the log.

Before/after is qualitative:

- **Before:** multi-minute flood-wait looks like a hang.
- **After:** `FloodWait: sleeping 47s before resuming (last_msg_id=87342, retry=1/5)` — operator immediately knows what's happening.

## Conflict notes

Rebased on top of the recently-merged `SKIP_TOPIC_IDS` feature (#118). Both conflict sites in `src/telegram_backup.py` are trivial — our flood-retry wrapper wraps the `iter_messages` call, and the topic-skip check stays inside the loop body where upstream added it.

## Test plan
- [x] `pytest tests/test_flood_wait_visibility.py` — 10/10 pass (3 original + 7 added in review)
- [x] `pytest tests/test_config.py` — passes
- [x] Manually triggered in production on a large chat; log now shows the flood-wait line with `retry=N/MAX` and resumes cleanly from the correct message id.
