### PR TITLE
fix: resolve relative paths, add session log, remove /app ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ COPY alembic.ini .
 # Create non-root user for security
 RUN useradd -m -u 1000 telegram && \
     mkdir -p /data/backups && \
-    chown -R telegram:telegram /app /data && \
+    chown -R telegram:telegram /data && \
     chmod +x /app/scripts/entrypoint.sh
 
 # Switch to non-root user
@@ -32,7 +32,9 @@ USER telegram
 # Set default environment variables
 ENV BACKUP_PATH=/data/backups \
     LOG_LEVEL=INFO \
-    PYTHONPATH=/app
+    PYTHONPATH=/app \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
 
 # Volume for persistent data
 VOLUME ["/data"]

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -79,6 +79,7 @@ def get_database_url() -> str:
     if not db_path:
         backup_path = os.getenv("BACKUP_PATH", "/data/backups")
         db_path = os.path.join(backup_path, "telegram_backup.db")
+    db_path = os.path.abspath(db_path)
     return f"sqlite+aiosqlite:///{db_path}"
 
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -226,10 +226,11 @@ print('Migrations complete.')
 "
   elif { [[ -n "$DATABASE_URL" ]] && { [[ "$DATABASE_URL" == sqlite://* ]] || [[ "$DATABASE_URL" == sqlite+aiosqlite://* ]]; }; } || { [[ -z "$DATABASE_URL" ]] && { [ "$DB_TYPE" = "sqlite" ] || [ -z "$DB_TYPE" ]; }; }; then
     # SQLite - check if database file exists before running migrations
-    DB_PATH="${DATABASE_PATH:-${DATABASE_DIR:+${DATABASE_DIR}/telegram_backup.db}}"
-    DB_PATH="${DB_PATH:-${BACKUP_PATH:-/data/backups}/telegram_backup.db}"
+    # Priority: DATABASE_PATH > DATABASE_DIR > DB_PATH > BACKUP_PATH/telegram_backup.db
+    _DB_FILE="${DATABASE_PATH:-${DATABASE_DIR:+${DATABASE_DIR}/telegram_backup.db}}"
+    _DB_FILE="${_DB_FILE:-${DB_PATH:-${BACKUP_PATH:-/data/backups}/telegram_backup.db}}"
     # Resolve to absolute path (realpath -m works even if file doesn't exist yet)
-    DB_PATH="$(realpath -m "$DB_PATH")"
+    DB_PATH="$(realpath -m "$_DB_FILE")"
     if [[ "$DATABASE_URL" == sqlite+aiosqlite:///* ]]; then
       DB_PATH="${DATABASE_URL#sqlite+aiosqlite:///}"
     elif [[ "$DATABASE_URL" == sqlite:///* ]]; then

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -226,7 +226,10 @@ print('Migrations complete.')
 "
   elif { [[ -n "$DATABASE_URL" ]] && { [[ "$DATABASE_URL" == sqlite://* ]] || [[ "$DATABASE_URL" == sqlite+aiosqlite://* ]]; }; } || { [[ -z "$DATABASE_URL" ]] && { [ "$DB_TYPE" = "sqlite" ] || [ -z "$DB_TYPE" ]; }; }; then
     # SQLite - check if database file exists before running migrations
-    DB_PATH="${DB_PATH:-${DATABASE_PATH:-${BACKUP_PATH:-/data/backups}/telegram_backup.db}}"
+    DB_PATH="${DATABASE_PATH:-${DATABASE_DIR:+${DATABASE_DIR}/telegram_backup.db}}"
+    DB_PATH="${DB_PATH:-${BACKUP_PATH:-/data/backups}/telegram_backup.db}"
+    # Resolve to absolute path (realpath -m works even if file doesn't exist yet)
+    DB_PATH="$(realpath -m "$DB_PATH")"
     if [[ "$DATABASE_URL" == sqlite+aiosqlite:///* ]]; then
       DB_PATH="${DATABASE_URL#sqlite+aiosqlite:///}"
     elif [[ "$DATABASE_URL" == sqlite:///* ]]; then

--- a/src/config.py
+++ b/src/config.py
@@ -219,7 +219,11 @@ class Config:
         elif db_dir_env:
             self.database_path = os.path.abspath(os.path.join(db_dir_env, "telegram_backup.db"))
         else:
-            self.database_path = os.path.join(self.backup_path, "telegram_backup.db")
+            db_path_v3 = os.getenv("DB_PATH")
+            if db_path_v3:
+                self.database_path = os.path.abspath(db_path_v3)
+            else:
+                self.database_path = os.path.join(self.backup_path, "telegram_backup.db")
 
         self.media_path = os.path.join(self.backup_path, "media")
 

--- a/src/config.py
+++ b/src/config.py
@@ -110,7 +110,7 @@ class Config:
         self.schedule = os.getenv("SCHEDULE", "0 */6 * * *")
 
         # Backup options
-        self.backup_path = os.getenv("BACKUP_PATH", "/data/backups")
+        self.backup_path = os.path.abspath(os.getenv("BACKUP_PATH", "/data/backups"))
         self.download_media = os.getenv("DOWNLOAD_MEDIA", "true").lower() == "true"
         self.max_media_size_mb = int(os.getenv("MAX_MEDIA_SIZE_MB", "100"))
 
@@ -205,7 +205,7 @@ class Config:
         # Store session in a separate directory from backups
         # If BACKUP_PATH is /data/backups, session goes to /data/session
         backup_parent = os.path.dirname(self.backup_path.rstrip("/\\"))
-        self.session_dir = os.getenv("SESSION_DIR", os.path.join(backup_parent, "session"))
+        self.session_dir = os.path.abspath(os.getenv("SESSION_DIR", os.path.join(backup_parent, "session")))
         self.session_path = os.path.join(self.session_dir, self.session_name)
 
         # Database path configuration
@@ -215,9 +215,9 @@ class Config:
         db_dir_env = os.getenv("DATABASE_DIR")
 
         if db_path_env:
-            self.database_path = db_path_env
+            self.database_path = os.path.abspath(db_path_env)
         elif db_dir_env:
-            self.database_path = os.path.join(db_dir_env, "telegram_backup.db")
+            self.database_path = os.path.abspath(os.path.join(db_dir_env, "telegram_backup.db"))
         else:
             self.database_path = os.path.join(self.backup_path, "telegram_backup.db")
 

--- a/src/connection.py
+++ b/src/connection.py
@@ -164,6 +164,7 @@ class TelegramConnection:
             return self._client
 
         logger.info("Connecting to Telegram...")
+        logger.info(f"Using Telethon session database: {self.config.session_path}.session")
 
         session_file = self.config.session_path + ".session"
         snapshot_file = self.config.session_path + ".session.bak"

--- a/src/db/base.py
+++ b/src/db/base.py
@@ -80,6 +80,10 @@ class DatabaseManager:
             backup_path = os.getenv("BACKUP_PATH", "/data/backups")
             db_path = os.path.join(backup_path, "telegram_backup.db")
 
+        # Resolve to absolute path so relative paths don't silently resolve
+        # against WORKDIR (/app) in Docker containers (fixes #144)
+        db_path = os.path.abspath(db_path)
+
         # Ensure directory exists
         os.makedirs(os.path.dirname(db_path) or ".", exist_ok=True)
         return f"sqlite+aiosqlite:///{db_path}"

--- a/src/db/migrate.py
+++ b/src/db/migrate.py
@@ -88,6 +88,7 @@ async def migrate_sqlite_to_postgres(
         if not sqlite_path:
             backup_path = os.getenv("BACKUP_PATH", "/data/backups")
             sqlite_path = os.path.join(backup_path, "telegram_backup.db")
+        sqlite_path = os.path.abspath(sqlite_path)
 
     if not os.path.exists(sqlite_path):
         raise FileNotFoundError(f"SQLite database not found: {sqlite_path}")
@@ -195,6 +196,7 @@ async def verify_migration(sqlite_path: str = None, postgres_url: str = None) ->
         if not sqlite_path:
             backup_path = os.getenv("BACKUP_PATH", "/data/backups")
             sqlite_path = os.path.join(backup_path, "telegram_backup.db")
+        sqlite_path = os.path.abspath(sqlite_path)
 
     if postgres_url is None:
         host = os.getenv("POSTGRES_HOST", "localhost")

--- a/src/listener.py
+++ b/src/listener.py
@@ -342,6 +342,7 @@ class TelegramListener:
             logger.info(f"Connected as {me.first_name} ({me.phone})")
         else:
             # Create new client
+            logger.info(f"Using Telethon session database: {self.config.session_path}.session")
             self.client = TelegramClient(
                 self.config.session_path,
                 self.config.api_id,

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -239,6 +239,7 @@ class TelegramBackup:
             return
 
         # Create new client
+        logger.info(f"Using Telethon session database: {self.config.session_path}.session")
         self.client = TelegramClient(
             self.config.session_path,
             self.config.api_id,

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -120,21 +120,25 @@ class TestListenerSessionPathLogging:
         listener = TelegramListener(config, db)
         return listener
 
-    async def test_listener_create_logs_session_path_at_info_level(self):
-        """listener.create() emits INFO log with session DB path before client creation."""
+    async def test_listener_connect_logs_session_path_at_info_level(self):
+        """listener.connect() emits INFO log with session DB path before client creation."""
         listener = self._make_listener()
 
         with (
             patch("src.listener.TelegramClient") as mock_client_cls,
             patch("src.listener.logger") as mock_logger,
+            patch("src.db.get_db_manager", new_callable=AsyncMock) as mock_get_db,
+            patch("src.listener.RealtimeNotifier") as mock_notifier_cls,
         ):
             mock_client = AsyncMock()
             mock_client.connect = AsyncMock()
             mock_client.is_user_authorized = AsyncMock(return_value=True)
             mock_client.get_me = AsyncMock(return_value=MagicMock(first_name="Test", phone="+1234567890"))
+            mock_client.on = MagicMock(return_value=lambda f: f)
             mock_client_cls.return_value = mock_client
+            mock_notifier_cls.return_value = AsyncMock()
 
-            await listener.create(listener.config)
+            await listener.connect()
 
         info_calls = [call for call in mock_logger.info.call_args_list]
         session_log_found = any(
@@ -142,7 +146,7 @@ class TestListenerSessionPathLogging:
         )
         assert session_log_found, f"Expected INFO log with session path, got: {info_calls}"
 
-    async def test_listener_create_logs_before_client_instantiation(self):
+    async def test_listener_connect_logs_before_client_instantiation(self):
         """The session path log appears BEFORE TelegramClient() is called in listener."""
         listener = self._make_listener()
 
@@ -156,19 +160,23 @@ class TestListenerSessionPathLogging:
             mock_client.connect = AsyncMock()
             mock_client.is_user_authorized = AsyncMock(return_value=True)
             mock_client.get_me = AsyncMock(return_value=MagicMock(first_name="Test", phone="+1234567890"))
+            mock_client.on = MagicMock(return_value=lambda f: f)
             call_order.append("client")
             return mock_client
 
         with (
             patch("src.listener.TelegramClient", side_effect=track_client),
             patch("src.listener.logger") as mock_logger,
+            patch("src.db.get_db_manager", new_callable=AsyncMock),
+            patch("src.listener.RealtimeNotifier") as mock_notifier_cls,
         ):
             mock_logger.info = track_log
             mock_logger.debug = MagicMock()
             mock_logger.warning = MagicMock()
             mock_logger.error = MagicMock()
+            mock_notifier_cls.return_value = AsyncMock()
 
-            await listener.create(listener.config)
+            await listener.connect()
 
         assert "log" in call_order
         assert "client" in call_order

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -304,7 +304,3 @@ class TestDockerfileAssumptions(unittest.TestCase):
         # Python will not write .pyc files. The actual enforcement is in the Dockerfile.
         # We verify the mechanism exists.
         self.assertTrue(hasattr(sys, "dont_write_bytecode"))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -1,0 +1,310 @@
+"""Tests for fixes to issues #142, #144, and #145.
+
+#142: INFO log emitted before TelegramClient instantiation with session path
+#144: os.path.abspath() applied to resolve relative DB paths in _build_database_url()
+#145: Dockerfile changes (no unit test needed — infra only)
+"""
+
+import os
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+# ============================================================
+# Issue #142: Session path logging before TelegramClient creation
+# ============================================================
+
+
+class TestSessionPathLogging:
+    """Test that INFO log with session DB path is emitted before TelegramClient instantiation."""
+
+    def _make_backup(self):
+        """Create a TelegramBackup instance with mocked dependencies."""
+        from src.telegram_backup import TelegramBackup
+
+        backup = TelegramBackup.__new__(TelegramBackup)
+        backup.config = MagicMock()
+        backup.config.session_path = "/data/sessions/my_session"
+        backup.config.api_id = 12345
+        backup.config.api_hash = "testhash"
+        backup.config.get_telegram_client_kwargs = MagicMock(return_value={"flood_sleep_threshold": 0})
+        backup.db = AsyncMock()
+        backup.client = None
+        backup._owns_client = True
+        return backup
+
+    async def test_backup_connect_logs_session_path_at_info_level(self):
+        """telegram_backup.connect() emits INFO log with session DB path before client creation."""
+        backup = self._make_backup()
+
+        with (
+            patch("src.telegram_backup.TelegramClient") as mock_client_cls,
+            patch("src.telegram_backup.logger") as mock_logger,
+        ):
+            mock_client_cls.return_value = MagicMock()
+            mock_client_cls.return_value.connect = AsyncMock()
+            mock_client_cls.return_value.is_user_authorized = AsyncMock(return_value=True)
+            mock_client_cls.return_value.get_me = AsyncMock(return_value=MagicMock(first_name="Test"))
+            await backup.connect()
+
+        # Verify INFO log was called with the session path
+        info_calls = [call for call in mock_logger.info.call_args_list]
+        session_log_found = any(
+            "session" in str(call).lower() and "/data/sessions/my_session" in str(call) for call in info_calls
+        )
+        assert session_log_found, f"Expected INFO log with session path, got: {info_calls}"
+
+    async def test_backup_connect_logs_before_client_instantiation(self):
+        """The session path log appears BEFORE TelegramClient() is called."""
+        backup = self._make_backup()
+
+        call_order = []
+
+        def track_log(*args, **kwargs):
+            call_order.append("log")
+
+        def track_client(*args, **kwargs):
+            mock = MagicMock()
+            mock.connect = AsyncMock()
+            mock.is_user_authorized = AsyncMock(return_value=True)
+            mock.get_me = AsyncMock(return_value=MagicMock(first_name="Test"))
+            call_order.append("client")
+            return mock
+
+        with (
+            patch("src.telegram_backup.TelegramClient", side_effect=track_client),
+            patch("src.telegram_backup.logger") as mock_logger,
+        ):
+            mock_logger.info = track_log
+            mock_logger.debug = MagicMock()
+            await backup.connect()
+
+        assert "log" in call_order
+        assert "client" in call_order
+        assert call_order.index("log") < call_order.index("client")
+
+
+class TestListenerSessionPathLogging:
+    """Test that listener.py emits INFO log with session DB path before TelegramClient creation."""
+
+    def _make_listener(self):
+        """Create a TelegramListener instance with mocked dependencies."""
+        from src.listener import TelegramListener
+
+        config = MagicMock()
+        config.api_id = 12345
+        config.api_hash = "testhash"
+        config.phone = "+1234567890"
+        config.session_path = "/data/sessions/listener_session"
+        config.global_include_ids = set()
+        config.private_include_ids = set()
+        config.groups_include_ids = set()
+        config.channels_include_ids = set()
+        config.validate_credentials = MagicMock()
+        config.whitelist_mode = False
+        config.chat_ids = set()
+        config.listen_edits = True
+        config.listen_deletions = False
+        config.listen_new_messages = False
+        config.listen_new_messages_media = False
+        config.listen_chat_actions = False
+        config.skip_topic_ids = {}
+        config.mass_operation_threshold = 10
+        config.mass_operation_window_seconds = 30
+        config.mass_operation_buffer_delay = 2.0
+        config.get_telegram_client_kwargs = MagicMock(return_value={"flood_sleep_threshold": 0})
+
+        db = AsyncMock()
+        db.get_all_chats = AsyncMock(return_value=[])
+        db.close = AsyncMock()
+
+        listener = TelegramListener(config, db)
+        return listener
+
+    async def test_listener_create_logs_session_path_at_info_level(self):
+        """listener.create() emits INFO log with session DB path before client creation."""
+        listener = self._make_listener()
+
+        with (
+            patch("src.listener.TelegramClient") as mock_client_cls,
+            patch("src.listener.logger") as mock_logger,
+        ):
+            mock_client = AsyncMock()
+            mock_client.connect = AsyncMock()
+            mock_client.is_user_authorized = AsyncMock(return_value=True)
+            mock_client.get_me = AsyncMock(return_value=MagicMock(first_name="Test", phone="+1234567890"))
+            mock_client_cls.return_value = mock_client
+
+            await listener.create(listener.config)
+
+        info_calls = [call for call in mock_logger.info.call_args_list]
+        session_log_found = any(
+            "session" in str(call).lower() and "/data/sessions/listener_session" in str(call) for call in info_calls
+        )
+        assert session_log_found, f"Expected INFO log with session path, got: {info_calls}"
+
+    async def test_listener_create_logs_before_client_instantiation(self):
+        """The session path log appears BEFORE TelegramClient() is called in listener."""
+        listener = self._make_listener()
+
+        call_order = []
+
+        def track_log(*args, **kwargs):
+            call_order.append("log")
+
+        def track_client(*args, **kwargs):
+            mock_client = AsyncMock()
+            mock_client.connect = AsyncMock()
+            mock_client.is_user_authorized = AsyncMock(return_value=True)
+            mock_client.get_me = AsyncMock(return_value=MagicMock(first_name="Test", phone="+1234567890"))
+            call_order.append("client")
+            return mock_client
+
+        with (
+            patch("src.listener.TelegramClient", side_effect=track_client),
+            patch("src.listener.logger") as mock_logger,
+        ):
+            mock_logger.info = track_log
+            mock_logger.debug = MagicMock()
+            mock_logger.warning = MagicMock()
+            mock_logger.error = MagicMock()
+
+            await listener.create(listener.config)
+
+        assert "log" in call_order
+        assert "client" in call_order
+        assert call_order.index("log") < call_order.index("client")
+
+
+# ============================================================
+# Issue #144: os.path.abspath() resolves relative DB paths
+# ============================================================
+
+
+class TestRelativeDbPathResolution(unittest.TestCase):
+    """Test that _build_database_url() resolves relative paths to absolute via os.path.abspath()."""
+
+    def test_relative_db_path_gets_resolved_to_absolute(self):
+        """DB_PATH=data/telegram_backup.db (relative) becomes an absolute path in the URL."""
+        from src.db.base import DatabaseManager
+
+        env = {"DB_PATH": "data/telegram_backup.db"}
+        with patch.dict(os.environ, env, clear=True), patch("os.makedirs"):
+            manager = DatabaseManager()
+            # The path in the URL must be absolute (starts with /)
+            url_path = manager.database_url.replace("sqlite+aiosqlite:///", "")
+            self.assertTrue(
+                os.path.isabs(url_path),
+                f"Expected absolute path in URL, got: {url_path}",
+            )
+
+    def test_absolute_db_path_remains_unchanged(self):
+        """DB_PATH=/data/backups/telegram_backup.db (already absolute) is not modified."""
+        from src.db.base import DatabaseManager
+
+        env = {"DB_PATH": "/data/backups/telegram_backup.db"}
+        with patch.dict(os.environ, env, clear=True), patch("os.makedirs"):
+            manager = DatabaseManager()
+            url_path = manager.database_url.replace("sqlite+aiosqlite:///", "")
+            self.assertEqual(url_path, "/data/backups/telegram_backup.db")
+
+    def test_relative_database_path_env_gets_resolved(self):
+        """DATABASE_PATH=./my.db (relative) becomes an absolute path."""
+        from src.db.base import DatabaseManager
+
+        env = {"DATABASE_PATH": "./my.db"}
+        with patch.dict(os.environ, env, clear=True), patch("os.makedirs"):
+            manager = DatabaseManager()
+            url_path = manager.database_url.replace("sqlite+aiosqlite:///", "")
+            self.assertTrue(
+                os.path.isabs(url_path),
+                f"Expected absolute path in URL, got: {url_path}",
+            )
+            self.assertNotIn("./", url_path)
+
+    def test_absolute_database_path_env_remains_unchanged(self):
+        """DATABASE_PATH=/custom/path/my.db (already absolute) is unchanged."""
+        from src.db.base import DatabaseManager
+
+        env = {"DATABASE_PATH": "/custom/path/my.db"}
+        with patch.dict(os.environ, env, clear=True), patch("os.makedirs"):
+            manager = DatabaseManager()
+            url_path = manager.database_url.replace("sqlite+aiosqlite:///", "")
+            self.assertEqual(url_path, "/custom/path/my.db")
+
+    def test_default_path_is_absolute(self):
+        """Default path (no env vars set) produces an absolute path."""
+        from src.db.base import DatabaseManager
+
+        with patch.dict(os.environ, {}, clear=True), patch("os.makedirs"):
+            manager = DatabaseManager()
+            url_path = manager.database_url.replace("sqlite+aiosqlite:///", "")
+            self.assertTrue(
+                os.path.isabs(url_path),
+                f"Expected absolute path in URL, got: {url_path}",
+            )
+
+    def test_relative_database_dir_gets_resolved(self):
+        """DATABASE_DIR=data (relative directory) produces an absolute path."""
+        from src.db.base import DatabaseManager
+
+        env = {"DATABASE_DIR": "data"}
+        with patch.dict(os.environ, env, clear=True), patch("os.makedirs"):
+            manager = DatabaseManager()
+            url_path = manager.database_url.replace("sqlite+aiosqlite:///", "")
+            self.assertTrue(
+                os.path.isabs(url_path),
+                f"Expected absolute path in URL, got: {url_path}",
+            )
+            self.assertTrue(url_path.endswith("/telegram_backup.db"))
+
+    def test_relative_backup_path_gets_resolved(self):
+        """BACKUP_PATH=backups (relative) produces an absolute path."""
+        from src.db.base import DatabaseManager
+
+        env = {"BACKUP_PATH": "backups"}
+        with patch.dict(os.environ, env, clear=True), patch("os.makedirs"):
+            manager = DatabaseManager()
+            url_path = manager.database_url.replace("sqlite+aiosqlite:///", "")
+            self.assertTrue(
+                os.path.isabs(url_path),
+                f"Expected absolute path in URL, got: {url_path}",
+            )
+
+
+# ============================================================
+# Issue #145: Dockerfile changes — no unit tests needed
+# ============================================================
+
+
+class TestDockerfileAssumptions(unittest.TestCase):
+    """Verify runtime assumptions that Dockerfile changes (#145) rely on.
+
+    The Dockerfile removes `chown /app` and sets PYTHONDONTWRITEBYTECODE=1.
+    These tests verify that the application does NOT expect to write .pyc files
+    or write to /app at runtime (only to configured data paths).
+    """
+
+    def test_no_hardcoded_app_directory_writes(self):
+        """Source code should not contain hardcoded /app write paths."""
+        import pathlib
+
+        # Check source files for hardcoded /app directory writes
+        src_dir = pathlib.Path(__file__).parent.parent / "src"
+        for py_file in (src_dir / "telegram_backup.py", src_dir / "listener.py"):
+            content = py_file.read_text()
+            # Should not have APP_DIR or open("/app/...") patterns
+            self.assertNotIn("APP_DIR", content)
+            self.assertNotIn('"/app/', content)
+
+    def test_pythondontwritebytecode_prevents_pyc_creation(self):
+        """PYTHONDONTWRITEBYTECODE=1 means sys.dont_write_bytecode is respected."""
+        import sys
+
+        # This just documents the expected behavior — if the env var is set,
+        # Python will not write .pyc files. The actual enforcement is in the Dockerfile.
+        # We verify the mechanism exists.
+        self.assertTrue(hasattr(sys, "dont_write_bytecode"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **#144**: Apply `os.path.abspath()` to all 7 independent path resolution sites (config.py, db/base.py, alembic/env.py, db/migrate.py, entrypoint.sh) so relative env vars like `BACKUP_PATH=backups` resolve against `/` not `/app` (Docker WORKDIR)
- **#142**: Log Telethon session DB path at INFO level before `TelegramClient()` instantiation in all 3 creation sites (connection.py, telegram_backup.py, listener.py) — users can now distinguish session DB errors from application DB errors
- **#145 comment**: Remove `/app` from `chown` in Dockerfile (static code shouldn't be writable), add `PYTHONDONTWRITEBYTECODE=1` + `PYTHONUNBUFFERED=1`
- **Bonus**: Fix entrypoint.sh env var priority to match Python code (was missing `DATABASE_DIR` check)

## Test plan

- [x] 178 tests pass locally (config, db_base, db_init, db_migrate, issue_fixes)
- [x] `ruff check .` + `ruff format --check .` pass
- [ ] CI tests pass (telethon-dependent tests need CI's pydantic version)
- [ ] Docker build succeeds with read-only `/app`

Closes #142, closes #144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time message edit/delete tracking with immediate DB updates
  * Chat action monitoring (title/photo/member changes) and pinned/unpinned handling
  * Mass-operation protection with per-chat rate limiting

* **Improvements**
  * More robust absolute-path handling for session and database files
  * Environment defaults adjusted for Python runtime behavior and module path

* **Tests**
  * New unit tests covering path resolution, session-path logging, and runtime assumptions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->