### PR TITLE
fix: harden flood-wait retry logic and expand test coverage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,11 @@ SKIP_MEDIA_DELETE_EXISTING=true
 # Logging level: DEBUG, INFO, WARNING, ERROR
 LOG_LEVEL=INFO
 
+# Suppress FloodWait log messages below this threshold (seconds)
+# Waits shorter than this are routine and logged at DEBUG instead of WARNING
+# Set to 0 to log every flood-wait
+# FLOOD_WAIT_LOG_THRESHOLD=10
+
 # Session name (use different names for multiple accounts)
 SESSION_NAME=telegram_backup
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [7.6.2] - 2026-04-25
+
+### Fixed
+
+- **FloodWaitError no longer crashes `get_dialogs()` or `get_me()`** — PR #124 set `flood_sleep_threshold=0` globally but only wrapped 2 of ~20 API call sites. The unwrapped `get_dialogs()` and `get_me()` calls could crash the entire backup or prevent startup. Both are now wrapped with bounded flood-wait retry logic.
+- **Negative `e.seconds` from Telegram no longer causes zero-delay retry storms** — Sleep duration is now clamped to `max(0, ...)` on both the iterator wrapper and the new one-shot retry helper.
+- **Invalid `FLOOD_WAIT_LOG_THRESHOLD` env var no longer crashes mid-backup** — Bare `int()` parsing replaced with defensive `try/except` that falls back to the default of 10 seconds.
+- **`iter_messages_with_flood_retry` now rejects `reverse=False`** — The resume tracking (`max(resume_from, msg.id)`) is only correct for ascending iteration. A `ValueError` is now raised if `reverse=True` is not passed, preventing silent data corruption from future misuse.
+- **Documented `FLOOD_WAIT_LOG_THRESHOLD`** — Added to `.env.example` alongside the other logging variables.
+
 ## [7.6.1] - 2026-04-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.6.1"
+version = "7.6.2"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.6.1"
+__version__ = "7.6.2"

--- a/src/connection.py
+++ b/src/connection.py
@@ -37,10 +37,18 @@ async def _call_with_flood_retry(coro_fn, *args, **kwargs):
         except FloodWaitError as e:
             retries += 1
             if retries > MAX_FLOOD_RETRIES:
-                logger.error("FloodWait: exceeded %d retries on %s", MAX_FLOOD_RETRIES, getattr(coro_fn, "__name__", coro_fn))
+                logger.error(
+                    "FloodWait: exceeded %d retries on %s", MAX_FLOOD_RETRIES, getattr(coro_fn, "__name__", coro_fn)
+                )
                 raise
             wait_seconds = max(0, min(e.seconds, MAX_FLOOD_WAIT_SECONDS))
-            logger.warning("FloodWait: sleeping %ss before retrying %s (retry=%d/%d)", wait_seconds, getattr(coro_fn, "__name__", coro_fn), retries, MAX_FLOOD_RETRIES)
+            logger.warning(
+                "FloodWait: sleeping %ss before retrying %s (retry=%d/%d)",
+                wait_seconds,
+                getattr(coro_fn, "__name__", coro_fn),
+                retries,
+                MAX_FLOOD_RETRIES,
+            )
             await asyncio.sleep(wait_seconds + 1)
 
 

--- a/src/connection.py
+++ b/src/connection.py
@@ -18,10 +18,30 @@ import shutil
 import sqlite3
 
 from telethon import TelegramClient
+from telethon.errors import FloodWaitError
 
 from .config import Config
 
 logger = logging.getLogger(__name__)
+
+MAX_FLOOD_RETRIES = 5
+MAX_FLOOD_WAIT_SECONDS = 600
+
+
+async def _call_with_flood_retry(coro_fn, *args, **kwargs):
+    """Retry a single async call on FloodWaitError with bounded sleep."""
+    retries = 0
+    while True:
+        try:
+            return await coro_fn(*args, **kwargs)
+        except FloodWaitError as e:
+            retries += 1
+            if retries > MAX_FLOOD_RETRIES:
+                logger.error("FloodWait: exceeded %d retries on %s", MAX_FLOOD_RETRIES, getattr(coro_fn, "__name__", coro_fn))
+                raise
+            wait_seconds = max(0, min(e.seconds, MAX_FLOOD_WAIT_SECONDS))
+            logger.warning("FloodWait: sleeping %ss before retrying %s (retry=%d/%d)", wait_seconds, getattr(coro_fn, "__name__", coro_fn), retries, MAX_FLOOD_RETRIES)
+            await asyncio.sleep(wait_seconds + 1)
 
 
 class TelegramConnection:
@@ -166,7 +186,7 @@ class TelegramConnection:
             logger.error("  Non-interactive: python scripts/auth_noninteractive.py send")
             raise RuntimeError("Session not authorized. Please run authentication setup.")
 
-        self._me = await self._client.get_me()
+        self._me = await _call_with_flood_retry(self._client.get_me)
         self._connected = True
 
         # Auth succeeded — update the golden backup (known-good state).
@@ -229,7 +249,7 @@ class TelegramConnection:
             if not self._client.is_connected():
                 logger.warning("Connection lost, reconnecting...")
                 await self._client.connect()
-                self._me = await self._client.get_me()
+                self._me = await _call_with_flood_retry(self._client.get_me)
                 logger.info(f"Reconnected as {self._me.first_name}")
         except Exception as e:
             logger.warning(f"Connection check failed: {e}, reconnecting...")

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -100,7 +100,7 @@ async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
         raise ValueError("iter_messages_with_flood_retry only supports reverse=True (ascending) iteration")
     try:
         log_threshold_seconds = int(os.getenv("FLOOD_WAIT_LOG_THRESHOLD", "10"))
-    except (ValueError, TypeError):
+    except ValueError, TypeError:
         log_threshold_seconds = 10
     resume_from = min_id
     retries = 0
@@ -757,9 +757,7 @@ class TelegramBackup:
         batches_since_checkpoint = 0
         running_max_id = last_message_id
 
-        async for message in iter_messages_with_flood_retry(
-            self.client, entity, min_id=last_message_id, reverse=True
-        ):
+        async for message in iter_messages_with_flood_retry(self.client, entity, min_id=last_message_id, reverse=True):
             running_max_id = max(running_max_id, message.id)
 
             # Skip messages belonging to excluded forum topics

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -42,6 +42,37 @@ MAX_FLOOD_RETRIES = 5
 MAX_FLOOD_WAIT_SECONDS = 600
 
 
+async def call_with_flood_retry(coro_fn, *args, max_retries=MAX_FLOOD_RETRIES, **kwargs):
+    """Retry a single async call on FloodWaitError with bounded sleep.
+
+    Use this for one-shot Telegram API calls (``get_dialogs``, ``get_me``, etc.)
+    that are not async iterators.  For ``iter_messages`` use
+    ``iter_messages_with_flood_retry`` instead.
+    """
+    retries = 0
+    while True:
+        try:
+            return await coro_fn(*args, **kwargs)
+        except FloodWaitError as e:
+            retries += 1
+            if retries > max_retries:
+                logger.error(
+                    "FloodWait: exceeded %d retries on %s, giving up",
+                    max_retries,
+                    getattr(coro_fn, "__name__", coro_fn),
+                )
+                raise
+            wait_seconds = max(0, min(e.seconds, MAX_FLOOD_WAIT_SECONDS))
+            logger.warning(
+                "FloodWait: sleeping %ss before retrying %s (retry=%d/%d)",
+                wait_seconds,
+                getattr(coro_fn, "__name__", coro_fn),
+                retries,
+                max_retries,
+            )
+            await asyncio.sleep(wait_seconds + 1)  # +1s buffer to avoid boundary re-trigger
+
+
 async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
     """Wrap ``client.iter_messages`` so FloodWaitError is logged and retried.
 
@@ -61,8 +92,16 @@ async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
     The ``FLOOD_WAIT_LOG_THRESHOLD`` env var (default 10) suppresses log
     output for short waits — those are routine and noisy in healthy backfills.
     Set to 0 to log every wait.
+
+    Note: resume tracking uses ``max(resume_from, msg.id)`` which is only
+    correct for ascending iteration (``reverse=True``).
     """
-    log_threshold_seconds = int(os.getenv("FLOOD_WAIT_LOG_THRESHOLD", "10"))
+    if not kwargs.get("reverse", False):
+        raise ValueError("iter_messages_with_flood_retry only supports reverse=True (ascending) iteration")
+    try:
+        log_threshold_seconds = int(os.getenv("FLOOD_WAIT_LOG_THRESHOLD", "10"))
+    except (ValueError, TypeError):
+        log_threshold_seconds = 10
     resume_from = min_id
     retries = 0
     while True:
@@ -82,7 +121,7 @@ async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
                     resume_from,
                 )
                 raise
