### PR TITLE
fix: harden notify pipeline — edit truncation, timing-safe auth, stable assertions

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [7.6.3] - 2026-04-25
+
+### Fixed
+
+- **Edit notifications no longer silently dropped on long messages** — The 500-char truncation guard only protected `data["message"]["text"]` (new_message path), leaving `data["new_text"]` (edit path) unprotected. A 4096-char emoji edit could produce a 16KB payload exceeding PostgreSQL's 8KB NOTIFY limit, causing a silent `pg_notify` error. Both paths are now truncated via a shared `_truncate_notify_data()` helper. (#123 follow-up)
+- **Use `pg_notify()` with bound parameters for PostgreSQL NOTIFY** — Replaces f-string SQL interpolation that was vulnerable to asyncpg `$N` placeholder parsing and fragile manual single-quote escaping. Contributed by @tondeaf in #123.
+- **Push secret comparison is now timing-safe** — `/internal/push` endpoint used `!=` for bearer token comparison; switched to `secrets.compare_digest()` consistent with the rest of the auth layer.
+- **Test assertions use stable `TextClause.text` attribute** — Replaced `str(stmt)` with `stmt.text` for SQLAlchemy SQL assertions, avoiding reliance on undocumented `__str__` behavior.
+
 ## [7.6.2] - 2026-04-25
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.6.2"
+version = "7.6.3"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.6.2"
+__version__ = "7.6.3"

--- a/src/realtime.py
+++ b/src/realtime.py
@@ -38,6 +38,32 @@ class NotificationType(str, Enum):
     PIN = "pin"
 
 
