### PR TITLE
fix: harden viewer auth and archive safety

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,7 +42,7 @@ DOWNLOAD_MEDIA=true
 
 # Maximum media file size to download (in MB)
 # Files larger than this will be skipped
-MAX_MEDIA_SIZE_MB=4096
+MAX_MEDIA_SIZE_MB=100
 
 # Messages processed per database batch
 # Higher values = faster but more memory usage
@@ -111,9 +111,10 @@ PRIVATE_EXCLUDE_CHAT_IDS=
 GROUPS_EXCLUDE_CHAT_IDS=
 CHANNELS_EXCLUDE_CHAT_IDS=
 
-# INCLUDE additional chats (additive — adds to what CHAT_TYPES selects)
-# Note: These ADD to the selection, they don't restrict it.
-# For exclusive selection, use CHAT_IDS mode instead.
+# INCLUDE specific chats in type-based mode.
+# GLOBAL_INCLUDE_CHAT_IDS acts as an allow-list across all selected types.
+# Type-specific include lists limit that chat type. For simplest exclusive
+# selection, use CHAT_IDS mode instead.
 GLOBAL_INCLUDE_CHAT_IDS=
 PRIVATE_INCLUDE_CHAT_IDS=
 GROUPS_INCLUDE_CHAT_IDS=
@@ -129,7 +130,7 @@ ENABLE_LISTENER=false
 
 # Granular listener controls (only apply when ENABLE_LISTENER=true):
 # LISTEN_EDITS=true
-# LISTEN_DELETIONS=true
+# LISTEN_DELETIONS=false
 # LISTEN_NEW_MESSAGES=true
 # LISTEN_NEW_MESSAGES_MEDIA=false
 # LISTEN_CHAT_ACTIONS=true
@@ -171,10 +172,12 @@ DB_PATH=/data/backups/telegram_backup.db
 # ==============================================================================
 # These apply to the telegram-archive-viewer container.
 
-# Basic auth — set BOTH to enable authentication (recommended)
+# Basic auth — set BOTH to enable the master account. The viewer fails closed
+# unless credentials are configured or ALLOW_ANONYMOUS_VIEWER=true is explicit.
 # VIEWER_USERNAME=admin
 # VIEWER_PASSWORD=your_secure_password
 # AUTH_SESSION_DAYS=30
+# ALLOW_ANONYMOUS_VIEWER=false
 
 # --- Multi-User Access Control (v7.0.0) ---
 # Viewer accounts are managed via the admin panel (gear icon in sidebar).
@@ -205,6 +208,18 @@ DB_PATH=/data/backups/telegram_backup.db
 # Default: auto-detect from request protocol (HTTPS reverse proxy or direct HTTPS = Secure)
 # Override: true = always Secure, false = never Secure
 # SECURE_COOKIES=
+
+# Only trust X-Forwarded-For / X-Real-IP when your reverse proxy overwrites
+# those headers. Leave false for direct/LAN deployments.
+# TRUST_PROXY_HEADERS=false
+
+# Shared secret for backup -> viewer realtime pushes when using SQLite split
+# containers. Required for non-loopback /internal/push calls.
+# INTERNAL_PUSH_SECRET=change_me_to_a_long_random_value
+
+# Backup container target for SQLite realtime pushes.
+# VIEWER_HOST=telegram-viewer
+# VIEWER_PORT=8000
 
 # ==============================================================================
 # NOTIFICATIONS

--- a/.github/workflows/docker-publish-viewer.yml
+++ b/.github/workflows/docker-publish-viewer.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - 'v*.*.*'
     branches:
-      - master
+      - main
     paths:
       - 'Dockerfile.viewer'
       - 'requirements-viewer.txt'
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Optional tag to use (e.g., v3.0.6). If not provided, uses latest from master.'
+        description: 'Optional tag to use (e.g., v3.0.6). If not provided, uses latest from main.'
         required: false
         type: string
 
@@ -24,8 +24,29 @@ env:
   DOCKER_IMAGE: drumsergio/telegram-archive-viewer
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio pytest-cov ruff beautifulsoup4 Pillow
+      - name: Run lint and tests
+        run: |
+          ruff check .
+          ruff format --check .
+          python -m pytest tests/ --tb=short
+
   build-and-push:
     runs-on: ubuntu-latest
+    needs: test
     permissions:
       contents: read
       packages: write