-            wait_seconds = min(e.seconds, MAX_FLOOD_WAIT_SECONDS)
+            wait_seconds = max(0, min(e.seconds, MAX_FLOOD_WAIT_SECONDS))
             if e.seconds >= log_threshold_seconds:
                 logger.warning(
                     "FloodWait: sleeping %ss before resuming (last_msg_id=%s, retry=%d/%d)",
@@ -91,7 +130,7 @@ async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
                     retries,
                     MAX_FLOOD_RETRIES,
                 )
-            await asyncio.sleep(wait_seconds + 1)
+            await asyncio.sleep(wait_seconds + 1)  # +1s buffer to avoid boundary re-trigger
 
 
 class TelegramBackup:
@@ -518,9 +557,9 @@ class TelegramBackup:
         archived ones, which causes overlap with the folder=1 results.
         """
         if archived:
-            dialogs = await self.client.get_dialogs(folder=1)
+            dialogs = await call_with_flood_retry(self.client.get_dialogs, folder=1)
         else:
-            dialogs = await self.client.get_dialogs(folder=0)
+            dialogs = await call_with_flood_retry(self.client.get_dialogs, folder=0)
         return dialogs
 
     async def _verify_and_redownload_media(self) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -806,6 +806,8 @@ class TestBuildTelegramClientKwargsWithProxy(unittest.TestCase):
             self.assertIn("proxy", result)
             self.assertEqual(result["proxy"]["addr"], "10.0.0.1")
             self.assertEqual(result["proxy"]["port"], 9050)
+            self.assertIn("flood_sleep_threshold", result)
+            self.assertEqual(result["flood_sleep_threshold"], 0)
 
 
 class TestLogLevelWarnAlias(unittest.TestCase):

--- a/tests/test_flood_wait_visibility.py
+++ b/tests/test_flood_wait_visibility.py
@@ -170,7 +170,7 @@ async def test_iter_with_flood_retry_handles_flood_before_any_yield(caplog, fake
         patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
     ):
         async for msg in telegram_backup.iter_messages_with_flood_retry(
-            fake_client, "chat", min_id=100
+            fake_client, "chat", min_id=100, reverse=True
         ):
             collected.append(msg.id)
 
@@ -204,7 +204,7 @@ async def test_iter_with_flood_retry_survives_consecutive_floods(caplog, fake_db
         patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
     ):
         async for msg in telegram_backup.iter_messages_with_flood_retry(
-            fake_client, "chat", min_id=0
+            fake_client, "chat", min_id=0, reverse=True
         ):
             collected.append(msg.id)
 
@@ -241,7 +241,7 @@ async def test_iter_with_flood_retry_resets_counter_on_progress(caplog, fake_db)
         patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
     ):
         async for msg in telegram_backup.iter_messages_with_flood_retry(
-            fake_client, "chat", min_id=0
+            fake_client, "chat", min_id=0, reverse=True
         ):
             collected.append(msg.id)
 
@@ -271,7 +271,7 @@ async def test_iter_with_flood_retry_gives_up_after_max_retries(caplog, fake_db)
         pytest.raises(FloodWaitError),
     ):
         async for _msg in telegram_backup.iter_messages_with_flood_retry(
-            fake_client, "chat", min_id=0
+            fake_client, "chat", min_id=0, reverse=True
         ):
             pass
 
@@ -301,7 +301,7 @@ async def test_iter_with_flood_retry_caps_sleep_seconds(fake_db):
 
     with patch.object(telegram_backup.asyncio, "sleep", record_sleep):
         async for _msg in telegram_backup.iter_messages_with_flood_retry(
-            fake_client, "chat", min_id=0
+            fake_client, "chat", min_id=0, reverse=True
         ):
             pass
 
@@ -367,9 +367,147 @@ async def test_iter_with_flood_retry_suppresses_short_wait_logs(caplog, fake_db)
         patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
     ):
         async for _msg in telegram_backup.iter_messages_with_flood_retry(
-            fake_client, "chat", min_id=0
+            fake_client, "chat", min_id=0, reverse=True
         ):
             pass
 
     flood_logs = [r for r in caplog.records if "FloodWait" in r.getMessage()]
     assert flood_logs == [], f"Short wait should be silent, got {[r.getMessage() for r in flood_logs]}"
+
+
+@pytest.mark.asyncio
+async def test_iter_with_flood_retry_rejects_non_reverse(fake_db):
+    """Wrapper must reject calls without reverse=True to prevent silent data corruption."""
+    from src import telegram_backup
+
+    with pytest.raises(ValueError, match="reverse=True"):
+        async for _ in telegram_backup.iter_messages_with_flood_retry(
+            None, "chat", min_id=0
+        ):
+            pass
+
+
+@pytest.mark.asyncio
+async def test_iter_with_flood_retry_clamps_negative_sleep(fake_db):
+    """Negative e.seconds must be clamped to 0 — never pass a negative to asyncio.sleep."""
+    from src import telegram_backup
+
+    calls = {"n": 0}
+
+    async def negative_flood(entity, min_id=0, **_):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise FloodWaitError(request=None, capture=-5)
+            yield
+        yield SimpleNamespace(id=1)
+
+    fake_client = SimpleNamespace(iter_messages=negative_flood)
+    sleeps: list[float] = []
+
+    async def record_sleep(seconds):
+        sleeps.append(seconds)
+
+    with patch.object(telegram_backup.asyncio, "sleep", record_sleep):
+        async for _msg in telegram_backup.iter_messages_with_flood_retry(
+            fake_client, "chat", min_id=0, reverse=True
+        ):
+            pass
+
+    assert sleeps == [1], f"Expected sleep(0+1=1) for negative e.seconds, got {sleeps}"
+
+
+@pytest.mark.asyncio
+async def test_iter_with_flood_retry_tolerates_bad_log_threshold_env(fake_db):
+    """Invalid FLOOD_WAIT_LOG_THRESHOLD must fall back to default 10, not crash."""
+    from src import telegram_backup
+
+    calls = {"n": 0}
+
+    async def one_flood(entity, min_id=0, **_):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise FloodWaitError(request=None, capture=15)
+            yield
+        yield SimpleNamespace(id=1)
+
+    fake_client = SimpleNamespace(iter_messages=one_flood)
+
+    async def fast_sleep(_):
+        return None
+
+    with (
+        patch.dict(os.environ, {"FLOOD_WAIT_LOG_THRESHOLD": "not_a_number"}),
+        patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
+    ):
+        collected = []
+        async for msg in telegram_backup.iter_messages_with_flood_retry(
+            fake_client, "chat", min_id=0, reverse=True
+        ):
+            collected.append(msg.id)
+
+    assert collected == [1]
+
+
+@pytest.mark.asyncio
+async def test_call_with_flood_retry_retries_and_succeeds(fake_db):
+    """call_with_flood_retry must retry on FloodWaitError then return the result."""
+    from src import telegram_backup
+
+    calls = {"n": 0}
+
+    async def flaky_get_me():
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            raise FloodWaitError(request=None, capture=5)
+        return SimpleNamespace(first_name="Test", phone="123")
+
+    async def fast_sleep(_):
+        return None
+
+    with patch.object(telegram_backup.asyncio, "sleep", fast_sleep):
+        result = await telegram_backup.call_with_flood_retry(flaky_get_me)
+
+    assert result.first_name == "Test"
+    assert calls["n"] == 3
+
+
+@pytest.mark.asyncio
+async def test_call_with_flood_retry_gives_up(fake_db):
+    """call_with_flood_retry must raise after exceeding max retries."""
+    from src import telegram_backup
+
+    async def always_floods():
+        raise FloodWaitError(request=None, capture=5)
+
+    async def fast_sleep(_):
+        return None
+
+    with (
+        patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
+        pytest.raises(FloodWaitError),
+    ):
+        await telegram_backup.call_with_flood_retry(always_floods)
+
+
+@pytest.mark.asyncio
+async def test_call_with_flood_retry_clamps_negative_sleep(fake_db):
+    """Negative e.seconds in call_with_flood_retry must be clamped to 0."""
+    from src import telegram_backup
+
+    calls = {"n": 0}
+    sleeps: list[float] = []
+
+    async def negative_then_ok():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise FloodWaitError(request=None, capture=-10)
+        return "ok"
+
+    async def record_sleep(seconds):
+        sleeps.append(seconds)
+
+    with patch.object(telegram_backup.asyncio, "sleep", record_sleep):
+        result = await telegram_backup.call_with_flood_retry(negative_then_ok)
+
+    assert result == "ok"
+    assert sleeps == [1], f"Expected sleep(0+1=1) for negative e.seconds, got {sleeps}"

--- a/tests/test_flood_wait_visibility.py
+++ b/tests/test_flood_wait_visibility.py
@@ -131,9 +131,7 @@ async def test_iter_with_flood_retry_logs_and_resumes_after_partial_progress(cap
         caplog.at_level(logging.WARNING, logger="src.telegram_backup"),
         patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
     ):
-        async for msg in telegram_backup.iter_messages_with_flood_retry(
-            fake_client, "chat", min_id=0, reverse=True
-        ):
+        async for msg in telegram_backup.iter_messages_with_flood_retry(fake_client, "chat", min_id=0, reverse=True):
             collected.append(msg.id)
 
     assert collected == [1, 2, 3]
@@ -169,9 +167,7 @@ async def test_iter_with_flood_retry_handles_flood_before_any_yield(caplog, fake
         caplog.at_level(logging.WARNING, logger="src.telegram_backup"),
         patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
     ):
-        async for msg in telegram_backup.iter_messages_with_flood_retry(
-            fake_client, "chat", min_id=100, reverse=True
-        ):
+        async for msg in telegram_backup.iter_messages_with_flood_retry(fake_client, "chat", min_id=100, reverse=True):
             collected.append(msg.id)
 
     assert collected == [101, 102]
@@ -203,9 +199,7 @@ async def test_iter_with_flood_retry_survives_consecutive_floods(caplog, fake_db
         caplog.at_level(logging.WARNING, logger="src.telegram_backup"),
         patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
     ):
-        async for msg in telegram_backup.iter_messages_with_flood_retry(
-            fake_client, "chat", min_id=0, reverse=True
-        ):
+        async for msg in telegram_backup.iter_messages_with_flood_retry(fake_client, "chat", min_id=0, reverse=True):
             collected.append(msg.id)
 
     assert collected == [1, 2]
@@ -240,9 +234,7 @@ async def test_iter_with_flood_retry_resets_counter_on_progress(caplog, fake_db)
         caplog.at_level(logging.WARNING, logger="src.telegram_backup"),
         patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
     ):
-        async for msg in telegram_backup.iter_messages_with_flood_retry(
-            fake_client, "chat", min_id=0, reverse=True
-        ):
+        async for msg in telegram_backup.iter_messages_with_flood_retry(fake_client, "chat", min_id=0, reverse=True):
             collected.append(msg.id)
 
     assert collected == [1, 2, 3, 4, 5, 6, 7, 99]
@@ -270,9 +262,7 @@ async def test_iter_with_flood_retry_gives_up_after_max_retries(caplog, fake_db)
         patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
         pytest.raises(FloodWaitError),
     ):
-        async for _msg in telegram_backup.iter_messages_with_flood_retry(
-            fake_client, "chat", min_id=0, reverse=True
-        ):
+        async for _msg in telegram_backup.iter_messages_with_flood_retry(fake_client, "chat", min_id=0, reverse=True):
             pass
 
     assert calls["n"] == telegram_backup.MAX_FLOOD_RETRIES + 1
@@ -300,9 +290,7 @@ async def test_iter_with_flood_retry_caps_sleep_seconds(fake_db):
         sleeps.append(seconds)
 
     with patch.object(telegram_backup.asyncio, "sleep", record_sleep):
-        async for _msg in telegram_backup.iter_messages_with_flood_retry(
-            fake_client, "chat", min_id=0, reverse=True
-        ):
+        async for _msg in telegram_backup.iter_messages_with_flood_retry(fake_client, "chat", min_id=0, reverse=True):
             pass
 
     assert sleeps == [telegram_backup.MAX_FLOOD_WAIT_SECONDS + 1]
@@ -366,9 +354,7 @@ async def test_iter_with_flood_retry_suppresses_short_wait_logs(caplog, fake_db)
         patch.dict(os.environ, {"FLOOD_WAIT_LOG_THRESHOLD": "10"}),
         patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
     ):
-        async for _msg in telegram_backup.iter_messages_with_flood_retry(
-            fake_client, "chat", min_id=0, reverse=True
-        ):
+        async for _msg in telegram_backup.iter_messages_with_flood_retry(fake_client, "chat", min_id=0, reverse=True):
             pass
 
     flood_logs = [r for r in caplog.records if "FloodWait" in r.getMessage()]
@@ -381,9 +367,7 @@ async def test_iter_with_flood_retry_rejects_non_reverse(fake_db):
     from src import telegram_backup
 
     with pytest.raises(ValueError, match="reverse=True"):
-        async for _ in telegram_backup.iter_messages_with_flood_retry(
-            None, "chat", min_id=0
-        ):
+        async for _ in telegram_backup.iter_messages_with_flood_retry(None, "chat", min_id=0):
             pass
 
 
@@ -408,9 +392,7 @@ async def test_iter_with_flood_retry_clamps_negative_sleep(fake_db):
         sleeps.append(seconds)
 
     with patch.object(telegram_backup.asyncio, "sleep", record_sleep):
-        async for _msg in telegram_backup.iter_messages_with_flood_retry(
-            fake_client, "chat", min_id=0, reverse=True
-        ):
+        async for _msg in telegram_backup.iter_messages_with_flood_retry(fake_client, "chat", min_id=0, reverse=True):
             pass
 
     assert sleeps == [1], f"Expected sleep(0+1=1) for negative e.seconds, got {sleeps}"
@@ -440,9 +422,7 @@ async def test_iter_with_flood_retry_tolerates_bad_log_threshold_env(fake_db):
         patch.object(telegram_backup.asyncio, "sleep", fast_sleep),
     ):
         collected = []
-        async for msg in telegram_backup.iter_messages_with_flood_retry(
-            fake_client, "chat", min_id=0, reverse=True
-        ):
+        async for msg in telegram_backup.iter_messages_with_flood_retry(fake_client, "chat", min_id=0, reverse=True):
             collected.append(msg.id)
 
     assert collected == [1]

--- a/tests/test_web_coverage.py
+++ b/tests/test_web_coverage.py
@@ -41,9 +41,7 @@ except Exception:
 
 
 def _skip_unless_web(cls_or_fn):
-    return unittest.skipUnless(
-        _WEB_AVAILABLE and _HTTPX_AVAILABLE, "web_main or httpx import failed"
-    )(cls_or_fn)
+    return unittest.skipUnless(_WEB_AVAILABLE and _HTTPX_AVAILABLE, "web_main or httpx import failed")(cls_or_fn)
 
 
 def _skip_unless_push(cls_or_fn):
@@ -69,9 +67,7 @@ def _mock_db():
     db.get_all_viewer_accounts = AsyncMock(return_value=[])
     db.get_viewer_by_username = AsyncMock(return_value=None)
     db.get_viewer_account = AsyncMock(return_value=None)
-    db.create_viewer_account = AsyncMock(
-        return_value={"id": 1, "username": "test", "is_active": 1, "no_download": 0}
-    )
+    db.create_viewer_account = AsyncMock(return_value={"id": 1, "username": "test", "is_active": 1, "no_download": 0})
     db.update_viewer_account = AsyncMock(
         return_value={"id": 1, "username": "test", "allowed_chat_ids": None, "is_active": 1}
     )
@@ -79,8 +75,11 @@ def _mock_db():
     db.get_all_viewer_tokens = AsyncMock(return_value=[])
     db.create_viewer_token = AsyncMock(
         return_value={
-            "id": 1, "label": "test", "no_download": 0,
-            "expires_at": None, "created_at": "2025-01-01",
+            "id": 1,
+            "label": "test",
+            "no_download": 0,
+            "expires_at": None,
+            "created_at": "2025-01-01",
         }
     )
     db.update_viewer_token = AsyncMock(return_value=None)
@@ -159,12 +158,8 @@ class TestSessionCleanupTask(_WebTestBase):
     async def test_cleans_expired_sessions(self):
         """session_cleanup_task evicts expired sessions from memory and DB."""
         expired_time = time.time() - web_main.AUTH_SESSION_SECONDS - 100
-        web_main._sessions["expired1"] = web_main.SessionData(
-            username="old", role="viewer", created_at=expired_time
-        )
-        web_main._sessions["valid1"] = web_main.SessionData(
-            username="current", role="viewer", created_at=time.time()
-        )
+        web_main._sessions["expired1"] = web_main.SessionData(username="old", role="viewer", created_at=expired_time)
+        web_main._sessions["valid1"] = web_main.SessionData(username="current", role="viewer", created_at=time.time())
 
         with patch.object(web_main, "_SESSION_CLEANUP_INTERVAL", 0):
             task = asyncio.create_task(web_main.session_cleanup_task())
@@ -201,9 +196,7 @@ class TestSessionCleanupTask(_WebTestBase):
         """session_cleanup_task continues when DB cleanup raises."""
         self.mock_db.cleanup_expired_sessions = AsyncMock(side_effect=Exception("db error"))
         expired_time = time.time() - web_main.AUTH_SESSION_SECONDS - 100
-        web_main._sessions["exp"] = web_main.SessionData(
-            username="u", role="viewer", created_at=expired_time
-        )
+        web_main._sessions["exp"] = web_main.SessionData(username="u", role="viewer", created_at=expired_time)
 
         with patch.object(web_main, "_SESSION_CLEANUP_INTERVAL", 0):
             task = asyncio.create_task(web_main.session_cleanup_task())
@@ -291,6 +284,7 @@ class TestServeMedia(_WebTestBase):
             # The path traversal check tests ".." in split("/") or startswith("/")
             # We test the function directly since httpx normalizes URLs
             from fastapi import HTTPException
+
             with self.assertRaises(HTTPException) as ctx:
                 await web_main.serve_media(
                     path="../etc/passwd",
@@ -305,13 +299,9 @@ class TestServeMedia(_WebTestBase):
             web_main._media_root = web_main.Path(tmpdir)
             web_main.AUTH_ENABLED = True
             token = "nd-token"
-            web_main._sessions[token] = web_main.SessionData(
-                username="viewer1", role="viewer", no_download=True
-            )
+            web_main._sessions[token] = web_main.SessionData(username="viewer1", role="viewer", no_download=True)
             async with self._client() as client:
-                resp = await client.get(
-                    "/media/test.jpg?download=1", cookies={"viewer_auth": token}
-                )
+                resp = await client.get("/media/test.jpg?download=1", cookies={"viewer_auth": token})
             self.assertEqual(resp.status_code, 403)
 
     async def test_media_serves_existing_file(self):
@@ -350,13 +340,9 @@ class TestServeMedia(_WebTestBase):
 
             web_main.AUTH_ENABLED = True
             token = "restricted-media"
-            web_main._sessions[token] = web_main.SessionData(
-                username="v1", role="viewer", allowed_chat_ids={999}
-            )
+            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={999})
             async with self._client() as client:
-                resp = await client.get(
-                    "/media/123/photo.jpg", cookies={"viewer_auth": token}
-                )
+                resp = await client.get("/media/123/photo.jpg", cookies={"viewer_auth": token})
             self.assertEqual(resp.status_code, 403)
 
     async def test_media_avatar_access_check(self):
@@ -370,13 +356,9 @@ class TestServeMedia(_WebTestBase):
 
             web_main.AUTH_ENABLED = True
             token = "av-restricted"
-            web_main._sessions[token] = web_main.SessionData(
-                username="v1", role="viewer", allowed_chat_ids={100}
-            )
+            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={100})
             async with self._client() as client:
-                resp = await client.get(
-                    "/media/avatars/chats/456_789.jpg", cookies={"viewer_auth": token}
-                )
+                resp = await client.get("/media/avatars/chats/456_789.jpg", cookies={"viewer_auth": token})
             self.assertEqual(resp.status_code, 403)
 
     async def test_media_avatar_invalid_chat_id_format(self):
@@ -390,13 +372,9 @@ class TestServeMedia(_WebTestBase):
 
             web_main.AUTH_ENABLED = True
             token = "av-bad"
-            web_main._sessions[token] = web_main.SessionData(
-                username="v1", role="viewer", allowed_chat_ids={100}
-            )
+            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={100})
             async with self._client() as client:
-                resp = await client.get(
-                    "/media/avatars/users/badname.jpg", cookies={"viewer_auth": token}
-                )
+                resp = await client.get("/media/avatars/users/badname.jpg", cookies={"viewer_auth": token})
             self.assertEqual(resp.status_code, 403)
 
 
@@ -422,13 +400,9 @@ class TestServeThumbnail(_WebTestBase):
             web_main._media_root = web_main.Path(tmpdir)
             web_main.AUTH_ENABLED = True
             token = "th-restrict"
-            web_main._sessions[token] = web_main.SessionData(
-                username="v1", role="viewer", allowed_chat_ids={999}
-            )
+            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={999})
             async with self._client() as client:
-                resp = await client.get(
-                    "/media/thumb/200/123/photo.jpg", cookies={"viewer_auth": token}
-                )
+                resp = await client.get("/media/thumb/200/123/photo.jpg", cookies={"viewer_auth": token})
             self.assertEqual(resp.status_code, 403)
 
     async def test_thumbnail_avatar_access_check(self):
@@ -437,9 +411,7 @@ class TestServeThumbnail(_WebTestBase):
             web_main._media_root = web_main.Path(tmpdir)
             web_main.AUTH_ENABLED = True
             token = "th-av"
-            web_main._sessions[token] = web_main.SessionData(
-                username="v1", role="viewer", allowed_chat_ids={100}
-            )
+            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={100})
             async with self._client() as client:
                 resp = await client.get(
                     "/media/thumb/100/avatars/chats/456_789.jpg",
@@ -453,9 +425,7 @@ class TestServeThumbnail(_WebTestBase):
             web_main._media_root = web_main.Path(tmpdir)
             web_main.AUTH_ENABLED = True
             token = "th-bad"
-            web_main._sessions[token] = web_main.SessionData(
-                username="v1", role="viewer", allowed_chat_ids={100}
-            )
+            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={100})
             async with self._client() as client:
                 resp = await client.get(
                     "/media/thumb/100/avatars/users/badname.jpg",
@@ -619,10 +589,16 @@ class TestLoginEdgeCases(_WebTestBase):
 
         salt = "testsalt"
         pw_hash = web_main._hash_password("viewerpass", salt)
-        self.mock_db.get_viewer_by_username = AsyncMock(return_value={
-            "username": "v1", "password_hash": pw_hash, "salt": salt,
-            "is_active": 1, "allowed_chat_ids": None, "no_download": 0,
-        })
+        self.mock_db.get_viewer_by_username = AsyncMock(
+            return_value={
+                "username": "v1",
+                "password_hash": pw_hash,
+                "salt": salt,
+                "is_active": 1,
+                "allowed_chat_ids": None,
+                "no_download": 0,
+            }
+        )
         self.mock_db.create_audit_log = AsyncMock(side_effect=Exception("audit fail"))
         try:
             async with self._client() as client:
@@ -649,9 +625,12 @@ class TestLogoutEdgeCases(_WebTestBase):
     async def test_logout_with_db_session_not_in_memory(self):
         """logout looks up session from DB when not in memory cache."""
         token = "db-only-token"
-        self.mock_db.get_session = AsyncMock(return_value={
-            "username": "dbuser", "role": "viewer",
-        })
+        self.mock_db.get_session = AsyncMock(
+            return_value={
+                "username": "dbuser",
+                "role": "viewer",
+            }
+        )
         async with self._client() as client:
             resp = await client.post("/api/logout", cookies={"viewer_auth": token})
         self.assertEqual(resp.status_code, 200)
@@ -705,10 +684,14 @@ class TestTokenAuthEdgeCases(_WebTestBase):
 
     async def test_token_auth_with_no_download(self):
         """auth_via_token includes no_download flag in response."""
-        self.mock_db.verify_viewer_token = AsyncMock(return_value={
-            "id": 2, "label": "restricted", "allowed_chat_ids": json.dumps([10]),
-            "no_download": 1,
-        })
+        self.mock_db.verify_viewer_token = AsyncMock(
+            return_value={
+                "id": 2,
+                "label": "restricted",
+                "allowed_chat_ids": json.dumps([10]),
+                "no_download": 1,
+            }
+        )
         async with self._client() as client:
             resp = await client.post("/auth/token", json={"token": "valid"})
         self.assertEqual(resp.status_code, 200)
@@ -729,26 +712,18 @@ class TestExportEndpoint(_WebTestBase):
         """export_chat returns 403 when user has no_download restriction."""
         web_main.AUTH_ENABLED = True
         token = "nd-export"
-        web_main._sessions[token] = web_main.SessionData(
-            username="v1", role="viewer", no_download=True
-        )
+        web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", no_download=True)
         async with self._client() as client:
-            resp = await client.get(
-                "/api/chats/1/export", cookies={"viewer_auth": token}
-            )
+            resp = await client.get("/api/chats/1/export", cookies={"viewer_auth": token})
         self.assertEqual(resp.status_code, 403)
 
     async def test_export_returns_403_for_restricted_chat(self):
         """export_chat returns 403 when user cannot access the chat."""
         web_main.AUTH_ENABLED = True
         token = "restricted-export"
-        web_main._sessions[token] = web_main.SessionData(
-            username="v1", role="viewer", allowed_chat_ids={100}
-        )
+        web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={100})
         async with self._client() as client:
-            resp = await client.get(
-                "/api/chats/999/export", cookies={"viewer_auth": token}
-            )
+            resp = await client.get("/api/chats/999/export", cookies={"viewer_auth": token})
         self.assertEqual(resp.status_code, 403)
 
     async def test_export_returns_404_when_chat_not_found(self):
@@ -760,9 +735,7 @@ class TestExportEndpoint(_WebTestBase):
 
     async def test_export_streams_json_successfully(self):
         """export_chat streams JSON for a valid chat."""
-        self.mock_db.get_chat_by_id = AsyncMock(
-            return_value={"title": "Test Chat", "username": None}
-        )
+        self.mock_db.get_chat_by_id = AsyncMock(return_value={"title": "Test Chat", "username": None})
 
         async def fake_export(chat_id):
             yield {"id": 1, "text": "hello", "date": "2025-01-01"}
@@ -796,9 +769,7 @@ class TestAdminViewerUpdateEdgeCases(_WebTestBase):
 
     async def test_update_viewer_password(self):
         """update_viewer updates password correctly."""
-        self.mock_db.get_viewer_account = AsyncMock(
-            return_value={"id": 1, "username": "v1"}
-        )
+        self.mock_db.get_viewer_account = AsyncMock(return_value={"id": 1, "username": "v1"})
         async with self._client() as client:
             resp = await client.put(
                 "/api/admin/viewers/1",
@@ -811,20 +782,14 @@ class TestAdminViewerUpdateEdgeCases(_WebTestBase):
 
     async def test_update_viewer_short_password_returns_400(self):
         """update_viewer returns 400 for password shorter than 8 chars."""
-        self.mock_db.get_viewer_account = AsyncMock(
-            return_value={"id": 1, "username": "v1"}
-        )
+        self.mock_db.get_viewer_account = AsyncMock(return_value={"id": 1, "username": "v1"})
         async with self._client() as client:
-            resp = await client.put(
-                "/api/admin/viewers/1", json={"password": "short"}
-            )
+            resp = await client.put("/api/admin/viewers/1", json={"password": "short"})
         self.assertEqual(resp.status_code, 400)
 
     async def test_update_viewer_allowed_chat_ids_null(self):
         """update_viewer sets allowed_chat_ids to None."""
-        self.mock_db.get_viewer_account = AsyncMock(
-            return_value={"id": 1, "username": "v1"}
-        )
+        self.mock_db.get_viewer_account = AsyncMock(return_value={"id": 1, "username": "v1"})
         async with self._client() as client:
             resp = await client.put(
                 "/api/admin/viewers/1",
@@ -834,13 +799,9 @@ class TestAdminViewerUpdateEdgeCases(_WebTestBase):
 
     async def test_update_viewer_no_download(self):
         """update_viewer updates no_download flag."""
-        self.mock_db.get_viewer_account = AsyncMock(
-            return_value={"id": 1, "username": "v1"}
-        )
+        self.mock_db.get_viewer_account = AsyncMock(return_value={"id": 1, "username": "v1"})
         async with self._client() as client:
-            resp = await client.put(
-                "/api/admin/viewers/1", json={"no_download": True}
-            )
+            resp = await client.put("/api/admin/viewers/1", json={"no_download": True})
         self.assertEqual(resp.status_code, 200)
 
     async def test_update_viewer_invalid_json_returns_400(self):
@@ -859,9 +820,7 @@ class TestAdminViewerUpdateEdgeCases(_WebTestBase):
         saved_user = web_main.VIEWER_USERNAME
         web_main.VIEWER_USERNAME = "admin"
         token = "master-tok-conflict"
-        web_main._sessions[token] = web_main.SessionData(
-            username="admin", role="master"
-        )
+        web_main._sessions[token] = web_main.SessionData(username="admin", role="master")
         try:
             async with self._client() as client:
                 resp = await client.post(
@@ -928,30 +887,36 @@ class TestAdminTokenEdgeCases(_WebTestBase):
 
     async def test_update_token_success(self):
         """update_token updates and returns token data."""
-        self.mock_db.update_viewer_token = AsyncMock(return_value={
-            "id": 1, "label": "updated", "allowed_chat_ids": json.dumps([1, 2]),
-            "is_revoked": 0, "no_download": 0, "expires_at": None,
-        })
+        self.mock_db.update_viewer_token = AsyncMock(
+            return_value={
+                "id": 1,
+                "label": "updated",
+                "allowed_chat_ids": json.dumps([1, 2]),
+                "is_revoked": 0,
+                "no_download": 0,
+                "expires_at": None,
+            }
+        )
         async with self._client() as client:
-            resp = await client.put(
-                "/api/admin/tokens/1", json={"label": "updated"}
-            )
+            resp = await client.put("/api/admin/tokens/1", json={"label": "updated"})
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["label"], "updated")
 
     async def test_update_token_revoke_invalidates_sessions(self):
         """update_token invalidates sessions when revoking."""
-        web_main._sessions["tok-sess"] = web_main.SessionData(
-            username="token:test", role="token", source_token_id=5
+        web_main._sessions["tok-sess"] = web_main.SessionData(username="token:test", role="token", source_token_id=5)
+        self.mock_db.update_viewer_token = AsyncMock(
+            return_value={
+                "id": 5,
+                "label": "test",
+                "allowed_chat_ids": None,
+                "is_revoked": 1,
+                "no_download": 0,
+                "expires_at": None,
+            }
         )
-        self.mock_db.update_viewer_token = AsyncMock(return_value={
-            "id": 5, "label": "test", "allowed_chat_ids": None,
-            "is_revoked": 1, "no_download": 0, "expires_at": None,
-        })
         async with self._client() as client:
-            resp = await client.put(
-                "/api/admin/tokens/5", json={"is_revoked": True}
-            )
+            resp = await client.put("/api/admin/tokens/5", json={"is_revoked": True})
         self.assertEqual(resp.status_code, 200)
         self.assertNotIn("tok-sess", web_main._sessions)
 
@@ -985,14 +950,18 @@ class TestAdminTokenEdgeCases(_WebTestBase):
 
     async def test_update_token_no_download(self):
         """update_token updates no_download flag."""
-        self.mock_db.update_viewer_token = AsyncMock(return_value={
-            "id": 1, "label": "test", "allowed_chat_ids": json.dumps([1]),
-            "is_revoked": 0, "no_download": 1, "expires_at": None,
-        })
+        self.mock_db.update_viewer_token = AsyncMock(
+            return_value={
+                "id": 1,
+                "label": "test",
+                "allowed_chat_ids": json.dumps([1]),
+                "is_revoked": 0,
+                "no_download": 1,
+                "expires_at": None,
+            }
+        )
         async with self._client() as client:
-            resp = await client.put(
-                "/api/admin/tokens/1", json={"no_download": True}
-            )
+            resp = await client.put("/api/admin/tokens/1", json={"no_download": True})
         self.assertEqual(resp.status_code, 200)
 
 
@@ -1058,9 +1027,7 @@ class TestPushEndpointEdgeCases(_WebTestBase):
         """push_subscribe returns 403 when user can't access the chat."""
         web_main.AUTH_ENABLED = True
         token = "push-restrict"