+def _truncate_notify_data(data: dict, max_text: int = 500) -> dict:
+    """Truncate large string fields in notification data to stay under PostgreSQL's 8KB NOTIFY limit.
+
+    Handles both ``data["message"]["text"]`` (new_message) and ``data["new_text"]`` (edit)
+    paths. Returns a shallow-copied dict so the caller's original is not mutated.
+    """
+    truncated = False
+
+    # new_message path: data["message"]["text"]
+    if "message" in data and isinstance(data["message"], dict):
+        msg = data["message"]
+        if "text" in msg and msg.get("text") and len(msg["text"]) > max_text:
+            data = data.copy()
+            data["message"] = msg.copy()
+            data["message"]["text"] = msg["text"][:max_text] + "…"
+            truncated = True
+
+    # edit path: data["new_text"]
+    if "new_text" in data and data.get("new_text") and len(data["new_text"]) > max_text:
+        if not truncated:
+            data = data.copy()
+        data["new_text"] = data["new_text"][:max_text] + "…"
+
+    return data
+
+
 class RealtimeNotifier:
     """
     Unified real-time notification sender.
@@ -93,14 +119,10 @@ class RealtimeNotifier:
         if not self._initialized:
             await self.init()
 
-        # Truncate message text to avoid PostgreSQL NOTIFY 8KB limit
-        # The viewer fetches full content via API, so truncation is fine
-        if "message" in data and isinstance(data["message"], dict):
-            msg = data["message"]
-            if "text" in msg and msg.get("text") and len(msg["text"]) > 500:
-                data = data.copy()
-                data["message"] = msg.copy()
-                data["message"]["text"] = msg["text"][:500] + "…"
+        # Truncate large string fields to stay under PostgreSQL's 8KB NOTIFY limit.
+        # The viewer fetches full content via API, so truncation is fine.
+        _MAX_NOTIFY_TEXT = 500
+        data = _truncate_notify_data(data, _MAX_NOTIFY_TEXT)
 
         payload = {"type": notification_type.value, "chat_id": chat_id, "data": data}
 

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1576,7 +1576,7 @@ async def internal_push(request: Request):
     push_secret = os.getenv("INTERNAL_PUSH_SECRET")
     if push_secret:
         auth_header = request.headers.get("Authorization", "")
-        if auth_header != f"Bearer {push_secret}":
+        if not secrets.compare_digest(auth_header, f"Bearer {push_secret}"):
             logger.warning(f"Rejected /internal/push: invalid or missing secret from {client_host}")
             raise HTTPException(status_code=403, detail="Forbidden")
 

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -267,6 +267,52 @@ class TestRealtimeNotifierNotify:
 
         assert len(original_data["message"]["text"]) == 1000  # Original unchanged
 
+    async def test_notify_truncates_long_edit_new_text(self):
+        """notify() truncates data["new_text"] for edit notifications (8KB guard)."""
+        mock_db = MagicMock()
+        mock_db._is_sqlite = False
+        notifier = RealtimeNotifier(db_manager=mock_db)
+        await notifier.init()
+
+        long_text = "x" * 1000
+        data = {"chat_id": 42, "message_id": 1, "new_text": long_text}
+
+        with patch.object(notifier, "_notify_postgres", new_callable=AsyncMock) as mock_pg:
+            await notifier.notify(NotificationType.EDIT, 42, data)
+
+            call_payload = mock_pg.call_args[0][0]
+            assert len(call_payload["data"]["new_text"]) == 501  # 500 + ellipsis char
+
+    async def test_notify_does_not_truncate_short_edit_new_text(self):
+        """notify() preserves short data["new_text"] for edit notifications."""
+        mock_db = MagicMock()
+        mock_db._is_sqlite = False
+        notifier = RealtimeNotifier(db_manager=mock_db)
+        await notifier.init()
+
+        data = {"chat_id": 42, "message_id": 1, "new_text": "short edit"}
+
+        with patch.object(notifier, "_notify_postgres", new_callable=AsyncMock) as mock_pg:
+            await notifier.notify(NotificationType.EDIT, 42, data)
+
+            call_payload = mock_pg.call_args[0][0]
+            assert call_payload["data"]["new_text"] == "short edit"
+
+    async def test_notify_does_not_mutate_original_edit_data(self):
+        """notify() creates a copy when truncating edit data, not mutating original."""
+        notifier = RealtimeNotifier()
+
+        with patch.dict(os.environ, {"DB_TYPE": "sqlite"}, clear=True):
+            await notifier.init()
+
+        long_text = "x" * 1000
+        original_data = {"chat_id": 42, "message_id": 1, "new_text": long_text}
+
+        with patch.object(notifier, "_notify_http", new_callable=AsyncMock):
+            await notifier.notify(NotificationType.EDIT, 42, original_data)
+
+        assert len(original_data["new_text"]) == 1000  # Original unchanged
+
 
 class TestRealtimeNotifierPostgres:
     """Tests for RealtimeNotifier._notify_postgres."""
@@ -312,8 +358,7 @@ class TestRealtimeNotifierPostgres:
         assert session.commit.await_count == 1
 
         stmt = session.execute.await_args.args[0]
-        sql = str(stmt).lower()
-        assert "pg_notify" in sql
+        assert "pg_notify" in stmt.text.lower()
 
         params = session.execute.await_args.args[1]
         assert params["channel"] == "telegram_updates"
@@ -336,10 +381,9 @@ class TestRealtimeNotifierPostgres:
         assert session.commit.await_count == 1
 
         stmt = session.execute.await_args.args[0]
-        sql = str(stmt)
-        assert "$1 break" not in sql
-        assert "$D" not in sql
-        assert "pg_notify" in sql.lower()
+        assert "$1 break" not in stmt.text
+        assert "$D" not in stmt.text
+        assert "pg_notify" in stmt.text.lower()
 
         params = session.execute.await_args.args[1]
         assert params["channel"] == "telegram_updates"


### PR DESCRIPTION
## Summary

Follow-up to #123 (pg_notify bound parameters by @tondeaf). Addresses all findings from the 11-agent review swarm:

- **Edit notifications no longer silently dropped on long messages** — The 500-char truncation guard only protected `data["message"]["text"]` (new_message path), leaving `data["new_text"]` (edit path) unprotected. A 4096-char emoji edit could produce a ~16KB payload exceeding PostgreSQL's 8KB NOTIFY limit. Both paths now truncated via shared `_truncate_notify_data()` helper.
- **Push secret comparison is now timing-safe** — `/internal/push` endpoint used `!=` for bearer token comparison; switched to `secrets.compare_digest()` consistent with the rest of the auth layer.
- **Test assertions use stable `TextClause.text` attribute** — Replaced `str(stmt)` with `stmt.text` for SQLAlchemy SQL assertions, avoiding reliance on undocumented `__str__` behavior.
- **3 new tests** for edit notification truncation (55 total realtime tests, 1557 full suite)

## Test plan

- [x] All 55 realtime tests pass
- [x] Full suite: 1557 passed, 0 failed
- [x] ruff lint + format clean