### PR TITLE
Fix forwarded media from private channels showing broken placeholder

### DIFF
--- a/src/listener.py
+++ b/src/listener.py
@@ -516,7 +516,8 @@ class TelegramListener:
                         return "sticker"
                 if is_animated:
                     return "animation"
-            return "document"
+                return "document"
+            return None  # document reference unavailable (e.g., forwarded from private channel)
         elif isinstance(media, MessageMediaContact):
             return "contact"
         elif isinstance(media, MessageMediaGeo):
@@ -571,6 +572,10 @@ class TelegramListener:
                 telegram_file_id = str(getattr(media.photo, "id", None))
             elif hasattr(media, "document"):
                 telegram_file_id = str(getattr(media.document, "id", None))
+
+            # Guard against inaccessible media producing "None" string IDs
+            if telegram_file_id == "None":
+                telegram_file_id = None
 
             # Check file size
             file_size = 0

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -1313,6 +1313,10 @@ class TelegramBackup:
         elif hasattr(media, "document"):
             telegram_file_id = str(getattr(media.document, "id", None))
 
+        # Guard against inaccessible media producing "None" string IDs
+        if telegram_file_id == "None":
+            telegram_file_id = None
+
         # Check file size (estimated)
         file_size = self._get_media_size(media)
         max_size = self.config.get_max_media_size_bytes()
@@ -1483,7 +1487,8 @@ class TelegramBackup:
                 # If animated but no video attribute, still an animation
                 if is_animated:
                     return "animation"
-            return "document"
+                return "document"
+            return None  # document reference unavailable (e.g., forwarded from private channel)
         elif isinstance(media, MessageMediaContact):
             return "contact"
         elif isinstance(media, MessageMediaGeo):

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -433,13 +433,13 @@ class TestGetMediaType:
         assert listener._get_media_type(media) == "sticker"
 
     def test_document_media_no_document_body(self):
-        """MessageMediaDocument with document=None returns 'document'."""
+        """MessageMediaDocument with document=None returns None (inaccessible)."""
         from telethon.tl.types import MessageMediaDocument
 
         listener = self._listener()
         media = MagicMock(spec=MessageMediaDocument)
         media.document = None
-        assert listener._get_media_type(media) == "document"
+        assert listener._get_media_type(media) is None
 
     def test_contact_media(self):
         """MessageMediaContact returns 'contact'."""

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -917,11 +917,11 @@ class TestGetMediaType(unittest.TestCase):
         media = MagicMock()
         self.assertIsNone(self.backup._get_media_type(media))
 
-    def test_document_without_document_attr_returns_document(self):
-        """MessageMediaDocument with no .document returns document."""
+    def test_document_without_document_attr_returns_none(self):
+        """MessageMediaDocument with no .document returns None (inaccessible)."""
         media = MagicMock(spec=MessageMediaDocument)
         media.document = None
-        self.assertEqual(self.backup._get_media_type(media), "document")
+        self.assertIsNone(self.backup._get_media_type(media))
 
 
 class TestGetMediaExtension(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Fix `_get_media_type()` returning `"document"` when `media.document` is `None` (forwarded from private channels), causing broken media records with `telegram_file_id = "None"` and permanent download failures
- Add safety guard in `_process_media` to catch any remaining `str(None)` file IDs

Fixes #125

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change

## Database Changes

- [ ] Schema changes (Alembic migration required)
- [ ] Data migration script added in `scripts/`
- [x] No database changes

## Data Consistency Checklist

- [x] All `chat_id` values use marked format (via `_get_marked_id()`)
- [x] All datetime values pass through `_strip_tz()` before DB operations
- [x] INSERT and UPDATE operations handle the same fields identically

## Testing

- [ ] Tests pass locally (`python -m pytest tests/ -v`)
- [x] Linting passes (`ruff check .`)
- [x] Formatting passes (`ruff format --check .`)
- [ ] Manually tested in development environment

## Security Checklist

- [x] No secrets or credentials committed
- [x] User input properly validated/sanitized
- [x] Authentication/authorization properly checked

## Deployment Notes

- Docker image rebuild needed
- Existing broken media records with `telegram_file_id = "None"` in the database will still show as broken; a future cleanup script or re-backup will fix those

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of media forwarded from private channels or with unavailable document references to prevent errors in filename generation and download operations.
  * Corrected deduplication logic to properly treat missing media identifiers instead of using literal string placeholders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->