-        web_main._sessions[token] = web_main.SessionData(
-            username="v1", role="viewer", allowed_chat_ids={100}
-        )
+        web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={100})
         mock_pm = MagicMock()
         mock_pm.is_enabled = True
         web_main.push_manager = mock_pm
@@ -1186,9 +1153,7 @@ class TestNotificationSettingsEdgeCases(_WebTestBase):
         """notification_settings returns enabled when session valid."""
         web_main.AUTH_ENABLED = True
         token = "notif-tok"
-        web_main._sessions[token] = web_main.SessionData(
-            username="u", role="master", created_at=time.time()
-        )
+        web_main._sessions[token] = web_main.SessionData(username="u", role="master", created_at=time.time())
         web_main.config.enable_notifications = True
         async with self._client() as client:
             resp = await client.get(
@@ -1204,7 +1169,8 @@ class TestNotificationSettingsEdgeCases(_WebTestBase):
         web_main.AUTH_ENABLED = True
         token = "exp-notif"
         web_main._sessions[token] = web_main.SessionData(
-            username="u", role="master",
+            username="u",
+            role="master",
             created_at=time.time() - web_main.AUTH_SESSION_SECONDS - 100,
         )
         async with self._client() as client:
@@ -1249,9 +1215,7 @@ class TestCreateSessionWithDb(_WebTestBase):
 
     async def test_creates_session_with_db_persistence(self):
         """_create_session persists session to DB when db is available."""
-        token = await web_main._create_session(
-            "admin", "master", allowed_chat_ids={1, 2}
-        )
+        token = await web_main._create_session("admin", "master", allowed_chat_ids={1, 2})
         self.assertIn(token, web_main._sessions)
         self.mock_db.save_session.assert_awaited_once()
 
@@ -1267,9 +1231,7 @@ class TestCreateSessionWithDb(_WebTestBase):
             await web_main._create_session("evict_user", "viewer")
 
         await web_main._create_session("evict_user", "viewer")
-        user_sessions = [
-            s for s in web_main._sessions.values() if s.username == "evict_user"
-        ]
+        user_sessions = [s for s in web_main._sessions.values() if s.username == "evict_user"]
         self.assertEqual(len(user_sessions), web_main._MAX_SESSIONS_PER_USER)
         self.mock_db.delete_session.assert_awaited()
 
@@ -1289,21 +1251,15 @@ class TestInvalidateWithDb(_WebTestBase):
         await web_main._create_session("user1", "viewer")
         await web_main._invalidate_user_sessions("user1")
         # Memory sessions should still be cleared
-        user_sessions = [
-            s for s in web_main._sessions.values() if s.username == "user1"
-        ]
+        user_sessions = [s for s in web_main._sessions.values() if s.username == "user1"]
         self.assertEqual(len(user_sessions), 0)
 
     async def test_invalidate_token_sessions_handles_db_error(self):
         """_invalidate_token_sessions continues when DB delete fails."""
-        self.mock_db.delete_sessions_by_source_token_id = AsyncMock(
-            side_effect=Exception("db err")
-        )
+        self.mock_db.delete_sessions_by_source_token_id = AsyncMock(side_effect=Exception("db err"))
         await web_main._create_session("t1", "token", source_token_id=10)
         await web_main._invalidate_token_sessions(10)
-        token_sessions = [
-            s for s in web_main._sessions.values() if s.source_token_id == 10
-        ]
+        token_sessions = [s for s in web_main._sessions.values() if s.source_token_id == 10]
         self.assertEqual(len(token_sessions), 0)
 
 
@@ -1321,9 +1277,7 @@ class TestChatsAvatarErrors(_WebTestBase):
         chats = [{"id": 1, "title": "Chat", "type": "private"}]
         self.mock_db.get_all_chats = AsyncMock(return_value=chats)
         self.mock_db.get_chat_count = AsyncMock(return_value=1)
-        with patch.object(
-            web_main, "_get_cached_avatar_path", side_effect=Exception("fs error")
-        ):
+        with patch.object(web_main, "_get_cached_avatar_path", side_effect=Exception("fs error")):
             async with self._client() as client:
                 resp = await client.get("/api/chats")
         self.assertEqual(resp.status_code, 200)
@@ -1463,9 +1417,7 @@ class TestEndpointDbErrors(_WebTestBase):
         """get_message_by_date falls back to UTC for invalid timezone."""
         self.mock_db.find_message_by_date_with_joins = AsyncMock(return_value={"id": 1})
         async with self._client() as client:
-            resp = await client.get(
-                "/api/chats/1/messages/by-date?date=2025-01-01&timezone=Invalid/Zone"
-            )
+            resp = await client.get("/api/chats/1/messages/by-date?date=2025-01-01&timezone=Invalid/Zone")
         self.assertEqual(resp.status_code, 200)
 
     async def test_export_db_connection_error(self):
@@ -1495,11 +1447,13 @@ class TestRealtimeNotificationPushNoSender(_WebTestBase):
         self.mock_db.get_user_by_id = AsyncMock(return_value=None)
 
         with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock):