@@ -55,8 +76,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{raw}}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event.inputs.tag != '' }}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
-            type=sha,prefix={{branch}}-,enable=${{ github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix={{branch}}-,enable=${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker-publish-viewer.yml
+++ b/.github/workflows/docker-publish-viewer.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           ruff check .
           ruff format --check .
-          python -m pytest tests/ --tb=short
+          python -m pytest tests/ -q -p no:cacheprovider --tb=short
 
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -5,7 +5,7 @@ on:
     tags:
       - 'v*.*.*'
     branches:
-      - master
+      - main
     paths:
       - 'Dockerfile'
       - 'requirements.txt'
@@ -19,7 +19,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Optional tag to use (e.g., v3.0.6). If not provided, uses latest from master.'
+        description: 'Optional tag to use (e.g., v3.0.6). If not provided, uses latest from main.'
         required: false
         type: string
 
@@ -27,8 +27,29 @@ env:
   DOCKER_IMAGE: drumsergio/telegram-archive
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio pytest-cov ruff beautifulsoup4 Pillow
+      - name: Run lint and tests
+        run: |
+          ruff check .
+          ruff format --check .
+          python -m pytest tests/ --tb=short
+
   build-and-push:
     runs-on: ubuntu-latest
+    needs: test
     permissions:
       contents: read
       packages: write
@@ -58,8 +79,8 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{raw}}
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event.inputs.tag != '' }}
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/master' }}
-            type=sha,prefix={{branch}}-,enable=${{ github.ref != 'refs/heads/master' && !startsWith(github.ref, 'refs/tags/') }}
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=sha,prefix={{branch}}-,enable=${{ github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags/') }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -45,7 +45,7 @@ jobs:
         run: |
           ruff check .
           ruff format --check .
-          python -m pytest tests/ --tb=short
+          python -m pytest tests/ -q -p no:cacheprovider --tb=short
 
   build-and-push:
     runs-on: ubuntu-latest

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -9,6 +9,11 @@ on:
 jobs:
   update-description:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        repository:
+          - drumsergio/telegram-archive
+          - drumsergio/telegram-archive-viewer
     steps:
       - uses: actions/checkout@v4
 
@@ -16,4 +21,4 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-          repository: drumsergio/telegram-archive
+          repository: ${{ matrix.repository }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,10 +3,10 @@ name: Lint
 on:
   push:
     branches: [main, master]
-    paths: ['src/**', '*.py', 'requirements*.txt', '.github/workflows/lint.yml']
+    paths: ['src/**', 'tests/**', 'scripts/**', 'alembic/**', '*.py', 'pyproject.toml', 'requirements*.txt', '.github/workflows/lint.yml']
   pull_request:
     branches: [main, master]
-    paths: ['src/**', '*.py', 'requirements*.txt', '.github/workflows/lint.yml']
+    paths: ['src/**', 'tests/**', 'scripts/**', 'alembic/**', '*.py', 'pyproject.toml', 'requirements*.txt', '.github/workflows/lint.yml']
 
 jobs:
   ruff:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
               echo "" >> /tmp/release_notes.md
               echo "---" >> /tmp/release_notes.md
               echo "" >> /tmp/release_notes.md
-              echo "📋 **Full changelog:** [docs/CHANGELOG.md](https://github.com/${{ github.repository }}/blob/master/docs/CHANGELOG.md)" >> /tmp/release_notes.md
+              echo "📋 **Full changelog:** [docs/CHANGELOG.md](https://github.com/${{ github.repository }}/blob/main/docs/CHANGELOG.md)" >> /tmp/release_notes.md
               echo "has_notes=true" >> $GITHUB_OUTPUT
             else
               echo "No changelog notes found for $VERSION"

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -3,10 +3,10 @@ name: Shellcheck
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths: ['**/*.sh', '.github/workflows/shellcheck.yml']
   pull_request:
-    branches: [master]
+    branches: [main]
     paths: ['**/*.sh', '.github/workflows/shellcheck.yml']
 
 permissions:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
   push:
     branches: [main, master]
-    paths: ['src/**', '*.py', 'tests/**', 'requirements*.txt', '.github/workflows/tests.yml']
+    paths: ['src/**', 'tests/**', 'scripts/**', 'alembic/**', '*.py', 'pyproject.toml', 'requirements*.txt', 'Dockerfile*', 'docker-compose.yml', '.github/workflows/tests.yml']
   pull_request:
     branches: [main, master]
-    paths: ['src/**', '*.py', 'tests/**', 'requirements*.txt', '.github/workflows/tests.yml']
+    paths: ['src/**', 'tests/**', 'scripts/**', 'alembic/**', '*.py', 'pyproject.toml', 'requirements*.txt', 'Dockerfile*', 'docker-compose.yml', '.github/workflows/tests.yml']
 
 jobs:
   test:

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ docker run -it --rm \
   -e TELEGRAM_PHONE=+YOUR_PHONE_NUMBER \
   -e SESSION_NAME=telegram_backup \
   -v /path/to/your/session:/data/session \
-  drumsergio/telegram-archive:7.6.4 \
+  drumsergio/telegram-archive:7.7.0 \
   python -m src auth
 ```
 
@@ -167,7 +167,7 @@ docker run -it --rm \
 docker run -it --rm \
   --env-file .env \
   -v ./data:/data \
-  drumsergio/telegram-archive:7.6.4 \
+  drumsergio/telegram-archive:7.7.0 \
   python -m src auth
 
 # Then restart the backup container
@@ -208,7 +208,7 @@ The standalone viewer image (`drumsergio/telegram-archive-viewer`) lets you brow
 # Example: Viewer-only deployment
 services:
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:7.6.4
+    image: drumsergio/telegram-archive-viewer:7.7.0
     ports:
       - "127.0.0.1:8000:8000"
     environment:
@@ -338,8 +338,8 @@ CHAT_TYPES=private,groups
 CHAT_TYPES=channels
 CHANNELS_EXCLUDE_CHAT_IDS=-1001234567890
 
-# Backup only one specific channel while keeping type-based options
-CHAT_TYPES=groups
+# Backup groups plus one specific channel
+CHAT_TYPES=groups,channels
 CHANNELS_INCLUDE_CHAT_IDS=-1001234567890
 ```
 
@@ -440,7 +440,7 @@ For production stability, pin to specific versions instead of `latest`:
 ```yaml
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:7.6.4  # Pin to a reviewed release
+    image: drumsergio/telegram-archive:7.7.0  # Pin to a reviewed release
 ```
 
 Check [Releases](https://github.com/GeiserX/Telegram-Archive/releases) for available versions.

--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ cp .env.example .env
 TELEGRAM_API_ID=12345678          # Your API ID
 TELEGRAM_API_HASH=abcdef123456    # Your API Hash  
 TELEGRAM_PHONE=+1234567890        # Your phone (with country code)
+VIEWER_USERNAME=admin             # Required for web access
+VIEWER_PASSWORD=change-this       # Required for web access
 ```
 
 **Optional: enable a SOCKS5 proxy for all Telegram connections** (useful in regions where Telegram is blocked or behind corporate firewalls)
@@ -154,7 +156,7 @@ docker run -it --rm \
   -e TELEGRAM_PHONE=+YOUR_PHONE_NUMBER \
   -e SESSION_NAME=telegram_backup \
   -v /path/to/your/session:/data/session \
-  drumsergio/telegram-archive:latest \
+  drumsergio/telegram-archive:7.6.4 \
   python -m src auth
 ```
 
@@ -164,8 +166,8 @@ docker run -it --rm \
 # If using docker compose with a session volume
 docker run -it --rm \
   --env-file .env \
-  -v telegram-archive_session:/data/session \
-  drumsergio/telegram-archive:latest \
+  -v ./data:/data \
+  drumsergio/telegram-archive:7.6.4 \
   python -m src auth
 
 # Then restart the backup container
@@ -187,6 +189,8 @@ docker compose up -d
 
 **View your backup** at http://localhost:8000
 
+The default compose binds the viewer to `127.0.0.1`. Put it behind a reverse proxy only after setting `VIEWER_USERNAME` and `VIEWER_PASSWORD`. To deliberately run without auth for a local-only viewer, set `ALLOW_ANONYMOUS_VIEWER=true`.
+
 ### Common Issues
 
 | Problem | Solution |
@@ -204,9 +208,9 @@ The standalone viewer image (`drumsergio/telegram-archive-viewer`) lets you brow
 # Example: Viewer-only deployment
 services:
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:latest
+    image: drumsergio/telegram-archive-viewer:7.6.4
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"
     environment:
       BACKUP_PATH: /data/backups
       DATABASE_DIR: /data/db
@@ -214,8 +218,9 @@ services:
       VIEWER_PASSWORD: your-secure-password
       VIEWER_TIMEZONE: Europe/Madrid
     volumes:
-      - /path/to/backups:/data/backups:ro
-      - /path/to/db:/data/db:ro
+      # SQLite needs write access for WAL files, sessions, audit logs, and thumbnails.
+      # Use :ro only when the database is PostgreSQL and media is mounted separately.
+      - /path/to/data:/data
 ```
 
 Browse your backups at **http://localhost:8000**
@@ -274,13 +279,13 @@ The **Scope** column shows whether each variable applies to the backup scheduler
 | **Real-time Listener** | | | See [Real-time Listener](#real-time-listener) below |
 | `ENABLE_LISTENER` | `false` | B | **Master switch** — enables all `LISTEN_*` features below |
 | `LISTEN_EDITS` | `true` | B | Apply text edits in real-time |
-| `LISTEN_DELETIONS` | `true` | B | Mirror deletions (protected by [mass operation rate limiting](#mass-operation-protection)) |
+| `LISTEN_DELETIONS` | `false` | B | Mirror deletions from Telegram. Opt-in only; enabling this can delete archived messages |
 | `LISTEN_NEW_MESSAGES` | `true` | B | Save new messages in real-time between scheduled backups |
 | `LISTEN_NEW_MESSAGES_MEDIA` | `false` | B | Also download media immediately (vs. next scheduled backup) |
 | `LISTEN_CHAT_ACTIONS` | `true` | B | Track chat photo, title, and member changes |
 | `MASS_OPERATION_THRESHOLD` | `10` | B | Max operations per chat before rate limiting triggers |
 | `MASS_OPERATION_WINDOW_SECONDS` | `30` | B | Sliding window for counting operations (seconds) |
-| `MASS_OPERATION_BUFFER_DELAY` | `2.0` | B | Seconds to buffer operations before applying |
+| `MASS_OPERATION_BUFFER_DELAY` | `2.0` | B | Deprecated compatibility setting; operations are rate-limited, not buffered |
 | **Database** | | | See [Database Configuration](#database-configuration) below |
 | `DATABASE_URL` | - | B/V | Full database URL (highest priority, overrides all below) |
 | `DB_TYPE` | `sqlite` | B/V | Database engine: `sqlite` or `postgresql` |
@@ -293,10 +298,15 @@ The **Scope** column shows whether each variable applies to the backup scheduler
 | `POSTGRES_PASSWORD` | - | B/V | PostgreSQL password (required when using PostgreSQL) |
 | `POSTGRES_DB` | `telegram_backup` | B/V | PostgreSQL database name |
 | **Viewer & Authentication** | | | |
-| `VIEWER_USERNAME` | - | V | Web viewer username (both username and password required to enable auth) |
-| `VIEWER_PASSWORD` | - | V | Web viewer password |
+| `VIEWER_USERNAME` | - | V | Master web viewer username |
+| `VIEWER_PASSWORD` | - | V | Master web viewer password |
+| `ALLOW_ANONYMOUS_VIEWER` | `false` | V | Explicitly allow unauthenticated local viewer mode |
 | `AUTH_SESSION_DAYS` | `30` | V | Days before re-authentication is required |
 | `DISPLAY_CHAT_IDS` | - | V | Restrict viewer to specific chats (comma-separated IDs) |
+| `TRUST_PROXY_HEADERS` | `false` | V | Trust `X-Forwarded-For` / `X-Real-IP` only when your reverse proxy overwrites them |
+| `INTERNAL_PUSH_SECRET` | - | B/V | Shared secret for SQLite backup-to-viewer realtime push over Docker/private networks |
+| `VIEWER_HOST` | `localhost` | B | Viewer host for SQLite realtime push from backup/listener |
+| `VIEWER_PORT` | `8080` | B | Viewer port for SQLite realtime push from backup/listener |
 | `VIEWER_TIMEZONE` | `Europe/Madrid` | V | Timezone for displayed timestamps ([tz database names](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)) |
 | `SHOW_STATS` | `true` | V | Show backup statistics dropdown in viewer header |
 | **Security** | | | |
@@ -328,12 +338,12 @@ CHAT_TYPES=private,groups
 CHAT_TYPES=channels
 CHANNELS_EXCLUDE_CHAT_IDS=-1001234567890
 
-# Backup all groups plus one specific channel
+# Backup only one specific channel while keeping type-based options
 CHAT_TYPES=groups
 CHANNELS_INCLUDE_CHAT_IDS=-1001234567890
 ```
 
-> `*_INCLUDE_*` variables are **additive** — they add chats to what `CHAT_TYPES` already selects. For exclusive selection, use `CHAT_IDS` instead.
+> Include variables are **allow-lists**, not additive overrides. `GLOBAL_INCLUDE_CHAT_IDS` limits all selected types to those IDs; type-specific include variables limit only that type. For the simplest exclusive selection, use `CHAT_IDS`.
 
 **Chat ID format** — Telegram uses "marked" IDs:
 - **Users**: positive numbers (`123456789`)
@@ -358,23 +368,23 @@ The scheduled backup only captures new messages. To also track edits and deletio
 ```yaml
 ENABLE_LISTENER: "true"        # Master switch — required
 LISTEN_EDITS: "true"           # Track text edits (safe, default: true)
-LISTEN_DELETIONS: "true"       # Mirror deletions (default: true, protected by rate limiting)
+LISTEN_DELETIONS: "false"      # Keep archive entries when Telegram messages are deleted
 LISTEN_NEW_MESSAGES: "true"    # Save new messages instantly (default: true)
 ```
 
 **How it works:** stays connected to Telegram between scheduled backups, captures changes as they happen, and automatically reconnects if disconnected.
 
-**Backup protection:** when `LISTEN_DELETIONS=true`, deletions are protected by the [mass operation rate limiter](#mass-operation-protection). Set `LISTEN_DELETIONS=false` to never delete anything from your backup.
+**Backup protection:** `LISTEN_DELETIONS=false` is the safe default. Set `LISTEN_DELETIONS=true` only if you explicitly want mirror behavior where Telegram deletions also remove archived messages.
 
 **Alternative — batch sync:** set `SYNC_DELETIONS_EDITS=true` to check ALL backed-up messages on each scheduled run. This is expensive and slow — only use for a one-time catch-up, then switch to the real-time listener.
 
 ### Mass Operation Protection
 
-When the listener is enabled and `LISTEN_DELETIONS=true`, a sliding-window rate limiter protects against mass deletion attacks:
+When the listener is enabled and `LISTEN_DELETIONS=true`, a sliding-window rate limiter limits mass deletion damage:
 
-1. Operations are **buffered** for `MASS_OPERATION_BUFFER_DELAY` seconds before being applied
+1. Operations under the threshold are applied immediately
 2. A sliding window tracks operations per chat over `MASS_OPERATION_WINDOW_SECONDS`
-3. When `MASS_OPERATION_THRESHOLD` is exceeded, the **entire buffer is discarded** — zero changes written
+3. When `MASS_OPERATION_THRESHOLD` is exceeded, remaining operations are blocked for that window
 
 **Example:** someone deletes 50 messages in 10 seconds with default settings (threshold=10, window=30s) — the first 10 are applied, remaining 40 are blocked. For **zero** deletions from your backup, set `LISTEN_DELETIONS=false`.
 
@@ -389,7 +399,7 @@ Telegram Archive supports **SQLite** (default, zero-config) and **PostgreSQL** (
 **Using PostgreSQL:**
 
 1. Uncomment the `postgres` service in `docker-compose.yml`
-2. Set `DB_TYPE=postgresql` and `POSTGRES_PASSWORD` in your `.env`
+2. Set `DB_TYPE=postgresql` and `POSTGRES_PASSWORD` in your `.env`, or use a full `DATABASE_URL`
 3. Uncomment `depends_on` in both backup and viewer services
 4. Run `docker compose up -d`
 
@@ -430,7 +440,7 @@ For production stability, pin to specific versions instead of `latest`:
 ```yaml
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:v7.1.7  # Pin to specific version
+    image: drumsergio/telegram-archive:7.6.4  # Pin to a reviewed release
 ```
 
 Check [Releases](https://github.com/GeiserX/Telegram-Archive/releases) for available versions.
@@ -551,7 +561,7 @@ DETAIL: Key (id)=(XXXX) already exists
 
    Or use the provided script:
    ```bash
-   curl -O https://raw.githubusercontent.com/GeiserX/Telegram-Archive/master/scripts/fix_reactions_sequence.sql
+   curl -O https://raw.githubusercontent.com/GeiserX/Telegram-Archive/main/scripts/fix_reactions_sequence.sql
    docker exec -i <postgres-container> psql -U telegram -d telegram_backup < fix_reactions_sequence.sql
    ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:latest
+    image: drumsergio/telegram-archive:7.6.4
     container_name: telegram-backup
     restart: unless-stopped
     command: ["python", "-m", "src", "schedule"]
@@ -44,7 +44,7 @@ services:
       #   CHAT_TYPES: "private,groups,channels"  # All chats of these types
       # =======================================================================
       CHAT_IDS: ${CHAT_IDS:-}
-      CHAT_TYPES: ${CHAT_TYPES-private,groups,channels}
+      CHAT_TYPES: ${CHAT_TYPES:-private,groups,channels}
 
       # Granular Filtering (only used in type-based mode)
       GLOBAL_INCLUDE_CHAT_IDS: ${GLOBAL_INCLUDE_CHAT_IDS:-}
@@ -74,7 +74,7 @@ services:
       ENABLE_LISTENER: ${ENABLE_LISTENER:-false}
       # Granular listener controls (only apply when ENABLE_LISTENER=true):
       # LISTEN_EDITS: ${LISTEN_EDITS:-true}
-      # LISTEN_DELETIONS: ${LISTEN_DELETIONS:-true}
+      # LISTEN_DELETIONS: ${LISTEN_DELETIONS:-false}
       # LISTEN_NEW_MESSAGES: ${LISTEN_NEW_MESSAGES:-true}
       # LISTEN_NEW_MESSAGES_MEDIA: ${LISTEN_NEW_MESSAGES_MEDIA:-false}
       # LISTEN_CHAT_ACTIONS: ${LISTEN_CHAT_ACTIONS:-true}
@@ -87,6 +87,7 @@ services:
       # Batch sync alternative (expensive — prefer ENABLE_LISTENER instead)
       SYNC_DELETIONS_EDITS: ${SYNC_DELETIONS_EDITS:-false}
       VERIFY_MEDIA: ${VERIFY_MEDIA:-false}
+      INTERNAL_PUSH_SECRET: ${INTERNAL_PUSH_SECRET:-}
 
       # Logging
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
@@ -119,17 +120,21 @@ services:
     #       memory: 512M
 
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:latest
+    image: drumsergio/telegram-archive-viewer:7.6.4
     container_name: telegram-viewer
     restart: unless-stopped
     ports:
-      - "8000:8000"
+      # Bind to localhost by default. Put this behind a reverse proxy with auth
+      # configured before exposing it publicly.
+      - "127.0.0.1:8000:8000"
     environment:
       BACKUP_PATH: /data/backups
 
-      # Authentication (recommended — set both to enable)
+      # Authentication is required by default. To deliberately run a local
+      # anonymous viewer, set ALLOW_ANONYMOUS_VIEWER=true.
       VIEWER_USERNAME: ${VIEWER_USERNAME:-}
       VIEWER_PASSWORD: ${VIEWER_PASSWORD:-}
+      ALLOW_ANONYMOUS_VIEWER: ${ALLOW_ANONYMOUS_VIEWER:-false}
       AUTH_SESSION_DAYS: ${AUTH_SESSION_DAYS:-30}
 
       # Display
@@ -143,6 +148,8 @@ services:
       # CORS_ORIGINS: ${CORS_ORIGINS:-*}
       # SECURE_COOKIES: auto-detect from protocol; override with true/false
       # SECURE_COOKIES: ${SECURE_COOKIES:-}
+      TRUST_PROXY_HEADERS: ${TRUST_PROXY_HEADERS:-false}
+      INTERNAL_PUSH_SECRET: ${INTERNAL_PUSH_SECRET:-}
 
       # Notifications
       # PUSH_NOTIFICATIONS: ${PUSH_NOTIFICATIONS:-basic}
@@ -186,7 +193,7 @@ services:
   # Example: Restricted Channel Viewer (optional)
   # Use this to share specific channels publicly with authentication
   # telegram-channel-viewer:
-  #   image: drumsergio/telegram-archive-viewer:latest
+  #   image: drumsergio/telegram-archive-viewer:7.6.4
   #   container_name: telegram-channel-viewer
   #   restart: unless-stopped
   #   ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:7.6.4
+    image: drumsergio/telegram-archive:7.7.0
     container_name: telegram-backup
     restart: unless-stopped
     command: ["python", "-m", "src", "schedule"]
@@ -120,7 +120,7 @@ services:
     #       memory: 512M
 
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:7.6.4
+    image: drumsergio/telegram-archive-viewer:7.7.0
     container_name: telegram-viewer
     restart: unless-stopped
     ports:
@@ -193,7 +193,7 @@ services:
   # Example: Restricted Channel Viewer (optional)
   # Use this to share specific channels publicly with authentication
   # telegram-channel-viewer:
-  #   image: drumsergio/telegram-archive-viewer:7.6.4
+  #   image: drumsergio/telegram-archive-viewer:7.7.0
   #   container_name: telegram-channel-viewer
   #   restart: unless-stopped
   #   ports:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [7.7.0] - 2026-04-29
+
+### Security
+
+- **Viewer now fails closed when credentials are missing** — If `VIEWER_USERNAME`/`VIEWER_PASSWORD` are not configured, the HTTP API and WebSocket endpoint reject access unless `ALLOW_ANONYMOUS_VIEWER=true` is explicitly set.
+- **Restricted media access is enforced consistently** — Media, thumbnails, avatars, and non-chat folders now share centralized chat ACL checks, preventing restricted users from reading `_shared` files or unrelated chat media.
+- **No-download users can no longer fetch original or thumbnail bytes** — Accounts and share tokens with `no_download=true` receive metadata only; direct original media and generated thumbnail URLs return 403, while UI avatars remain available.
+- **Internal push events require a secret off-loopback** — `/internal/push` requires `INTERNAL_PUSH_SECRET` for non-loopback/private-network callers, reducing spoofing risk between co-located containers.
+- **WebSocket upgrades validate origin** — Cross-origin WebSocket connections must be same-origin or explicitly allowed by `CORS_ORIGINS`.
+- **Non-interactive auth hash files are owner-only** — Persisted `phone_code_hash` sidecar files are now created with `0600` permissions.
+
+### Fixed
+
+- **Scheduled backups no longer overlap** — The scheduler uses a backup lock so initial and cron-triggered jobs cannot run concurrently.
+- **FloodWait handling is explicit and bounded** — One-shot Telegram API calls now retry through shared helpers and abort instead of sleeping when Telegram asks for waits above `MAX_FLOOD_WAIT_SECONDS`.
+- **FloodWait env parsing is resilient** — Invalid `MAX_FLOOD_RETRIES` and `MAX_FLOOD_WAIT_SECONDS` values fall back to safe defaults instead of crashing imports.
+- **Media downloads finalize atomically** — Temporary `.part` files are moved into place only when an actual file exists, preserving Telethon-selected extensions and avoiding bogus stored paths.
+- **Telegram contact, geo, and poll media are metadata-only** — These message types no longer trigger file download attempts.
+- **Database URL precedence is consistent** — Entrypoint migrations and realtime notifier/listener mode detection now honor `DATABASE_URL` before `DB_TYPE`, including `postgres://`, `postgresql://`, `postgresql+asyncpg://`, and SQLite URLs.
+- **Database migration coverage includes app-state tables** — SQLite-to-PostgreSQL migration now includes viewer accounts, sessions, tokens, folders, forum topics, push subscriptions, and settings.
+- **Share token URLs avoid query-string leakage** — Generated links use `#token=` fragments and preserve subpath deployments.
+
+### Changed
+
+- **Deletion listening is safer by default** — `LISTEN_DELETIONS` now defaults to `false` so archives do not mirror Telegram deletions unless explicitly configured.
+- **Docker examples pin the 7.7.0 release** — Compose and README snippets now reference `drumsergio/telegram-archive:7.7.0` and `drumsergio/telegram-archive-viewer:7.7.0`.
+- **Viewer compose binds to localhost by default** — The example viewer service binds `127.0.0.1:8000:8000` and documents reverse-proxy/auth requirements before public exposure.
+- **CI and release checks are stricter** — Docker publish workflows run ruff and pytest before publishing, shellcheck tracks `main`, Docker Hub description sync covers both images, and release checks match the documented local test command.
+
+### Documentation
+
+- **Viewer authentication setup is documented** — README and `.env.example` now show required viewer credentials and the explicit anonymous opt-in.
+- **Chat include filters are documented as allow-lists** — Examples now correctly show `CHAT_TYPES=groups,channels` when including one specific channel alongside groups.
+- **Operational safety docs were refreshed** — README and `.env.example` now describe deletion mirroring, flood-wait controls, proxy header trust, and internal push secrets.
+
+### Tests
+
+- Added regression coverage for fail-closed viewer auth, no-download media restrictions, thumbnail ACLs, WebSocket subscription filtering, internal push auth, scheduler locking, flood-wait aborts, atomic downloads, `DATABASE_URL` behavior, non-interactive auth hash reuse, and migration model enumeration.
+
 ## [7.6.4] - 2026-04-25
 
 ### Fixed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -509,7 +509,7 @@ For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
 - **Docker Compose security hardening** — Both services now use `read_only: true`, `cap_drop: [ALL]`, `security_opt: [no-new-privileges:true]`, and `tmpfs: [/tmp]`. Viewer volume mounted read-only.
 - **GitHub Actions bumped** — `docker/build-push-action` v5→v6, `codecov/codecov-action` v4→v5.
-- **Removed `.cursor/rules/project.mdc`** — Redundant with `AGENTS.md` which is the single source of truth for AI assistant configuration.
+- **Removed `.cursor/rules/project.mdc`** — Redundant with `CLAUDE.md` which is the single source of truth for AI assistant configuration.
 
 ## [6.2.2] - 2026-02-07
 
@@ -1103,7 +1103,7 @@ See [Upgrading to v5.0.0](#upgrading-to-v500-from-v4x) below for detailed instru
 
 ### Improved
 - Release workflow now extracts changelog notes for GitHub releases
-- Added release guidelines to AGENTS.md
+- Added release guidelines to CLAUDE.md
 - Documented chat ID format requirements
 
 ## [4.1.3] - 2026-01-15

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,18 +29,22 @@ dependencies = [
     "APScheduler>=3.10.4",
     "python-dotenv>=1.0.1",
     "cryptg>=0.4.0",
-    "fastapi>=0.135.3",
+    "fastapi>=0.115.0",
     "uvicorn>=0.32.0",
     "jinja2>=3.1.4",
     "httpx>=0.28.1",
-    "websockets>=16.0",
+    "websockets>=12.0",
     "sqlalchemy[asyncio]>=2.0.36",
     "aiosqlite>=0.20.0",
-    "asyncpg>=0.31.0",
+    "asyncpg>=0.30.0",
     "psycopg2-binary>=2.9.9",
     "alembic>=1.14.0",
-    "greenlet>=3.4.0",
+    "greenlet>=3.1.0",
     "beautifulsoup4>=4.12.0",
+    "pywebpush>=2.0.0",
+    "py-vapid>=1.9.0",
+    "cryptography>=42.0.0",
+    "Pillow>=10.0.0",
 ]
 
 [project.optional-dependencies]
@@ -59,13 +63,13 @@ dev = [
 Homepage = "https://github.com/GeiserX/Telegram-Archive"
 Repository = "https://github.com/GeiserX/Telegram-Archive"
 Issues = "https://github.com/GeiserX/Telegram-Archive/issues"
-Changelog = "https://github.com/GeiserX/Telegram-Archive/blob/master/docs/CHANGELOG.md"
+Changelog = "https://github.com/GeiserX/Telegram-Archive/blob/main/docs/CHANGELOG.md"
 
 [project.scripts]
 telegram-archive = "src.__main__:main"
 
-[tool.setuptools]
-packages = ["src"]
+[tool.setuptools.packages.find]
+include = ["src", "src.*"]
 
 [tool.setuptools.package-data]
 src = ["web/templates/**/*", "web/static/**/*"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.6.4"
+version = "7.7.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/requirements-viewer.txt
+++ b/requirements-viewer.txt
@@ -20,6 +20,7 @@ greenlet>=3.1.0
 # Web Push notifications (v5.0+)
 pywebpush>=2.0.0
 py-vapid>=1.9.0
+cryptography>=42.0.0
 
 # Image processing for thumbnails (v7.2.0+)
 Pillow>=10.0.0

--- a/scripts/auth_noninteractive.py
+++ b/scripts/auth_noninteractive.py
@@ -34,6 +34,10 @@ def _get_session_path() -> str:
     return os.path.join(session_dir, session_name)
 
 
+def _get_phone_code_hash_path(session_path: str) -> str:
+    return f"{session_path}.phone_code_hash"
+
+
 async def main():
     if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help", "help"):
         print(__doc__)
@@ -57,6 +61,8 @@ async def main():
 
     if action == "send":
         result = await client.send_code_request(phone)
+        with open(_get_phone_code_hash_path(session_path), "w") as f:
+            f.write(result.phone_code_hash)
         print(f"Verification code sent to Telegram app ({result.type.__class__.__name__})")
         print(f"Phone code hash: {result.phone_code_hash}")
         await client.disconnect()
@@ -69,11 +75,18 @@ async def main():
         code = sys.argv[2]
         password = sys.argv[3] if len(sys.argv) > 3 else None
 
-        # Must send_code_request first to establish the flow
-        await client.send_code_request(phone)
+        phone_code_hash = os.getenv("TELEGRAM_PHONE_CODE_HASH", "").strip()
+        hash_path = _get_phone_code_hash_path(session_path)
+        if not phone_code_hash and os.path.exists(hash_path):
+            with open(hash_path) as f:
+                phone_code_hash = f.read().strip()
+        if not phone_code_hash:
+            print("Missing phone_code_hash. Run `send` first or set TELEGRAM_PHONE_CODE_HASH.")
+            await client.disconnect()
+            sys.exit(1)
 
         try:
-            await client.sign_in(phone, code)
+            await client.sign_in(phone=phone, code=code, phone_code_hash=phone_code_hash)
         except Exception as e:
             error_str = str(e)
             if (
@@ -93,6 +106,10 @@ async def main():
 
         me = await client.get_me()
         print(f"Authenticated as {me.first_name} (@{me.username})")
+        try:
+            os.remove(hash_path)
+        except FileNotFoundError:
+            pass
         await client.disconnect()
 
     else:

--- a/scripts/auth_noninteractive.py
+++ b/scripts/auth_noninteractive.py
@@ -61,7 +61,9 @@ async def main():
 
     if action == "send":
         result = await client.send_code_request(phone)
-        with open(_get_phone_code_hash_path(session_path), "w") as f:
+        hash_path = _get_phone_code_hash_path(session_path)
+        fd = os.open(hash_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        with os.fdopen(fd, "w") as f:
             f.write(result.phone_code_hash)
         print(f"Verification code sent to Telegram app ({result.type.__class__.__name__})")
         print(f"Phone code hash: {result.phone_code_hash}")

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -13,7 +13,7 @@ fi
 
 # Run Alembic migrations if database exists
 if [ "$SKIP_MIGRATIONS" = "false" ]; then
-  if [ "$DB_TYPE" = "postgresql" ] || [ "$DB_TYPE" = "postgres" ]; then
+  if [ "$DB_TYPE" = "postgresql" ] || [ "$DB_TYPE" = "postgres" ] || [[ "$DATABASE_URL" == postgresql* ]]; then
     echo "Running database migrations..."
     python -c "
 from alembic.config import Config
@@ -22,14 +22,25 @@ import os
 import sys
 import time
 import psycopg2
+from urllib.parse import urlparse
 
-# Build connection URL
-host = os.getenv('POSTGRES_HOST', 'localhost')
-port = os.getenv('POSTGRES_PORT', '5432')
-user = os.getenv('POSTGRES_USER', 'telegram')
-password = os.getenv('POSTGRES_PASSWORD', '')
-db = os.getenv('POSTGRES_DB', 'telegram_backup')
-url = f'postgresql://{user}:{password}@{host}:{port}/{db}'
+# Build connection URL from the same DATABASE_URL-preferred contract the app uses.
+raw_url = os.getenv('DATABASE_URL', '')
+if raw_url:
+    url = raw_url.replace('postgresql+asyncpg://', 'postgresql://', 1)
+    parsed = urlparse(url)
+    host = parsed.hostname or 'localhost'
+    port = str(parsed.port or 5432)
+    user = parsed.username or 'telegram'
+    password = parsed.password or ''
+    db = (parsed.path or '/telegram_backup').lstrip('/')
+else:
+    host = os.getenv('POSTGRES_HOST', 'localhost')
+    port = os.getenv('POSTGRES_PORT', '5432')
+    user = os.getenv('POSTGRES_USER', 'telegram')
+    password = os.getenv('POSTGRES_PASSWORD', '')
+    db = os.getenv('POSTGRES_DB', 'telegram_backup')
+    url = f'postgresql://{user}:{password}@{host}:{port}/{db}'
 
 print(f'Connecting to PostgreSQL at {host}:{port}...')
 
@@ -202,9 +213,14 @@ config.set_main_option('sqlalchemy.url', url)
 command.upgrade(config, 'head')
 print('Migrations complete.')
 "
-  elif [ "$DB_TYPE" = "sqlite" ] || [ -z "$DB_TYPE" ]; then
+  elif [ "$DB_TYPE" = "sqlite" ] || [ -z "$DB_TYPE" ] || [[ "$DATABASE_URL" == sqlite* ]]; then
     # SQLite - check if database file exists before running migrations
     DB_PATH="${DB_PATH:-${DATABASE_PATH:-${BACKUP_PATH:-/data/backups}/telegram_backup.db}}"
+    if [[ "$DATABASE_URL" == sqlite+aiosqlite:///* ]]; then
+      DB_PATH="${DATABASE_URL#sqlite+aiosqlite:///}"
+    elif [[ "$DATABASE_URL" == sqlite:///* ]]; then
+      DB_PATH="${DATABASE_URL#sqlite:///}"
+    fi
 
     if [ -f "$DB_PATH" ]; then
       echo "SQLite database found at $DB_PATH - running migrations..."
@@ -214,7 +230,13 @@ from alembic import command
 import os
 import sqlite3
 
-db_path = os.getenv('DB_PATH', os.getenv('DATABASE_PATH', os.path.join(os.getenv('BACKUP_PATH', '/data/backups'), 'telegram_backup.db')))
+database_url = os.getenv('DATABASE_URL', '')
+if database_url.startswith('sqlite+aiosqlite:///'):
+    db_path = database_url.removeprefix('sqlite+aiosqlite:///')
+elif database_url.startswith('sqlite:///'):
+    db_path = database_url.removeprefix('sqlite:///')
+else:
+    db_path = os.getenv('DB_PATH', os.getenv('DATABASE_PATH', os.path.join(os.getenv('BACKUP_PATH', '/data/backups'), 'telegram_backup.db')))
 url = f'sqlite:///{db_path}'
 
 # Check if this is a pre-Alembic database that needs stamping

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -13,7 +13,7 @@ fi
 
 # Run Alembic migrations if database exists
 if [ "$SKIP_MIGRATIONS" = "false" ]; then
-  if [ "$DB_TYPE" = "postgresql" ] || [ "$DB_TYPE" = "postgres" ] || [[ "$DATABASE_URL" == postgresql* ]]; then
+  if { [[ -n "$DATABASE_URL" ]] && { [[ "$DATABASE_URL" == postgresql://* ]] || [[ "$DATABASE_URL" == postgresql+asyncpg://* ]] || [[ "$DATABASE_URL" == postgres://* ]]; }; } || { [[ -z "$DATABASE_URL" ]] && { [ "$DB_TYPE" = "postgresql" ] || [ "$DB_TYPE" = "postgres" ]; }; }; then
     echo "Running database migrations..."
     python -c "
 from alembic.config import Config
@@ -27,7 +27,7 @@ from urllib.parse import urlparse
 # Build connection URL from the same DATABASE_URL-preferred contract the app uses.
 raw_url = os.getenv('DATABASE_URL', '')
 if raw_url:
-    url = raw_url.replace('postgresql+asyncpg://', 'postgresql://', 1)
+    url = raw_url.replace('postgresql+asyncpg://', 'postgresql://', 1).replace('postgres://', 'postgresql://', 1)
     parsed = urlparse(url)
     host = parsed.hostname or 'localhost'
     port = str(parsed.port or 5432)
@@ -213,7 +213,7 @@ config.set_main_option('sqlalchemy.url', url)
 command.upgrade(config, 'head')
 print('Migrations complete.')
 "
-  elif [ "$DB_TYPE" = "sqlite" ] || [ -z "$DB_TYPE" ] || [[ "$DATABASE_URL" == sqlite* ]]; then
+  elif { [[ -n "$DATABASE_URL" ]] && { [[ "$DATABASE_URL" == sqlite://* ]] || [[ "$DATABASE_URL" == sqlite+aiosqlite://* ]]; }; } || { [[ -z "$DATABASE_URL" ]] && { [ "$DB_TYPE" = "sqlite" ] || [ -z "$DB_TYPE" ]; }; }; then
     # SQLite - check if database file exists before running migrations
     DB_PATH="${DB_PATH:-${DATABASE_PATH:-${BACKUP_PATH:-/data/backups}/telegram_backup.db}}"
     if [[ "$DATABASE_URL" == sqlite+aiosqlite:///* ]]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -66,7 +66,7 @@ echo "🧪 Running release checks..."
 PYTHON_BIN="${PYTHON:-python3}"
 "$PYTHON_BIN" -m ruff check .
 "$PYTHON_BIN" -m ruff format --check .
-"$PYTHON_BIN" -m pytest tests/ --tb=short
+"$PYTHON_BIN" -m pytest tests/ -q -p no:cacheprovider --tb=short
 
 # Create and push tag
 echo "📦 Creating tag $VERSION..."

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -62,6 +62,12 @@ if [[ "$BRANCH" != "master" && "$BRANCH" != "main" ]]; then
     fi
 fi
 
+echo "🧪 Running release checks..."
+PYTHON_BIN="${PYTHON:-python3}"
+"$PYTHON_BIN" -m ruff check .
+"$PYTHON_BIN" -m ruff format --check .
+"$PYTHON_BIN" -m pytest tests/ --tb=short
+
 # Create and push tag
 echo "📦 Creating tag $VERSION..."
 git tag "$VERSION" -m "Release $VERSION"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.6.4"
+__version__ = "7.7.0"

--- a/src/config.py
+++ b/src/config.py
@@ -253,7 +253,7 @@ class Config:
         # LISTEN_DELETIONS: Delete messages from backup when deleted on Telegram
         # ⚠️ DEFAULT FALSE - Enabling defeats the purpose of having a backup!
         # Only enable if you explicitly want to mirror Telegram exactly
-        self.listen_deletions = os.getenv("LISTEN_DELETIONS", "false").lower() == "true"
+        self.listen_deletions = _parse_bool(os.getenv("LISTEN_DELETIONS"), default=False)
 
         # LISTEN_NEW_MESSAGES: Save new messages to backup in real-time
         # When enabled, new messages are saved immediately instead of waiting for scheduled backup

--- a/src/config.py
+++ b/src/config.py
@@ -253,7 +253,7 @@ class Config:
         # LISTEN_DELETIONS: Delete messages from backup when deleted on Telegram
         # ⚠️ DEFAULT FALSE - Enabling defeats the purpose of having a backup!
         # Only enable if you explicitly want to mirror Telegram exactly
-        self.listen_deletions = os.getenv("LISTEN_DELETIONS", "true").lower() == "true"
+        self.listen_deletions = os.getenv("LISTEN_DELETIONS", "false").lower() == "true"
 
         # LISTEN_NEW_MESSAGES: Save new messages to backup in real-time
         # When enabled, new messages are saved immediately instead of waiting for scheduled backup

--- a/src/connection.py
+++ b/src/connection.py
@@ -24,8 +24,20 @@ from .config import Config
 
 logger = logging.getLogger(__name__)
 
-MAX_FLOOD_RETRIES = int(os.getenv("MAX_FLOOD_RETRIES", "5"))
-MAX_FLOOD_WAIT_SECONDS = int(os.getenv("MAX_FLOOD_WAIT_SECONDS", "3600"))
+
+def _get_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r, using default=%d", name, raw, default)
+        return default
+
+
+MAX_FLOOD_RETRIES = _get_int_env("MAX_FLOOD_RETRIES", 5)
+MAX_FLOOD_WAIT_SECONDS = _get_int_env("MAX_FLOOD_WAIT_SECONDS", 3600)
 
 
 async def _call_with_flood_retry(coro_fn, *args, **kwargs):

--- a/src/connection.py
+++ b/src/connection.py
@@ -24,8 +24,8 @@ from .config import Config
 
 logger = logging.getLogger(__name__)
 
-MAX_FLOOD_RETRIES = 5
-MAX_FLOOD_WAIT_SECONDS = 600
+MAX_FLOOD_RETRIES = int(os.getenv("MAX_FLOOD_RETRIES", "5"))
+MAX_FLOOD_WAIT_SECONDS = int(os.getenv("MAX_FLOOD_WAIT_SECONDS", "3600"))
 
 
 async def _call_with_flood_retry(coro_fn, *args, **kwargs):
@@ -41,7 +41,15 @@ async def _call_with_flood_retry(coro_fn, *args, **kwargs):
                     "FloodWait: exceeded %d retries on %s", MAX_FLOOD_RETRIES, getattr(coro_fn, "__name__", coro_fn)
                 )
                 raise
-            wait_seconds = max(0, min(e.seconds, MAX_FLOOD_WAIT_SECONDS))
+            if e.seconds > MAX_FLOOD_WAIT_SECONDS:
+                logger.error(
+                    "FloodWait: required wait %ss exceeds MAX_FLOOD_WAIT_SECONDS=%s on %s",
+                    e.seconds,
+                    MAX_FLOOD_WAIT_SECONDS,
+                    getattr(coro_fn, "__name__", coro_fn),
+                )
+                raise
+            wait_seconds = max(0, e.seconds)
             logger.warning(
                 "FloodWait: sleeping %ss before retrying %s (retry=%d/%d)",
                 wait_seconds,
@@ -261,6 +269,12 @@ class TelegramConnection:
                 logger.info(f"Reconnected as {self._me.first_name}")
         except Exception as e:
             logger.warning(f"Connection check failed: {e}, reconnecting...")
+            self._connected = False
+            if self._client:
+                try:
+                    await self._client.disconnect()
+                except Exception:
+                    pass
             await self.connect()
 
         return self._client

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1120,7 +1120,7 @@ class DatabaseAdapter:
                 stmt = stmt.order_by(Message.date.desc(), Message.id.desc()).limit(limit)
             else:
                 # Offset-based pagination (legacy fallback)
-                stmt = stmt.order_by(Message.date.desc()).limit(limit).offset(offset)
+                stmt = stmt.order_by(Message.date.desc(), Message.id.desc()).limit(limit).offset(offset)
 
             result = await session.execute(stmt)
             messages = []

--- a/src/db/migrate.py
+++ b/src/db/migrate.py
@@ -12,17 +12,45 @@ from sqlalchemy import func, select
 
 from .base import DatabaseManager
 from .models import (
+    AppSettings,
     Base,
     Chat,
+    ChatFolder,
+    ChatFolderMember,
+    ForumTopic,
     Media,
     Message,
     Metadata,
+    PushSubscription,
     Reaction,
     SyncStatus,
     User,
+    ViewerAccount,
+    ViewerAuditLog,
+    ViewerSession,
+    ViewerToken,
 )
 
 logger = logging.getLogger(__name__)
+
+MIGRATION_MODELS = [
+    User,
+    Chat,
+    Message,
+    Media,
+    Reaction,
+    SyncStatus,
+    Metadata,
+    PushSubscription,
+    ForumTopic,
+    ChatFolder,
+    ChatFolderMember,
+    ViewerAccount,
+    ViewerAuditLog,
+    ViewerSession,
+    ViewerToken,
+    AppSettings,
+]
 
 
 async def migrate_sqlite_to_postgres(
@@ -91,22 +119,9 @@ async def migrate_sqlite_to_postgres(
     counts = {}
 
     try:
-        # Migration order matters due to foreign key relationships
-        # 1. Users (no dependencies)
-        # 2. Chats (no dependencies)
-        # 3. Messages (depends on chats, users)
-        # 4. Media (depends on messages)
-        # 5. Reactions (depends on messages, users)
-        # 6. SyncStatus (depends on chats)
-        # 7. Metadata (no dependencies)
-
-        counts["users"] = await _migrate_table(source, target, User, batch_size)
-        counts["chats"] = await _migrate_table(source, target, Chat, batch_size)
-        counts["messages"] = await _migrate_table(source, target, Message, batch_size)
-        counts["media"] = await _migrate_table(source, target, Media, batch_size)
-        counts["reactions"] = await _migrate_table(source, target, Reaction, batch_size)
-        counts["sync_status"] = await _migrate_table(source, target, SyncStatus, batch_size)
-        counts["metadata"] = await _migrate_table(source, target, Metadata, batch_size)
+        # Migration order matters due to foreign key relationships.
+        for model in MIGRATION_MODELS:
+            counts[model.__tablename__] = await _migrate_table(source, target, model, batch_size)
 
         logger.info(f"Migration complete: {counts}")
 
@@ -198,7 +213,7 @@ async def verify_migration(sqlite_path: str = None, postgres_url: str = None) ->
     await target.init()
 
     results = {}
-    models = [User, Chat, Message, Media, Reaction, SyncStatus, Metadata]
+    models = MIGRATION_MODELS
 
     try:
         for model in models:

--- a/src/listener.py
+++ b/src/listener.py
@@ -42,19 +42,19 @@ from .telegram_backup import call_with_flood_retry
 logger = logging.getLogger(__name__)
 
 
-def _finalize_atomic_download(actual_path: str | None, temporary_path: str, fallback_path: str) -> str:
+def _finalize_atomic_download(actual_path: str | None, temporary_path: str, fallback_path: str) -> str | None:
     """Move a temporary download into place while preserving Telethon's chosen extension."""
     if actual_path and os.path.exists(actual_path):
-        final_path = actual_path.replace(".part", "", 1)
+        final_path = actual_path[:-5] if actual_path.endswith(".part") else actual_path
         if final_path != actual_path:
             os.replace(actual_path, final_path)
-        return final_path
+        return final_path if os.path.exists(final_path) else None
 
     if os.path.exists(temporary_path):
         os.replace(temporary_path, fallback_path)
-        return fallback_path
+        return fallback_path if os.path.exists(fallback_path) else None
 
-    return actual_path or fallback_path
+    return None
 
 
 class MassOperationProtector:
@@ -649,6 +649,9 @@ class TelegramListener:
                             tmp_shared_file_path,
                             shared_file_path,
                         )
+                        if not shared_file_path or not os.path.exists(shared_file_path):
+                            logger.warning("Media download did not produce a file")
+                            return None
                         logger.debug(f"📥 Downloaded media to shared: {file_name}")
 
                         try:
@@ -673,6 +676,9 @@ class TelegramListener:
                         tmp_file_path,
                         file_path,
                     )
+                    if not file_path or not os.path.exists(file_path):
+                        logger.warning("Media download did not produce a file")
+                        return None
 
             # Return the path as stored in DB (relative to media root)
             return f"{self.config.media_path}/{chat_id}/{file_name}"

--- a/src/listener.py
+++ b/src/listener.py
@@ -4,13 +4,12 @@ Catches events as they happen and updates the local database immediately.
 
 Safety features:
 - LISTEN_EDITS: Apply text edits (default: true, safe)
-- LISTEN_DELETIONS: Delete messages (default: true, protected by zero-footprint)
+- LISTEN_DELETIONS: Delete messages (default: false, opt-in mirror mode)
 - Mass operation detection: Blocks bulk edits/deletions to protect data
 
-ZERO-FOOTPRINT PROTECTION:
-When mass operations are detected, NO changes are written to the database.
-Operations are buffered and only applied after a safety delay, ensuring
-that burst attacks are caught BEFORE any data is modified.
+Mass operation protection is rate limiting, not buffering. Operations under
+the threshold are applied immediately; disable LISTEN_DELETIONS to guarantee
+Telegram deletions never remove archived messages.
 """
 
 import asyncio
@@ -38,8 +37,24 @@ from .config import Config
 from .db import DatabaseAdapter, create_adapter
 from .message_utils import extract_topic_id
 from .realtime import NotificationType, RealtimeNotifier
+from .telegram_backup import call_with_flood_retry
 
 logger = logging.getLogger(__name__)
+
+
+def _finalize_atomic_download(actual_path: str | None, temporary_path: str, fallback_path: str) -> str:
+    """Move a temporary download into place while preserving Telethon's chosen extension."""
+    if actual_path and os.path.exists(actual_path):
+        final_path = actual_path.replace(".part", "", 1)
+        if final_path != actual_path:
+            os.replace(actual_path, final_path)
+        return final_path
+
+    if os.path.exists(temporary_path):
+        os.replace(temporary_path, fallback_path)
+        return fallback_path
+
+    return actual_path or fallback_path
 
 
 class MassOperationProtector:
@@ -623,9 +638,17 @@ class TelegramListener:
                             shutil.copy2(shared_file_path, file_path)
                     else:
                         # First time seeing this file - download to shared and create symlink
-                        actual_path = await self.client.download_media(message, shared_file_path)
-                        if actual_path and isinstance(actual_path, str):
-                            shared_file_path = actual_path
+                        tmp_shared_file_path = f"{shared_file_path}.part"
+                        if os.path.exists(tmp_shared_file_path):
+                            os.remove(tmp_shared_file_path)
+                        actual_path = await call_with_flood_retry(
+                            self.client.download_media, message, tmp_shared_file_path
+                        )
+                        shared_file_path = _finalize_atomic_download(
+                            actual_path if isinstance(actual_path, str) else None,
+                            tmp_shared_file_path,
+                            shared_file_path,
+                        )
                         logger.debug(f"📥 Downloaded media to shared: {file_name}")
 
                         try:
@@ -641,9 +664,15 @@ class TelegramListener:
             else:
                 # No deduplication - download directly
                 if not os.path.exists(file_path):
-                    actual_path = await self.client.download_media(message, file_path)
-                    if actual_path and isinstance(actual_path, str):
-                        file_path = actual_path
+                    tmp_file_path = f"{file_path}.part"
+                    if os.path.exists(tmp_file_path):
+                        os.remove(tmp_file_path)
+                    actual_path = await call_with_flood_retry(self.client.download_media, message, tmp_file_path)
+                    file_path = _finalize_atomic_download(
+                        actual_path if isinstance(actual_path, str) else None,
+                        tmp_file_path,
+                        file_path,
+                    )
 
             # Return the path as stored in DB (relative to media root)
             return f"{self.config.media_path}/{chat_id}/{file_name}"
@@ -720,7 +749,7 @@ class TelegramListener:
             Rate-limited: if too many deletions occur in a short time,
             further deletions are blocked to protect the backup.
             """
-            # Check if deletions are enabled (DEFAULT: TRUE with rate limiting)
+            # Check if deletions are enabled (DEFAULT: FALSE; opt-in mirror mode)
             if not self.config.listen_deletions:
                 if event.deleted_ids:
                     self.stats["deletions_skipped"] += len(event.deleted_ids)
@@ -979,7 +1008,7 @@ class TelegramListener:
                         if hasattr(event, "user_id") and event.user_id:
                             actor_id = event.user_id
                             try:
-                                actor = await self.client.get_entity(event.user_id)
+                                actor = await call_with_flood_retry(self.client.get_entity, event.user_id)
                                 actor_name = getattr(actor, "first_name", "") or getattr(actor, "title", "")
                                 if hasattr(actor, "last_name") and actor.last_name:
                                     actor_name += f" {actor.last_name}"
@@ -1045,7 +1074,7 @@ class TelegramListener:
                 if action_type in ("photo_changed", "title_changed"):
                     # Get full entity for update
                     try:
-                        entity = await self.client.get_entity(chat_id)
+                        entity = await call_with_flood_retry(self.client.get_entity, chat_id)
                         if entity:
                             # Update chat in database
                             chat_data = {

--- a/src/realtime.py
+++ b/src/realtime.py
@@ -93,8 +93,9 @@ class RealtimeNotifier:
         if self._db_manager:
             self._is_postgresql = not self._db_manager._is_sqlite
         else:
+            database_url = os.getenv("DATABASE_URL", "").lower()
             db_type = os.getenv("DB_TYPE", "sqlite").lower()
-            self._is_postgresql = db_type in ("postgresql", "postgres")
+            self._is_postgresql = database_url.startswith("postgresql") or db_type in ("postgresql", "postgres")
 
         if self._is_postgresql:
             logger.info("Realtime notifier: Using PostgreSQL LISTEN/NOTIFY")

--- a/src/realtime.py
+++ b/src/realtime.py
@@ -28,6 +28,18 @@ def _json_serializer(obj):
     raise TypeError(f"Object of type {type(obj).__name__} is not JSON serializable")
 
 
+def _database_url_uses_postgres(database_url: str) -> bool:
+    return database_url.startswith(("postgresql://", "postgresql+asyncpg://", "postgres://"))
+
+
+def _env_uses_postgres() -> bool:
+    database_url = os.getenv("DATABASE_URL", "").lower()
+    if database_url:
+        return _database_url_uses_postgres(database_url)
+    db_type = os.getenv("DB_TYPE", "sqlite").lower()
+    return db_type in ("postgresql", "postgres")
+
+
 class NotificationType(str, Enum):
     """Types of real-time notifications."""
 
@@ -93,9 +105,7 @@ class RealtimeNotifier:
         if self._db_manager:
             self._is_postgresql = not self._db_manager._is_sqlite
         else:
-            database_url = os.getenv("DATABASE_URL", "").lower()
-            db_type = os.getenv("DB_TYPE", "sqlite").lower()
-            self._is_postgresql = database_url.startswith("postgresql") or db_type in ("postgresql", "postgres")
+            self._is_postgresql = _env_uses_postgres()
 
         if self._is_postgresql:
             logger.info("Realtime notifier: Using PostgreSQL LISTEN/NOTIFY")
@@ -217,8 +227,7 @@ class RealtimeListener:
         if self._db_manager:
             self._is_postgresql = not self._db_manager._is_sqlite
         else:
-            db_type = os.getenv("DB_TYPE", "sqlite").lower()
-            self._is_postgresql = db_type in ("postgresql", "postgres")
+            self._is_postgresql = _env_uses_postgres()
 
         if self._is_postgresql:
             logger.info("Realtime listener: Using PostgreSQL LISTEN")

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -43,6 +43,7 @@ class BackupScheduler:
         self.config = config
         self.scheduler = AsyncIOScheduler()
         self.running = False
+        self._backup_lock = asyncio.Lock()
 
         # Shared Telegram connection (used by both backup and listener)
         self._connection: TelegramConnection | None = None
@@ -67,45 +68,50 @@ class BackupScheduler:
         Uses the shared connection - no need to pause the listener since both
         use the same TelegramClient.
         """
-        try:
-            logger.info("Scheduled backup starting...")
+        if self._backup_lock.locked():
+            logger.warning("Skipping scheduled backup because another backup is already running")
+            return
 
-            # Ensure connection is still alive
-            client = await self._connection.ensure_connected()
+        async with self._backup_lock:
+            try:
+                logger.info("Scheduled backup starting...")
 
-            # Run backup using shared client
-            await run_backup(self.config, client=client)
+                # Ensure connection is still alive
+                client = await self._connection.ensure_connected()
 
-            # Run gap-fill if enabled
-            gap_fill_ok = True
-            if self.config.fill_gaps:
-                try:
-                    from .telegram_backup import run_fill_gaps
+                # Run backup using shared client
+                await run_backup(self.config, client=client)
 
-                    logger.info("Running post-backup gap-fill...")
-                    result = await run_fill_gaps(self.config, client=client)
-                    if result.get("errors", 0) > 0:
+                # Run gap-fill if enabled
+                gap_fill_ok = True
+                if self.config.fill_gaps:
+                    try:
+                        from .telegram_backup import run_fill_gaps
+
+                        logger.info("Running post-backup gap-fill...")
+                        result = await run_fill_gaps(self.config, client=client)
+                        if result.get("errors", 0) > 0:
+                            gap_fill_ok = False
+                            logger.warning(
+                                f"Gap-fill completed with {result['errors']} error(s) "
+                                f"({result['total_recovered']} messages recovered)"
+                            )
+                    except Exception as e:
                         gap_fill_ok = False
-                        logger.warning(
-                            f"Gap-fill completed with {result['errors']} error(s) "
-                            f"({result['total_recovered']} messages recovered)"
-                        )
-                except Exception as e:
-                    gap_fill_ok = False
-                    logger.error(f"Gap-fill failed: {e}", exc_info=True)
+                        logger.error(f"Gap-fill failed: {e}", exc_info=True)
 
-            # Reload tracked chats in listener after backup
-            # (new chats may have been added)
-            if self._listener:
-                await self._listener._load_tracked_chats()
+                # Reload tracked chats in listener after backup
+                # (new chats may have been added)
+                if self._listener:
+                    await self._listener._load_tracked_chats()
 
-            if gap_fill_ok:
-                logger.info("Scheduled backup completed successfully")
-            else:
-                logger.warning("Scheduled backup completed, but gap-fill had errors")
+                if gap_fill_ok:
+                    logger.info("Scheduled backup completed successfully")
+                else:
+                    logger.warning("Scheduled backup completed, but gap-fill had errors")
 
-        except Exception as e:
-            logger.error(f"Scheduled backup failed: {e}", exc_info=True)
+            except Exception as e:
+                logger.error(f"Scheduled backup failed: {e}", exc_info=True)
 
     def start(self):
         """Start the scheduler."""
@@ -231,28 +237,29 @@ class BackupScheduler:
 
         # Run initial backup immediately on startup (uses shared connection)
         logger.info("Running initial backup on startup...")
-        try:
-            await run_backup(self.config, client=self._connection.client)
-            logger.info("Initial backup completed")
+        async with self._backup_lock:
+            try:
+                await run_backup(self.config, client=self._connection.client)
+                logger.info("Initial backup completed")
 
-            # Run gap-fill if enabled
-            if self.config.fill_gaps:
-                try:
-                    from .telegram_backup import run_fill_gaps
+                # Run gap-fill if enabled
+                if self.config.fill_gaps:
+                    try:
+                        from .telegram_backup import run_fill_gaps
 
-                    logger.info("Running initial gap-fill...")
-                    result = await run_fill_gaps(self.config, client=self._connection.client)
-                    if result.get("errors", 0) > 0:
-                        logger.warning(f"Initial gap-fill completed with {result['errors']} error(s)")
-                except Exception as e:
-                    logger.error(f"Initial gap-fill failed: {e}", exc_info=True)
+                        logger.info("Running initial gap-fill...")
+                        result = await run_fill_gaps(self.config, client=self._connection.client)
+                        if result.get("errors", 0) > 0:
+                            logger.warning(f"Initial gap-fill completed with {result['errors']} error(s)")
+                    except Exception as e:
+                        logger.error(f"Initial gap-fill failed: {e}", exc_info=True)
 
-            # Reload tracked chats in listener after initial backup
-            if self._listener:
-                await self._listener._load_tracked_chats()
+                # Reload tracked chats in listener after initial backup
+                if self._listener:
+                    await self._listener._load_tracked_chats()
 
-        except Exception as e:
-            logger.error(f"Initial backup failed: {e}", exc_info=True)
+            except Exception as e:
+                logger.error(f"Initial backup failed: {e}", exc_info=True)
 
         # Keep running until stopped
         try:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -38,8 +38,8 @@ from .message_utils import extract_topic_id
 logger = logging.getLogger(__name__)
 
 
-MAX_FLOOD_RETRIES = 5
-MAX_FLOOD_WAIT_SECONDS = 600
+MAX_FLOOD_RETRIES = int(os.getenv("MAX_FLOOD_RETRIES", "5"))
+MAX_FLOOD_WAIT_SECONDS = int(os.getenv("MAX_FLOOD_WAIT_SECONDS", "3600"))
 
 
 async def call_with_flood_retry(coro_fn, *args, max_retries=MAX_FLOOD_RETRIES, **kwargs):
@@ -62,7 +62,15 @@ async def call_with_flood_retry(coro_fn, *args, max_retries=MAX_FLOOD_RETRIES, *
                     getattr(coro_fn, "__name__", coro_fn),
                 )
                 raise
-            wait_seconds = max(0, min(e.seconds, MAX_FLOOD_WAIT_SECONDS))
+            if e.seconds > MAX_FLOOD_WAIT_SECONDS:
+                logger.error(
+                    "FloodWait: required wait %ss exceeds MAX_FLOOD_WAIT_SECONDS=%s on %s",
+                    e.seconds,
+                    MAX_FLOOD_WAIT_SECONDS,
+                    getattr(coro_fn, "__name__", coro_fn),
+                )
+                raise
+            wait_seconds = max(0, e.seconds)
             logger.warning(
                 "FloodWait: sleeping %ss before retrying %s (retry=%d/%d)",
                 wait_seconds,
@@ -71,6 +79,21 @@ async def call_with_flood_retry(coro_fn, *args, max_retries=MAX_FLOOD_RETRIES, *
                 max_retries,
             )
             await asyncio.sleep(wait_seconds + 1)  # +1s buffer to avoid boundary re-trigger
+
+
+def _finalize_atomic_download(actual_path: str | None, temporary_path: str, fallback_path: str) -> str:
+    """Move a temporary download into place while preserving Telethon's chosen extension."""
+    if actual_path and os.path.exists(actual_path):
+        final_path = actual_path.replace(".part", "", 1)
+        if final_path != actual_path:
+            os.replace(actual_path, final_path)
+        return final_path
+
+    if os.path.exists(temporary_path):
+        os.replace(temporary_path, fallback_path)
+        return fallback_path
+
+    return actual_path or fallback_path
 
 
 async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
@@ -85,9 +108,8 @@ async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
     time iteration yields a message. Without the cap, an account-restricted
     Telegram session would loop forever on one chat and block every later one.
 
-    Bounded sleep: ``e.seconds`` is clamped at ``MAX_FLOOD_WAIT_SECONDS`` so a
-    pathologically large value (buggy or malicious server response) cannot
-    hang the process for hours.
+    Bounded sleep: waits above ``MAX_FLOOD_WAIT_SECONDS`` abort the current
+    operation instead of retrying before Telegram's required wait has elapsed.
 
     The ``FLOOD_WAIT_LOG_THRESHOLD`` env var (default 10) suppresses log
     output for short waits — those are routine and noisy in healthy backfills.
@@ -121,7 +143,15 @@ async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
                     resume_from,
                 )
                 raise
-            wait_seconds = max(0, min(e.seconds, MAX_FLOOD_WAIT_SECONDS))
+            if e.seconds > MAX_FLOOD_WAIT_SECONDS:
+                logger.error(
+                    "FloodWait: required wait %ss exceeds MAX_FLOOD_WAIT_SECONDS=%s; aborting (last_msg_id=%s)",
+                    e.seconds,
+                    MAX_FLOOD_WAIT_SECONDS,
+                    resume_from,
+                )
+                raise
+            wait_seconds = max(0, e.seconds)
             if e.seconds >= log_threshold_seconds:
                 logger.warning(
                     "FloodWait: sleeping %ss before resuming (last_msg_id=%s, retry=%d/%d)",
@@ -285,7 +315,7 @@ class TelegramBackup:
                 seen_chat_ids = set()
                 for cid in self.config.chat_ids:
                     try:
-                        entity = await self.client.get_entity(cid)
+                        entity = await call_with_flood_retry(self.client.get_entity, cid)
 
                         class SimpleDialog:
                             def __init__(self, entity):
@@ -369,7 +399,7 @@ class TelegramBackup:
                     for include_id in missing_include_ids:
                         is_in_archive = include_id in archived_chat_ids
                         try:
-                            entity = await self.client.get_entity(include_id)
+                            entity = await call_with_flood_retry(self.client.get_entity, include_id)
 
                             class SimpleDialog:
                                 def __init__(self, entity):
@@ -649,7 +679,7 @@ class TelegramBackup:
 
                 # Fetch messages from Telegram in batch
                 try:
-                    messages = await self.client.get_messages(chat_id, ids=message_ids)
+                    messages = await call_with_flood_retry(self.client.get_messages, chat_id, ids=message_ids)
                 except Exception as e:
                     logger.warning(f"Cannot access chat {chat_id} for media verification: {e}")
                     failed += len(records)
@@ -915,7 +945,7 @@ class TelegramBackup:
             summary["chats_scanned"] += 1
 
             try:
-                entity = await self.client.get_entity(cid)
+                entity = await call_with_flood_retry(self.client.get_entity, cid)
             except (ChannelPrivateError, ChatForbiddenError, UserBannedInChannelError) as e:
                 logger.warning(f"Gap-fill: skipping chat {cid} (no access): {e.__class__.__name__}")
                 continue
@@ -998,7 +1028,7 @@ class TelegramBackup:
 
             try:
                 # Fetch current state from Telegram
-                remote_messages = await self.client.get_messages(entity, ids=batch_ids)
+                remote_messages = await call_with_flood_retry(self.client.get_messages, entity, ids=batch_ids)
 
                 for msg_id, remote_msg in zip(batch_ids, remote_messages):
                     # Check for deletion
@@ -1054,7 +1084,9 @@ class TelegramBackup:
             from telethon.tl.types import InputMessagesFilterPinned
 
             # Fetch all pinned messages from Telegram (up to 100)
-            pinned_messages = await self.client.get_messages(entity, filter=InputMessagesFilterPinned(), limit=100)
+            pinned_messages = await call_with_flood_retry(
+                self.client.get_messages, entity, filter=InputMessagesFilterPinned(), limit=100
+            )
 
             if pinned_messages:
                 pinned_ids = [msg.id for msg in pinned_messages]
@@ -1161,7 +1193,7 @@ class TelegramBackup:
             elif fwd.from_id:
                 # Try to resolve the name from the entity
                 try:
-                    fwd_entity = await self.client.get_entity(fwd.from_id)
+                    fwd_entity = await call_with_flood_retry(self.client.get_entity, fwd.from_id)
                     if hasattr(fwd_entity, "title"):
                         message_data["raw_data"]["forward_from_name"] = fwd_entity.title
                     elif hasattr(fwd_entity, "first_name"):
@@ -1405,6 +1437,19 @@ class TelegramBackup:
         # Generate unique media ID
         media_id = f"{chat_id}_{message.id}_{media_type}"
 
+        # Contacts, locations, and polls are Telegram message payloads rather
+        # than downloadable files. Store them as metadata-only records when the
+        # caller asks for media processing.
+        if media_type in {"contact", "geo", "poll"}:
+            return {
+                "id": media_id,
+                "type": media_type,
+                "message_id": message.id,
+                "chat_id": chat_id,
+                "file_size": 0,
+                "downloaded": False,
+            }
+
         # Get Telegram's file unique ID for deduplication
         telegram_file_id = None
         if hasattr(media, "photo"):
@@ -1467,9 +1512,17 @@ class TelegramBackup:
                             shutil.copy2(shared_file_path, file_path)
                     else:
                         # First time seeing this file - download to shared and create symlink
-                        actual_path = await self.client.download_media(message, shared_file_path)
-                        if actual_path and isinstance(actual_path, str):
-                            shared_file_path = actual_path
+                        tmp_shared_file_path = f"{shared_file_path}.part"
+                        if os.path.exists(tmp_shared_file_path):
+                            os.remove(tmp_shared_file_path)
+                        actual_path = await call_with_flood_retry(
+                            self.client.download_media, message, tmp_shared_file_path
+                        )
+                        shared_file_path = _finalize_atomic_download(
+                            actual_path if isinstance(actual_path, str) else None,
+                            tmp_shared_file_path,
+                            shared_file_path,
+                        )
                         logger.debug(f"Downloaded media to shared: {file_name}")
 
                         # Create symlink in chat directory
@@ -1492,9 +1545,15 @@ class TelegramBackup:
             else:
                 # No deduplication - download directly to chat directory
                 if not os.path.exists(file_path):
-                    actual_path = await self.client.download_media(message, file_path)
-                    if actual_path and isinstance(actual_path, str):
-                        file_path = actual_path
+                    tmp_file_path = f"{file_path}.part"
+                    if os.path.exists(tmp_file_path):
+                        os.remove(tmp_file_path)
+                    actual_path = await call_with_flood_retry(self.client.download_media, message, tmp_file_path)
+                    file_path = _finalize_atomic_download(
+                        actual_path if isinstance(actual_path, str) else None,
+                        tmp_file_path,
+                        file_path,
+                    )
                     logger.debug(f"Downloaded media: {file_name}")
 
                 # Update file_size with actual size from disk
@@ -1820,7 +1879,7 @@ class TelegramBackup:
                     continue
                 # Try to get the topic's first message for metadata
                 try:
-                    msgs = await self.client.get_messages(entity, ids=[topic_id])
+                    msgs = await call_with_flood_retry(self.client.get_messages, entity, ids=[topic_id])
                     if msgs and msgs[0]:
                         msg = msgs[0]
                         topic_data = {

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -38,8 +38,19 @@ from .message_utils import extract_topic_id
 logger = logging.getLogger(__name__)
 
 
-MAX_FLOOD_RETRIES = int(os.getenv("MAX_FLOOD_RETRIES", "5"))
-MAX_FLOOD_WAIT_SECONDS = int(os.getenv("MAX_FLOOD_WAIT_SECONDS", "3600"))
+def _get_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r, using default=%d", name, raw, default)
+        return default
+
+
+MAX_FLOOD_RETRIES = _get_int_env("MAX_FLOOD_RETRIES", 5)
+MAX_FLOOD_WAIT_SECONDS = _get_int_env("MAX_FLOOD_WAIT_SECONDS", 3600)
 
 
 async def call_with_flood_retry(coro_fn, *args, max_retries=MAX_FLOOD_RETRIES, **kwargs):
@@ -81,19 +92,19 @@ async def call_with_flood_retry(coro_fn, *args, max_retries=MAX_FLOOD_RETRIES, *
             await asyncio.sleep(wait_seconds + 1)  # +1s buffer to avoid boundary re-trigger
 
 
-def _finalize_atomic_download(actual_path: str | None, temporary_path: str, fallback_path: str) -> str:
+def _finalize_atomic_download(actual_path: str | None, temporary_path: str, fallback_path: str) -> str | None:
     """Move a temporary download into place while preserving Telethon's chosen extension."""
     if actual_path and os.path.exists(actual_path):
-        final_path = actual_path.replace(".part", "", 1)
+        final_path = actual_path[:-5] if actual_path.endswith(".part") else actual_path
         if final_path != actual_path:
             os.replace(actual_path, final_path)
-        return final_path
+        return final_path if os.path.exists(final_path) else None
 
     if os.path.exists(temporary_path):
         os.replace(temporary_path, fallback_path)
-        return fallback_path
+        return fallback_path if os.path.exists(fallback_path) else None
 
-    return actual_path or fallback_path
+    return None
 
 
 async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
@@ -1523,6 +1534,9 @@ class TelegramBackup:
                             tmp_shared_file_path,
                             shared_file_path,
                         )
+                        if not shared_file_path or not os.path.exists(shared_file_path):
+                            logger.warning("Media download did not produce a file")
+                            return None
                         logger.debug(f"Downloaded media to shared: {file_name}")
 
                         # Create symlink in chat directory
@@ -1554,6 +1568,9 @@ class TelegramBackup:
                         tmp_file_path,
                         file_path,
                     )
+                    if not file_path or not os.path.exists(file_path):
+                        logger.warning("Media download did not produce a file")
+                        return None
                     logger.debug(f"Downloaded media: {file_name}")
 
                 # Update file_size with actual size from disk

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -806,6 +806,9 @@ async def serve_thumbnail(size: int, folder: str, filename: str, user: UserConte
     if not _media_root:
         raise HTTPException(status_code=404, detail="Media directory not configured")
 
+    if user.no_download and not folder.startswith("avatars/"):
+        raise HTTPException(status_code=403, detail="Downloads disabled for this account")
+
     # Chat-level access check
     _enforce_media_acl(f"{folder}/{filename}", user, thumbnail=True)
 
@@ -2199,6 +2202,9 @@ async def websocket_endpoint(websocket: WebSocket):
             return
         user_ctx = UserContext(session.username, session.role, session.allowed_chat_ids)
         ws_user_chat_ids = get_user_chat_ids(user_ctx)
+    elif not ALLOW_ANONYMOUS_VIEWER:
+        await websocket.close(code=4001, reason="Viewer authentication is not configured")
+        return
 
     await ws_manager.connect(websocket, allowed_chat_ids=ws_user_chat_ids)
 

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -17,10 +17,10 @@ import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 from zoneinfo import ZoneInfo
 
 from fastapi import Cookie, Depends, FastAPI, HTTPException, Query, Request, WebSocket, WebSocketDisconnect
@@ -90,7 +90,7 @@ class ConnectionManager:
             allowed = self._allowed_chats.get(websocket)
             if allowed is not None and chat_id not in allowed:
                 continue
-            if chat_id in subscribed_chats or not subscribed_chats:
+            if chat_id in subscribed_chats:
                 try:
                     await websocket.send_json(message)
                 except Exception as e:
@@ -275,7 +275,7 @@ async def stats_calculation_scheduler():
 
             # If we've passed the target time today, schedule for tomorrow
             if now.hour >= target_hour:
-                next_run = next_run.replace(day=now.day + 1)
+                next_run = next_run + timedelta(days=1)
 
             # Wait until next run
             wait_seconds = (next_run - now).total_seconds()
@@ -442,6 +442,8 @@ async def add_security_headers(request: Request, call_next):
 VIEWER_USERNAME = os.getenv("VIEWER_USERNAME", "").strip()
 VIEWER_PASSWORD = os.getenv("VIEWER_PASSWORD", "").strip()
 AUTH_ENABLED = bool(VIEWER_USERNAME and VIEWER_PASSWORD)
+ALLOW_ANONYMOUS_VIEWER = os.getenv("ALLOW_ANONYMOUS_VIEWER", "false").lower() == "true"
+TRUST_PROXY_HEADERS = os.getenv("TRUST_PROXY_HEADERS", "false").lower() == "true"
 AUTH_COOKIE_NAME = "viewer_auth"
 
 AUTH_SESSION_DAYS = int(os.getenv("AUTH_SESSION_DAYS", "30"))
@@ -453,8 +455,12 @@ _LOGIN_RATE_WINDOW = 300  # per 5 minutes
 
 if AUTH_ENABLED:
     logger.info(f"Viewer authentication is ENABLED (Master: {VIEWER_USERNAME}, Session: {AUTH_SESSION_DAYS} days)")
+elif ALLOW_ANONYMOUS_VIEWER:
+    logger.warning("Viewer authentication is DISABLED by explicit ALLOW_ANONYMOUS_VIEWER=true")
 else:
-    logger.info("Viewer authentication is DISABLED (no VIEWER_USERNAME / VIEWER_PASSWORD set)")
+    logger.error(
+        "Viewer authentication is not configured. Set VIEWER_USERNAME/VIEWER_PASSWORD or ALLOW_ANONYMOUS_VIEWER=true"
+    )
 
 
 @dataclass
@@ -499,6 +505,32 @@ def _check_rate_limit(ip: str) -> bool:
 
 def _record_login_attempt(ip: str) -> None:
     _login_attempts.setdefault(ip, []).append(time.time())
+
+
+def _get_client_ip(request: Request) -> str:
+    """Return the rate-limit/audit IP, only trusting proxy headers when explicitly enabled."""
+    direct_ip = request.client.host if request.client else "unknown"
+    if not TRUST_PROXY_HEADERS:
+        return direct_ip
+
+    forwarded = request.headers.get("x-forwarded-for", "").split(",")[0].strip()
+    return forwarded or request.headers.get("x-real-ip", "") or direct_ip
+
+
+def _websocket_origin_allowed(websocket: WebSocket) -> bool:
+    """Allow same-origin WebSockets and explicitly configured CORS origins."""
+    origin = websocket.headers.get("origin")
+    if not origin:
+        return True
+
+    parsed = urlparse(origin)
+    origin_host = parsed.netloc
+    host = websocket.headers.get("host", "")
+    if origin_host and origin_host == host:
+        return True
+
+    allowed_origins = [o.strip() for o in os.getenv("CORS_ORIGINS", "*").split(",") if o.strip()]
+    return origin in allowed_origins
 
 
 def _is_db_connection_error(exc: Exception) -> bool:
@@ -639,7 +671,9 @@ async def _resolve_session(auth_cookie: str) -> SessionData | None:
 async def require_auth(auth_cookie: str | None = Cookie(default=None, alias=AUTH_COOKIE_NAME)) -> UserContext:
     """Dependency that enforces session-based auth. Returns UserContext."""
     if not AUTH_ENABLED:
-        return UserContext(username="anonymous", role="master", allowed_chat_ids=None)
+        if ALLOW_ANONYMOUS_VIEWER:
+            return UserContext(username="anonymous", role="master", allowed_chat_ids=None)
+        raise HTTPException(status_code=503, detail="Viewer authentication is not configured")
 
     if not auth_cookie:
         raise HTTPException(status_code=401, detail="Unauthorized")
@@ -688,6 +722,55 @@ def get_user_chat_ids(user: UserContext) -> set[int] | None:
     return user.allowed_chat_ids & master_filter
 
 
+def _enforce_media_acl(path: str, user: UserContext, *, thumbnail: bool = False) -> None:
+    """Enforce chat-scoped access for a media URL path before serving bytes."""
+    user_chat_ids = get_user_chat_ids(user)
+    if user_chat_ids is None:
+        return
+
+    parts = path.split("/")
+    if len(parts) < 2:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    if parts[0] == "avatars":
+        # Avatar path: avatars/{users|chats}/{chat_id}_{photo_id}.jpg
+        if len(parts) < 3:
+            raise HTTPException(status_code=403, detail="Access denied")
+        name = parts[2].rsplit(".", 1)[0] if "." in parts[2] else parts[2]
+        try:
+            avatar_chat_id = int(name.split("_")[0])
+        except ValueError:
+            raise HTTPException(status_code=403, detail="Access denied")
+        if avatar_chat_id not in user_chat_ids:
+            raise HTTPException(status_code=403, detail="Access denied")
+        return
+
+    try:
+        media_chat_id = int(parts[0])
+    except ValueError:
+        logger.warning("Blocked restricted media request for non-chat folder: %s", parts[0])
+        raise HTTPException(status_code=403, detail="Access denied")
+    if media_chat_id not in user_chat_ids:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+
+def _strip_original_media_paths(messages: list[dict]) -> None:
+    """Remove original media file paths from API responses for no-download sessions."""
+    for message in messages:
+        media = message.get("media")
+        if isinstance(media, dict):
+            media["file_path"] = None
+            media["downloaded"] = False
+            media["no_download"] = True
+        media_items = message.get("media_items")
+        if isinstance(media_items, list):
+            for item in media_items:
+                if isinstance(item, dict):
+                    item["file_path"] = None
+                    item["downloaded"] = False
+                    item["no_download"] = True
+
+
 # Setup paths
 templates_dir = Path(__file__).parent / "templates"
 static_dir = Path(__file__).parent / "static"
@@ -724,25 +807,7 @@ async def serve_thumbnail(size: int, folder: str, filename: str, user: UserConte
         raise HTTPException(status_code=404, detail="Media directory not configured")
 
     # Chat-level access check
-    user_chat_ids = get_user_chat_ids(user)
-    if user_chat_ids is not None:
-        folder_parts = folder.split("/")
-        if folder_parts[0] == "avatars":
-            # Avatar thumbnail: folder=avatars/{users|chats}, filename={chat_id}_{photo_id}.jpg
-            name = filename.rsplit(".", 1)[0] if "." in filename else filename
-            try:
-                avatar_chat_id = int(name.split("_")[0])
-                if avatar_chat_id not in user_chat_ids:
-                    raise HTTPException(status_code=403, detail="Access denied")
-            except ValueError:
-                raise HTTPException(status_code=403, detail="Access denied")
-        else:
-            try:
-                media_chat_id = int(folder_parts[0])
-                if media_chat_id not in user_chat_ids:
-                    raise HTTPException(status_code=403, detail="Access denied")
-            except ValueError:
-                pass
+    _enforce_media_acl(f"{folder}/{filename}", user, thumbnail=True)
 
     from .thumbnails import ensure_thumbnail
 
@@ -759,10 +824,10 @@ async def serve_media(path: str, download: int = Query(0), user: UserContext = D
     if not _media_root:
         raise HTTPException(status_code=404, detail="Media directory not configured")
 
-    # v7.2.0: Server-side download restriction
-    # Inline rendering (images, video, audio in browser) is always allowed.
-    # Explicit downloads (download=1 query param) are blocked for restricted users.
-    if user.no_download and download:
+    # Server-side download restriction. Original media bytes are not served to
+    # no-download users because a direct GET is indistinguishable from browser
+    # inline rendering once the URL is known. Avatars stay available for UI chrome.
+    if user.no_download and not path.startswith("avatars/"):
         raise HTTPException(status_code=403, detail="Downloads disabled for this account")
 
     # Reject path traversal and absolute paths before any filesystem operations
@@ -778,27 +843,7 @@ async def serve_media(path: str, download: int = Query(0), user: UserContext = D
     if not resolved.is_relative_to(_media_root):
         raise HTTPException(status_code=403, detail="Access denied")
 
-    user_chat_ids = get_user_chat_ids(user)
-    if user_chat_ids is not None:
-        parts = path.split("/")
-        if len(parts) >= 2:
-            if parts[0] == "avatars" and len(parts) >= 3:
-                # Avatar path: avatars/{users|chats}/{chat_id}_{photo_id}.jpg
-                # Extract chat_id from filename to enforce per-chat ACL
-                name = parts[2].rsplit(".", 1)[0] if "." in parts[2] else parts[2]
-                try:
-                    avatar_chat_id = int(name.split("_")[0])
-                    if avatar_chat_id not in user_chat_ids:
-                        raise HTTPException(status_code=403, detail="Access denied")
-                except ValueError:
-                    raise HTTPException(status_code=403, detail="Access denied")
-            elif parts[0] != "avatars":
-                try:
-                    media_chat_id = int(parts[0])
-                    if media_chat_id not in user_chat_ids:
-                        raise HTTPException(status_code=403, detail="Access denied")
-                except ValueError:
-                    pass
+    _enforce_media_acl(path, user)
 
     if not resolved.is_file():
         raise HTTPException(status_code=404, detail="File not found")
@@ -844,7 +889,9 @@ async def health_check():
 async def check_auth(auth_cookie: str | None = Cookie(default=None, alias=AUTH_COOKIE_NAME)):
     """Check current authentication status. Returns role and username if authenticated."""
     if not AUTH_ENABLED:
-        return {"authenticated": True, "auth_required": False, "role": "master", "username": "anonymous"}
+        if ALLOW_ANONYMOUS_VIEWER:
+            return {"authenticated": True, "auth_required": False, "role": "master", "username": "anonymous"}
+        return {"authenticated": False, "auth_required": True, "setup_required": True}
 
     if not auth_cookie:
         return {"authenticated": False, "auth_required": True}
@@ -869,18 +916,11 @@ async def check_auth(auth_cookie: str | None = Cookie(default=None, alias=AUTH_C
 async def login(request: Request):
     """Authenticate user (master via env vars or viewer via DB accounts)."""
     if not AUTH_ENABLED:
-        return JSONResponse({"success": True, "message": "Auth disabled"})
+        if ALLOW_ANONYMOUS_VIEWER:
+            return JSONResponse({"success": True, "message": "Auth disabled by explicit opt-in"})
+        raise HTTPException(status_code=503, detail="Viewer authentication is not configured")
 
-    direct_ip = request.client.host if request.client else "unknown"
-    _trusted = direct_ip.startswith(("172.", "10.", "192.168.", "127.")) or direct_ip in ("::1", "localhost")
-    if _trusted:
-        client_ip = (
-            request.headers.get("x-forwarded-for", "").split(",")[0].strip()
-            or request.headers.get("x-real-ip", "")
-            or direct_ip
-        )
-    else:
-        client_ip = direct_ip
+    client_ip = _get_client_ip(request)
 
     if not _check_rate_limit(client_ip):
         raise HTTPException(status_code=429, detail="Too many login attempts. Try again later.")
@@ -915,7 +955,8 @@ async def login(request: Request):
                     try:
                         allowed = set(json.loads(viewer["allowed_chat_ids"]))
                     except json.JSONDecodeError, TypeError:
-                        allowed = None
+                        logger.warning("Corrupted allowed_chat_ids for viewer %s, denying login", username)
+                        raise HTTPException(status_code=403, detail="Invalid viewer scope")
 
                 viewer_no_download = bool(viewer.get("no_download", 0))
                 token = await _create_session(username, "viewer", allowed, no_download=viewer_no_download)
@@ -1034,16 +1075,7 @@ async def auth_via_token(request: Request):
     if not db:
         raise HTTPException(status_code=500, detail="Database not available")
 
-    direct_ip = request.client.host if request.client else "unknown"
-    _trusted = direct_ip.startswith(("172.", "10.", "192.168.", "127.")) or direct_ip in ("::1", "localhost")
-    if _trusted:
-        client_ip = (
-            request.headers.get("x-forwarded-for", "").split(",")[0].strip()
-            or request.headers.get("x-real-ip", "")
-            or direct_ip
-        )
-    else:
-        client_ip = direct_ip
+    client_ip = _get_client_ip(request)
 
     if not _check_rate_limit(client_ip):
         raise HTTPException(status_code=429, detail="Too many attempts. Try again later.")
@@ -1075,7 +1107,8 @@ async def auth_via_token(request: Request):
         try:
             allowed = set(json.loads(token_record["allowed_chat_ids"]))
         except json.JSONDecodeError, TypeError:
-            allowed = None
+            logger.warning("Corrupted allowed_chat_ids for share token %s, denying login", token_record["id"])
+            raise HTTPException(status_code=403, detail="Invalid token scope")
 
     token_no_download = bool(token_record.get("no_download", 0))
     token_label = token_record.get("label") or f"token:{token_record['id']}"
@@ -1236,8 +1269,8 @@ async def get_chats(
 async def get_messages(
     chat_id: int,
     user: UserContext = Depends(require_auth),
-    limit: int = 50,
-    offset: int = 0,
+    limit: int = Query(50, ge=1, le=500),
+    offset: int = Query(0, ge=0),
     search: str | None = None,
     before_date: str | None = None,
     before_id: int | None = None,
@@ -1279,6 +1312,8 @@ async def get_messages(
             before_id=before_id,
             topic_id=topic_id,
         )
+        if user.no_download:
+            _strip_original_media_paths(messages)
         return messages
     except Exception as e:
         logger.error(f"Error fetching messages: {e}", exc_info=True)
@@ -1561,10 +1596,12 @@ async def internal_push(request: Request):
 
     # Accept from loopback + private IPs (Docker internal, RFC1918)
     is_allowed = False
+    is_loopback = False
     if client_host:
         try:
             ip = ipaddress.ip_address(client_host)
-            is_allowed = ip.is_loopback or ip.is_private
+            is_loopback = ip.is_loopback
+            is_allowed = is_loopback or ip.is_private
         except ValueError:
             pass
 
@@ -1572,8 +1609,12 @@ async def internal_push(request: Request):
         logger.warning(f"Rejected /internal/push from non-private IP: {client_host}")
         raise HTTPException(status_code=403, detail="Forbidden")
 
-    # Optional shared secret for multi-tenant Docker environments
+    # Require a shared secret for non-loopback private/Docker networks. Loopback
+    # stays usable for single-container/local setups.
     push_secret = os.getenv("INTERNAL_PUSH_SECRET")
+    if not is_loopback and not push_secret:
+        logger.warning(f"Rejected /internal/push from {client_host}: INTERNAL_PUSH_SECRET is required")
+        raise HTTPException(status_code=403, detail="INTERNAL_PUSH_SECRET required")
     if push_secret:
         auth_header = request.headers.get("Authorization", "")
         if not secrets.compare_digest(auth_header, f"Bearer {push_secret}"):
@@ -2139,6 +2180,10 @@ async def websocket_endpoint(websocket: WebSocket):
     Auth is enforced via cookie sent during WebSocket upgrade.
     Per-user chat filtering is applied to subscriptions.
     """
+    if not _websocket_origin_allowed(websocket):
+        await websocket.close(code=4003, reason="Forbidden origin")
+        return
+
     # Validate auth from cookie before accepting
     cookies = websocket.cookies
     auth_cookie = cookies.get(AUTH_COOKIE_NAME)

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -532,7 +532,7 @@
                         <div v-else v-for="topic in topics" :key="topic.id"
                             @click="selectTopic(topicsNavEntry.chat || { id: topicsNavEntry.chatId, is_forum: true }, topic)"
                             class="p-3 cursor-pointer hover:bg-tg-hover transition-colors flex items-center gap-3 border-b border-gray-700/30"
-                            :class="{'bg-tg-active': currentNav.topicId === topic.id}"
+                            :class="{'bg-tg-active': currentNav.topicId === topic.id}">
                             <!-- Topic icon -->
                             <div class="w-10 h-10 rounded-full flex items-center justify-center text-white shrink-0"
                                 :style="{ backgroundColor: getTopicColor(topic.icon_color) }">
@@ -1939,10 +1939,14 @@
                             noDownload.value = !!data.no_download
                             console.log('[DEBUG] authRequired:', authRequired.value, 'isAuthenticated:', isAuthenticated.value)
 
-                            // Auto-login via ?token= URL parameter
+                            // Auto-login via token URL. Prefer #token= so bearer-equivalent
+                            // share tokens are not sent to servers/proxies in request logs.
                             if (!isAuthenticated.value && authRequired.value) {
                                 const urlParams = new URLSearchParams(window.location.search)
-                                const urlToken = urlParams.get('token')
+                                const hashParams = window.location.hash.startsWith('#')
+                                    ? new URLSearchParams(window.location.hash.slice(1))
+                                    : new URLSearchParams()
+                                const urlToken = hashParams.get('token') || urlParams.get('token')
                                 if (urlToken) {
                                     try {
                                         const tokenRes = await fetch('/auth/token', {
@@ -1963,6 +1967,7 @@
                                     // Remove token from URL to prevent leaking in browser history
                                     const cleanUrl = new URL(window.location)
                                     cleanUrl.searchParams.delete('token')
+                                    cleanUrl.hash = ''
                                     window.history.replaceState({}, '', cleanUrl)
                                 }
                             }
@@ -3489,7 +3494,7 @@
                 const adminNewToken = ref('')
                 const adminNewTokenUrl = computed(() => {
                     if (!adminNewToken.value) return ''
-                    return `${window.location.origin}/?token=${adminNewToken.value}`
+                    return `${window.location.origin}/#token=${encodeURIComponent(adminNewToken.value)}`
                 })
 
                 const loadAdminViewers = async () => {

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -3494,7 +3494,10 @@
                 const adminNewToken = ref('')
                 const adminNewTokenUrl = computed(() => {
                     if (!adminNewToken.value) return ''
-                    return `${window.location.origin}/#token=${encodeURIComponent(adminNewToken.value)}`
+                    const url = new URL(window.location.href)
+                    url.search = ''
+                    url.hash = `token=${encodeURIComponent(adminNewToken.value)}`
+                    return url.toString()
                 })
 
                 const loadAdminViewers = async () => {

--- a/tests/test_atomic_download_helpers.py
+++ b/tests/test_atomic_download_helpers.py
@@ -1,0 +1,42 @@
+"""Tests for shared atomic media download finalization helpers."""
+
+from src import listener, telegram_backup
+
+
+def test_telegram_backup_finalize_atomic_download_uses_temporary_fallback(tmp_path):
+    """When Telethon leaves the requested temp file behind, move it to the fallback path."""
+    temporary_path = tmp_path / "download.part"
+    fallback_path = tmp_path / "download.jpg"
+    temporary_path.write_bytes(b"image")
+
+    result = telegram_backup._finalize_atomic_download(None, str(temporary_path), str(fallback_path))
+
+    assert result == str(fallback_path)
+    assert fallback_path.read_bytes() == b"image"
+    assert not temporary_path.exists()
+
+
+def test_telegram_backup_finalize_atomic_download_strips_part_suffix(tmp_path):
+    """When Telethon returns a .part path, remove the suffix atomically."""
+    actual_path = tmp_path / "chosen.jpg.part"
+    actual_path.write_bytes(b"image")
+    fallback_path = tmp_path / "fallback.jpg"
+
+    result = telegram_backup._finalize_atomic_download(str(actual_path), str(actual_path), str(fallback_path))
+
+    assert result == str(tmp_path / "chosen.jpg")
+    assert (tmp_path / "chosen.jpg").read_bytes() == b"image"
+    assert not actual_path.exists()
+
+
+def test_listener_finalize_atomic_download_uses_temporary_fallback(tmp_path):
+    """Listener downloads share the same temporary-file fallback behavior."""
+    temporary_path = tmp_path / "listener.part"
+    fallback_path = tmp_path / "listener.jpg"
+    temporary_path.write_bytes(b"image")
+
+    result = listener._finalize_atomic_download(None, str(temporary_path), str(fallback_path))
+
+    assert result == str(fallback_path)
+    assert fallback_path.read_bytes() == b"image"
+    assert not temporary_path.exists()

--- a/tests/test_atomic_download_helpers.py
+++ b/tests/test_atomic_download_helpers.py
@@ -40,3 +40,13 @@ def test_listener_finalize_atomic_download_uses_temporary_fallback(tmp_path):
     assert result == str(fallback_path)
     assert fallback_path.read_bytes() == b"image"
     assert not temporary_path.exists()
+
+
+def test_finalize_atomic_download_returns_none_when_no_file_was_created(tmp_path):
+    """Helpers must not report success when Telethon did not create a file."""
+    missing_temp = tmp_path / "missing.part"
+    fallback_path = tmp_path / "fallback.jpg"
+
+    assert telegram_backup._finalize_atomic_download(None, str(missing_temp), str(fallback_path)) is None
+    assert listener._finalize_atomic_download(None, str(missing_temp), str(fallback_path)) is None
+    assert not fallback_path.exists()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -923,6 +923,18 @@ class TestListenerLogging(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
+    def test_listener_deletions_default_false(self):
+        """LISTEN_DELETIONS defaults to false to preserve archive data."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "ENABLE_LISTENER": "true",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertTrue(config.enable_listener)
+            self.assertFalse(config.listen_deletions)
+
     def test_listener_enabled_with_deletions(self):
         """ENABLE_LISTENER=true with LISTEN_DELETIONS=true covers deletion warning path."""
         env_vars = {

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -14,6 +14,12 @@ from src import connection
 from src.connection import TelegramConnection
 
 
+def test_get_int_env_falls_back_for_invalid_value():
+    """Malformed flood-wait env values fall back instead of crashing imports."""
+    with patch.dict(os.environ, {"MAX_FLOOD_RETRIES": "not-an-int"}):
+        assert connection._get_int_env("MAX_FLOOD_RETRIES", 5) == 5
+
+
 @pytest.mark.asyncio
 async def test_connection_call_with_flood_retry_aborts_excessive_wait():
     """Shared connection retry helper must fail fast on excessive FloodWaits."""

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -8,8 +8,31 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from telethon.errors import FloodWaitError
 
+from src import connection
 from src.connection import TelegramConnection
+
+
+@pytest.mark.asyncio
+async def test_connection_call_with_flood_retry_aborts_excessive_wait():
+    """Shared connection retry helper must fail fast on excessive FloodWaits."""
+    sleeps: list[float] = []
+
+    async def huge_wait():
+        raise FloodWaitError(request=None, capture=86400)
+
+    async def record_sleep(seconds):
+        sleeps.append(seconds)
+
+    with (
+        patch.object(connection, "MAX_FLOOD_WAIT_SECONDS", 30),
+        patch.object(connection.asyncio, "sleep", record_sleep),
+        pytest.raises(FloodWaitError),
+    ):
+        await connection._call_with_flood_retry(huge_wait)
+
+    assert sleeps == []
 
 
 class TestTelegramConnectionInit(unittest.TestCase):

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -11,6 +11,7 @@ import pytest
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from src.db.adapter import DatabaseAdapter, _strip_tz, retry_on_locked
+from src.db.models import Message
 
 # ============================================================
 # _strip_tz helper
@@ -2048,6 +2049,26 @@ class TestGetMessagesPaginated:
 
         result = await adapter.get_messages_paginated(chat_id=100, before_date=datetime(2025, 6, 1), before_id=50)
         assert result == []
+
+    @pytest.mark.asyncio
+    async def test_offset_pagination_orders_same_timestamp_by_id_desc(self):
+        """Offset pagination uses the deterministic date DESC, id DESC ordering."""
+        db_manager, mock_session = _make_mock_db_manager()
+        adapter = DatabaseAdapter(db_manager)
+
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter([]))
+        mock_session.execute.return_value = mock_result
+        adapter.get_reactions = AsyncMock(return_value=[])
+
+        await adapter.get_messages_paginated(chat_id=100, limit=2, offset=4)
+
+        stmt = mock_session.execute.await_args.args[0]
+        order_by = list(stmt._order_by_clauses)
+        assert str(order_by[0]) == str(Message.date.desc())
+        assert str(order_by[1]) == str(Message.id.desc())
+        assert stmt._limit_clause.value == 2
+        assert stmt._offset_clause.value == 4
 
     @pytest.mark.asyncio
     async def test_with_search_filter(self):

--- a/tests/test_db_migrate.py
+++ b/tests/test_db_migrate.py
@@ -9,7 +9,7 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
-from src.db.migrate import _migrate_table, migrate_sqlite_to_postgres, verify_migration
+from src.db.migrate import MIGRATION_MODELS, _migrate_table, migrate_sqlite_to_postgres, verify_migration
 
 # ============================================================
 # Helper: build a mock DatabaseManager whose get_session()
@@ -177,7 +177,7 @@ class TestMigrateFullFlow:
         mock_target.close.assert_awaited_once()
 
         # All tables should have 0 records since source is empty
-        for table in ["users", "chats", "messages", "media", "reactions", "sync_status", "metadata"]:
+        for table in [model.__tablename__ for model in MIGRATION_MODELS]:
             assert result[table] == 0
 
     @pytest.mark.asyncio
@@ -334,8 +334,8 @@ class TestVerifyMigrationFlow:
                 postgres_url="postgresql+asyncpg://u:p@h/d",
             )
 
-        # Should have entries for all 7 tables
-        assert len(result) == 7
+        # Should have entries for every ORM table that participates in app state
+        assert len(result) == len(MIGRATION_MODELS)
         for _table_name, counts in result.items():
             assert counts["sqlite"] == 100
             assert counts["postgres"] == 100

--- a/tests/test_flood_wait_visibility.py
+++ b/tests/test_flood_wait_visibility.py
@@ -470,6 +470,29 @@ async def test_call_with_flood_retry_gives_up(fake_db):
 
 
 @pytest.mark.asyncio
+async def test_call_with_flood_retry_aborts_excessive_wait(fake_db):
+    """call_with_flood_retry must not sleep when Telegram asks for an excessive wait."""
+    from src import telegram_backup
+
+    sleeps: list[float] = []
+
+    async def huge_wait():
+        raise FloodWaitError(request=None, capture=86400)
+
+    async def record_sleep(seconds):
+        sleeps.append(seconds)
+
+    with (
+        patch.object(telegram_backup, "MAX_FLOOD_WAIT_SECONDS", 30),
+        patch.object(telegram_backup.asyncio, "sleep", record_sleep),
+        pytest.raises(FloodWaitError),
+    ):
+        await telegram_backup.call_with_flood_retry(huge_wait)
+
+    assert sleeps == []
+
+
+@pytest.mark.asyncio
 async def test_call_with_flood_retry_clamps_negative_sleep(fake_db):
     """Negative e.seconds in call_with_flood_retry must be clamped to 0."""
     from src import telegram_backup

--- a/tests/test_flood_wait_visibility.py
+++ b/tests/test_flood_wait_visibility.py
@@ -77,6 +77,17 @@ def test_config_kwargs_include_flood_sleep_threshold_zero():
     assert kwargs.get("flood_sleep_threshold") == 0
 
 
+def test_flood_env_int_parser_invalid_falls_back(fake_db, caplog):
+    """Invalid retry/wait env values should fall back consistently."""
+    from src import telegram_backup
+
+    with patch.dict(os.environ, {"MAX_FLOOD_WAIT_SECONDS": "not-an-int"}), caplog.at_level(logging.WARNING):
+        value = telegram_backup._get_int_env("MAX_FLOOD_WAIT_SECONDS", 3600)
+
+    assert value == 3600
+    assert any("Invalid MAX_FLOOD_WAIT_SECONDS" in r.getMessage() for r in caplog.records)
+
+
 @pytest.mark.asyncio
 async def test_connection_passes_flood_sleep_threshold_to_client(fake_db):
     from src.connection import TelegramConnection
@@ -294,6 +305,7 @@ async def test_iter_with_flood_retry_aborts_waits_above_max(fake_db):
             pass
 
     assert sleeps == []
+    assert calls["n"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/test_flood_wait_visibility.py
+++ b/tests/test_flood_wait_visibility.py
@@ -10,8 +10,8 @@ Three things under test:
    logs the wait (above ``FLOOD_WAIT_LOG_THRESHOLD``), resumes iteration from
    the last yielded message id, and gives up after ``MAX_FLOOD_RETRIES``
    consecutive flood-waits without progress.
-3. ``e.seconds`` is clamped at ``MAX_FLOOD_WAIT_SECONDS`` so a pathologically
-   large value cannot hang the process for hours.
+3. waits above ``MAX_FLOOD_WAIT_SECONDS`` abort instead of retrying before
+   Telegram's required wait has elapsed.
 """
 
 import importlib
@@ -270,8 +270,8 @@ async def test_iter_with_flood_retry_gives_up_after_max_retries(caplog, fake_db)
 
 
 @pytest.mark.asyncio
-async def test_iter_with_flood_retry_caps_sleep_seconds(fake_db):
-    """An e.seconds value above MAX_FLOOD_WAIT_SECONDS must be clamped."""
+async def test_iter_with_flood_retry_aborts_waits_above_max(fake_db):
+    """An e.seconds value above MAX_FLOOD_WAIT_SECONDS must not retry early."""
     from src import telegram_backup
 
     calls = {"n": 0}
@@ -289,11 +289,11 @@ async def test_iter_with_flood_retry_caps_sleep_seconds(fake_db):
     async def record_sleep(seconds):
         sleeps.append(seconds)
 
-    with patch.object(telegram_backup.asyncio, "sleep", record_sleep):
+    with patch.object(telegram_backup.asyncio, "sleep", record_sleep), pytest.raises(FloodWaitError):
         async for _msg in telegram_backup.iter_messages_with_flood_retry(fake_client, "chat", min_id=0, reverse=True):
             pass
 
-    assert sleeps == [telegram_backup.MAX_FLOOD_WAIT_SECONDS + 1]
+    assert sleeps == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -646,7 +646,17 @@ class TestDownloadMedia:
         msg.media = media
         msg.id = 1
 
-        result = await listener._download_media(msg, -100)
+        shared_checks = {"n": 0}
+
+        def exists(path):
+            if str(path) == "/tmp/test_media/_shared/123.jpg":
+                shared_checks["n"] += 1
+                return shared_checks["n"] > 1
+            return False
+
+        mock_exists.side_effect = exists
+        with patch("src.listener._finalize_atomic_download", return_value="/tmp/test_media/_shared/123.jpg"):
+            result = await listener._download_media(msg, -100)
         assert result is not None
         listener.client.download_media.assert_called_once()
 
@@ -667,7 +677,17 @@ class TestDownloadMedia:
         msg.media = media
         msg.id = 1
 
-        result = await listener._download_media(msg, -100)
+        file_checks = {"n": 0}
+
+        def exists(path):
+            if str(path) == "/tmp/test_media/-100/123.jpg":
+                file_checks["n"] += 1
+                return file_checks["n"] > 1
+            return False
+
+        mock_exists.side_effect = exists
+        with patch("src.listener._finalize_atomic_download", return_value="/tmp/test_media/-100/123.jpg"):
+            result = await listener._download_media(msg, -100)
         assert result is not None
         listener.client.download_media.assert_called_once()
 
@@ -2163,7 +2183,17 @@ class TestDownloadMediaSymlinkFallback:
         msg.media = media
         msg.id = 1
 
-        result = await listener._download_media(msg, -100)
+        shared_checks = {"n": 0}
+
+        def exists(path):
+            if str(path) == "/tmp/test_media/_shared/123.jpg":
+                shared_checks["n"] += 1
+                return shared_checks["n"] > 1
+            return False
+
+        mock_exists.side_effect = exists
+        with patch("src.listener._finalize_atomic_download", return_value="/tmp/test_media/_shared/123.jpg"):
+            result = await listener._download_media(msg, -100)
         assert result is not None
         mock_move.assert_called_once()
 

--- a/tests/test_multi_user_auth.py
+++ b/tests/test_multi_user_auth.py
@@ -70,12 +70,13 @@ def auth_env():
 
 @pytest.fixture
 def no_auth_env():
-    """Clear auth env vars."""
+    """Clear auth env vars and explicitly opt in to anonymous mode."""
     with patch.dict(
         os.environ,
         {
             "VIEWER_USERNAME": "",
             "VIEWER_PASSWORD": "",
+            "ALLOW_ANONYMOUS_VIEWER": "true",
         },
     ):
         yield

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -109,6 +109,15 @@ class TestRealtimeNotifierInitMethod:
 
         assert notifier._is_postgresql is True
 
+    async def test_init_database_url_takes_precedence_over_db_type(self):
+        """DATABASE_URL chooses transport before DB_TYPE fallback."""
+        notifier = RealtimeNotifier()
+
+        with patch.dict(os.environ, {"DATABASE_URL": "postgres://u:p@host/db", "DB_TYPE": "sqlite"}, clear=True):
+            await notifier.init()
+
+        assert notifier._is_postgresql is True
+
     async def test_init_detects_postgres_alias_from_env(self):
         """init() recognizes 'postgres' as PostgreSQL."""
         notifier = RealtimeNotifier()
@@ -602,6 +611,15 @@ class TestRealtimeListenerInitMethod:
         listener = RealtimeListener()
 
         with patch.dict(os.environ, {"DB_TYPE": "postgresql"}, clear=True):
+            await listener.init()
+
+        assert listener._is_postgresql is True
+
+    async def test_init_database_url_takes_precedence_over_db_type(self):
+        """Listener and notifier share DATABASE_URL-first transport detection."""
+        listener = RealtimeListener()
+
+        with patch.dict(os.environ, {"DATABASE_URL": "postgres://u:p@host/db", "DB_TYPE": "sqlite"}, clear=True):
             await listener.init()
 
         assert listener._is_postgresql is True

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -59,8 +59,10 @@ class TestBackupSchedulerInit:
             from src.scheduler import BackupScheduler
 
             config = MagicMock()
+            config.should_skip_topic = MagicMock(return_value=False)
             scheduler = BackupScheduler(config)
 
+            assert hasattr(scheduler, "_backup_lock")
             assert hasattr(scheduler._backup_lock, "locked")
 
     def test_init_registers_signal_handlers(self):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -53,6 +53,16 @@ class TestBackupSchedulerInit:
             assert scheduler._listener is None
             assert scheduler._listener_task is None
 
+    def test_init_creates_backup_lock(self):
+        """BackupScheduler creates a lock to prevent overlapping backup runs."""
+        with patch("src.scheduler.signal.signal"):
+            from src.scheduler import BackupScheduler
+
+            config = MagicMock()
+            scheduler = BackupScheduler(config)
+
+            assert hasattr(scheduler._backup_lock, "locked")
+
     def test_init_registers_signal_handlers(self):
         """BackupScheduler registers SIGINT and SIGTERM handlers."""
         with patch("src.scheduler.signal.signal") as mock_signal:
@@ -228,6 +238,17 @@ class TestBackupSchedulerRunBackupJob:
 
         # Should NOT raise
         await scheduler._run_backup_job()
+
+    async def test_run_backup_job_skips_when_another_backup_running(self, scheduler_with_connection):
+        """Backup job does not overlap with an already running backup."""
+        scheduler = scheduler_with_connection
+        await scheduler._backup_lock.acquire()
+        try:
+            with patch("src.scheduler.run_backup", new_callable=AsyncMock) as mock_backup:
+                await scheduler._run_backup_job()
+            mock_backup.assert_not_called()
+        finally:
+            scheduler._backup_lock.release()
 
     async def test_run_backup_job_gap_fill_with_errors(self):
         """Backup job logs warning when gap-fill has errors."""

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -1492,7 +1492,13 @@ class TestProcessMedia(unittest.TestCase):
 
         self.backup._get_media_type = MagicMock(return_value="video")
         self.backup._get_media_filename = MagicMock(return_value="test.mp4")
-        self.backup.client.download_media = AsyncMock(return_value=None)
+
+        async def fake_download(_message, path):
+            with open(path, "wb") as f:
+                f.write(b"video")
+            return path
+
+        self.backup.client.download_media = AsyncMock(side_effect=fake_download)
 
         result = _run(self.backup._process_media(msg, 100))
 

--- a/tests/test_telegram_proxy.py
+++ b/tests/test_telegram_proxy.py
@@ -1,6 +1,7 @@
 import importlib
 import os
 import sys
+import tempfile
 import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -256,6 +257,37 @@ async def test_auth_noninteractive_passes_proxy_kwargs():
         "hash",
         proxy={"proxy_type": "socks5", "addr": "127.0.0.1", "port": 1080},
     )
+
+
+@pytest.mark.asyncio
+async def test_auth_noninteractive_verify_uses_saved_phone_code_hash():
+    client = AsyncMock()
+    client.is_user_authorized.return_value = False
+    client.get_me.return_value = SimpleNamespace(first_name="Test", username="tester")
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        session_dir = os.path.join(tmpdir, "session")
+        os.makedirs(session_dir)
+        hash_path = os.path.join(session_dir, "telegram_backup.phone_code_hash")
+        with open(hash_path, "w") as f:
+            f.write("saved-hash")
+
+        env = {
+            "TELEGRAM_API_ID": "12345",
+            "TELEGRAM_API_HASH": "hash",
+            "TELEGRAM_PHONE": "+123456789",
+            "SESSION_DIR": session_dir,
+        }
+
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch.object(auth_noninteractive.sys, "argv", ["auth_noninteractive.py", "verify", "12345"]),
+            patch("scripts.auth_noninteractive.TelegramClient", return_value=client),
+        ):
+            await auth_noninteractive.main()
+
+    client.send_code_request.assert_not_called()
+    client.sign_in.assert_awaited_once_with(phone="+123456789", code="12345", phone_code_hash="saved-hash")
 
 
 @pytest.mark.asyncio

--- a/tests/test_v720_features.py
+++ b/tests/test_v720_features.py
@@ -343,8 +343,8 @@ class TestNoDownload:
         resp = client.get("/media/-1001/photo.jpg?download=1", cookies={"viewer_auth": cookie})
         assert resp.status_code == 403
 
-    def test_no_download_allows_inline_media(self, auth_env, tmp_path):
-        """no_download users can still view media inline (without download=1)."""
+    def test_no_download_blocks_original_media_without_download_param(self, auth_env, tmp_path):
+        """no_download users cannot fetch original bytes by omitting download=1."""
         client, mod, db = _get_client()
         db.verify_viewer_token.return_value = {
             "id": 10,
@@ -360,9 +360,9 @@ class TestNoDownload:
         (media_dir / "photo.jpg").write_bytes(b"\xff\xd8\xff\xe0" + b"\x00" * 100)
         mod._media_root = tmp_path / "media"
 
-        # Inline request (no download param) should succeed
+        # Inline request (no download param) is still a direct byte fetch.
         resp = client.get("/media/-1001/photo.jpg", cookies={"viewer_auth": cookie})
-        assert resp.status_code == 200
+        assert resp.status_code == 403
 
     def test_no_download_blocks_export(self, auth_env):
         """no_download users cannot export chat history."""

--- a/tests/test_web_coverage.py
+++ b/tests/test_web_coverage.py
@@ -109,6 +109,7 @@ class _WebTestBase(unittest.IsolatedAsyncioTestCase):
             return
         self._saved_db = web_main.db
         self._saved_auth = web_main.AUTH_ENABLED
+        self._saved_allow_anonymous = web_main.ALLOW_ANONYMOUS_VIEWER
         self._saved_sessions = dict(web_main._sessions)
         self._saved_push = web_main.push_manager
         self._saved_display = web_main.config.display_chat_ids
@@ -120,6 +121,7 @@ class _WebTestBase(unittest.IsolatedAsyncioTestCase):
         self.mock_db = _mock_db()
         web_main.db = self.mock_db
         web_main.AUTH_ENABLED = False
+        web_main.ALLOW_ANONYMOUS_VIEWER = True
         web_main._sessions.clear()
         web_main.push_manager = None
         web_main.config.display_chat_ids = set()
@@ -131,6 +133,7 @@ class _WebTestBase(unittest.IsolatedAsyncioTestCase):
             return
         web_main.db = self._saved_db
         web_main.AUTH_ENABLED = self._saved_auth
+        web_main.ALLOW_ANONYMOUS_VIEWER = self._saved_allow_anonymous
         web_main._sessions.clear()
         web_main._sessions.update(self._saved_sessions)
         web_main.push_manager = self._saved_push
@@ -345,6 +348,40 @@ class TestServeMedia(_WebTestBase):
                 resp = await client.get("/media/123/photo.jpg", cookies={"viewer_auth": token})
             self.assertEqual(resp.status_code, 403)
 
+    async def test_media_rejects_shared_folder_for_restricted_user(self):
+        """Restricted users cannot fetch deduplicated _shared files directly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            web_main._media_root = web_main.Path(tmpdir)
+            shared_dir = os.path.join(tmpdir, "_shared")
+            os.makedirs(shared_dir)
+            with open(os.path.join(shared_dir, "secret.jpg"), "w") as f:
+                f.write("secret")
+
+            web_main.AUTH_ENABLED = True
+            token = "restricted-shared"
+            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={123})
+            async with self._client() as client:
+                resp = await client.get("/media/_shared/secret.jpg", cookies={"viewer_auth": token})
+            self.assertEqual(resp.status_code, 403)
+
+    async def test_media_rejects_original_file_for_no_download_user(self):
+        """no_download users cannot fetch original media bytes by omitting download=1."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            web_main._media_root = web_main.Path(tmpdir)
+            chat_dir = os.path.join(tmpdir, "123")
+            os.makedirs(chat_dir)
+            with open(os.path.join(chat_dir, "photo.jpg"), "w") as f:
+                f.write("img")
+
+            web_main.AUTH_ENABLED = True
+            token = "no-download-original"
+            web_main._sessions[token] = web_main.SessionData(
+                username="v1", role="viewer", allowed_chat_ids={123}, no_download=True
+            )
+            async with self._client() as client:
+                resp = await client.get("/media/123/photo.jpg", cookies={"viewer_auth": token})
+            self.assertEqual(resp.status_code, 403)
+
     async def test_media_avatar_access_check(self):
         """serve_media enforces chat-level access for avatar paths."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -403,6 +440,17 @@ class TestServeThumbnail(_WebTestBase):
             web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={999})
             async with self._client() as client:
                 resp = await client.get("/media/thumb/200/123/photo.jpg", cookies={"viewer_auth": token})
+            self.assertEqual(resp.status_code, 403)
+
+    async def test_thumbnail_rejects_shared_folder_for_restricted_user(self):
+        """Restricted users cannot request thumbnails for non-chat media folders."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            web_main._media_root = web_main.Path(tmpdir)
+            web_main.AUTH_ENABLED = True
+            token = "th-shared"
+            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={123})
+            async with self._client() as client:
+                resp = await client.get("/media/thumb/200/_shared/secret.jpg", cookies={"viewer_auth": token})
             self.assertEqual(resp.status_code, 403)
 
     async def test_thumbnail_avatar_access_check(self):
@@ -1138,6 +1186,14 @@ class TestInternalPushEdgeCases(_WebTestBase):
             resp = await client.post("/internal/push", json={"type": "test"})
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["status"], "error")
+
+    async def test_internal_push_requires_secret_for_private_network(self):
+        """Non-loopback private network callers need INTERNAL_PUSH_SECRET."""
+        transport = ASGITransport(app=web_main.app, client=("172.18.0.2", 12345))
+        with patch.dict(os.environ, {}, clear=True):
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                resp = await client.post("/internal/push", json={"type": "test"})
+        self.assertEqual(resp.status_code, 403)
 
 
 # ============================================================================

--- a/tests/test_web_coverage.py
+++ b/tests/test_web_coverage.py
@@ -453,6 +453,19 @@ class TestServeThumbnail(_WebTestBase):
                 resp = await client.get("/media/thumb/200/_shared/secret.jpg", cookies={"viewer_auth": token})
             self.assertEqual(resp.status_code, 403)
 
+    async def test_thumbnail_rejects_no_download_for_media_bytes(self):
+        """no_download users cannot fetch derived thumbnail bytes for media."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            web_main._media_root = web_main.Path(tmpdir)
+            web_main.AUTH_ENABLED = True
+            token = "th-no-download"
+            web_main._sessions[token] = web_main.SessionData(
+                username="v1", role="viewer", allowed_chat_ids={123}, no_download=True
+            )
+            async with self._client() as client:
+                resp = await client.get("/media/thumb/200/123/photo.jpg", cookies={"viewer_auth": token})
+            self.assertEqual(resp.status_code, 403)
+
     async def test_thumbnail_avatar_access_check(self):
         """serve_thumbnail enforces access for avatar thumbnails."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -506,6 +519,31 @@ class TestServeThumbnail(_WebTestBase):
                     resp = await client.get("/media/thumb/200/123/photo.jpg")
             self.assertEqual(resp.status_code, 200)
             self.assertIn("image/webp", resp.headers.get("content-type", ""))
+
+
+# ============================================================================
+# WebSocket endpoint
+# ============================================================================
+
+
+@_skip_unless_web
+class TestWebSocketEndpoint(_WebTestBase):
+    """Test /ws/updates auth decisions."""
+
+    async def test_websocket_fails_closed_when_auth_not_configured(self):
+        """WebSockets must not bypass setup-required auth mode."""
+        web_main.AUTH_ENABLED = False
+        web_main.ALLOW_ANONYMOUS_VIEWER = False
+        websocket = MagicMock()
+        websocket.headers = {"host": "test"}
+        websocket.cookies = {}
+        websocket.close = AsyncMock()
+
+        with patch.object(web_main.ws_manager, "connect", new_callable=AsyncMock) as mock_connect:
+            await web_main.websocket_endpoint(websocket)
+
+        websocket.close.assert_awaited_once_with(code=4001, reason="Viewer authentication is not configured")
+        mock_connect.assert_not_awaited()
 
 
 # ============================================================================

--- a/tests/test_web_main.py
+++ b/tests/test_web_main.py
@@ -142,8 +142,8 @@ class TestConnectionManagerBroadcast(unittest.IsolatedAsyncioTestCase):
         await self.mgr.broadcast_to_chat(42, {"type": "test"})
 
         ws1.send_json.assert_awaited_once_with({"type": "test"})
-        # ws2 has empty subscriptions, so it also receives (matches "not subscribed_chats" branch)
-        ws2.send_json.assert_awaited_once()
+        # Empty subscriptions no longer receive chat-specific events.
+        ws2.send_json.assert_not_awaited()
 
     async def test_broadcast_to_chat_respects_acl(self):
         """broadcast_to_chat skips connections whose ACL excludes the chat."""
@@ -159,6 +159,7 @@ class TestConnectionManagerBroadcast(unittest.IsolatedAsyncioTestCase):
         ws = AsyncMock()
         ws.send_json.side_effect = Exception("broken pipe")
         await self.mgr.connect(ws)
+        self.mgr.subscribe(ws, 1)
 
         await self.mgr.broadcast_to_chat(1, {"type": "test"})
         self.assertNotIn(ws, self.mgr.active_connections)

--- a/tests/test_web_main.py
+++ b/tests/test_web_main.py
@@ -9,6 +9,7 @@ import os
 import tempfile
 import time
 import unittest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 # The module import triggers FastAPI initialization, which may fail on
@@ -761,6 +762,105 @@ class TestHandleRealtimeNotification(unittest.IsolatedAsyncioTestCase):
         msg = mock_bc.call_args[0][1]
         self.assertEqual(msg["type"], "pin")
         self.assertEqual(msg["message_ids"], [1, 2])
+
+
+@_skip_unless_web_main
+class TestSecurityHelpers(unittest.TestCase):
+    """Test small security helper branches directly."""
+
+    def test_get_client_ip_uses_direct_ip_by_default(self):
+        """Proxy headers are ignored unless TRUST_PROXY_HEADERS is enabled."""
+        request = SimpleNamespace(
+            client=SimpleNamespace(host="10.0.0.5"),
+            headers={"x-forwarded-for": "203.0.113.10", "x-real-ip": "203.0.113.11"},
+        )
+
+        with patch.object(web_main, "TRUST_PROXY_HEADERS", False):
+            self.assertEqual(web_main._get_client_ip(request), "10.0.0.5")
+
+    def test_get_client_ip_uses_proxy_headers_when_trusted(self):
+        """Trusted proxy mode prefers X-Forwarded-For, then X-Real-IP."""
+        request = SimpleNamespace(
+            client=SimpleNamespace(host="10.0.0.5"),
+            headers={"x-forwarded-for": "203.0.113.10, 198.51.100.8", "x-real-ip": "203.0.113.11"},
+        )
+
+        with patch.object(web_main, "TRUST_PROXY_HEADERS", True):
+            self.assertEqual(web_main._get_client_ip(request), "203.0.113.10")
+
+    def test_get_client_ip_falls_back_to_real_ip_when_forwarded_empty(self):
+        """Trusted proxy mode falls back to X-Real-IP when X-Forwarded-For is blank."""
+        request = SimpleNamespace(
+            client=SimpleNamespace(host="10.0.0.5"),
+            headers={"x-forwarded-for": " ", "x-real-ip": "203.0.113.11"},
+        )
+
+        with patch.object(web_main, "TRUST_PROXY_HEADERS", True):
+            self.assertEqual(web_main._get_client_ip(request), "203.0.113.11")
+
+    def test_websocket_origin_allows_missing_and_same_origin(self):
+        """Originless and same-origin WebSockets are allowed."""
+        self.assertTrue(web_main._websocket_origin_allowed(SimpleNamespace(headers={"host": "example.test"})))
+        self.assertTrue(
+            web_main._websocket_origin_allowed(
+                SimpleNamespace(headers={"origin": "https://example.test", "host": "example.test"})
+            )
+        )
+
+    def test_websocket_origin_uses_cors_allowlist(self):
+        """Cross-origin WebSockets must match CORS_ORIGINS."""
+        websocket = SimpleNamespace(headers={"origin": "https://viewer.example", "host": "archive.example"})
+        with patch.dict(os.environ, {"CORS_ORIGINS": "https://viewer.example, https://other.example"}):
+            self.assertTrue(web_main._websocket_origin_allowed(websocket))
+        with patch.dict(os.environ, {"CORS_ORIGINS": "https://other.example"}):
+            self.assertFalse(web_main._websocket_origin_allowed(websocket))
+
+    def test_enforce_media_acl_allows_unrestricted_user(self):
+        """Master/unrestricted users can access any normalized media path."""
+        user = web_main.UserContext(username="master", role="master", allowed_chat_ids=None)
+        web_main._enforce_media_acl("123/file.jpg", user)
+
+    def test_enforce_media_acl_avatar_branches(self):
+        """Restricted users only get avatars for allowed chat IDs."""
+        user = web_main.UserContext(username="viewer", role="viewer", allowed_chat_ids={123})
+        web_main._enforce_media_acl("avatars/chats/123_456.jpg", user)
+
+        for path in ("avatars/chats", "avatars/chats/not-a-number.jpg", "avatars/chats/999_456.jpg"):
+            with self.subTest(path=path), self.assertRaises(web_main.HTTPException) as ctx:
+                web_main._enforce_media_acl(path, user)
+            self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_enforce_media_acl_rejects_malformed_or_unallowed_media_path(self):
+        """Restricted users cannot access non-chat folders or unallowed chat IDs."""
+        user = web_main.UserContext(username="viewer", role="viewer", allowed_chat_ids={123})
+        for path in ("one-segment", "_shared/file.jpg", "999/file.jpg"):
+            with self.subTest(path=path), self.assertRaises(web_main.HTTPException) as ctx:
+                web_main._enforce_media_acl(path, user)
+            self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_strip_original_media_paths_handles_media_items(self):
+        """No-download sessions strip both legacy media and multi-media item paths."""
+        messages = [
+            {
+                "media": {"file_path": "1/original.jpg", "downloaded": True},
+                "media_items": [
+                    {"file_path": "1/a.jpg", "downloaded": True},
+                    "not-a-dict",
+                    {"file_path": "1/b.jpg", "downloaded": True},
+                ],
+            },
+            {"media": None, "media_items": None},
+        ]
+
+        web_main._strip_original_media_paths(messages)
+
+        self.assertEqual(messages[0]["media"]["file_path"], None)
+        self.assertFalse(messages[0]["media"]["downloaded"])
+        self.assertTrue(messages[0]["media"]["no_download"])
+        self.assertEqual(messages[0]["media_items"][0]["file_path"], None)
+        self.assertFalse(messages[0]["media_items"][0]["downloaded"])
+        self.assertTrue(messages[0]["media_items"][0]["no_download"])
+        self.assertEqual(messages[0]["media_items"][2]["file_path"], None)
 
 
 if __name__ == "__main__":

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -84,6 +84,7 @@ class _WebTestBase(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self._saved_db = web_main.db
         self._saved_auth = web_main.AUTH_ENABLED
+        self._saved_allow_anonymous = web_main.ALLOW_ANONYMOUS_VIEWER
         self._saved_sessions = dict(web_main._sessions)
         self._saved_push = web_main.push_manager
         self._saved_display = web_main.config.display_chat_ids
@@ -93,6 +94,7 @@ class _WebTestBase(unittest.IsolatedAsyncioTestCase):
         self.mock_db = _mock_db()
         web_main.db = self.mock_db
         web_main.AUTH_ENABLED = False
+        web_main.ALLOW_ANONYMOUS_VIEWER = True
         web_main._sessions.clear()
         web_main.push_manager = None
         web_main.config.display_chat_ids = set()
@@ -102,6 +104,7 @@ class _WebTestBase(unittest.IsolatedAsyncioTestCase):
     def tearDown(self):
         web_main.db = self._saved_db
         web_main.AUTH_ENABLED = self._saved_auth
+        web_main.ALLOW_ANONYMOUS_VIEWER = self._saved_allow_anonymous
         web_main._sessions.clear()
         web_main._sessions.update(self._saved_sessions)
         web_main.push_manager = self._saved_push
@@ -155,7 +158,7 @@ class TestAuthCheckEndpoint(_WebTestBase):
     """Test /api/auth/check endpoint."""
 
     async def test_returns_authenticated_when_auth_disabled(self):
-        """auth check returns authenticated=True and role=master when auth is disabled."""
+        """auth check returns anonymous master only with explicit anonymous opt-in."""
         async with self._client() as client:
             resp = await client.get("/api/auth/check")
         self.assertEqual(resp.status_code, 200)
@@ -163,6 +166,17 @@ class TestAuthCheckEndpoint(_WebTestBase):
         self.assertTrue(data["authenticated"])
         self.assertFalse(data["auth_required"])
         self.assertEqual(data["role"], "master")
+
+    async def test_returns_setup_required_when_auth_missing_without_opt_in(self):
+        """auth check fails closed when credentials are missing and anonymous mode is not explicit."""
+        web_main.ALLOW_ANONYMOUS_VIEWER = False
+        async with self._client() as client:
+            resp = await client.get("/api/auth/check")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertFalse(data["authenticated"])
+        self.assertTrue(data["auth_required"])
+        self.assertTrue(data["setup_required"])
 
     async def test_returns_unauthenticated_when_no_cookie(self):
         """auth check returns authenticated=False when auth enabled but no cookie."""
@@ -1365,10 +1379,19 @@ class TestRequireAuth(_WebTestBase):
     """Test require_auth dependency."""
 
     async def test_returns_anonymous_master_when_auth_disabled(self):
-        """require_auth returns anonymous master when auth is disabled."""
+        """require_auth returns anonymous master only with explicit anonymous opt-in."""
         result = await web_main.require_auth(auth_cookie=None)
         self.assertEqual(result.username, "anonymous")
         self.assertEqual(result.role, "master")
+
+    async def test_auth_disabled_without_opt_in_fails_closed(self):
+        """require_auth raises setup error when auth is missing and anonymous mode is not explicit."""
+        web_main.ALLOW_ANONYMOUS_VIEWER = False
+        from fastapi import HTTPException
+
+        with self.assertRaises(HTTPException) as ctx:
+            await web_main.require_auth(auth_cookie=None)
+        self.assertEqual(ctx.exception.status_code, 503)
 
     async def test_raises_401_when_no_cookie(self):
         """require_auth raises 401 when auth enabled and no cookie."""


### PR DESCRIPTION
## Summary
- Fail closed when viewer credentials are missing unless anonymous mode is explicitly enabled.
- Tighten media ACLs, no-download behavior, WebSocket/internal push handling, FloodWait retries, scheduler locking, and migration coverage.
- Align Docker/CI/docs/dependencies and add regression coverage for the audited failure modes.

## Test plan
- [x] `ruff check .`
- [x] `ruff format --check .`
- [x] `pytest tests/ -q -p no:cacheprovider --tb=short` in isolated Python 3.14 venv
- [x] `shellcheck scripts/entrypoint.sh scripts/release.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added viewer authentication with username/password and anonymous access mode.
  * Implemented atomic media downloads and WebSocket origin validation.
  * Added configurable flood-wait retry limits and proxy header trust settings.

* **Bug Fixes**
  * Changed default deletion listener behavior to opt-in (`LISTEN_DELETIONS=false`) for safer operation.
  * Fixed message pagination ordering and WebSocket broadcasting to prevent data inconsistencies.
  * Added backup concurrency prevention to prevent overlapping backup operations.

* **Configuration**
  * Reduced default max media size from 4GB to 100MB.
  * Updated Docker images to version 7.6.4 and switched primary branch references from `master` to `main`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->