### PR TITLE
ENH: idempotent rerun on git-annex'ed archives (symlinks etc)

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,7 +537,24 @@ data/
 | "Permission denied" | `chmod -R 755 data/` |
 | Media files missing/corrupted | Set `VERIFY_MEDIA=true` to re-download them |
 | Backup interrupted | Set `VERIFY_MEDIA=true` once to recover missing files |
+| Re-run touches every media file in a git-annex / DataLad backup | See [git-annex / DataLad layouts](#git-annex--datalad-layouts) below |
 | "duplicate key value violates unique constraint reactions_pkey" | See [Reactions Sequence Fix](#reactions-sequence-fix-postgresql) below |
+
+### git-annex / DataLad layouts
+
+When the media tree is committed to git-annex (or DataLad), files appear
+as symlinks pointing into the repository's annex object store. The
+backup process treats an existing symlink as authoritative and never
+overwrites it on re-run -- but content-hash deduplication only
+recognizes existing `_shared/` blobs when their symlink targets are
+reachable from the running process. If you mount only the working tree
+into a container, the annex object store sits outside the mount and is
+invisible to the backup.
+
+For fully idempotent re-runs against an annex-managed archive, ensure
+the annex object store is reachable -- typically by mounting the
+repository root (not just the per-session subdirectory) and pointing
+the data path at the session subdirectory inside it.
 
 ### Reactions Sequence Fix (PostgreSQL)
 

--- a/src/listener.py
+++ b/src/listener.py
@@ -496,10 +496,13 @@ class TelegramListener:
                 logger.debug(f"No avatar set for {chat_id}")
                 return
 
-            needs_download = not os.path.exists(avatar_path) or os.path.getsize(avatar_path) == 0
-
-            if not needs_download:
-                return
+            # lexists short-circuits when an avatar (even a symlink whose
+            # target is unreachable from this process) is already on disk,
+            # so we don't try to overwrite an archive entry. Mirrors the
+            # backup-flow guard in src/telegram_backup.py (issue #143).
+            if os.path.lexists(avatar_path):
+                if os.path.islink(avatar_path) or os.path.getsize(avatar_path) > 0:
+                    return
 
             result = await self.client.download_profile_photo(entity, file=avatar_path, download_big=False)
             if result:

--- a/src/listener.py
+++ b/src/listener.py
@@ -623,10 +623,16 @@ class TelegramListener:
                 os.makedirs(shared_dir, exist_ok=True)
                 shared_file_path = os.path.join(shared_dir, file_name)
 
-                if not os.path.exists(file_path):
-                    if os.path.exists(shared_file_path):
-                        # File exists in shared - create symlink
-                        content_hash = compute_file_hash(shared_file_path)
+                # lexists treats an existing symlink as "already recorded"
+                # even when its ultimate target is unreachable (e.g. a
+                # git-annex object outside the bind mount). Mirrors the
+                # backup-flow gate in src/telegram_backup.py for idempotent
+                # behavior on archived layouts. See issue #143.
+                if not os.path.lexists(file_path):
+                    if os.path.lexists(shared_file_path):
+                        # File exists in shared - create symlink. Hash only
+                        # when the target resolves; skip on broken links.
+                        content_hash = compute_file_hash(shared_file_path) if os.path.exists(shared_file_path) else None
                         try:
                             rel_path = os.path.relpath(shared_file_path, chat_media_dir)
                             if os.path.lexists(file_path):
@@ -675,8 +681,10 @@ class TelegramListener:
                             else:
                                 shutil.move(shared_file_path, file_path)
             else:
-                # No deduplication - download directly
-                if not os.path.exists(file_path):
+                # No deduplication - download directly. lexists short-circuits
+                # the download when a symlink is already recorded, even if its
+                # target is unreachable.
+                if not os.path.lexists(file_path):
                     tmp_file_path = f"{file_path}.part"
                     if os.path.exists(tmp_file_path):
                         os.remove(tmp_file_path)

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -1346,11 +1346,18 @@ class TelegramBackup:
             return
 
         try:
-            # Avoid redundant downloads when we already have the current photo
-            needs_download = not os.path.exists(avatar_path) or os.path.getsize(avatar_path) == 0
-
-            if not needs_download:
-                return
+            # Avoid redundant downloads when we already have the current photo.
+            # lexists treats an existing symlink (even one pointing into an
+            # archive store like git-annex whose target may be unreachable
+            # from this process) as "we have it". Without this guard, a
+            # broken-but-intentional symlink at avatar_path made
+            # download_profile_photo follow the symlink into a missing
+            # parent directory and surface as ENOENT (issue #143).
+            if os.path.lexists(avatar_path):
+                # Symlink-or-file already in place: skip unless it is a
+                # zero-byte regular file from a prior interrupted download.
+                if os.path.islink(avatar_path) or os.path.getsize(avatar_path) > 0:
+                    return
 
             result = await self.client.download_profile_photo(
                 entity,

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -1505,11 +1505,20 @@ class TelegramBackup:
                 os.makedirs(shared_dir, exist_ok=True)
                 shared_file_path = os.path.join(shared_dir, file_name)
 
-                # Check if file already exists (either directly or in shared)
-                if not os.path.exists(file_path):
-                    if os.path.exists(shared_file_path):
-                        # File exists in shared - create symlink
-                        content_hash = compute_file_hash(shared_file_path)
+                # Check if file already exists (either directly or in shared).
+                # Uses lexists so a previously recorded symlink short-circuits
+                # the download even when its ultimate target is unreachable
+                # (e.g. a git-annex object outside the bind mount). Without
+                # this, intentional broken symlinks cause re-downloads that
+                # overwrite _shared/ entries via atomic rename and may rewrite
+                # chat-dir targets through content-hash dedup -- breaking
+                # idempotency for archived layouts.
+                if not os.path.lexists(file_path):
+                    if os.path.lexists(shared_file_path):
+                        # File exists in shared - create symlink. Hash only
+                        # when the target resolves; skip on a broken link to
+                        # avoid raising in compute_file_hash.
+                        content_hash = compute_file_hash(shared_file_path) if os.path.exists(shared_file_path) else None
                         try:
                             # Use relative symlink for portability
                             rel_path = os.path.relpath(shared_file_path, chat_media_dir)
@@ -1569,8 +1578,10 @@ class TelegramBackup:
                     if not content_hash:
                         content_hash = compute_file_hash(actual_path)
             else:
-                # No deduplication - download directly to chat directory
-                if not os.path.exists(file_path):
+                # No deduplication - download directly to chat directory.
+                # lexists short-circuits the download when a symlink is
+                # already recorded, even if its target is unreachable.
+                if not os.path.lexists(file_path):
                     tmp_file_path = f"{file_path}.part"
                     if os.path.exists(tmp_file_path):
                         os.remove(tmp_file_path)

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -636,9 +636,19 @@ class TelegramBackup:
             if not file_path:
                 continue
 
-            # Check if file exists
-            if not os.path.exists(file_path):
+            # Detect "truly missing" via lexists so an existing symlink
+            # whose ultimate target is unreachable (e.g. git-annex object
+            # outside the bind mount) is not flagged for re-download.
+            # Re-downloading it would atomic-rename a regular file on top
+            # of the symlink, mutating an archived working tree (issue #143).
+            if not os.path.lexists(file_path):
                 missing_files.append(record)
+                continue
+
+            # Trust symlinks: their content is managed externally and may
+            # be unreachable from this process. We cannot meaningfully
+            # check size or emptiness without following the link.
+            if os.path.islink(file_path):
                 continue
 
             # Check if file is empty (interrupted download)

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -783,9 +783,10 @@ class TestDownloadAvatar:
         listener.client.download_profile_photo.assert_not_called()
 
     @patch("src.listener.get_avatar_paths", return_value=("/path/avatar.jpg", "/legacy/path"))
-    @patch("os.path.exists", return_value=True)
+    @patch("os.path.lexists", return_value=True)
+    @patch("os.path.islink", return_value=False)
     @patch("os.path.getsize", return_value=1024)
-    async def test_skips_download_when_file_exists(self, mock_size, mock_exists, mock_paths):
+    async def test_skips_download_when_file_exists(self, mock_size, mock_islink, mock_lexists, mock_paths):
         """If avatar file already exists with content, skip download."""
         listener = TelegramListener(_make_config(), _make_db())
         listener.client = AsyncMock()

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -646,12 +646,20 @@ class TestDownloadMedia:
         msg.media = media
         msg.id = 1
 
-        shared_checks = {"n": 0}
+        # The shared file "appears" once download_media is called. Track that
+        # state with a flag rather than a call counter so the test is robust
+        # to changes in how many times `os.path.exists` is consulted.
+        downloaded = {"done": False}
+
+        async def fake_download(*args, **kwargs):
+            downloaded["done"] = True
+            return "/tmp/test_media/_shared/123.jpg"
+
+        listener.client.download_media = AsyncMock(side_effect=fake_download)
 
         def exists(path):
             if str(path) == "/tmp/test_media/_shared/123.jpg":
-                shared_checks["n"] += 1
-                return shared_checks["n"] > 1
+                return downloaded["done"]
             return False
 
         mock_exists.side_effect = exists
@@ -677,12 +685,18 @@ class TestDownloadMedia:
         msg.media = media
         msg.id = 1
 
-        file_checks = {"n": 0}
+        # The chat file "appears" once download_media is called.
+        downloaded = {"done": False}
+
+        async def fake_download(*args, **kwargs):
+            downloaded["done"] = True
+            return "/tmp/test_media/-100/123.jpg"
+
+        listener.client.download_media = AsyncMock(side_effect=fake_download)
 
         def exists(path):
             if str(path) == "/tmp/test_media/-100/123.jpg":
-                file_checks["n"] += 1
-                return file_checks["n"] > 1
+                return downloaded["done"]
             return False
 
         mock_exists.side_effect = exists
@@ -2175,8 +2189,6 @@ class TestDownloadMediaSymlinkFallback:
         db = _make_db()
         listener = TelegramListener(config, db)
         listener.client = AsyncMock()
-        listener.client.download_media = AsyncMock(return_value="/tmp/test_media/_shared/123.jpg")
-
         msg = MagicMock()
         media = MagicMock(spec=MessageMediaPhoto)
         media.photo = MagicMock()
@@ -2185,12 +2197,19 @@ class TestDownloadMediaSymlinkFallback:
         msg.media = media
         msg.id = 1
 
-        shared_checks = {"n": 0}
+        # Track when the shared file "appears" so the post-download exists()
+        # check sees it on the first call (the gate now uses lexists).
+        downloaded = {"done": False}
+
+        async def fake_download(*args, **kwargs):
+            downloaded["done"] = True
+            return "/tmp/test_media/_shared/123.jpg"
+
+        listener.client.download_media = AsyncMock(side_effect=fake_download)
 
         def exists(path):
             if str(path) == "/tmp/test_media/_shared/123.jpg":
-                shared_checks["n"] += 1
-                return shared_checks["n"] > 1
+                return downloaded["done"]
             return False
 
         mock_exists.side_effect = exists

--- a/tests/test_symlink_dedup.py
+++ b/tests/test_symlink_dedup.py
@@ -239,12 +239,14 @@ class TestProcessMediaDedupSymlink(unittest.TestCase):
             resolved = os.path.realpath(chat_file)
             self.assertEqual(resolved, os.path.realpath(returned_path))
 
-    def test_process_media_dedup_removes_dangling_before_symlink(self):
-        """A dangling symlink at the file_path is replaced with a valid one during first-download dedup.
+    def test_process_media_preserves_existing_symlink(self):
+        """An existing symlink at file_path short-circuits the download path.
 
-        This exercises the "first time seeing this file" branch (Path B) in _process_media,
-        where the shared file does NOT exist yet. download_media creates it, then the
-        lexists+unlink guard removes the dangling symlink before os.symlink.
+        The dedup gate uses ``os.path.lexists`` so a symlink already recorded
+        in the chat directory is treated as "we have it", regardless of whether
+        the ultimate target resolves. This is the idempotent-rerun contract
+        from issue #143: archived layouts (e.g. git-annex) keep their
+        symlinks intact across re-runs.
         """
         shared_dir = os.path.join(self.media_path, "_shared")
         chat_dir = os.path.join(self.media_path, "300")
@@ -253,48 +255,42 @@ class TestProcessMediaDedupSymlink(unittest.TestCase):
 
         file_name = "video_xyz.mp4"
 
-        # Create a dangling symlink in the chat directory pointing to a deleted file
+        # Reproduce the user's git-annex-style layout: chat dir holds a
+        # symlink pointing at a target that is unreachable from this process.
         old_target = os.path.join(shared_dir, "old_deleted_file.mp4")
         chat_link = os.path.join(chat_dir, file_name)
         with open(old_target, "w") as f:
             f.write("old")
         os.symlink(os.path.relpath(old_target, chat_dir), chat_link)
+        original_target = os.readlink(chat_link)
         os.remove(old_target)
 
-        # Confirm dangling
+        # Confirm the symlink is present but its target is unreachable.
         self.assertTrue(os.path.lexists(chat_link))
         self.assertFalse(os.path.exists(chat_link))
 
-        # The shared file must NOT exist yet so we hit the "first download" branch.
-        # download_media will "create" it as a side effect.
-        new_shared = os.path.join(shared_dir, file_name)
-
-        def fake_download(message, path):
-            """Simulate Telethon writing the file at the requested path."""
-            with open(path, "wb") as f:
-                f.write(b"new video data")
-            return path
-
-        self.backup.client.download_media = AsyncMock(side_effect=fake_download)
+        download_mock = AsyncMock()
+        self.backup.client.download_media = download_mock
         self.backup._get_media_type = MagicMock(return_value="video")
         self.backup._get_media_filename = MagicMock(return_value=file_name)
         self.backup._get_media_size = MagicMock(return_value=1024)
 
         msg = self._make_message(msg_id=20, file_id="xyz")
 
-        # The dangling symlink means os.path.exists(file_path) is False AND
-        # shared file doesn't exist, so we enter the first-download branch.
-        # The fix uses lexists+unlink before os.symlink to avoid EEXIST.
         result = self._run(self.backup._process_media(msg, 300))
 
+        # Metadata is still returned so the caller can reinsert the DB row.
         self.assertIsNotNone(result)
         self.assertTrue(result["downloaded"])
+        self.assertEqual(result["file_path"], chat_link)
 
-        # After the fix, the symlink should be valid and point to new shared file
-        self.assertTrue(os.path.lexists(chat_link))
-        self.assertTrue(os.path.exists(chat_link))
+        # No download was attempted -- the symlink was trusted.
+        download_mock.assert_not_awaited()
+
+        # The original symlink is preserved byte-for-byte; nothing was
+        # rewritten or replaced.
         self.assertTrue(os.path.islink(chat_link))
-        self.assertEqual(os.path.realpath(chat_link), os.path.realpath(new_shared))
+        self.assertEqual(os.readlink(chat_link), original_target)
 
 
 class TestVerifyCleanupDanglingSymlink(unittest.TestCase):
@@ -539,8 +535,14 @@ class TestListenerDownloadMediaDedup(unittest.TestCase):
         msg.reply_to = None
         return msg
 
-    def test_listener_dedup_pre_unlink_dangling_shared_exists(self):
-        """Listener removes dangling symlink before creating new one when shared file exists."""
+    def test_listener_dedup_preserves_dangling_when_shared_exists(self):
+        """An existing chat-dir symlink is preserved as-is, even if dangling.
+
+        Even when a candidate shared file is present at the expected path, the
+        listener trusts the chat-dir symlink that was already recorded. This
+        avoids rewriting symlink targets across runs (issue #143) when content
+        is managed by an external system like git-annex.
+        """
         chat_id = 100
         shared_dir = os.path.join(self.media_path, "_shared")
         chat_dir = os.path.join(self.media_path, str(chat_id))
@@ -551,18 +553,18 @@ class TestListenerDownloadMediaDedup(unittest.TestCase):
         shared_file = os.path.join(shared_dir, file_name)
         chat_file = os.path.join(chat_dir, file_name)
 
-        # Create shared file
+        # Shared file is present (e.g. recovered or freshly downloaded by a
+        # parallel job), but the chat dir already records a dangling link.
         with open(shared_file, "wb") as f:
             f.write(b"shared data")
 
-        # Create dangling symlink in chat dir
         old_target = os.path.join(shared_dir, "old_gone.jpg")
         with open(old_target, "w") as f:
             f.write("old")
         os.symlink(os.path.relpath(old_target, chat_dir), chat_file)
+        original_target = os.readlink(chat_file)
         os.remove(old_target)
 
-        # Dangling: lexists=True, exists=False
         self.assertTrue(os.path.lexists(chat_file))
         self.assertFalse(os.path.exists(chat_file))
 
@@ -573,9 +575,8 @@ class TestListenerDownloadMediaDedup(unittest.TestCase):
         result = self._run(self.listener._download_media(msg, chat_id))
 
         self.assertIsNotNone(result)
-        # After fix: symlink should now point to the correct shared file
-        self.assertTrue(os.path.exists(chat_file))
         self.assertTrue(os.path.islink(chat_file))
+        self.assertEqual(os.readlink(chat_file), original_target)
 
     def test_listener_dedup_copy2_fallback_when_symlink_fails(self):
         """Listener uses shutil.copy2 when symlink fails on shared-exists path."""
@@ -634,8 +635,13 @@ class TestListenerDownloadMediaDedup(unittest.TestCase):
             resolved = os.path.realpath(chat_file)
             self.assertEqual(resolved, os.path.realpath(returned_path))
 
-    def test_listener_dedup_first_download_pre_unlink_dangling(self):
-        """Listener removes dangling symlink before new symlink on first-download path."""
+    def test_listener_dedup_preserves_existing_symlink(self):
+        """Listener leaves an existing chat-dir symlink alone, even when broken.
+
+        The dedup gate uses ``os.path.lexists`` so an already-recorded symlink
+        short-circuits the download. This is the listener-side mirror of the
+        backup-flow contract from issue #143.
+        """
         chat_id = 400
         shared_dir = os.path.join(self.media_path, "_shared")
         chat_dir = os.path.join(self.media_path, str(chat_id))
@@ -645,24 +651,18 @@ class TestListenerDownloadMediaDedup(unittest.TestCase):
         file_name = "doc_abc.pdf"
         chat_file = os.path.join(chat_dir, file_name)
 
-        # Create dangling symlink
         old_target = os.path.join(shared_dir, "old.pdf")
         with open(old_target, "w") as f:
             f.write("old")
         os.symlink(os.path.relpath(old_target, chat_dir), chat_file)
+        original_target = os.readlink(chat_file)
         os.remove(old_target)
 
         self.assertTrue(os.path.lexists(chat_file))
         self.assertFalse(os.path.exists(chat_file))
 
-        new_shared = os.path.join(shared_dir, file_name)
-
-        def fake_download(message, path):
-            with open(path, "wb") as f:
-                f.write(b"new pdf content")
-            return path
-
-        self.listener.client.download_media = AsyncMock(side_effect=fake_download)
+        download_mock = AsyncMock()
+        self.listener.client.download_media = download_mock
         self.listener._get_media_type = MagicMock(return_value="document")
         self.listener._get_media_filename = MagicMock(return_value=file_name)
 
@@ -670,9 +670,13 @@ class TestListenerDownloadMediaDedup(unittest.TestCase):
 
         result = self._run(self.listener._download_media(msg, chat_id))
 
+        # Result is still produced so the listener can record DB metadata.
         self.assertIsNotNone(result)
-        self.assertTrue(os.path.exists(chat_file))
+
+        # No download was attempted; the symlink is byte-for-byte unchanged.
+        download_mock.assert_not_awaited()
         self.assertTrue(os.path.islink(chat_file))
+        self.assertEqual(os.readlink(chat_file), original_target)
 
     def test_listener_no_dedup_captures_return_value(self):
         """Listener captures download_media return value in non-dedup path."""
@@ -739,8 +743,14 @@ class TestBackupDedupSharedExistsPreUnlink(unittest.TestCase):
         msg.reply_to = None
         return msg
 
-    def test_shared_exists_pre_unlinks_dangling_symlink(self):
-        """When shared file exists and chat dir has dangling symlink, pre-unlink before new symlink."""
+    def test_shared_exists_preserves_existing_chat_symlink(self):
+        """An existing chat-dir symlink is preserved even when shared file is present.
+
+        Once the chat directory records a symlink for a media name, we treat
+        it as authoritative -- we never rewrite its target on a subsequent
+        run, even if the candidate shared file exists. Idempotent rerun
+        contract from issue #143.
+        """
         chat_id = 800
         shared_dir = os.path.join(self.media_path, "_shared")
         chat_dir = os.path.join(self.media_path, str(chat_id))
@@ -751,18 +761,16 @@ class TestBackupDedupSharedExistsPreUnlink(unittest.TestCase):
         shared_file = os.path.join(shared_dir, file_name)
         chat_file = os.path.join(chat_dir, file_name)
 
-        # Create shared file (the valid target)
         with open(shared_file, "wb") as f:
             f.write(b"shared photo data")
 
-        # Create dangling symlink in chat dir (points to deleted old file)
         old_target = os.path.join(shared_dir, "old_deleted.jpg")
         with open(old_target, "w") as f:
             f.write("old")
         os.symlink(os.path.relpath(old_target, chat_dir), chat_file)
+        original_target = os.readlink(chat_file)
         os.remove(old_target)
 
-        # Dangling: exists=False (follows symlink), lexists=True
         self.assertFalse(os.path.exists(chat_file))
         self.assertTrue(os.path.lexists(chat_file))
 
@@ -774,10 +782,8 @@ class TestBackupDedupSharedExistsPreUnlink(unittest.TestCase):
         result = self._run(self.backup._process_media(msg, chat_id))
 
         self.assertIsNotNone(result)
-        # After fix: symlink replaced, now valid
-        self.assertTrue(os.path.exists(chat_file))
         self.assertTrue(os.path.islink(chat_file))
-        self.assertEqual(os.path.realpath(chat_file), os.path.realpath(shared_file))
+        self.assertEqual(os.readlink(chat_file), original_target)
 
     def test_shared_exists_copy2_fallback_when_symlink_fails(self):
         """When shared file exists but symlink fails, use shutil.copy2 instead of re-downloading."""

--- a/tests/test_symlink_dedup.py
+++ b/tests/test_symlink_dedup.py
@@ -321,26 +321,34 @@ class TestVerifyCleanupDanglingSymlink(unittest.TestCase):
         finally:
             loop.close()
 
-    def test_verify_cleanup_removes_dangling_symlink(self):
-        """_verify_and_redownload_media removes dangling symlinks via lexists before re-download."""
+    def test_verify_trusts_existing_symlink_even_when_dangling(self):
+        """Verify-media trusts an existing chat-dir symlink, even when its target is unreachable.
+
+        For archived layouts (issue #143), a chat-dir symlink whose target
+        sits in a separate object store may resolve only on the host -- not
+        from inside the container that runs the backup. Re-downloading such
+        files would atomic-rename a regular file on top of the user's
+        symlink, mutating the working tree. Verify must therefore treat any
+        symlink as authoritative and skip it.
+        """
         chat_id = -1001234567890
         chat_dir = os.path.join(self.media_path, str(chat_id))
         shared_dir = os.path.join(self.media_path, "_shared")
         os.makedirs(chat_dir)
         os.makedirs(shared_dir)
 
-        # Create a dangling symlink
+        # Reproduce the dangling-symlink layout.
         old_target = os.path.join(shared_dir, "deleted.jpg")
         dangling_link = os.path.join(chat_dir, "photo.jpg")
         with open(old_target, "w") as f:
             f.write("old")
         os.symlink(os.path.relpath(old_target, chat_dir), dangling_link)
+        original_target = os.readlink(dangling_link)
         os.remove(old_target)
 
         self.assertTrue(os.path.lexists(dangling_link))
         self.assertFalse(os.path.exists(dangling_link))
 
-        # Set up DB to return media record pointing at the dangling symlink
         self.backup.db.get_media_for_verification.return_value = [
             {
                 "file_path": dangling_link,
@@ -350,35 +358,64 @@ class TestVerifyCleanupDanglingSymlink(unittest.TestCase):
             }
         ]
 
-        # Mock the Telegram message fetch
+        # Sentinel: a redownload would call _process_media. We assert it does
+        # NOT, so prepare it as a strict mock that fails the test if invoked.
+        self.backup._process_media = AsyncMock()
+        self.backup.client.get_messages = AsyncMock()
+
+        self._run(self.backup._verify_and_redownload_media())
+
+        # Verify nothing was re-downloaded or inserted.
+        self.backup._process_media.assert_not_awaited()
+        self.backup.client.get_messages.assert_not_awaited()
+        self.backup.db.insert_media.assert_not_awaited()
+
+        # The dangling symlink is byte-for-byte unchanged.
+        self.assertTrue(os.path.islink(dangling_link))
+        self.assertEqual(os.readlink(dangling_link), original_target)
+
+    def test_verify_redownloads_when_path_truly_missing(self):
+        """When file_path doesn't even lexist, verify still triggers a re-download.
+
+        Distinguishes "truly absent" (no entry on disk at all) from
+        "symlink whose target is unreachable" -- only the former is a
+        legitimate verify-flow recovery target.
+        """
+        chat_id = -1001234567891
+        chat_dir = os.path.join(self.media_path, str(chat_id))
+        os.makedirs(chat_dir)
+        gone = os.path.join(chat_dir, "never_existed.jpg")
+
+        self.assertFalse(os.path.lexists(gone))
+
+        self.backup.db.get_media_for_verification.return_value = [
+            {
+                "file_path": gone,
+                "file_size": 1024,
+                "chat_id": chat_id,
+                "message_id": 99,
+            }
+        ]
+
         mock_msg = MagicMock()
-        mock_msg.id = 42
+        mock_msg.id = 99
         mock_msg.media = MagicMock()
         self.backup.client.get_messages = AsyncMock(return_value=[mock_msg])
 
-        # Mock _process_media to return a successful result
-        new_shared = os.path.join(shared_dir, "photo_new.jpg")
-        with open(new_shared, "wb") as f:
-            f.write(b"new photo data")
-
         self.backup._process_media = AsyncMock(
             return_value={
-                "id": f"{chat_id}_42_photo",
+                "id": f"{chat_id}_99_photo",
                 "type": "photo",
-                "message_id": 42,
+                "message_id": 99,
                 "chat_id": chat_id,
-                "file_path": dangling_link,
+                "file_path": gone,
                 "downloaded": True,
             }
         )
 
         self._run(self.backup._verify_and_redownload_media())
 
-        # The cleanup code should have removed the dangling symlink before re-download
-        # (lexists check + os.remove in the verification loop)
-        # Verify _process_media was called (re-download attempted)
         self.backup._process_media.assert_awaited_once()
-        # Verify db.insert_media was called (successful re-download)
         self.backup.db.insert_media.assert_awaited_once()
 
 

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -1383,6 +1383,37 @@ class TestEnsureProfilePhoto(unittest.TestCase):
         _run(self.backup._ensure_profile_photo(entity, 42))
 
     @patch("src.telegram_backup.get_avatar_paths")
+    def test_existing_symlink_avatar_is_preserved(self, mock_get_paths):
+        """A symlink at avatar_path is trusted, even when its target is unreachable.
+
+        Reproduces the archived-layout scenario from issue #143: avatar files
+        committed to git-annex appear as symlinks pointing into
+        ``.git/annex/objects/...``. From inside a container that only mounts
+        the working tree, those targets resolve to a missing path and the
+        old ``os.path.exists`` check tried to overwrite the symlink, which
+        crashed with ENOENT. With the lexists guard the symlink is treated
+        as authoritative and no download is attempted.
+        """
+        target = os.path.join(self.temp_dir, "absent_target.jpg")
+        avatar_path = os.path.join(self.temp_dir, "broken_symlink_avatar.jpg")
+        os.symlink(target, avatar_path)
+        original_target = os.readlink(avatar_path)
+
+        # Confirm the dangling symlink scenario.
+        self.assertTrue(os.path.lexists(avatar_path))
+        self.assertFalse(os.path.exists(avatar_path))
+
+        mock_get_paths.return_value = (avatar_path, "/legacy.jpg")
+        entity = MagicMock()
+
+        _run(self.backup._ensure_profile_photo(entity, 42))
+
+        # No download was attempted; symlink is byte-for-byte unchanged.
+        self.backup.client.download_profile_photo.assert_not_awaited()
+        self.assertTrue(os.path.islink(avatar_path))
+        self.assertEqual(os.readlink(avatar_path), original_target)
+
+    @patch("src.telegram_backup.get_avatar_paths")
     def test_uses_marked_id_when_no_marked_id_passed(self, mock_get_paths):
         """When marked_id is None, falls back to _get_marked_id."""
         mock_get_paths.return_value = (None, "/legacy.jpg")

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -1414,6 +1414,30 @@ class TestEnsureProfilePhoto(unittest.TestCase):
         self.assertEqual(os.readlink(avatar_path), original_target)
 
     @patch("src.telegram_backup.get_avatar_paths")
+    def test_empty_regular_file_avatar_triggers_download(self, mock_get_paths):
+        """A 0-byte regular file at avatar_path falls through to download.
+
+        The lexists gate short-circuits only when the entry is a symlink or a
+        non-empty regular file. An empty regular file (e.g. left over from a
+        prior interrupted download) must not be trusted -- the gate falls
+        through and a fresh download replaces it.
+        """
+        avatar_path = os.path.join(self.temp_dir, "empty_avatar.jpg")
+        with open(avatar_path, "wb"):
+            pass  # 0-byte regular file
+        self.assertTrue(os.path.lexists(avatar_path))
+        self.assertFalse(os.path.islink(avatar_path))
+        self.assertEqual(os.path.getsize(avatar_path), 0)
+
+        mock_get_paths.return_value = (avatar_path, "/legacy.jpg")
+        self.backup.client.download_profile_photo = AsyncMock(return_value=avatar_path)
+        entity = MagicMock()
+
+        _run(self.backup._ensure_profile_photo(entity, 42))
+
+        self.backup.client.download_profile_photo.assert_awaited_once()
+
+    @patch("src.telegram_backup.get_avatar_paths")
     def test_uses_marked_id_when_no_marked_id_passed(self, mock_get_paths):
         """When marked_id is None, falls back to _get_marked_id."""
         mock_get_paths.return_value = (None, "/legacy.jpg")


### PR DESCRIPTION
- Closes #143.

Re-runs of `python -m src.telegram_backup` against an archived media tree
(committed to git-annex / DataLad, where files are symlinks pointing into
`.git/annex/objects/`) currently mutate the working tree on every run:
- `_shared/<name>` symlinks get atomic-renamed and become regular files
  (visible as `typechange` in `git status`),
- chat-dir symlinks get repointed at different `_shared/` blobs across
  runs because content-hash dedup (#139) picks a non-deterministic
  canonical name from the cross-chat duplicate set.

Root cause: every "do I already have this?" gate uses `os.path.exists`,
which follows symlinks to the bottom. When the ultimate target lives
outside the running process's filesystem view (e.g. the bind mount only
covers the working tree, not `.git/`), the gate concludes the file is
missing and triggers a re-download that overwrites the symlink. See
#143 for the full diagnosis with line references.

## Changes

Each commit is a single conceptual change so they can be reviewed (or
backed out) independently.

1. **`fix(media): trust existing symlinks via os.path.lexists in dedup gate`** — switches both arms of the dedup gate (chat path and `_shared/`-path) from `os.path.exists` to `os.path.lexists` in `_process_media` (`src/telegram_backup.py`) and the listener twin in `src/listener.py`. Updates the existing dangling-symlink tests in `tests/test_symlink_dedup.py` and the listener-side tests in `tests/test_listener_extended.py` to assert the new "preserve existing symlink" contract instead of the old "replace dangling symlink" one.
2. **`fix(avatars): trust existing avatar symlinks via os.path.lexists`** — same gate change in `_ensure_profile_photo` and the listener's `_download_avatar`. Adds a regression test (`test_existing_symlink_avatar_is_preserved`) that reproduces the exact `[Errno 2] No such file or directory` log line from the issue.
3. **`fix(verify): preserve symlinks during VERIFY_MEDIA scans`** — Phase 1 of `_verify_and_redownload_media` now uses `lexists` for missing-file detection and short-circuits on `os.path.islink`, so an intact symlink is never re-downloaded. Truly absent paths still trigger recovery. New tests cover both branches.
4. **`docs(readme): note bind-mount caveat for git-annex / DataLad backups`** — adds a Troubleshooting row + a short subsection showing the recommended `-v $PWD:/repo` + `-w /repo/ses-acct` mount layout so the symlink targets resolve from inside the container.

## Test plan

- [x] `python -m pytest tests/` (excluding the FastAPI/pydantic-only viewer suites, same as CI scope) — `1419 passed, 153 warnings, 6 subtests passed`
- [x] `ruff check . && ruff format --check .` — clean
- [x] Existing dedup / dangling-symlink / verify tests updated to assert the new contract; no test asserts both old and new behaviors.
- [ ] Reporter (@yarikoptic) confirms an idempotent rerun against the original archived layout from #143.
   - yet to do after recreating db 

## Notes for review

- The new contract is "if it lexists, leave it alone." This intentionally rolls back part of the recovery path added in #119, where `_verify_and_redownload_media` used to "rescue" dangling symlinks by re-downloading. That recovery is unsafe for archived layouts and was the actual mutation source observed in #143; users on plain installs are unaffected (their entries are regular files, not symlinks). If preserving the rescue path is important, we can gate it behind an env var (e.g. `VERIFY_MEDIA_REDOWNLOAD_DANGLING=true`, default false) — happy to add as a follow-up.
- Comments in the code reference issue #143 so future readers know why the seemingly-paranoid `lexists` is load-bearing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new troubleshooting subsection for git-annex/DataLad layouts and moved PostgreSQL duplicate-key guidance into its own troubleshooting subsection.

* **Bug Fixes**
  * Improved idempotency by trusting existing symlinks and avoiding redundant media/avatar re-downloads; safer handling of deduplicated/shared media.

* **Tests**
  * Expanded and hardened tests to cover symlink-preserving behavior, deduplication paths, avatar handling, and listener/backup lifecycle cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->