-            await web_main.handle_realtime_notification({
-                "type": "new_message",
-                "chat_id": 42,
-                "data": {"message": {"id": 1, "text": "hello", "sender_id": 100}},
-            })
+            await web_main.handle_realtime_notification(
+                {
+                    "type": "new_message",
+                    "chat_id": 42,
+                    "data": {"message": {"id": 1, "text": "hello", "sender_id": 100}},
+                }
+            )
 
         mock_pm.notify_new_message.assert_awaited_once()
         call_kwargs = mock_pm.notify_new_message.call_args.kwargs
@@ -1514,11 +1468,13 @@ class TestRealtimeNotificationPushNoSender(_WebTestBase):
         self.mock_db.get_chat_by_id = AsyncMock(return_value={"title": "Chat"})
 
         with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock):
-            await web_main.handle_realtime_notification({
-                "type": "new_message",
-                "chat_id": 42,
-                "data": {"message": {"id": 1, "text": "hello"}},
-            })
+            await web_main.handle_realtime_notification(
+                {
+                    "type": "new_message",
+                    "chat_id": 42,
+                    "data": {"message": {"id": 1, "text": "hello"}},
+                }
+            )
 
         mock_pm.notify_new_message.assert_awaited_once()
         call_kwargs = mock_pm.notify_new_message.call_args.kwargs
