### PR TITLE
fix(media): retry permanently stuck downloaded=0 media on each backup

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -761,6 +761,38 @@ class DatabaseAdapter:
                 for m in result.scalars()
             ]
 
+    async def get_pending_media_downloads(self) -> list[dict[str, Any]]:
+        """Get media records that failed to download and need retry.
+
+        Returns records where downloaded=0 for downloadable media types
+        (excludes contact/geo/poll which are metadata-only).
+        """
+        async with self.db_manager.async_session_factory() as session:
+            stmt = (
+                select(Media)
+                .where(
+                    and_(
+                        Media.downloaded == 0,
+                        Media.type.notin_(["contact", "geo", "poll"]),
+                    )
+                )
+                .order_by(Media.chat_id, Media.message_id)
+            )
+            result = await session.execute(stmt)
+            return [
+                {
+                    "id": m.id,
+                    "message_id": m.message_id,
+                    "chat_id": m.chat_id,
+                    "type": m.type,
+                    "file_path": m.file_path,
+                    "file_name": m.file_name,
+                    "file_size": m.file_size,
+                    "downloaded": m.downloaded,
+                }
+                for m in result.scalars()
+            ]
+
     async def mark_media_for_redownload(self, media_id: str) -> None:
         """Mark a media record as needing re-download."""
         async with self.db_manager.async_session_factory() as session:

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -761,23 +761,22 @@ class DatabaseAdapter:
                 for m in result.scalars()
             ]
 
-    async def get_pending_media_downloads(self) -> list[dict[str, Any]]:
+    async def get_pending_media_downloads(self, max_media_size_bytes: int | None = None) -> list[dict[str, Any]]:
         """Get media records that failed to download and need retry.
 
         Returns records where downloaded=0 for downloadable media types
         (excludes contact/geo/poll which are metadata-only).
+        Files exceeding max_media_size_bytes are excluded to prevent
+        infinite retry of over-limit media.
         """
         async with self.db_manager.async_session_factory() as session:
