### PR TITLE
fix: use datetime.timezone.utc instead of ZoneInfo("UTC")

### DIFF
--- a/src/web/main.py
+++ b/src/web/main.py
@@ -17,7 +17,7 @@ import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone as datetime_module_timezone
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import quote, urlparse
@@ -1673,14 +1673,14 @@ async def get_message_by_date(
             user_tz = ZoneInfo(tz_str)
         except Exception:
             logger.warning(f"Invalid timezone '{tz_str}', falling back to UTC")
-            user_tz = ZoneInfo("UTC")
+            user_tz = datetime_module_timezone.utc
 
         # Parse date string (YYYY-MM-DD) as a date in the user's timezone
         naive_date = datetime.strptime(date, "%Y-%m-%d")
         # Create timezone-aware datetime at start of day in user's timezone
         local_start_of_day = naive_date.replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=user_tz)
         # Convert to UTC for database query
-        target_date = local_start_of_day.astimezone(ZoneInfo("UTC")).replace(tzinfo=None)
+        target_date = local_start_of_day.astimezone(datetime_module_timezone.utc).replace(tzinfo=None)
 
         message = await db.find_message_by_date_with_joins(chat_id, target_date)
 

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -17,7 +17,7 @@ import time
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta, timezone as datetime_module_timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.parse import quote, urlparse
@@ -1673,14 +1673,14 @@ async def get_message_by_date(
             user_tz = ZoneInfo(tz_str)
         except Exception:
             logger.warning(f"Invalid timezone '{tz_str}', falling back to UTC")
-            user_tz = datetime_module_timezone.utc
+            user_tz = UTC
 
         # Parse date string (YYYY-MM-DD) as a date in the user's timezone
         naive_date = datetime.strptime(date, "%Y-%m-%d")
         # Create timezone-aware datetime at start of day in user's timezone
         local_start_of_day = naive_date.replace(hour=0, minute=0, second=0, microsecond=0, tzinfo=user_tz)
         # Convert to UTC for database query
-        target_date = local_start_of_day.astimezone(datetime_module_timezone.utc).replace(tzinfo=None)
+        target_date = local_start_of_day.astimezone(UTC).replace(tzinfo=None)
 
         message = await db.find_message_by_date_with_joins(chat_id, target_date)
 


### PR DESCRIPTION
## Summary
- Self-hosted runner lacks `tzdata` package, causing `ZoneInfo("UTC")` to raise `KeyError: 'No time zone found with key UTC'`
- Replace with `datetime.timezone.utc` (stdlib constant, always available)
- Fixes 6 test failures in `test_web_routes` and `test_web_coverage`

## Test plan
- [ ] CI Tests workflow passes (6 previously failing tests now pass)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal timezone handling for date-based message queries to enhance system reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/Telegram-Archive/pull/155)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->