### PR TITLE
fix: include symlinks in sharding migration

### DIFF
--- a/src/migrate_shared_media.py
+++ b/src/migrate_shared_media.py
@@ -41,16 +41,14 @@ def migrate_shared_media(media_path: str) -> int:
     if os.path.exists(marker):
         return 0
 
-    # Only process regular files directly in _shared/.
-    # Symlinks are excluded: moving a symlink to a subdirectory breaks its
-    # relative target (e.g. git-annex pointers like ../../.git/annex/objects/...).
-    # They remain in flat _shared/ and are found via the fallback in
-    # resolve_shared_file_path().
-    # .part files are excluded: they are in-progress downloads.
     flat_files = []
     try:
         for e in os.scandir(shared_dir):
-            if e.is_file(follow_symlinks=False) and not e.name.startswith(".") and not e.name.endswith(".part"):
+            if (
+                (e.is_file(follow_symlinks=False) or e.is_symlink())
+                and not e.name.startswith(".")
+                and not e.name.endswith(".part")
+            ):
                 flat_files.append(e)
     except OSError:
         return 0

--- a/tests/test_shared_media_sharding.py
+++ b/tests/test_shared_media_sharding.py
@@ -193,3 +193,29 @@ class TestMigrateSharedMedia(unittest.TestCase):
         count = migrate_shared_media(self.media_path)
         assert count == 0
         assert os.path.exists(os.path.join(bucket_dir, "photo.jpg"))
+
+    def test_migrates_symlinks_with_reachable_targets(self):
+        # Simulate git-annex: symlink whose target is readable
+        content = "annex object data"
+        annex_obj = self._create_file(os.path.join(self.tmpdir, ".git", "annex", "objects", "obj"), content)
+        link_path = os.path.join(self.shared_dir, "annexed.jpg")
+        os.symlink(os.path.relpath(annex_obj, self.shared_dir), link_path)
+
+        count = migrate_shared_media(self.media_path)
+
+        assert count == 1
+        assert not os.path.lexists(link_path)
+        expected_hash = self._content_hash(content)
+        sharded = os.path.join(self.shared_dir, expected_hash[:2], "annexed.jpg")
+        assert os.path.islink(sharded)
+
+    def test_skips_symlinks_with_unreachable_targets(self):
+        # Docker case: symlink target doesn't exist, hash fails → skipped
+        link_path = os.path.join(self.shared_dir, "broken.jpg")
+        os.symlink("../../.git/annex/objects/XX/YY/key", link_path)
+
+        count = migrate_shared_media(self.media_path)
+
+        assert count == 0
+        # Symlink stays in flat location
+        assert os.path.islink(link_path)


### PR DESCRIPTION
## Summary
- Removes the explicit symlink exclusion from `migrate_shared_media()`, addressing @yarikoptic's feedback in #149
- Symlinks with reachable targets (git-annex on host) now get sharded like regular files — the user's next `git commit` auto-fixes relative symlink targets via git-annex's pre-commit hook
- Symlinks with unreachable targets (Docker without `.git/`) are naturally skipped because `_compute_hash()` returns `None` on `OSError`
- No behavior change for non-git-annex users (regular files were never affected by the exclusion)

## Test plan
- [x] New test: `test_migrates_symlinks_with_reachable_targets` — verifies symlinks get sharded when target is readable
- [x] New test: `test_skips_symlinks_with_unreachable_targets` — verifies Docker case (broken targets) still skips gracefully
- [x] All existing sharding tests continue to pass (21/21)

Ref: https://github.com/GeiserX/Telegram-Archive/issues/149#issuecomment-4455495427

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Symlinked media files are now included in the shared media migration process and properly moved to the sharded directory structure alongside regular files. Broken symlinks are handled appropriately.

* **Tests**
  * Added test coverage for symlink migration scenarios, including validation of reachable target conversion and handling of unreachable (broken) symlinks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/Telegram-Archive/pull/156)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->