### PR TITLE
feat(media): hierarchical _shared/ sharding via content-hash prefix

### DIFF
--- a/scripts/deduplicate_media.py
+++ b/scripts/deduplicate_media.py
@@ -30,18 +30,19 @@ from collections import defaultdict
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from src.config import Config
+from src.message_utils import get_shared_file_path
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
 logger = logging.getLogger(__name__)
 
 
 def get_file_hash(filepath: str, chunk_size: int = 8192) -> str:
-    """Get MD5 hash of a file for content comparison."""
-    hash_md5 = hashlib.md5()
+    """Get SHA-256 hash of a file for content comparison and shard placement."""
+    h = hashlib.sha256()
     with open(filepath, "rb") as f:
         for chunk in iter(lambda: f.read(chunk_size), b""):
-            hash_md5.update(chunk)
-    return hash_md5.hexdigest()
+            h.update(chunk)
+    return h.hexdigest()
 
 
 def deduplicate_media(dry_run: bool = False, verbose: bool = False):
@@ -105,35 +106,33 @@ def deduplicate_media(dry_run: bool = False, verbose: bool = False):
     errors = 0
 
     for filename, file_paths in all_files_to_process.items():
-        # Resolve existing shared path (sharded or flat)
+        # Check if file already exists in shared store
         shared_path = None
         source_existed = False
 
-        # Check sharded locations (scan 256 buckets) then flat
-        for entry in os.scandir(shared_dir):
-            if entry.is_dir() and len(entry.name) == 2:
-                candidate = os.path.join(entry.path, filename)
-                if os.path.exists(candidate):
-                    shared_path = candidate
-                    source_existed = True
-                    break
-        if not shared_path:
-            flat_candidate = os.path.join(shared_dir, filename)
-            if os.path.exists(flat_candidate):
-                shared_path = flat_candidate
-                source_existed = True
-
-        if not source_existed:
-            # Use first file as source — compute hash to determine shard bucket
+        # Check flat location first (fast path)
+        flat_candidate = os.path.join(shared_dir, filename)
+        if os.path.exists(flat_candidate):
+            shared_path = flat_candidate
+            source_existed = True
+        else:
+            # Compute hash of first available file to check sharded location
             source_path = file_paths[0]
             source_hash = get_file_hash(source_path)
             if source_hash:
-                bucket = source_hash[:2]
-                shared_path = os.path.join(shared_dir, bucket, filename)
+                sharded_candidate = get_shared_file_path(shared_dir, filename, source_hash)
+                if os.path.exists(sharded_candidate):
+                    shared_path = sharded_candidate
+                    source_existed = True
+                else:
+                    shared_path = sharded_candidate  # destination
             else:
-                shared_path = os.path.join(shared_dir, filename)
-        else:
+                shared_path = flat_candidate  # fallback
+
+        if source_existed:
             source_path = shared_path
+        else:
+            source_path = file_paths[0]
 
         try:
             source_size = os.path.getsize(source_path)

--- a/scripts/deduplicate_media.py
+++ b/scripts/deduplicate_media.py
@@ -105,17 +105,35 @@ def deduplicate_media(dry_run: bool = False, verbose: bool = False):
     errors = 0
 
     for filename, file_paths in all_files_to_process.items():
-        shared_path = os.path.join(shared_dir, filename)
+        # Resolve existing shared path (sharded or flat)
+        shared_path = None
+        source_existed = False
 
-        # Check if already in shared
-        if os.path.exists(shared_path):
-            # File already in shared, just need to create symlinks
-            source_path = shared_path
-            source_existed = True
-        else:
-            # Use first file as source
+        # Check sharded locations (scan 256 buckets) then flat
+        for entry in os.scandir(shared_dir):
+            if entry.is_dir() and len(entry.name) == 2:
+                candidate = os.path.join(entry.path, filename)
+                if os.path.exists(candidate):
+                    shared_path = candidate
+                    source_existed = True
+                    break
+        if not shared_path:
+            flat_candidate = os.path.join(shared_dir, filename)
+            if os.path.exists(flat_candidate):
+                shared_path = flat_candidate
+                source_existed = True
+
+        if not source_existed:
+            # Use first file as source — compute hash to determine shard bucket
             source_path = file_paths[0]
-            source_existed = False
+            source_hash = get_file_hash(source_path)
+            if source_hash:
+                bucket = source_hash[:2]
+                shared_path = os.path.join(shared_dir, bucket, filename)
+            else:
+                shared_path = os.path.join(shared_dir, filename)
+        else:
+            source_path = shared_path
 
         try:
             source_size = os.path.getsize(source_path)
@@ -132,9 +150,10 @@ def deduplicate_media(dry_run: bool = False, verbose: bool = False):
 
             # Skip if this is the source file and we haven't moved it yet
             if file_path == source_path and not source_existed:
-                # Move source to shared
+                # Move source to shared (sharded path)
                 if not dry_run:
                     try:
+                        os.makedirs(os.path.dirname(shared_path), exist_ok=True)
                         os.rename(source_path, shared_path)
                         # Create symlink in original location
                         rel_path = os.path.relpath(shared_path, chat_dir)

--- a/src/listener.py
+++ b/src/listener.py
@@ -35,7 +35,13 @@ from telethon.utils import get_peer_id
 from .avatar_utils import get_avatar_paths
 from .config import Config
 from .db import DatabaseAdapter, create_adapter
-from .message_utils import compute_file_hash, deduplicate_shared_file, extract_topic_id
+from .message_utils import (
+    compute_file_hash,
+    deduplicate_shared_file,
+    extract_topic_id,
+    get_shared_file_path,
+    resolve_shared_file_path,
+)
 from .realtime import NotificationType, RealtimeNotifier
 from .telegram_backup import call_with_flood_retry
 
@@ -625,15 +631,12 @@ class TelegramListener:
                 # Global deduplication: use _shared directory for actual files
                 shared_dir = os.path.join(self.config.media_path, "_shared")
                 os.makedirs(shared_dir, exist_ok=True)
-                shared_file_path = os.path.join(shared_dir, file_name)
 
-                # lexists treats an existing symlink as "already recorded"
-                # even when its ultimate target is unreachable (e.g. a
-                # git-annex object outside the bind mount). Mirrors the
-                # backup-flow gate in src/telegram_backup.py for idempotent
-                # behavior on archived layouts. See issue #143.
+                # Resolve existing file in shared store (sharded or flat fallback)
+                shared_file_path = resolve_shared_file_path(shared_dir, file_name, None)
+
                 if not os.path.lexists(file_path):
-                    if os.path.lexists(shared_file_path):
+                    if shared_file_path:
                         # File exists in shared - create symlink. Hash only
                         # when the target resolves; skip on broken links.
                         content_hash = compute_file_hash(shared_file_path) if os.path.exists(shared_file_path) else None
@@ -649,27 +652,37 @@ class TelegramListener:
 
                             shutil.copy2(shared_file_path, file_path)
                     else:
-                        # First time seeing this file - download to shared and create symlink
-                        tmp_shared_file_path = f"{shared_file_path}.part"
+                        # First time seeing this file - download to sharded shared path
+                        tmp_shared_file_path = os.path.join(shared_dir, f"{file_name}.part")
                         if os.path.exists(tmp_shared_file_path):
                             os.remove(tmp_shared_file_path)
                         actual_path = await call_with_flood_retry(
                             self.client.download_media, message, tmp_shared_file_path
                         )