@@ -1533,11 +1489,13 @@ class TestRealtimeNotificationPushNoSender(_WebTestBase):
         web_main.db = None
 
         with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock):
-            await web_main.handle_realtime_notification({
-                "type": "new_message",
-                "chat_id": 42,
-                "data": {"message": {"id": 1, "text": "hello", "sender_id": 100}},
-            })
+            await web_main.handle_realtime_notification(
+                {
+                    "type": "new_message",
+                    "chat_id": 42,
+                    "data": {"message": {"id": 1, "text": "hello", "sender_id": 100}},
+                }
+            )
 
         mock_pm.notify_new_message.assert_awaited_once()
 
@@ -1632,7 +1590,8 @@ class TestPushSubscribe(unittest.IsolatedAsyncioTestCase):
 
         result = await mgr.subscribe(
             endpoint="https://push.example.com/sub",
-            p256dh="k", auth="a",
+            p256dh="k",
+            auth="a",
         )
         self.assertFalse(result)
 
@@ -1654,9 +1613,7 @@ class TestPushUnsubscribe(unittest.IsolatedAsyncioTestCase):
         mock_ctx.__aexit__ = AsyncMock(return_value=None)
         mgr.db.db_manager.async_session_factory.return_value = mock_ctx
 
-        result = await mgr.unsubscribe(
-            endpoint="https://push.example.com/sub", username="u1"
-        )
+        result = await mgr.unsubscribe(endpoint="https://push.example.com/sub", username="u1")
         self.assertTrue(result)
         mock_session.commit.assert_awaited_once()
 
