### PR TITLE
fix(db): apply abspath to logged path in _safe_url()

### DIFF
--- a/src/db/base.py
+++ b/src/db/base.py
@@ -204,6 +204,7 @@ class DatabaseManager:
             if not db_path:
                 backup_path = os.getenv("BACKUP_PATH", "/data/backups")
                 db_path = os.path.join(backup_path, "telegram_backup.db")
+            db_path = os.path.abspath(db_path)
             return f"sqlite+aiosqlite:///{db_path}"
         # PostgreSQL — build from non-sensitive env vars, mask password
         host = os.getenv("POSTGRES_HOST", "localhost")


### PR DESCRIPTION
## Summary

- Adds `os.path.abspath()` to the path reconstructed in `_safe_url()` before logging, matching the same resolution done in `_build_database_url()`
- Without this, relative paths (e.g. `./backups/telegram_backup.db`) would appear in logs while the actual DB connection uses the absolute path

Fixes CodeRabbit review comment from PR #147.

## Test plan

- [ ] CI passes (lint + tests)
- [ ] Verify logged path matches the connection path when using relative `BACKUP_PATH`