### PR TITLE
fix: address CodeRabbit nitpicks from PR #146

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.7.4"
+version = "7.7.5"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.7.4"
+__version__ = "7.7.5"

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -630,6 +630,7 @@ class TelegramBackup:
 
         missing_files = []
         corrupted_files = []
+        skipped_symlinks = 0
 
         # Phase 1: Check which files need re-downloading
         for record in media_records:
@@ -650,6 +651,7 @@ class TelegramBackup:
             # be unreachable from this process. We cannot meaningfully
             # check size or emptiness without following the link.
             if os.path.islink(file_path):
+                skipped_symlinks += 1
                 continue
 
             # Check if file is empty (interrupted download)
@@ -667,7 +669,10 @@ class TelegramBackup:
 
         total_issues = len(missing_files) + len(corrupted_files)
         if total_issues == 0:
-            logger.info("✓ All media files verified - no issues found")
+            msg = "✓ All media files verified - no issues found"
+            if skipped_symlinks:
+                msg += f" ({skipped_symlinks} symlink entries skipped)"
+            logger.info(msg)
             logger.info("=" * 60)
             return
 

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -796,8 +796,8 @@ class TestDownloadAvatar:
         listener.client.download_profile_photo.assert_not_called()
 
     @patch("src.listener.get_avatar_paths", return_value=("/path/avatar.jpg", "/legacy/path"))
-    @patch("os.path.exists", return_value=False)
-    async def test_downloads_avatar_when_file_missing(self, mock_exists, mock_paths):
+    @patch("os.path.lexists", return_value=False)
+    async def test_downloads_avatar_when_file_missing(self, mock_lexists, mock_paths):
         """Downloads avatar when file does not exist."""
         listener = TelegramListener(_make_config(), _make_db())
         listener.client = AsyncMock()
@@ -808,9 +808,10 @@ class TestDownloadAvatar:
         listener.client.download_profile_photo.assert_called_once()
 
     @patch("src.listener.get_avatar_paths", return_value=("/path/avatar.jpg", "/legacy/path"))
-    @patch("os.path.exists", return_value=True)
+    @patch("os.path.lexists", return_value=True)
+    @patch("os.path.islink", return_value=False)
     @patch("os.path.getsize", return_value=0)
-    async def test_downloads_avatar_when_file_empty(self, mock_size, mock_exists, mock_paths):
+    async def test_downloads_avatar_when_file_empty(self, mock_size, mock_islink, mock_lexists, mock_paths):
         """Downloads avatar when file exists but is empty (0 bytes)."""
         listener = TelegramListener(_make_config(), _make_db())
         listener.client = AsyncMock()
@@ -831,8 +832,8 @@ class TestDownloadAvatar:
         await listener._download_avatar(entity, 123)
 
     @patch("src.listener.get_avatar_paths", return_value=("/path/avatar.jpg", "/legacy/path"))
-    @patch("os.path.exists", return_value=False)
-    async def test_handles_none_download_result(self, mock_exists, mock_paths):
+    @patch("os.path.lexists", return_value=False)
+    async def test_handles_none_download_result(self, mock_lexists, mock_paths):
         """When download_profile_photo returns None, logs debug instead of info."""
         listener = TelegramListener(_make_config(), _make_db())
         listener.client = AsyncMock()


### PR DESCRIPTION
## Summary

- Patch `os.path.lexists` instead of `os.path.exists` in avatar tests to match the production guard in `_download_avatar` (tests were environment-dependent)
- Add `skipped_symlinks` counter to `_verify_and_redownload_media` output so users see how many symlink entries were intentionally bypassed during verification

Addresses CodeRabbit nitpicks from #146.

## Test plan

- [ ] CI passes (lint + tests)
- [ ] Verify log output includes symlink count when symlinks are present