@@ -1833,6 +1790,7 @@ class TestSendNotificationEdgeCases(unittest.IsolatedAsyncioTestCase):
         mgr.unsubscribe = AsyncMock()
 
         from pywebpush import WebPushException
+
         mock_response = MagicMock()
         mock_response.status_code = 404
 
@@ -1851,6 +1809,7 @@ class TestSendNotificationEdgeCases(unittest.IsolatedAsyncioTestCase):
         mgr.get_subscriptions = AsyncMock(return_value=subs)
 
         from pywebpush import WebPushException
+
         mock_response = MagicMock()
         mock_response.status_code = 500
 

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -30,9 +30,7 @@ except Exception:
 
 
 def _skip_unless_web(cls_or_fn):
-    return unittest.skipUnless(
-        _WEB_AVAILABLE and _HTTPX_AVAILABLE, "web_main or httpx import failed"
-    )(cls_or_fn)
+    return unittest.skipUnless(_WEB_AVAILABLE and _HTTPX_AVAILABLE, "web_main or httpx import failed")(cls_or_fn)
 
 
 def _mock_db():
@@ -55,10 +53,14 @@ def _mock_db():
     db.get_viewer_by_username = AsyncMock(return_value=None)
     db.get_viewer_account = AsyncMock(return_value=None)
     db.create_viewer_account = AsyncMock(return_value={"id": 1, "username": "test", "is_active": 1, "no_download": 0})
-    db.update_viewer_account = AsyncMock(return_value={"id": 1, "username": "test", "allowed_chat_ids": None, "is_active": 1})
+    db.update_viewer_account = AsyncMock(
+        return_value={"id": 1, "username": "test", "allowed_chat_ids": None, "is_active": 1}
+    )
     db.delete_viewer_account = AsyncMock()
     db.get_all_viewer_tokens = AsyncMock(return_value=[])
-    db.create_viewer_token = AsyncMock(return_value={"id": 1, "label": "test", "no_download": 0, "expires_at": None, "created_at": "2025-01-01"})
+    db.create_viewer_token = AsyncMock(
+        return_value={"id": 1, "label": "test", "no_download": 0, "expires_at": None, "created_at": "2025-01-01"}
+    )
     db.update_viewer_token = AsyncMock(return_value=None)
     db.delete_viewer_token = AsyncMock(return_value=True)
     db.verify_viewer_token = AsyncMock(return_value=None)
@@ -175,9 +177,7 @@ class TestAuthCheckEndpoint(_WebTestBase):
         """auth check returns authenticated=True with valid session cookie."""
         web_main.AUTH_ENABLED = True
         token = "test-session-token-abc"
-        web_main._sessions[token] = web_main.SessionData(
-            username="admin", role="master", created_at=time.time()
-        )
+        web_main._sessions[token] = web_main.SessionData(username="admin", role="master", created_at=time.time())
         async with self._client() as client:
             resp = await client.get("/api/auth/check", cookies={"viewer_auth": token})
         data = resp.json()
@@ -190,7 +190,8 @@ class TestAuthCheckEndpoint(_WebTestBase):
         web_main.AUTH_ENABLED = True
         token = "expired-token"
         web_main._sessions[token] = web_main.SessionData(
-            username="old", role="viewer",
+            username="old",
+            role="viewer",
             created_at=time.time() - web_main.AUTH_SESSION_SECONDS - 100,
         )
         async with self._client() as client:
@@ -237,9 +238,7 @@ class TestChatsEndpoint(_WebTestBase):
         """get_chats filters chats when user has allowed_chat_ids."""
         web_main.AUTH_ENABLED = True
         token = "viewer-token"
-        web_main._sessions[token] = web_main.SessionData(
-            username="viewer1", role="viewer", allowed_chat_ids={1, 3}
-        )
+        web_main._sessions[token] = web_main.SessionData(username="viewer1", role="viewer", allowed_chat_ids={1, 3})
         all_chats = [
             {"id": 1, "title": "Allowed", "type": "private"},
             {"id": 2, "title": "Denied", "type": "group"},
@@ -301,9 +300,7 @@ class TestMessagesEndpoint(_WebTestBase):
         """get_messages returns 403 when user cannot access the chat."""
         web_main.AUTH_ENABLED = True
         token = "restricted-viewer"
-        web_main._sessions[token] = web_main.SessionData(
-            username="v1", role="viewer", allowed_chat_ids={100}
-        )
+        web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={100})
         async with self._client() as client:
             resp = await client.get("/api/chats/999/messages", cookies={"viewer_auth": token})
         self.assertEqual(resp.status_code, 403)