-            stmt = (
-                select(Media)
-                .where(
-                    and_(
-                        Media.downloaded == 0,
-                        Media.type.notin_(["contact", "geo", "poll"]),
-                    )
-                )
-                .order_by(Media.chat_id, Media.message_id)
-            )
+            conditions = [
+                Media.downloaded == 0,
+                Media.type.notin_(["contact", "geo", "poll"]),
+            ]
+            if max_media_size_bytes is not None:
+                conditions.append(or_(Media.file_size.is_(None), Media.file_size <= max_media_size_bytes))
+            stmt = select(Media).where(and_(*conditions)).order_by(Media.chat_id, Media.message_id)
             result = await session.execute(stmt)
             return [
                 {

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -567,6 +567,9 @@ class TelegramBackup:
             logger.info(f"Total storage: {stats['total_size_mb']} MB")
             logger.info("=" * 60)
 
+            # Retry previously failed media downloads
+            await self._retry_pending_media_downloads()
+
             # Run media verification if enabled
             if self.config.verify_media:
                 await self._verify_and_redownload_media()
@@ -752,6 +755,88 @@ class TelegramBackup:
         logger.info("Media verification completed!")
         logger.info(f"Re-downloaded: {redownloaded} files")
         logger.info(f"Failed/Unrecoverable: {failed} files")
+        logger.info("=" * 60)
+
+    async def _retry_pending_media_downloads(self) -> None:
+        """Retry downloading media that previously failed.
+
+        Picks up records with downloaded=0 (excluding metadata-only types
+        like contact/geo/poll) and re-attempts the download from Telegram.
+        Respects MAX_MEDIA_SIZE_BYTES — files that still exceed the limit
+        are skipped silently.
+        """
+        pending = await self.db.get_pending_media_downloads()
+        if not pending:
+            return
+
+        logger.info("=" * 60)
+        logger.info(f"Retrying {len(pending)} pending media downloads...")
+
+        # Group by chat_id for efficient batch fetching
+        by_chat: dict[int, list[dict]] = {}
+        for record in pending:
+            chat_id = record.get("chat_id")
+            if chat_id:
+                by_chat.setdefault(chat_id, []).append(record)
+
+        downloaded = 0
+        skipped = 0
+        failed = 0
+
+        for chat_id, records in by_chat.items():
+            if chat_id in self.config.skip_media_chat_ids:
+                skipped += len(records)
+                continue
+
+            try:
+                message_ids = [r["message_id"] for r in records if r.get("message_id")]
+                if not message_ids:
+                    continue
+
+                try:
+                    messages = await call_with_flood_retry(self.client.get_messages, chat_id, ids=message_ids)
+                except Exception as e:
+                    logger.warning(f"Cannot access chat for pending media retry: {e}")
+                    failed += len(records)
+                    continue
+
+                msg_map = {}
+                for msg in messages:
+                    if msg:
+                        msg_map[msg.id] = msg
+
+                for record in records:
+                    msg_id = record.get("message_id")
+                    msg = msg_map.get(msg_id)
+
+                    if not msg:
+                        skipped += 1
+                        continue
+
+                    if not msg.media:
+                        skipped += 1
+                        continue
+
+                    # Re-attempt _process_media (which handles size checks internally)
+                    try:
+                        result = await self._process_media(msg, chat_id)
+                        if result and result.get("downloaded"):
+                            await self.db.insert_media(result)
+                            downloaded += 1
+                        else:
+                            skipped += 1
+                    except Exception as e:
+                        logger.debug(f"Retry failed for pending media: {e}")
+                        failed += 1
+
+            except Exception as e:
+                logger.error(f"Error retrying pending media for chat: {e}")
+                failed += len(records)
+
+        if downloaded > 0 or failed > 0:
+            logger.info(f"Pending media retry: {downloaded} downloaded, {skipped} skipped, {failed} failed")
+        else:
+            logger.info("Pending media retry: no actionable items")
         logger.info("=" * 60)
 
     async def _backup_dialog(self, dialog, is_archived: bool = False) -> int:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -765,7 +765,7 @@ class TelegramBackup:
         Respects MAX_MEDIA_SIZE_BYTES — files that still exceed the limit
         are skipped silently.
         """
-        pending = await self.db.get_pending_media_downloads()
+        pending = await self.db.get_pending_media_downloads(self.config.get_max_media_size_bytes())
         if not pending:
             return
 


### PR DESCRIPTION
## Summary

- Adds `get_pending_media_downloads()` query that finds records with `downloaded=0` excluding metadata-only types (contact/geo/poll)
- Adds `_retry_pending_media_downloads()` that runs before `VERIFY_MEDIA` on each backup cycle
- Re-fetches messages from Telegram and re-attempts download via `_process_media()`
- Respects `MAX_MEDIA_SIZE_BYTES` and `SKIP_MEDIA_CHAT_IDS`

## Root Cause

When `_process_media()` fails (network error, rate limit, timeout), it returns `{downloaded: False, file_path: null}`. This record is inserted but:
1. Incremental checkpoint advances past the message → never re-fetched
2. `VERIFY_MEDIA` only queries `downloaded=1 OR file_path IS NOT NULL` → invisible
3. Result: permanently stuck media showing "Will download on next backup"

## Test plan

- [ ] Deploy with existing stuck `downloaded=0` records in DB
- [ ] Verify log shows "Retrying N pending media downloads..."
- [ ] Confirm previously stuck media gets downloaded
- [ ] Verify media exceeding `MAX_MEDIA_SIZE_BYTES` is skipped (not re-attempted endlessly)
- [ ] Verify deleted messages are skipped gracefully

Closes #153

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic retry of previously failed media downloads after each backup, grouped by chat and respecting configured exclusions.
  * Retries honor max media size limits and tolerate individual failures without aborting the overall process.
  * Summary logs show counts of downloaded, skipped, and failed items.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/Telegram-Archive/pull/154)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->