-                        shared_file_path = _finalize_atomic_download(
+                        tmp_shared_file_path = _finalize_atomic_download(
                             actual_path if isinstance(actual_path, str) else None,
                             tmp_shared_file_path,
-                            shared_file_path,
+                            os.path.join(shared_dir, file_name),
                         )
-                        if not shared_file_path or not os.path.exists(shared_file_path):
+                        if not tmp_shared_file_path or not os.path.exists(tmp_shared_file_path):
                             logger.warning("Media download did not produce a file")
                             return None
                         logger.debug(f"Downloaded media to shared: {file_name}")
 
                         # Content-hash dedup: check if identical content already exists
-                        shared_file_path, content_hash, reused = await deduplicate_shared_file(
-                            self.db, shared_file_path, shared_dir
+                        tmp_shared_file_path, content_hash, reused = await deduplicate_shared_file(
+                            self.db, tmp_shared_file_path, shared_dir
                         )
+
+                        # Move to sharded location if we own this file (not reused)
+                        if not reused and content_hash:
+                            final_shared = get_shared_file_path(shared_dir, file_name, content_hash)
+                            os.makedirs(os.path.dirname(final_shared), exist_ok=True)
+                            if tmp_shared_file_path != final_shared:
+                                os.replace(tmp_shared_file_path, final_shared)
+                            shared_file_path = final_shared
+                        else:
+                            shared_file_path = tmp_shared_file_path
 
                         try:
                             rel_path = os.path.relpath(shared_file_path, chat_media_dir)

--- a/src/listener.py
+++ b/src/listener.py
@@ -37,30 +37,14 @@ from .config import Config
 from .db import DatabaseAdapter, create_adapter
 from .message_utils import (
     compute_file_hash,
-    deduplicate_shared_file,
+    download_and_shard_media,
     extract_topic_id,
-    get_shared_file_path,
-    resolve_shared_file_path,
+    finalize_atomic_download,
 )
 from .realtime import NotificationType, RealtimeNotifier
 from .telegram_backup import call_with_flood_retry
 
 logger = logging.getLogger(__name__)
-
-
-def _finalize_atomic_download(actual_path: str | None, temporary_path: str, fallback_path: str) -> str | None:
-    """Move a temporary download into place while preserving Telethon's chosen extension."""
-    if actual_path and os.path.exists(actual_path):
-        final_path = actual_path[:-5] if actual_path.endswith(".part") else actual_path
-        if final_path != actual_path:
-            os.replace(actual_path, final_path)
-        return final_path if os.path.exists(final_path) else None
-
-    if os.path.exists(temporary_path):
-        os.replace(temporary_path, fallback_path)
-        return fallback_path if os.path.exists(fallback_path) else None
-
-    return None
 
 
 class MassOperationProtector:
@@ -632,81 +616,31 @@ class TelegramListener:
                 shared_dir = os.path.join(self.config.media_path, "_shared")
                 os.makedirs(shared_dir, exist_ok=True)
 
-                # Resolve existing file in shared store (sharded or flat fallback)
-                shared_file_path = resolve_shared_file_path(shared_dir, file_name, None)
+                async def _download_fn(tmp_path):
+                    return await call_with_flood_retry(self.client.download_media, message, tmp_path)
 
-                if not os.path.lexists(file_path):
-                    if shared_file_path:
-                        # File exists in shared - create symlink. Hash only
-                        # when the target resolves; skip on broken links.
-                        content_hash = compute_file_hash(shared_file_path) if os.path.exists(shared_file_path) else None
-                        try:
-                            rel_path = os.path.relpath(shared_file_path, chat_media_dir)
-                            if os.path.lexists(file_path):
-                                os.unlink(file_path)
-                            os.symlink(rel_path, file_path)
-                            logger.debug(f"Created symlink for deduplicated media: {file_name}")
-                        except OSError as e:
-                            logger.warning(f"Symlink not supported, using direct path: {e}")
-                            import shutil
-
-                            shutil.copy2(shared_file_path, file_path)
-                    else:
-                        # First time seeing this file - download to sharded shared path
-                        tmp_shared_file_path = os.path.join(shared_dir, f"{file_name}.part")
-                        if os.path.exists(tmp_shared_file_path):
-                            os.remove(tmp_shared_file_path)
-                        actual_path = await call_with_flood_retry(
-                            self.client.download_media, message, tmp_shared_file_path
-                        )
-                        tmp_shared_file_path = _finalize_atomic_download(
-                            actual_path if isinstance(actual_path, str) else None,
-                            tmp_shared_file_path,
-                            os.path.join(shared_dir, file_name),
-                        )
-                        if not tmp_shared_file_path or not os.path.exists(tmp_shared_file_path):
-                            logger.warning("Media download did not produce a file")
-                            return None
-                        logger.debug(f"Downloaded media to shared: {file_name}")
-
-                        # Content-hash dedup: check if identical content already exists
-                        tmp_shared_file_path, content_hash, reused = await deduplicate_shared_file(
-                            self.db, tmp_shared_file_path, shared_dir
-                        )
-
-                        # Move to sharded location if we own this file (not reused)
-                        if not reused and content_hash:
-                            final_shared = get_shared_file_path(shared_dir, file_name, content_hash)
-                            os.makedirs(os.path.dirname(final_shared), exist_ok=True)
-                            if tmp_shared_file_path != final_shared:
-                                os.replace(tmp_shared_file_path, final_shared)
-                            shared_file_path = final_shared
-                        else:
-                            shared_file_path = tmp_shared_file_path
-
-                        try:
-                            rel_path = os.path.relpath(shared_file_path, chat_media_dir)
-                            if os.path.lexists(file_path):
-                                os.unlink(file_path)
-                            os.symlink(rel_path, file_path)
-                        except OSError as e:
-                            logger.warning(f"Symlink not supported, using direct path: {e}")
-                            import shutil
-
-                            if reused:
-                                shutil.copy2(shared_file_path, file_path)
-                            else:
-                                shutil.move(shared_file_path, file_path)
+                shared_file_path, content_hash = await download_and_shard_media(
+                    db=self.db,
+                    download_coro=_download_fn,
+                    shared_dir=shared_dir,
+                    chat_media_dir=chat_media_dir,
+                    file_name=file_name,
+                    file_path=file_path,
+                    logger=logger,
+                )
+                if not shared_file_path and not os.path.lexists(file_path):
+                    return None
             else:
                 # No deduplication - download directly. lexists short-circuits
                 # the download when a symlink is already recorded, even if its
                 # target is unreachable.
                 if not os.path.lexists(file_path):
-                    tmp_file_path = f"{file_path}.part"
+                    task_id = id(asyncio.current_task()) if asyncio.current_task() else 0
+                    tmp_file_path = f"{file_path}.{os.getpid()}.{task_id}.part"
                     if os.path.exists(tmp_file_path):
                         os.remove(tmp_file_path)
                     actual_path = await call_with_flood_retry(self.client.download_media, message, tmp_file_path)
-                    file_path = _finalize_atomic_download(
+                    file_path = finalize_atomic_download(
                         actual_path if isinstance(actual_path, str) else None,
                         tmp_file_path,
                         file_path,

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -193,7 +193,8 @@ async def download_and_shard_media(
 
     # Move to sharded location if we own this file (not reused)
     if not reused and content_hash:
-        final_shared = get_shared_file_path(shared_dir, file_name, content_hash)
+        actual_name = os.path.basename(tmp_shared_file_path)
+        final_shared = get_shared_file_path(shared_dir, actual_name, content_hash)
         os.makedirs(os.path.dirname(final_shared), exist_ok=True)
         if tmp_shared_file_path != final_shared:
             os.replace(tmp_shared_file_path, final_shared)

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -7,6 +7,37 @@ import os
 logger = logging.getLogger(__name__)
 
 
+def get_shared_file_path(shared_dir: str, file_name: str, content_hash: str | None) -> str:
+    """Build the sharded path for a file in the shared store.
+
+    Uses the first 2 hex characters of the content_hash as a subdirectory
+    (256 buckets). Falls back to flat layout when no hash is available.
+    """
+    file_name = os.path.basename(file_name)
+    if content_hash and len(content_hash) >= 2:
+        bucket = content_hash[:2]
+        return os.path.join(shared_dir, bucket, file_name)
+    return os.path.join(shared_dir, file_name)
+
+
+def resolve_shared_file_path(shared_dir: str, file_name: str, content_hash: str | None) -> str | None:
+    """Find an existing file in the shared store, checking sharded then flat.
+
+    Returns the path if found (via lexists, so symlinks count), else None.
+    """
+    file_name = os.path.basename(file_name)
+    # Check sharded location first
+    if content_hash and len(content_hash) >= 2:
+        sharded = os.path.join(shared_dir, content_hash[:2], file_name)
+        if os.path.lexists(sharded):
+            return sharded
+    # Fallback: flat layout (pre-sharding installs)
+    flat = os.path.join(shared_dir, file_name)
+    if os.path.lexists(flat):
+        return flat
+    return None
+
+
 async def deduplicate_shared_file(
     db: object,
     shared_file_path: str,
@@ -29,7 +60,10 @@ async def deduplicate_shared_file(
     if not existing or not existing.get("file_name"):
         return shared_file_path, content_hash, False
 
-    existing_shared = os.path.join(shared_dir, existing["file_name"])
+    existing_hash = existing.get("content_hash", "")
+    existing_shared = resolve_shared_file_path(shared_dir, existing["file_name"], existing_hash)
+    if not existing_shared:
+        return shared_file_path, content_hash, False
 
     # Path traversal guard: resolved path must stay within shared_dir
     real_shared_dir = os.path.realpath(shared_dir)

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -1,5 +1,6 @@
 """Shared message processing utilities used by backup and listener modules."""
 
+import asyncio
 import hashlib
 import logging
 import os
@@ -31,6 +32,16 @@ def resolve_shared_file_path(shared_dir: str, file_name: str, content_hash: str 
         sharded = os.path.join(shared_dir, content_hash[:2], file_name)
         if os.path.lexists(sharded):
             return sharded
+    else:
+        # Hash unknown — scan shard buckets for the file
+        try:
+            for entry in os.scandir(shared_dir):
+                if entry.is_dir() and len(entry.name) == 2:
+                    candidate = os.path.join(entry.path, file_name)
+                    if os.path.lexists(candidate):
+                        return candidate
+        except OSError:
+            pass
     # Fallback: flat layout (pre-sharding installs)
     flat = os.path.join(shared_dir, file_name)
     if os.path.lexists(flat):
@@ -94,6 +105,118 @@ def compute_file_hash(filepath: str, chunk_size: int = 65536) -> str | None:
         return h.hexdigest()
     except OSError:
         return None
+
+
+def finalize_atomic_download(actual_path: str | None, temporary_path: str, fallback_path: str) -> str | None:
+    """Move a temporary download into place while preserving Telethon's chosen extension."""
+    if actual_path and os.path.exists(actual_path):
+        final_path = actual_path[:-5] if actual_path.endswith(".part") else actual_path
+        if final_path != actual_path:
+            os.replace(actual_path, final_path)
+        return final_path if os.path.exists(final_path) else None
+
+    if os.path.exists(temporary_path):
+        os.replace(temporary_path, fallback_path)
+        return fallback_path if os.path.exists(fallback_path) else None
+
+    return None
+
+
+async def download_and_shard_media(
+    db,
+    download_coro,
+    shared_dir: str,
+    chat_media_dir: str,
+    file_name: str,
+    file_path: str,
+    logger: logging.Logger,
+) -> tuple[str | None, str | None]:
+    """Download media to sharded shared store, create symlink in chat dir.
+
+    Args:
+        db: Database adapter (for deduplicate_shared_file)
+        download_coro: Async callable that takes a tmp_path and returns actual path
+        shared_dir: Path to _shared/ directory
+        chat_media_dir: Chat's media directory (for relative symlinks)
+        file_name: Media filename
+        file_path: Full path where chat-dir symlink should be created
+        logger: Logger instance
+
+    Returns:
+        (shared_file_path, content_hash) or (None, None) on failure
+    """
+    # Resolve existing file in shared store (sharded or flat fallback)
+    shared_file_path = resolve_shared_file_path(shared_dir, file_name, None)
+
+    if os.path.lexists(file_path):
+        # Chat symlink already exists — resolve hash if possible
+        content_hash = None
+        if shared_file_path and os.path.exists(shared_file_path):
+            content_hash = compute_file_hash(shared_file_path)
+        return shared_file_path, content_hash
+
+    if shared_file_path:
+        # File exists in shared — create symlink. Hash only when target resolves.
+        content_hash = compute_file_hash(shared_file_path) if os.path.exists(shared_file_path) else None
+        try:
+            rel_path = os.path.relpath(shared_file_path, chat_media_dir)
+            if os.path.lexists(file_path):
+                os.unlink(file_path)
+            os.symlink(rel_path, file_path)
+            logger.debug(f"Created symlink for deduplicated media: {file_name}")
+        except OSError as e:
+            logger.warning(f"Symlink not supported, using direct path: {e}")
+            import shutil
+
+            shutil.copy2(shared_file_path, file_path)
+        return shared_file_path, content_hash
+
+    # First time seeing this file — download to unique .part then shard
+    task_id = id(asyncio.current_task()) if asyncio.current_task() else 0
+    tmp_shared_file_path = os.path.join(shared_dir, f"{file_name}.{os.getpid()}.{task_id}.part")
+    if os.path.exists(tmp_shared_file_path):
+        os.remove(tmp_shared_file_path)
+
+    actual_path = await download_coro(tmp_shared_file_path)
+    tmp_shared_file_path = finalize_atomic_download(
+        actual_path if isinstance(actual_path, str) else None,
+        tmp_shared_file_path,
+        os.path.join(shared_dir, file_name),
+    )
+    if not tmp_shared_file_path or not os.path.exists(tmp_shared_file_path):
+        logger.warning("Media download did not produce a file")
+        return None, None
+    logger.debug(f"Downloaded media to shared: {file_name}")
+
+    # Content-hash dedup: check if identical content already exists
+    tmp_shared_file_path, content_hash, reused = await deduplicate_shared_file(db, tmp_shared_file_path, shared_dir)
+
+    # Move to sharded location if we own this file (not reused)
+    if not reused and content_hash:
+        final_shared = get_shared_file_path(shared_dir, file_name, content_hash)
+        os.makedirs(os.path.dirname(final_shared), exist_ok=True)
+        if tmp_shared_file_path != final_shared:
+            os.replace(tmp_shared_file_path, final_shared)
+        shared_file_path = final_shared
+    else:
+        shared_file_path = tmp_shared_file_path
+
+    # Create symlink in chat directory
+    try:
+        rel_path = os.path.relpath(shared_file_path, chat_media_dir)
+        if os.path.lexists(file_path):
+            os.unlink(file_path)
+        os.symlink(rel_path, file_path)
+    except OSError as e:
+        logger.warning(f"Symlink not supported, using direct path: {e}")
+        import shutil
+
+        if reused:
+            shutil.copy2(shared_file_path, file_path)
+        else:
+            shutil.move(shared_file_path, file_path)
+
+    return shared_file_path, content_hash
 
 
 def extract_topic_id(message: object) -> int | None:

--- a/src/migrate_shared_media.py
+++ b/src/migrate_shared_media.py
@@ -41,18 +41,19 @@ def migrate_shared_media(media_path: str) -> int:
     if os.path.exists(marker):
         return 0
 
-    entries = []
-    try:
-        entries = list(os.scandir(shared_dir))
-    except OSError:
-        return 0
-
     # Only process regular files directly in _shared/.
     # Symlinks are excluded: moving a symlink to a subdirectory breaks its
     # relative target (e.g. git-annex pointers like ../../.git/annex/objects/...).
     # They remain in flat _shared/ and are found via the fallback in
     # resolve_shared_file_path().
-    flat_files = [e for e in entries if e.is_file(follow_symlinks=False) and not e.name.startswith(".")]
+    # .part files are excluded: they are in-progress downloads.
+    flat_files = []
+    try:
+        for e in os.scandir(shared_dir):
+            if e.is_file(follow_symlinks=False) and not e.name.startswith(".") and not e.name.endswith(".part"):
+                flat_files.append(e)
+    except OSError:
+        return 0
 
     if not flat_files:
         # No flat files — mark as migrated
@@ -60,6 +61,12 @@ def migrate_shared_media(media_path: str) -> int:
         return 0
 
     logger.info(f"Migrating {len(flat_files)} files from flat _shared/ to sharded layout...")
+
+    # Compute chat directories once (not per file)
+    try:
+        chat_dirs = [e.path for e in os.scandir(media_path) if e.is_dir() and not e.name.startswith("_")]
+    except OSError:
+        chat_dirs = []
 
     migrated = 0
     for entry in flat_files:
@@ -80,24 +87,22 @@ def migrate_shared_media(media_path: str) -> int:
                 os.remove(src_path)
             continue
 
+        # Relink symlinks BEFORE moving: if crash occurs between relink and move,
+        # symlinks are dangling but file is still in flat_files on restart → full retry.
+        _relink_chat_symlinks(media_path, shared_dir, entry.name, dest_path, chat_dirs)
+
         os.replace(src_path, dest_path)
         migrated += 1
-
-        # Update symlinks in chat directories that pointed at the old flat path
-        _relink_chat_symlinks(media_path, shared_dir, entry.name, dest_path)
 
     _write_marker(marker)
     logger.info(f"Migration complete: {migrated} files moved to sharded layout")
     return migrated
 
 
-def _relink_chat_symlinks(media_path: str, shared_dir: str, file_name: str, new_target: str) -> None:
+def _relink_chat_symlinks(
+    media_path: str, shared_dir: str, file_name: str, new_target: str, chat_dirs: list[str]
+) -> None:
     """Find and update chat-dir symlinks that pointed at the old flat shared path."""
-    try:
-        chat_dirs = [e.path for e in os.scandir(media_path) if e.is_dir() and not e.name.startswith("_")]
-    except OSError:
-        return
-
     old_rel_suffix = os.path.join("_shared", file_name)
 
     for chat_dir in chat_dirs:
@@ -107,7 +112,9 @@ def _relink_chat_symlinks(media_path: str, shared_dir: str, file_name: str, new_
 
         target = os.readlink(link_path)
         # Check if this symlink points to the old flat location
-        if target.endswith(old_rel_suffix) or os.path.basename(os.path.dirname(target)) == "_shared":
+        if target.endswith(old_rel_suffix) or (
+            os.path.basename(os.path.dirname(target)) == "_shared" and os.path.basename(target) == file_name
+        ):
             new_rel = os.path.relpath(new_target, chat_dir)
             os.unlink(link_path)
             os.symlink(new_rel, link_path)
@@ -117,5 +124,5 @@ def _write_marker(marker_path: str) -> None:
     try:
         with open(marker_path, "w") as f:
             f.write("sharding migration complete\n")
-    except OSError:
-        pass
+    except OSError as e:
+        logger.error(f"Failed to write migration marker: {e}")

--- a/src/migrate_shared_media.py
+++ b/src/migrate_shared_media.py
@@ -1,0 +1,121 @@
+"""Auto-migrate flat _shared/ layout to sharded (hash-prefix) layout.
+
+On startup, scans _shared/ for files directly in the root (not in a
+2-char hex subdirectory). For each file, computes SHA-256, moves it to
+_shared/<hash[:2]>/<filename>, and updates any chat-dir symlinks that
+pointed at the old flat location.
+
+Idempotent: files already in shard buckets are skipped.
+"""
+
+import hashlib
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+SHARD_MARKER = ".sharded"
+
+
+def _compute_hash(filepath: str) -> str | None:
+    try:
+        h = hashlib.sha256()
+        with open(filepath, "rb") as f:
+            for chunk in iter(lambda: f.read(65536), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except OSError:
+        return None
+
+
+def migrate_shared_media(media_path: str) -> int:
+    """Migrate flat _shared/ files into hash-prefix sharded subdirectories.
+
+    Returns the number of files migrated.
+    """
+    shared_dir = os.path.join(media_path, "_shared")
+    if not os.path.isdir(shared_dir):
+        return 0
+
+    marker = os.path.join(shared_dir, SHARD_MARKER)
+    if os.path.exists(marker):
+        return 0
+
+    entries = []
+    try:
+        entries = list(os.scandir(shared_dir))
+    except OSError:
+        return 0
+
+    # Only process regular files directly in _shared/.
+    # Symlinks are excluded: moving a symlink to a subdirectory breaks its
+    # relative target (e.g. git-annex pointers like ../../.git/annex/objects/...).
+    # They remain in flat _shared/ and are found via the fallback in
+    # resolve_shared_file_path().
+    flat_files = [e for e in entries if e.is_file(follow_symlinks=False) and not e.name.startswith(".")]
+
+    if not flat_files:
+        # No flat files — mark as migrated
+        _write_marker(marker)
+        return 0
+
+    logger.info(f"Migrating {len(flat_files)} files from flat _shared/ to sharded layout...")
+
+    migrated = 0
+    for entry in flat_files:
+        src_path = entry.path
+
+        content_hash = _compute_hash(src_path)
+        if not content_hash:
+            continue
+
+        bucket = content_hash[:2]
+        dest_dir = os.path.join(shared_dir, bucket)
+        os.makedirs(dest_dir, exist_ok=True)
+        dest_path = os.path.join(dest_dir, entry.name)
+
+        if os.path.lexists(dest_path):
+            # Already exists in shard — remove flat duplicate
+            if os.path.isfile(dest_path):
+                os.remove(src_path)
+            continue
+
+        os.replace(src_path, dest_path)
+        migrated += 1
+
+        # Update symlinks in chat directories that pointed at the old flat path
+        _relink_chat_symlinks(media_path, shared_dir, entry.name, dest_path)
+
+    _write_marker(marker)
+    logger.info(f"Migration complete: {migrated} files moved to sharded layout")
+    return migrated
+
+
+def _relink_chat_symlinks(media_path: str, shared_dir: str, file_name: str, new_target: str) -> None:
+    """Find and update chat-dir symlinks that pointed at the old flat shared path."""
+    try:
+        chat_dirs = [e.path for e in os.scandir(media_path) if e.is_dir() and not e.name.startswith("_")]
+    except OSError:
+        return
+
+    old_rel_suffix = os.path.join("_shared", file_name)
+
+    for chat_dir in chat_dirs:
+        link_path = os.path.join(chat_dir, file_name)
+        if not os.path.islink(link_path):
+            continue
+
+        target = os.readlink(link_path)
+        # Check if this symlink points to the old flat location
+        if target.endswith(old_rel_suffix) or os.path.basename(os.path.dirname(target)) == "_shared":
+            new_rel = os.path.relpath(new_target, chat_dir)
+            os.unlink(link_path)
+            os.symlink(new_rel, link_path)
+
+
+def _write_marker(marker_path: str) -> None:
+    try:
+        with open(marker_path, "w") as f:
+            f.write("sharding migration complete\n")
+    except OSError:
+        pass

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -313,6 +313,11 @@ async def main():
             logger.warning("   → This is expensive but catches changes made while offline")
         logger.info("=" * 60)
 
+        # Migrate flat _shared/ to sharded layout (idempotent, runs once)
+        from .migrate_shared_media import migrate_shared_media
+
+        migrate_shared_media(config.media_path)
+
         # Create and run scheduler
         scheduler = BackupScheduler(config)
         await scheduler.run_forever()

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -35,9 +35,9 @@ from .config import Config
 from .db import DatabaseAdapter, create_adapter
 from .message_utils import (
     compute_file_hash,
-    deduplicate_shared_file,
+    download_and_shard_media,
     extract_topic_id,
-    get_shared_file_path,
+    finalize_atomic_download,
     resolve_shared_file_path,
 )
 
@@ -96,21 +96,6 @@ async def call_with_flood_retry(coro_fn, *args, max_retries=MAX_FLOOD_RETRIES, *
                 max_retries,
             )
             await asyncio.sleep(wait_seconds + 1)  # +1s buffer to avoid boundary re-trigger
-
-
-def _finalize_atomic_download(actual_path: str | None, temporary_path: str, fallback_path: str) -> str | None:
-    """Move a temporary download into place while preserving Telethon's chosen extension."""
-    if actual_path and os.path.exists(actual_path):
-        final_path = actual_path[:-5] if actual_path.endswith(".part") else actual_path
-        if final_path != actual_path:
-            os.replace(actual_path, final_path)
-        return final_path if os.path.exists(final_path) else None
-
-    if os.path.exists(temporary_path):
-        os.replace(temporary_path, fallback_path)
-        return fallback_path if os.path.exists(fallback_path) else None
-
-    return None
 
 
 async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
@@ -1533,75 +1518,22 @@ class TelegramBackup:
                 shared_dir = os.path.join(self.config.media_path, "_shared")
                 os.makedirs(shared_dir, exist_ok=True)
 
-                # Resolve existing file in shared store (sharded or flat fallback)
-                shared_file_path = resolve_shared_file_path(shared_dir, file_name, None)
+                async def _download_fn(tmp_path):
+                    return await call_with_flood_retry(self.client.download_media, message, tmp_path)
 
-                if not os.path.lexists(file_path):
-                    if shared_file_path:
-                        # File exists in shared - create symlink. Hash only
-                        # when the target resolves; skip on broken links.
-                        content_hash = compute_file_hash(shared_file_path) if os.path.exists(shared_file_path) else None
-                        try:
-                            rel_path = os.path.relpath(shared_file_path, chat_media_dir)
-                            if os.path.lexists(file_path):
-                                os.unlink(file_path)
-                            os.symlink(rel_path, file_path)
-                            logger.debug(f"Created symlink for deduplicated media: {file_name}")
-                        except OSError as e:
-                            logger.warning(f"Symlink not supported, using direct path: {e}")
-                            import shutil
+                shared_file_path, content_hash = await download_and_shard_media(
+                    db=self.db,
+                    download_coro=_download_fn,
+                    shared_dir=shared_dir,
+                    chat_media_dir=chat_media_dir,
+                    file_name=file_name,
+                    file_path=file_path,
+                    logger=logger,
+                )
+                if not shared_file_path and not os.path.lexists(file_path):
+                    return None
 
-                            shutil.copy2(shared_file_path, file_path)
-                    else:
-                        # First time seeing this file - download to sharded shared path
-                        # Use a flat temp path; we'll move to the shard after hashing
-                        tmp_shared_file_path = os.path.join(shared_dir, f"{file_name}.part")
-                        if os.path.exists(tmp_shared_file_path):
-                            os.remove(tmp_shared_file_path)
-                        actual_path = await call_with_flood_retry(
-                            self.client.download_media, message, tmp_shared_file_path
-                        )
-                        tmp_shared_file_path = _finalize_atomic_download(
-                            actual_path if isinstance(actual_path, str) else None,
-                            tmp_shared_file_path,
-                            os.path.join(shared_dir, file_name),
-                        )
-                        if not tmp_shared_file_path or not os.path.exists(tmp_shared_file_path):
-                            logger.warning("Media download did not produce a file")
-                            return None
-                        logger.debug(f"Downloaded media to shared: {file_name}")
-
-                        # Content-hash dedup: check if identical content already exists
-                        tmp_shared_file_path, content_hash, reused = await deduplicate_shared_file(
-                            self.db, tmp_shared_file_path, shared_dir
-                        )
-
-                        # Move to sharded location if we own this file (not reused)
-                        if not reused and content_hash:
-                            final_shared = get_shared_file_path(shared_dir, file_name, content_hash)
-                            os.makedirs(os.path.dirname(final_shared), exist_ok=True)
-                            if tmp_shared_file_path != final_shared:
-                                os.replace(tmp_shared_file_path, final_shared)
-                            shared_file_path = final_shared
-                        else:
-                            shared_file_path = tmp_shared_file_path
-
-                        # Create symlink in chat directory
-                        try:
-                            rel_path = os.path.relpath(shared_file_path, chat_media_dir)
-                            if os.path.lexists(file_path):
-                                os.unlink(file_path)
-                            os.symlink(rel_path, file_path)
-                        except OSError as e:
-                            logger.warning(f"Symlink not supported, using direct path: {e}")
-                            import shutil
-
-                            if reused:
-                                shutil.copy2(shared_file_path, file_path)
-                            else:
-                                shutil.move(shared_file_path, file_path)
-
-                # Update file_size with actual size from disk (follow symlinks)
+                # Backup-specific post-processing: update file_size from disk
                 if not shared_file_path:
                     shared_file_path = resolve_shared_file_path(shared_dir, file_name, content_hash)
                 actual_path = shared_file_path if shared_file_path and os.path.exists(shared_file_path) else file_path
@@ -1614,11 +1546,12 @@ class TelegramBackup:
                 # lexists short-circuits the download when a symlink is
                 # already recorded, even if its target is unreachable.
                 if not os.path.lexists(file_path):
-                    tmp_file_path = f"{file_path}.part"
+                    task_id = id(asyncio.current_task()) if asyncio.current_task() else 0
+                    tmp_file_path = f"{file_path}.{os.getpid()}.{task_id}.part"
                     if os.path.exists(tmp_file_path):
                         os.remove(tmp_file_path)
                     actual_path = await call_with_flood_retry(self.client.download_media, message, tmp_file_path)
-                    file_path = _finalize_atomic_download(
+                    file_path = finalize_atomic_download(
                         actual_path if isinstance(actual_path, str) else None,
                         tmp_file_path,
                         file_path,

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -33,7 +33,13 @@ from telethon.utils import get_peer_id
 from .avatar_utils import get_avatar_paths
 from .config import Config
 from .db import DatabaseAdapter, create_adapter
-from .message_utils import compute_file_hash, deduplicate_shared_file, extract_topic_id
+from .message_utils import (
+    compute_file_hash,
+    deduplicate_shared_file,
+    extract_topic_id,
+    get_shared_file_path,
+    resolve_shared_file_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1526,57 +1532,59 @@ class TelegramBackup:
                 # Global deduplication: use _shared directory for actual files
                 shared_dir = os.path.join(self.config.media_path, "_shared")
                 os.makedirs(shared_dir, exist_ok=True)
-                shared_file_path = os.path.join(shared_dir, file_name)
 
-                # Check if file already exists (either directly or in shared).
-                # Uses lexists so a previously recorded symlink short-circuits
-                # the download even when its ultimate target is unreachable
-                # (e.g. a git-annex object outside the bind mount). Without
-                # this, intentional broken symlinks cause re-downloads that
-                # overwrite _shared/ entries via atomic rename and may rewrite
-                # chat-dir targets through content-hash dedup -- breaking
-                # idempotency for archived layouts.
+                # Resolve existing file in shared store (sharded or flat fallback)
+                shared_file_path = resolve_shared_file_path(shared_dir, file_name, None)
+
                 if not os.path.lexists(file_path):
-                    if os.path.lexists(shared_file_path):
+                    if shared_file_path:
                         # File exists in shared - create symlink. Hash only
-                        # when the target resolves; skip on a broken link to
-                        # avoid raising in compute_file_hash.
+                        # when the target resolves; skip on broken links.
                         content_hash = compute_file_hash(shared_file_path) if os.path.exists(shared_file_path) else None
                         try:
-                            # Use relative symlink for portability
                             rel_path = os.path.relpath(shared_file_path, chat_media_dir)
                             if os.path.lexists(file_path):
                                 os.unlink(file_path)
                             os.symlink(rel_path, file_path)
                             logger.debug(f"Created symlink for deduplicated media: {file_name}")
                         except OSError as e:
-                            # Symlink not supported (e.g., Windows), copy shared file instead
                             logger.warning(f"Symlink not supported, using direct path: {e}")
                             import shutil
 
                             shutil.copy2(shared_file_path, file_path)
                     else:
-                        # First time seeing this file - download to shared and create symlink
-                        tmp_shared_file_path = f"{shared_file_path}.part"
+                        # First time seeing this file - download to sharded shared path
+                        # Use a flat temp path; we'll move to the shard after hashing
+                        tmp_shared_file_path = os.path.join(shared_dir, f"{file_name}.part")
                         if os.path.exists(tmp_shared_file_path):
                             os.remove(tmp_shared_file_path)
                         actual_path = await call_with_flood_retry(
                             self.client.download_media, message, tmp_shared_file_path
                         )
-                        shared_file_path = _finalize_atomic_download(
+                        tmp_shared_file_path = _finalize_atomic_download(
                             actual_path if isinstance(actual_path, str) else None,
                             tmp_shared_file_path,
-                            shared_file_path,
+                            os.path.join(shared_dir, file_name),
                         )
-                        if not shared_file_path or not os.path.exists(shared_file_path):
+                        if not tmp_shared_file_path or not os.path.exists(tmp_shared_file_path):
                             logger.warning("Media download did not produce a file")
                             return None
                         logger.debug(f"Downloaded media to shared: {file_name}")
 
                         # Content-hash dedup: check if identical content already exists
-                        shared_file_path, content_hash, reused = await deduplicate_shared_file(
-                            self.db, shared_file_path, shared_dir
+                        tmp_shared_file_path, content_hash, reused = await deduplicate_shared_file(
+                            self.db, tmp_shared_file_path, shared_dir
                         )
+
+                        # Move to sharded location if we own this file (not reused)
+                        if not reused and content_hash:
+                            final_shared = get_shared_file_path(shared_dir, file_name, content_hash)
+                            os.makedirs(os.path.dirname(final_shared), exist_ok=True)
+                            if tmp_shared_file_path != final_shared:
+                                os.replace(tmp_shared_file_path, final_shared)
+                            shared_file_path = final_shared
+                        else:
+                            shared_file_path = tmp_shared_file_path
 
                         # Create symlink in chat directory
                         try:
@@ -1585,7 +1593,6 @@ class TelegramBackup:
                                 os.unlink(file_path)
                             os.symlink(rel_path, file_path)
                         except OSError as e:
-                            # Symlink not supported (e.g., Windows) - copy/move to chat dir
                             logger.warning(f"Symlink not supported, using direct path: {e}")
                             import shutil
 
@@ -1595,7 +1602,9 @@ class TelegramBackup:
                                 shutil.move(shared_file_path, file_path)
 
                 # Update file_size with actual size from disk (follow symlinks)
-                actual_path = shared_file_path if os.path.exists(shared_file_path) else file_path
+                if not shared_file_path:
+                    shared_file_path = resolve_shared_file_path(shared_dir, file_name, content_hash)
+                actual_path = shared_file_path if shared_file_path and os.path.exists(shared_file_path) else file_path
                 if os.path.exists(actual_path):
                     file_size = os.path.getsize(actual_path)
                     if not content_hash:
@@ -2098,9 +2107,12 @@ def main():
     import asyncio
 
     from .config import Config, setup_logging
+    from .migrate_shared_media import migrate_shared_media
 
     config = Config()
     setup_logging(config)
+
+    migrate_shared_media(config.media_path)
 
     return asyncio.run(run_backup(config))
 

--- a/tests/test_atomic_download_helpers.py
+++ b/tests/test_atomic_download_helpers.py
@@ -1,52 +1,38 @@
 """Tests for shared atomic media download finalization helpers."""
 
-from src import listener, telegram_backup
+from src.message_utils import finalize_atomic_download
 
 
-def test_telegram_backup_finalize_atomic_download_uses_temporary_fallback(tmp_path):
+def test_finalize_atomic_download_uses_temporary_fallback(tmp_path):
     """When Telethon leaves the requested temp file behind, move it to the fallback path."""
     temporary_path = tmp_path / "download.part"
     fallback_path = tmp_path / "download.jpg"
     temporary_path.write_bytes(b"image")
 
-    result = telegram_backup._finalize_atomic_download(None, str(temporary_path), str(fallback_path))
+    result = finalize_atomic_download(None, str(temporary_path), str(fallback_path))
 
     assert result == str(fallback_path)
     assert fallback_path.read_bytes() == b"image"
     assert not temporary_path.exists()
 
 
-def test_telegram_backup_finalize_atomic_download_strips_part_suffix(tmp_path):
+def test_finalize_atomic_download_strips_part_suffix(tmp_path):
     """When Telethon returns a .part path, remove the suffix atomically."""
     actual_path = tmp_path / "chosen.jpg.part"
     actual_path.write_bytes(b"image")
     fallback_path = tmp_path / "fallback.jpg"
 
-    result = telegram_backup._finalize_atomic_download(str(actual_path), str(actual_path), str(fallback_path))
+    result = finalize_atomic_download(str(actual_path), str(actual_path), str(fallback_path))
 
     assert result == str(tmp_path / "chosen.jpg")
     assert (tmp_path / "chosen.jpg").read_bytes() == b"image"
     assert not actual_path.exists()
 
 
-def test_listener_finalize_atomic_download_uses_temporary_fallback(tmp_path):
-    """Listener downloads share the same temporary-file fallback behavior."""
-    temporary_path = tmp_path / "listener.part"
-    fallback_path = tmp_path / "listener.jpg"
-    temporary_path.write_bytes(b"image")
-
-    result = listener._finalize_atomic_download(None, str(temporary_path), str(fallback_path))
-
-    assert result == str(fallback_path)
-    assert fallback_path.read_bytes() == b"image"
-    assert not temporary_path.exists()
-
-
 def test_finalize_atomic_download_returns_none_when_no_file_was_created(tmp_path):
-    """Helpers must not report success when Telethon did not create a file."""
+    """Helper must not report success when Telethon did not create a file."""
     missing_temp = tmp_path / "missing.part"
     fallback_path = tmp_path / "fallback.jpg"
 
-    assert telegram_backup._finalize_atomic_download(None, str(missing_temp), str(fallback_path)) is None
-    assert listener._finalize_atomic_download(None, str(missing_temp), str(fallback_path)) is None
+    assert finalize_atomic_download(None, str(missing_temp), str(fallback_path)) is None
     assert not fallback_path.exists()

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -663,7 +663,7 @@ class TestDownloadMedia:
             return False
 
         mock_exists.side_effect = exists
-        with patch("src.listener._finalize_atomic_download", return_value="/tmp/test_media/_shared/123.jpg"):
+        with patch("src.message_utils.finalize_atomic_download", return_value="/tmp/test_media/_shared/123.jpg"):
             result = await listener._download_media(msg, -100)
         assert result is not None
         listener.client.download_media.assert_called_once()
@@ -700,7 +700,7 @@ class TestDownloadMedia:
             return False
 
         mock_exists.side_effect = exists
-        with patch("src.listener._finalize_atomic_download", return_value="/tmp/test_media/-100/123.jpg"):
+        with patch("src.message_utils.finalize_atomic_download", return_value="/tmp/test_media/-100/123.jpg"):
             result = await listener._download_media(msg, -100)
         assert result is not None
         listener.client.download_media.assert_called_once()
@@ -2215,7 +2215,7 @@ class TestDownloadMediaSymlinkFallback:
             return False
 
         mock_exists.side_effect = exists
-        with patch("src.listener._finalize_atomic_download", return_value="/tmp/test_media/_shared/123.jpg"):
+        with patch("src.message_utils.finalize_atomic_download", return_value="/tmp/test_media/_shared/123.jpg"):
             result = await listener._download_media(msg, -100)
         assert result is not None
         mock_move.assert_called_once()

--- a/tests/test_shared_media_sharding.py
+++ b/tests/test_shared_media_sharding.py
@@ -1,0 +1,195 @@
+"""Tests for hierarchical _shared/ media sharding (issue #149)."""
+
+import hashlib
+import os
+import tempfile
+import unittest
+
+from src.message_utils import get_shared_file_path, resolve_shared_file_path
+from src.migrate_shared_media import migrate_shared_media
+
+
+class TestGetSharedFilePath(unittest.TestCase):
+    """Test get_shared_file_path utility."""
+
+    def test_with_hash_returns_sharded_path(self):
+        result = get_shared_file_path("/data/_shared", "photo.jpg", "abcdef1234567890")
+        assert result == "/data/_shared/ab/photo.jpg"
+
+    def test_with_short_hash_returns_sharded_path(self):
+        result = get_shared_file_path("/data/_shared", "photo.jpg", "ff")
+        assert result == "/data/_shared/ff/photo.jpg"
+
+    def test_without_hash_returns_flat_path(self):
+        result = get_shared_file_path("/data/_shared", "photo.jpg", None)
+        assert result == "/data/_shared/photo.jpg"
+
+    def test_with_empty_hash_returns_flat_path(self):
+        result = get_shared_file_path("/data/_shared", "photo.jpg", "")
+        assert result == "/data/_shared/photo.jpg"
+
+    def test_with_single_char_hash_returns_flat_path(self):
+        result = get_shared_file_path("/data/_shared", "photo.jpg", "a")
+        assert result == "/data/_shared/photo.jpg"
+
+    def test_strips_directory_from_filename(self):
+        result = get_shared_file_path("/data/_shared", "../../etc/passwd", "abcdef")
+        assert result == "/data/_shared/ab/passwd"
+
+    def test_strips_nested_path_from_filename(self):
+        result = get_shared_file_path("/data/_shared", "subdir/photo.jpg", "abcdef")
+        assert result == "/data/_shared/ab/photo.jpg"
+
+
+class TestResolveSharedFilePath(unittest.TestCase):
+    """Test resolve_shared_file_path with fallback logic."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.shared_dir = os.path.join(self.tmpdir, "_shared")
+        os.makedirs(self.shared_dir)
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmpdir)
+
+    def test_finds_file_in_sharded_location(self):
+        bucket_dir = os.path.join(self.shared_dir, "ab")
+        os.makedirs(bucket_dir)
+        filepath = os.path.join(bucket_dir, "photo.jpg")
+        with open(filepath, "w") as f:
+            f.write("data")
+
+        result = resolve_shared_file_path(self.shared_dir, "photo.jpg", "abcdef1234")
+        assert result == filepath
+
+    def test_falls_back_to_flat_location(self):
+        filepath = os.path.join(self.shared_dir, "photo.jpg")
+        with open(filepath, "w") as f:
+            f.write("data")
+
+        result = resolve_shared_file_path(self.shared_dir, "photo.jpg", "abcdef1234")
+        assert result == filepath
+
+    def test_prefers_sharded_over_flat(self):
+        # Both exist — sharded wins
+        flat = os.path.join(self.shared_dir, "photo.jpg")
+        with open(flat, "w") as f:
+            f.write("flat")
+        bucket_dir = os.path.join(self.shared_dir, "ab")
+        os.makedirs(bucket_dir)
+        sharded = os.path.join(bucket_dir, "photo.jpg")
+        with open(sharded, "w") as f:
+            f.write("sharded")
+
+        result = resolve_shared_file_path(self.shared_dir, "photo.jpg", "abcdef1234")
+        assert result == sharded
+
+    def test_returns_none_when_not_found(self):
+        result = resolve_shared_file_path(self.shared_dir, "missing.jpg", "abcdef1234")
+        assert result is None
+
+    def test_finds_flat_when_no_hash(self):
+        filepath = os.path.join(self.shared_dir, "photo.jpg")
+        with open(filepath, "w") as f:
+            f.write("data")
+
+        result = resolve_shared_file_path(self.shared_dir, "photo.jpg", None)
+        assert result == filepath
+
+    def test_recognizes_symlinks_via_lexists(self):
+        bucket_dir = os.path.join(self.shared_dir, "ab")
+        os.makedirs(bucket_dir)
+        link_path = os.path.join(bucket_dir, "photo.jpg")
+        os.symlink("/nonexistent/target", link_path)
+
+        result = resolve_shared_file_path(self.shared_dir, "photo.jpg", "abcdef1234")
+        assert result == link_path
+
+
+class TestMigrateSharedMedia(unittest.TestCase):
+    """Test the flat-to-sharded migration."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.media_path = self.tmpdir
+        self.shared_dir = os.path.join(self.media_path, "_shared")
+        os.makedirs(self.shared_dir)
+
+    def tearDown(self):
+        import shutil
+
+        shutil.rmtree(self.tmpdir)
+
+    def _create_file(self, path, content="test data"):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            f.write(content)
+        return path
+
+    def _content_hash(self, content="test data"):
+        return hashlib.sha256(content.encode()).hexdigest()
+
+    def test_migrates_flat_files_to_sharded(self):
+        content = "hello world"
+        flat_file = self._create_file(os.path.join(self.shared_dir, "photo.jpg"), content)
+        expected_hash = self._content_hash(content)
+        expected_bucket = expected_hash[:2]
+
+        count = migrate_shared_media(self.media_path)
+
+        assert count == 1
+        assert not os.path.exists(flat_file)
+        sharded = os.path.join(self.shared_dir, expected_bucket, "photo.jpg")
+        assert os.path.exists(sharded)
+
+    def test_updates_chat_symlinks(self):
+        content = "media content"
+        flat_file = self._create_file(os.path.join(self.shared_dir, "video.mp4"), content)
+
+        # Create a chat dir with a symlink pointing to the flat location
+        chat_dir = os.path.join(self.media_path, "-1001234")
+        os.makedirs(chat_dir)
+        link_path = os.path.join(chat_dir, "video.mp4")
+        os.symlink(os.path.relpath(flat_file, chat_dir), link_path)
+
+        migrate_shared_media(self.media_path)
+
+        # Symlink should be updated to point to sharded location
+        assert os.path.islink(link_path)
+        target = os.readlink(link_path)
+        expected_hash = self._content_hash(content)
+        assert expected_hash[:2] in target
+
+    def test_idempotent_with_marker(self):
+        self._create_file(os.path.join(self.shared_dir, "photo.jpg"), "data")
+
+        count1 = migrate_shared_media(self.media_path)
+        assert count1 == 1
+
+        # Second run should do nothing (marker exists)
+        count2 = migrate_shared_media(self.media_path)
+        assert count2 == 0
+
+    def test_skips_hidden_files(self):
+        self._create_file(os.path.join(self.shared_dir, ".gitkeep"), "")
+        count = migrate_shared_media(self.media_path)
+        assert count == 0
+
+    def test_no_shared_dir_returns_zero(self):
+        import shutil
+
+        shutil.rmtree(self.shared_dir)
+        count = migrate_shared_media(self.media_path)
+        assert count == 0
+
+    def test_skips_files_already_in_buckets(self):
+        # File already in a shard bucket should not be touched
+        bucket_dir = os.path.join(self.shared_dir, "ab")
+        os.makedirs(bucket_dir)
+        self._create_file(os.path.join(bucket_dir, "photo.jpg"), "data")
+
+        count = migrate_shared_media(self.media_path)
+        assert count == 0
+        assert os.path.exists(os.path.join(bucket_dir, "photo.jpg"))

--- a/tests/test_symlink_dedup.py
+++ b/tests/test_symlink_dedup.py
@@ -166,7 +166,9 @@ class TestDownloadReturnValueCapture(unittest.TestCase):
         chat_link = os.path.join(chat_dir, "fileid123.bin")
         if os.path.lexists(chat_link):
             resolved = os.path.realpath(chat_link)
-            self.assertEqual(resolved, os.path.realpath(actual_returned_path))
+            # File is sharded but retains Telethon's .mp4 extension
+            self.assertTrue(os.path.exists(resolved))
+            self.assertTrue(resolved.endswith("fileid123.mp4"))
 
 
 class TestProcessMediaDedupSymlink(unittest.TestCase):
@@ -237,7 +239,8 @@ class TestProcessMediaDedupSymlink(unittest.TestCase):
         chat_file = os.path.join(chat_dir, "photo_abc")
         if os.path.lexists(chat_file):
             resolved = os.path.realpath(chat_file)
-            self.assertEqual(resolved, os.path.realpath(returned_path))
+            self.assertTrue(os.path.exists(resolved))
+            self.assertTrue(resolved.endswith("photo_abc.mp4"))
 
     def test_process_media_preserves_existing_symlink(self):
         """An existing symlink at file_path short-circuits the download path.
@@ -497,8 +500,12 @@ class TestShutilMoveFallback(unittest.TestCase):
 
         self.assertIsNotNone(result)
         self.assertTrue(result["downloaded"])
-        # shutil.move should have been called as fallback
-        mock_move.assert_called_once_with(shared_file, chat_file)
+        # shutil.move should have been called with the sharded path as source
+        mock_move.assert_called_once()
+        call_args = mock_move.call_args[0]
+        self.assertTrue(call_args[0].startswith(shared_dir))
+        self.assertIn("fallback_file.jpg", call_args[0])
+        self.assertEqual(call_args[1], chat_file)
 
     def test_no_shutil_move_when_symlink_succeeds(self):
         """shutil.move is NOT called when os.symlink succeeds normally."""
@@ -670,7 +677,8 @@ class TestListenerDownloadMediaDedup(unittest.TestCase):
         chat_file = os.path.join(chat_dir, file_name)
         if os.path.lexists(chat_file):
             resolved = os.path.realpath(chat_file)
-            self.assertEqual(resolved, os.path.realpath(returned_path))
+            self.assertTrue(os.path.exists(resolved))
+            self.assertTrue(resolved.endswith("video_xyz.mp4"))
 
     def test_listener_dedup_preserves_existing_symlink(self):
         """Listener leaves an existing chat-dir symlink alone, even when broken.


### PR DESCRIPTION
## Summary

Introduces hierarchical storage for deduplicated media in `_shared/` to solve filesystem performance degradation at scale (436K+ files in a flat directory).

- New layout: `_shared/<content_hash[:2]>/<filename>` (256 buckets)
- Auto-migration on startup moves flat files to sharded subdirectories
- Backward-compatible: `resolve_shared_file_path()` checks sharded first, then flat fallback
- Chat-dir symlinks are updated during migration
- git-annex symlinks are explicitly excluded from migration (relative targets would break)

### Architecture

| Component | Change |
|-----------|--------|
| `src/message_utils.py` | New `get_shared_file_path()` and `resolve_shared_file_path()` utilities |
| `src/telegram_backup.py` | Uses resolve/get utilities for all `_shared/` path construction |
| `src/listener.py` | Same pattern as backup |
| `src/migrate_shared_media.py` | New module: auto-migration (idempotent, marker-file gated) |
| `src/scheduler.py` | Calls migration on startup |
| `scripts/deduplicate_media.py` | Updated to write to sharded paths |

### git-annex / DataLad compatibility

- Symlinks in `_shared/` are **never migrated** (`is_file(follow_symlinks=False)` excludes them)
- They remain in flat `_shared/` and are found via the fallback path in `resolve_shared_file_path()`
- All download guards still use `lexists` (PR #146 philosophy preserved)
- Chat-dir symlinks managed by git-annex are not touched during `_relink_chat_symlinks()`

Closes #149.

## Test plan

- [x] 19 new tests covering path construction, resolution, migration, symlink handling
- [x] `ruff check . && ruff format --check .` clean
- [ ] CI passes (lint + tests)
- [ ] Reporter (@yarikoptic) confirms layout on real 436K-file archive