@@ -312,9 +309,7 @@ class TestMessagesEndpoint(_WebTestBase):
         """get_messages forwards before_date and before_id to db."""
         self.mock_db.get_messages_paginated = AsyncMock(return_value=[])
         async with self._client() as client:
-            resp = await client.get(
-                "/api/chats/1/messages?before_date=2025-06-15T12:00:00Z&before_id=500"
-            )
+            resp = await client.get("/api/chats/1/messages?before_date=2025-06-15T12:00:00Z&before_id=500")
         self.assertEqual(resp.status_code, 200)
         call_kwargs = self.mock_db.get_messages_paginated.call_args.kwargs
         self.assertIsNotNone(call_kwargs["before_date"])
@@ -421,12 +416,8 @@ class TestArchivedCountEndpoint(_WebTestBase):
         """get_archived_count filters by user allowed chats."""
         web_main.AUTH_ENABLED = True
         token = "av"
-        web_main._sessions[token] = web_main.SessionData(
-            username="v1", role="viewer", allowed_chat_ids={1, 2, 3}
-        )
-        self.mock_db.get_all_chats = AsyncMock(return_value=[
-            {"id": 1}, {"id": 2}, {"id": 99}
-        ])
+        web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={1, 2, 3})
+        self.mock_db.get_all_chats = AsyncMock(return_value=[{"id": 1}, {"id": 2}, {"id": 99}])
         async with self._client() as client:
             resp = await client.get("/api/archived/count", cookies={"viewer_auth": token})
         self.assertEqual(resp.status_code, 200)
@@ -458,16 +449,16 @@ class TestStatsEndpoint(_WebTestBase):
         """get_stats filters per_chat_message_counts by user allowed chats."""
         web_main.AUTH_ENABLED = True
         token = "sv"
-        web_main._sessions[token] = web_main.SessionData(
-            username="v1", role="viewer", allowed_chat_ids={1}
+        web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={1})
+        self.mock_db.get_cached_statistics = AsyncMock(
+            return_value={
+                "per_chat_message_counts": {"1": 100, "2": 200},
+                "chats": 2,
+                "messages": 300,
+                "media_files": 50,
+                "total_size_mb": 1000,
+            }
         )
-        self.mock_db.get_cached_statistics = AsyncMock(return_value={
-            "per_chat_message_counts": {"1": 100, "2": 200},
-            "chats": 2,
-            "messages": 300,
-            "media_files": 50,
-            "total_size_mb": 1000,
-        })
         self.mock_db.get_metadata = AsyncMock(return_value=None)
         async with self._client() as client:
             resp = await client.get("/api/stats", cookies={"viewer_auth": token})
@@ -499,9 +490,7 @@ class TestStatsRefreshEndpoint(_WebTestBase):
         """refresh_stats returns 403 for non-master users."""
         web_main.AUTH_ENABLED = True
         token = "viewer-tok"
-        web_main._sessions[token] = web_main.SessionData(
-            username="v1", role="viewer"
-        )
+        web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer")
         async with self._client() as client:
             resp = await client.post("/api/stats/refresh", cookies={"viewer_auth": token})
         self.assertEqual(resp.status_code, 403)
@@ -544,9 +533,7 @@ class TestMessageByDateEndpoint(_WebTestBase):
 
     async def test_returns_message_for_valid_date(self):
         """get_message_by_date returns message when found."""
-        self.mock_db.find_message_by_date_with_joins = AsyncMock(
-            return_value={"id": 100, "text": "found"}
-        )
+        self.mock_db.find_message_by_date_with_joins = AsyncMock(return_value={"id": 100, "text": "found"})
         async with self._client() as client:
             resp = await client.get("/api/chats/1/messages/by-date?date=2025-06-15")
         self.assertEqual(resp.status_code, 200)
@@ -569,9 +556,7 @@ class TestMessageByDateEndpoint(_WebTestBase):
         """get_message_by_date uses timezone parameter for date interpretation."""
         self.mock_db.find_message_by_date_with_joins = AsyncMock(return_value={"id": 1})
         async with self._client() as client:
-            resp = await client.get(
-                "/api/chats/1/messages/by-date?date=2025-06-15&timezone=Europe/Madrid"
-            )
+            resp = await client.get("/api/chats/1/messages/by-date?date=2025-06-15&timezone=Europe/Madrid")
         self.assertEqual(resp.status_code, 200)
 
 
@@ -620,10 +605,13 @@ class TestPushSubscribeEndpoint(_WebTestBase):
     async def test_subscribe_returns_400_when_push_disabled(self):
         """push_subscribe returns 400 when push is not enabled."""
         async with self._client() as client:
-            resp = await client.post("/api/push/subscribe", json={
-                "endpoint": "https://push.example.com/sub",
-                "keys": {"p256dh": "k", "auth": "a"},
-            })
+            resp = await client.post(
+                "/api/push/subscribe",
+                json={
+                    "endpoint": "https://push.example.com/sub",
+                    "keys": {"p256dh": "k", "auth": "a"},
+                },
+            )
         self.assertEqual(resp.status_code, 400)
 
     async def test_subscribe_stores_subscription(self):
@@ -633,10 +621,13 @@ class TestPushSubscribeEndpoint(_WebTestBase):
         mock_pm.subscribe = AsyncMock(return_value=True)
         web_main.push_manager = mock_pm
         async with self._client() as client:
-            resp = await client.post("/api/push/subscribe", json={
-                "endpoint": "https://push.example.com/sub",
-                "keys": {"p256dh": "key1", "auth": "auth1"},
-            })
+            resp = await client.post(
+                "/api/push/subscribe",
+                json={
+                    "endpoint": "https://push.example.com/sub",
+                    "keys": {"p256dh": "key1", "auth": "auth1"},
+                },
+            )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["status"], "subscribed")
 
@@ -747,14 +738,16 @@ class TestLoginEndpoint(_WebTestBase):
 
         salt = "testsalt123"
         pw_hash = web_main._hash_password("viewerpass", salt)
-        self.mock_db.get_viewer_by_username = AsyncMock(return_value={
-            "username": "viewer1",
-            "password_hash": pw_hash,
-            "salt": salt,
-            "is_active": 1,
-            "allowed_chat_ids": json.dumps([1, 2, 3]),
-            "no_download": 0,
-        })
+        self.mock_db.get_viewer_by_username = AsyncMock(
+            return_value={
+                "username": "viewer1",
+                "password_hash": pw_hash,
+                "salt": salt,
+                "is_active": 1,
+                "allowed_chat_ids": json.dumps([1, 2, 3]),
+                "no_download": 0,
+            }
+        )
         try:
             async with self._client() as client:
                 resp = await client.post("/api/login", json={"username": "viewer1", "password": "viewerpass"})
@@ -818,12 +811,14 @@ class TestTokenAuthEndpoint(_WebTestBase):
 
     async def test_token_auth_valid_token_creates_session(self):
         """auth_via_token creates session for valid token."""
-        self.mock_db.verify_viewer_token = AsyncMock(return_value={
-            "id": 1,
-            "label": "share-link",
-            "allowed_chat_ids": json.dumps([10, 20]),
-            "no_download": 0,
-        })
+        self.mock_db.verify_viewer_token = AsyncMock(
+            return_value={
+                "id": 1,
+                "label": "share-link",
+                "allowed_chat_ids": json.dumps([10, 20]),
+                "no_download": 0,
+            }
+        )
         async with self._client() as client:
             resp = await client.post("/auth/token", json={"token": "valid-token-hex"})
         self.assertEqual(resp.status_code, 200)
@@ -856,11 +851,20 @@ class TestAdminViewersEndpoint(_WebTestBase):
 
     async def test_list_viewers_returns_accounts(self):
         """list_viewers returns viewer account data."""
-        self.mock_db.get_all_viewer_accounts = AsyncMock(return_value=[{
-            "id": 1, "username": "v1", "allowed_chat_ids": json.dumps([1, 2]),
-            "is_active": 1, "no_download": 0, "created_by": "admin",
-            "created_at": "2025-01-01", "updated_at": "2025-01-01",
-        }])
+        self.mock_db.get_all_viewer_accounts = AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "username": "v1",
+                    "allowed_chat_ids": json.dumps([1, 2]),
+                    "is_active": 1,
+                    "no_download": 0,
+                    "created_by": "admin",
+                    "created_at": "2025-01-01",
+                    "updated_at": "2025-01-01",
+                }
+            ]
+        )
         async with self._client() as client:
             resp = await client.get("/api/admin/viewers")
         data = resp.json()
@@ -882,9 +886,9 @@ class TestAdminViewersEndpoint(_WebTestBase):
     async def test_create_viewer_success(self):
         """create_viewer creates account and returns data."""
         async with self._client() as client:
-            resp = await client.post("/api/admin/viewers", json={
-                "username": "newviewer", "password": "longpassword123"
-            })
+            resp = await client.post(
+                "/api/admin/viewers", json={"username": "newviewer", "password": "longpassword123"}
+            )
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
         self.assertEqual(data["username"], "test")
@@ -893,9 +897,7 @@ class TestAdminViewersEndpoint(_WebTestBase):
         """create_viewer returns 409 for existing username."""
         self.mock_db.get_viewer_by_username = AsyncMock(return_value={"username": "existing"})
         async with self._client() as client:
-            resp = await client.post("/api/admin/viewers", json={
-                "username": "existing", "password": "longpassword123"
-            })
+            resp = await client.post("/api/admin/viewers", json={"username": "existing", "password": "longpassword123"})
         self.assertEqual(resp.status_code, 409)
 
     async def test_update_viewer_not_found(self):
@@ -950,12 +952,22 @@ class TestAdminTokensEndpoint(_WebTestBase):
 
     async def test_list_tokens_returns_data(self):
         """list_tokens returns token data."""
-        self.mock_db.get_all_viewer_tokens = AsyncMock(return_value=[{
-            "id": 1, "label": "test", "created_by": "admin",
-            "allowed_chat_ids": json.dumps([1]), "is_revoked": 0,
-            "no_download": 0, "expires_at": None, "last_used_at": None,
-            "use_count": 0, "created_at": "2025-01-01",
-        }])
+        self.mock_db.get_all_viewer_tokens = AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "label": "test",
+                    "created_by": "admin",
+                    "allowed_chat_ids": json.dumps([1]),
+                    "is_revoked": 0,
+                    "no_download": 0,
+                    "expires_at": None,
+                    "last_used_at": None,
+                    "use_count": 0,
+                    "created_at": "2025-01-01",
+                }
+            ]
+        )
         async with self._client() as client:
             resp = await client.get("/api/admin/tokens")
         data = resp.json()
@@ -970,9 +982,7 @@ class TestAdminTokensEndpoint(_WebTestBase):
     async def test_create_token_success(self):
         """create_token returns token with plaintext."""
         async with self._client() as client:
-            resp = await client.post("/api/admin/tokens", json={
-                "allowed_chat_ids": [1, 2, 3], "label": "my-token"
-            })
+            resp = await client.post("/api/admin/tokens", json={"allowed_chat_ids": [1, 2, 3], "label": "my-token"})
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
         self.assertIn("token", data)
@@ -1085,10 +1095,26 @@ class TestAdminChatsEndpoint(_WebTestBase):
 
     async def test_returns_all_chats(self):
         """admin_list_chats returns all chats with display metadata."""
-        self.mock_db.get_all_chats = AsyncMock(return_value=[
-            {"id": 1, "title": "Group Chat", "type": "group", "username": None, "first_name": None, "last_name": None},
-            {"id": 2, "title": None, "type": "private", "username": "john", "first_name": "John", "last_name": "Doe"},
-        ])
+        self.mock_db.get_all_chats = AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "title": "Group Chat",
+                    "type": "group",
+                    "username": None,
+                    "first_name": None,
+                    "last_name": None,
+                },
+                {
+                    "id": 2,
+                    "title": None,
+                    "type": "private",
+                    "username": "john",
+                    "first_name": "John",
+                    "last_name": "Doe",
+                },
+            ]
+        )
         async with self._client() as client:
             resp = await client.get("/api/admin/chats")
         self.assertEqual(resp.status_code, 200)
@@ -1292,30 +1318,34 @@ class TestResolveSession(_WebTestBase):
 
     async def test_returns_none_for_expired_db_session(self):
         """_resolve_session returns None for expired session from db."""
-        self.mock_db.get_session = AsyncMock(return_value={
-            "username": "old",
-            "role": "viewer",
-            "allowed_chat_ids": None,
-            "no_download": 0,
-            "source_token_id": None,
-            "created_at": time.time() - web_main.AUTH_SESSION_SECONDS - 100,
-            "last_accessed": time.time() - web_main.AUTH_SESSION_SECONDS - 100,
-        })
+        self.mock_db.get_session = AsyncMock(
+            return_value={
+                "username": "old",
+                "role": "viewer",
+                "allowed_chat_ids": None,
+                "no_download": 0,
+                "source_token_id": None,
+                "created_at": time.time() - web_main.AUTH_SESSION_SECONDS - 100,
+                "last_accessed": time.time() - web_main.AUTH_SESSION_SECONDS - 100,
+            }
+        )
         result = await web_main._resolve_session("expired-db-tok")
         self.assertIsNone(result)
 
     async def test_loads_valid_session_from_db(self):
         """_resolve_session loads valid session from db and caches it."""
         now = time.time()
-        self.mock_db.get_session = AsyncMock(return_value={
-            "username": "dbuser",
-            "role": "viewer",
-            "allowed_chat_ids": json.dumps([1, 2]),
-            "no_download": 1,
-            "source_token_id": 5,
-            "created_at": now,
-            "last_accessed": now,
-        })
+        self.mock_db.get_session = AsyncMock(
+            return_value={
+                "username": "dbuser",
+                "role": "viewer",
+                "allowed_chat_ids": json.dumps([1, 2]),
+                "no_download": 1,
+                "source_token_id": 5,
+                "created_at": now,
+                "last_accessed": now,
+            }
+        )
         result = await web_main._resolve_session("db-tok")
         self.assertIsNotNone(result)
         self.assertEqual(result.username, "dbuser")
@@ -1344,6 +1374,7 @@ class TestRequireAuth(_WebTestBase):
         """require_auth raises 401 when auth enabled and no cookie."""
         web_main.AUTH_ENABLED = True
         from fastapi import HTTPException
+
         with self.assertRaises(HTTPException) as ctx:
             await web_main.require_auth(auth_cookie=None)
         self.assertEqual(ctx.exception.status_code, 401)
@@ -1352,6 +1383,7 @@ class TestRequireAuth(_WebTestBase):
         """require_auth raises 401 when session not found."""
         web_main.AUTH_ENABLED = True
         from fastapi import HTTPException
+
         with self.assertRaises(HTTPException) as ctx:
             await web_main.require_auth(auth_cookie="bad-token")
         self.assertEqual(ctx.exception.status_code, 401)
@@ -1375,6 +1407,7 @@ class TestRequireMaster(unittest.TestCase):
         req = MagicMock()
         req.headers = {}
         from fastapi import HTTPException
+
         with self.assertRaises(HTTPException) as ctx:
             web_main.require_master(req, user)
         self.assertEqual(ctx.exception.status_code, 403)
@@ -1385,6 +1418,7 @@ class TestRequireMaster(unittest.TestCase):
         req = MagicMock()
         req.headers = {"x-viewer-only": "true"}
         from fastapi import HTTPException
+
         with self.assertRaises(HTTPException) as ctx:
             web_main.require_master(req, user)
         self.assertEqual(ctx.exception.status_code, 403)
@@ -1409,11 +1443,13 @@ class TestRealtimeNotificationWithPush(_WebTestBase):
         self.mock_db.get_user_by_id = AsyncMock(return_value={"first_name": "Alice", "username": "alice"})
 
         with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock):
-            await web_main.handle_realtime_notification({
-                "type": "new_message",
-                "chat_id": 42,
-                "data": {"message": {"id": 1, "text": "hello", "sender_id": 100}},
-            })
+            await web_main.handle_realtime_notification(
+                {
+                    "type": "new_message",
+                    "chat_id": 42,
+                    "data": {"message": {"id": 1, "text": "hello", "sender_id": 100}},
+                }
+            )
 
         mock_pm.notify_new_message.assert_awaited_once()
         call_kwargs = mock_pm.notify_new_message.call_args.kwargs


### PR DESCRIPTION
## Summary

Follow-up to #124 (flood-wait visibility by @tondeaf). Addresses all edge cases and hardening issues identified during review:

- **`call_with_flood_retry()` helper** — new bounded retry wrapper for non-iterator API calls (`get_dialogs`, `get_me`); prevents silent hangs during connection and dialog enumeration
- **`connection.py` flood protection** — wrap both `get_me()` call sites with retry logic
- **Negative `e.seconds` clamp** — prevents zero-delay retry storms when Telethon returns negative wait times
- **`reverse=True` validation** — `iter_messages_with_flood_retry` now rejects `reverse=False` to prevent silent data corruption (resume tracking via `max()` only works ascending)
- **Defensive `FLOOD_WAIT_LOG_THRESHOLD` parsing** — invalid env values fall back to default 10 instead of crashing
- **`.env.example` documentation** — added `FLOOD_WAIT_LOG_THRESHOLD` with explanation
- **6 new tests** (16 total flood-wait tests): non-reverse rejection, negative sleep clamp, bad env parsing, `call_with_flood_retry` success/failure/negative paths

## Test plan

- [x] All 16 flood-wait tests pass
- [x] Full suite: 1551 passed, 0 failed
- [x] ruff lint clean