### PR TITLE
feat: trusted proxy header authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -185,6 +185,22 @@ DB_PATH=/data/backups/telegram_backup.db
 # Create additional viewer accounts with per-chat access via the admin UI.
 # Viewer account data is stored in the database (viewer_accounts table).
 
+# --- Trusted Proxy Authentication (v7.9.0) ---
+# For use behind auth proxies like Authelia, Authentik, or Keycloak.
+# The proxy authenticates the user and forwards their identity in a header.
+# Set AUTH_PROXY_HEADER to enable (e.g., "Remote-User" or "X-Forwarded-User").
+# IMPORTANT: Only enable if your reverse proxy strips this header from client requests.
+# AUTH_PROXY_HEADER=Remote-User
+
+# Comma-separated list of usernames that get admin (master) role.
+# Users not in this list are auto-created as viewers with restricted access.
+# AUTH_PROXY_ADMIN_USERS=admin@example.com
+
+# Default chat access for auto-created proxy users: "none" or "all".
+# "none" = no chats visible until admin grants access via the admin panel.
+# "all" = full access to all chats (suitable for single-user setups).
+# AUTH_PROXY_DEFAULT_ACCESS=none
+
 # Timezone for displayed timestamps (tz database name)
 # VIEWER_TIMEZONE=Europe/Madrid
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.8.5"
+version = "7.9.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.8.5"
+__version__ = "7.9.0"

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -446,6 +446,12 @@ ALLOW_ANONYMOUS_VIEWER = os.getenv("ALLOW_ANONYMOUS_VIEWER", "false").lower() ==
 TRUST_PROXY_HEADERS = os.getenv("TRUST_PROXY_HEADERS", "false").lower() == "true"
 AUTH_COOKIE_NAME = "viewer_auth"
 
+# Trusted Proxy Authentication (v7.9.0)
+AUTH_PROXY_HEADER = os.getenv("AUTH_PROXY_HEADER", "").strip()
+AUTH_PROXY_ADMIN_USERS = {u.strip() for u in os.getenv("AUTH_PROXY_ADMIN_USERS", "").split(",") if u.strip()}
+AUTH_PROXY_DEFAULT_ACCESS = os.getenv("AUTH_PROXY_DEFAULT_ACCESS", "none").strip().lower()
+_PROXY_AUTH_ENABLED = bool(AUTH_PROXY_HEADER)
+
 AUTH_SESSION_DAYS = int(os.getenv("AUTH_SESSION_DAYS", "30"))
 AUTH_SESSION_SECONDS = AUTH_SESSION_DAYS * 24 * 60 * 60
 _MAX_SESSIONS_PER_USER = 10
@@ -455,6 +461,8 @@ _LOGIN_RATE_WINDOW = 300  # per 5 minutes
 
 if AUTH_ENABLED:
     logger.info(f"Viewer authentication is ENABLED (Master: {VIEWER_USERNAME}, Session: {AUTH_SESSION_DAYS} days)")
+elif _PROXY_AUTH_ENABLED:
+    logger.info(f"Trusted proxy authentication is ENABLED (Header: {AUTH_PROXY_HEADER})")
 elif ALLOW_ANONYMOUS_VIEWER:
     logger.warning("Viewer authentication is DISABLED by explicit ALLOW_ANONYMOUS_VIEWER=true")
 else:
@@ -668,12 +676,73 @@ async def _resolve_session(auth_cookie: str) -> SessionData | None:
     return session
 
 
-async def require_auth(auth_cookie: str | None = Cookie(default=None, alias=AUTH_COOKIE_NAME)) -> UserContext:
+async def _resolve_proxy_user(proxy_username: str) -> UserContext:
+    """Resolve a trusted proxy-authenticated user to a UserContext.
+
+    Admin users (in AUTH_PROXY_ADMIN_USERS) get master role with full access.
+    Other users are auto-created as viewer accounts with access determined by
+    AUTH_PROXY_DEFAULT_ACCESS (none = no chats until admin grants, all = full access).
+    """
+    if proxy_username in AUTH_PROXY_ADMIN_USERS:
+        return UserContext(username=proxy_username, role="master", allowed_chat_ids=None)
+
+    # Look up or auto-create viewer account
+    if db:
+        viewer = await db.get_viewer_by_username(proxy_username)
+        if viewer:
+            if not viewer["is_active"]:
+                raise HTTPException(status_code=403, detail="Account disabled")
+            allowed = None
+            if viewer["allowed_chat_ids"]:
+                try:
+                    allowed = set(json.loads(viewer["allowed_chat_ids"]))
+                except json.JSONDecodeError, TypeError:
+                    allowed = set()
+            return UserContext(
+                username=proxy_username,
+                role="viewer",
+                allowed_chat_ids=allowed,
+                no_download=bool(viewer.get("no_download", 0)),
+            )
+
+        # Auto-create with configured default access
+        allowed_json = None  # None = all chats
+        if AUTH_PROXY_DEFAULT_ACCESS != "all":
+            allowed_json = "[]"  # Empty = no chats until admin grants access
+        await db.create_viewer_account(
+            username=proxy_username,
+            password_hash="",
+            salt="proxy-auth",
+            allowed_chat_ids=allowed_json,
+            created_by="proxy-auth",
+            is_active=1,
+        )
+        logger.info(f"Auto-created proxy-authenticated viewer account: {proxy_username}")
+
+        allowed_set: set[int] | None = None if AUTH_PROXY_DEFAULT_ACCESS == "all" else set()
+        return UserContext(username=proxy_username, role="viewer", allowed_chat_ids=allowed_set)
+
+    # No DB — proxy admin users are the only ones that work without DB
+    raise HTTPException(status_code=503, detail="Database required for proxy authentication")
+
+
+async def require_auth(
+    request: Request, auth_cookie: str | None = Cookie(default=None, alias=AUTH_COOKIE_NAME)
+) -> UserContext:
     """Dependency that enforces session-based auth. Returns UserContext."""
-    if not AUTH_ENABLED:
+    if not AUTH_ENABLED and not _PROXY_AUTH_ENABLED:
         if ALLOW_ANONYMOUS_VIEWER:
             return UserContext(username="anonymous", role="master", allowed_chat_ids=None)
         raise HTTPException(status_code=503, detail="Viewer authentication is not configured")
+
+    # Trusted proxy header authentication (v7.9.0)
+    if _PROXY_AUTH_ENABLED:
+        proxy_user = request.headers.get(AUTH_PROXY_HEADER, "").strip()
+        if proxy_user:
+            return await _resolve_proxy_user(proxy_user)
+
+    if not AUTH_ENABLED:
+        raise HTTPException(status_code=401, detail="Unauthorized")
 
     if not auth_cookie:
         raise HTTPException(status_code=401, detail="Unauthorized")
@@ -889,9 +958,26 @@ async def health_check():
 
 
 @app.get("/api/auth/check")
-async def check_auth(auth_cookie: str | None = Cookie(default=None, alias=AUTH_COOKIE_NAME)):
+async def check_auth(request: Request, auth_cookie: str | None = Cookie(default=None, alias=AUTH_COOKIE_NAME)):
     """Check current authentication status. Returns role and username if authenticated."""
-    if not AUTH_ENABLED:
+    # Trusted proxy header — if header present, user is authenticated by the proxy
+    if _PROXY_AUTH_ENABLED:
+        proxy_user = request.headers.get(AUTH_PROXY_HEADER, "").strip()
+        if proxy_user:
+            try:
+                user_ctx = await _resolve_proxy_user(proxy_user)
+                return {
+                    "authenticated": True,
+                    "auth_required": True,
+                    "role": user_ctx.role,
+                    "username": user_ctx.username,
+                    "no_download": user_ctx.no_download,
+                    "proxy_auth": True,
+                }
+            except HTTPException:
+                return {"authenticated": False, "auth_required": True}
+
+    if not AUTH_ENABLED and not _PROXY_AUTH_ENABLED:
         if ALLOW_ANONYMOUS_VIEWER:
             return {"authenticated": True, "auth_required": False, "role": "master", "username": "anonymous"}
         return {"authenticated": False, "auth_required": True, "setup_required": True}
@@ -2192,7 +2278,20 @@ async def websocket_endpoint(websocket: WebSocket):
     auth_cookie = cookies.get(AUTH_COOKIE_NAME)
     ws_user_chat_ids: set[int] | None = None
 
-    if AUTH_ENABLED:
+    # Trusted proxy header auth for WebSocket upgrade
+    if _PROXY_AUTH_ENABLED:
+        proxy_user = websocket.headers.get(AUTH_PROXY_HEADER, "").strip()
+        if proxy_user:
+            try:
+                user_ctx = await _resolve_proxy_user(proxy_user)
+                ws_user_chat_ids = get_user_chat_ids(user_ctx)
+            except HTTPException:
+                await websocket.close(code=4001, reason="Proxy auth failed")
+                return
+        elif not AUTH_ENABLED and not ALLOW_ANONYMOUS_VIEWER:
+            await websocket.close(code=4001, reason="Unauthorized")
+            return
+    elif AUTH_ENABLED:
         if not auth_cookie:
             await websocket.close(code=4001, reason="Unauthorized")
             return

--- a/tests/test_proxy_auth.py
+++ b/tests/test_proxy_auth.py
@@ -1,0 +1,305 @@
+"""Integration tests for trusted proxy header authentication (v7.9.0).
+
+Tests the AUTH_PROXY_HEADER flow: header-based identity forwarding from
+reverse proxies like Authelia, Authentik, and Keycloak.
+"""
+
+import json
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _reset_auth_module():
+    """Reset auth module state between tests."""
+    import src.web.main as main_mod
+
+    main_mod._sessions.clear()
+    main_mod._login_attempts.clear()
+    yield
+    main_mod._sessions.clear()
+    main_mod._login_attempts.clear()
+
+
+def _make_mock_db():
+    db = AsyncMock()
+    db.get_all_chats = AsyncMock(
+        return_value=[
+            {"id": -1001, "title": "Chat A", "type": "channel"},
+            {"id": -1002, "title": "Chat B", "type": "channel"},
+        ]
+    )
+    db.get_chat_count = AsyncMock(return_value=2)
+    db.get_cached_statistics = AsyncMock(return_value={"total_chats": 2, "total_messages": 50})
+    db.get_metadata = AsyncMock(return_value=None)
+    db.get_viewer_by_username = AsyncMock(return_value=None)
+    db.get_all_viewer_accounts = AsyncMock(return_value=[])
+    db.create_viewer_account = AsyncMock(
+        return_value={"id": 1, "username": "testuser", "allowed_chat_ids": "[]", "is_active": 1}
+    )
+    db.create_audit_log = AsyncMock()
+    db.get_all_folders = AsyncMock(return_value=[])
+    db.get_archived_chat_count = AsyncMock(return_value=0)
+    db.get_session = AsyncMock(return_value=None)
+    db.save_session = AsyncMock()
+    db.delete_session = AsyncMock()
+    return db
+
+
+@pytest.fixture
+def proxy_env():
+    """Set up proxy auth env vars (no basic auth)."""
+    with patch.dict(
+        os.environ,
+        {
+            "VIEWER_USERNAME": "",
+            "VIEWER_PASSWORD": "",
+            "AUTH_PROXY_HEADER": "Remote-User",
+            "AUTH_PROXY_ADMIN_USERS": "admin@example.com,root@example.com",
+            "AUTH_PROXY_DEFAULT_ACCESS": "none",
+            "SECURE_COOKIES": "false",
+        },
+    ):
+        yield
+
+
+@pytest.fixture
+def proxy_env_all_access():
+    """Proxy auth with default access = all."""
+    with patch.dict(
+        os.environ,
+        {
+            "VIEWER_USERNAME": "",
+            "VIEWER_PASSWORD": "",
+            "AUTH_PROXY_HEADER": "Remote-User",
+            "AUTH_PROXY_ADMIN_USERS": "admin@example.com",
+            "AUTH_PROXY_DEFAULT_ACCESS": "all",
+            "SECURE_COOKIES": "false",
+        },
+    ):
+        yield
+
+
+@pytest.fixture
+def proxy_with_basic_env():
+    """Proxy auth combined with basic auth."""
+    with patch.dict(
+        os.environ,
+        {
+            "VIEWER_USERNAME": "admin",
+            "VIEWER_PASSWORD": "testpass123",
+            "AUTH_PROXY_HEADER": "X-Forwarded-User",
+            "AUTH_PROXY_ADMIN_USERS": "sso-admin@corp.com",
+            "AUTH_PROXY_DEFAULT_ACCESS": "none",
+            "SECURE_COOKIES": "false",
+        },
+    ):
+        yield
+
+
+def _get_client(mock_db=None):
+    """Create a fresh TestClient by reloading the module with current env."""
+    import importlib
+
+    import src.web.main as main_mod
+
+    importlib.reload(main_mod)
+
+    if mock_db is None:
+        mock_db = _make_mock_db()
+    main_mod.db = mock_db
+
+    return TestClient(main_mod.app, raise_server_exceptions=False), main_mod, mock_db
+
+
+class TestProxyAuthAdminUser:
+    """Tests for proxy-authenticated admin users."""
+
+    def test_admin_gets_master_role(self, proxy_env):
+        client, _, _ = _get_client()
+        resp = client.get("/api/auth/check", headers={"Remote-User": "admin@example.com"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["authenticated"] is True
+        assert data["role"] == "master"
+        assert data["username"] == "admin@example.com"
+        assert data.get("proxy_auth") is True
+
+    def test_admin_can_access_protected_endpoints(self, proxy_env):
+        client, _, _ = _get_client()
+        resp = client.get("/api/chats", headers={"Remote-User": "admin@example.com"})
+        assert resp.status_code == 200
+
+    def test_second_admin_also_works(self, proxy_env):
+        client, _, _ = _get_client()
+        resp = client.get("/api/auth/check", headers={"Remote-User": "root@example.com"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["role"] == "master"
+
+
+class TestProxyAuthViewerUser:
+    """Tests for proxy-authenticated regular (non-admin) users."""
+
+    def test_unknown_user_auto_created_with_no_access(self, proxy_env):
+        mock_db = _make_mock_db()
+        client, _, _ = _get_client(mock_db)
+        resp = client.get("/api/auth/check", headers={"Remote-User": "newuser@example.com"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["authenticated"] is True
+        assert data["role"] == "viewer"
+        assert data["username"] == "newuser@example.com"
+
+        mock_db.create_viewer_account.assert_called_once()
+        call_kwargs = mock_db.create_viewer_account.call_args[1]
+        assert call_kwargs["username"] == "newuser@example.com"
+        assert call_kwargs["salt"] == "proxy-auth"
+        assert call_kwargs["allowed_chat_ids"] == "[]"
+        assert call_kwargs["created_by"] == "proxy-auth"
+
+    def test_auto_created_user_default_all_access(self, proxy_env_all_access):
+        mock_db = _make_mock_db()
+        client, _, _ = _get_client(mock_db)
+        resp = client.get("/api/auth/check", headers={"Remote-User": "newuser@example.com"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["authenticated"] is True
+        assert data["role"] == "viewer"
+
+        call_kwargs = mock_db.create_viewer_account.call_args[1]
+        assert call_kwargs["allowed_chat_ids"] is None
+
+    def test_existing_viewer_account_used(self, proxy_env):
+        mock_db = _make_mock_db()
+        mock_db.get_viewer_by_username = AsyncMock(
+            return_value={
+                "id": 5,
+                "username": "existing@example.com",
+                "password_hash": "",
+                "salt": "proxy-auth",
+                "allowed_chat_ids": json.dumps([-1001]),
+                "is_active": 1,
+                "no_download": 0,
+            }
+        )
+        client, _, _ = _get_client(mock_db)
+        resp = client.get("/api/auth/check", headers={"Remote-User": "existing@example.com"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["authenticated"] is True
+        assert data["role"] == "viewer"
+        mock_db.create_viewer_account.assert_not_called()
+
+    def test_disabled_account_rejected(self, proxy_env):
+        mock_db = _make_mock_db()
+        mock_db.get_viewer_by_username = AsyncMock(
+            return_value={
+                "id": 5,
+                "username": "disabled@example.com",
+                "password_hash": "",
+                "salt": "proxy-auth",
+                "allowed_chat_ids": None,
+                "is_active": 0,
+                "no_download": 0,
+            }
+        )
+        client, _, _ = _get_client(mock_db)
+        resp = client.get("/api/auth/check", headers={"Remote-User": "disabled@example.com"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["authenticated"] is False
+
+
+class TestProxyAuthNoHeader:
+    """Tests when proxy auth is enabled but no header is provided."""
+
+    def test_no_header_returns_unauthenticated(self, proxy_env):
+        client, _, _ = _get_client()
+        resp = client.get("/api/auth/check")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["authenticated"] is False
+        assert data["auth_required"] is True
+
+    def test_empty_header_returns_unauthenticated(self, proxy_env):
+        client, _, _ = _get_client()
+        resp = client.get("/api/auth/check", headers={"Remote-User": ""})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["authenticated"] is False
+
+    def test_protected_endpoint_returns_401(self, proxy_env):
+        client, _, _ = _get_client()
+        resp = client.get("/api/chats")
+        assert resp.status_code == 401
+
+
+class TestProxyAuthCombinedWithBasic:
+    """Tests when both proxy auth and basic auth are enabled together."""
+
+    def test_proxy_header_takes_priority(self, proxy_with_basic_env):
+        client, _, _ = _get_client()
+        resp = client.get("/api/auth/check", headers={"X-Forwarded-User": "sso-admin@corp.com"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["authenticated"] is True
+        assert data["role"] == "master"
+        assert data.get("proxy_auth") is True
+
+    def test_basic_auth_still_works_without_header(self, proxy_with_basic_env):
+        client, _, _ = _get_client()
+        resp = client.post("/api/login", json={"username": "admin", "password": "testpass123"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["role"] == "master"
+
+    def test_cookie_session_works_without_proxy_header(self, proxy_with_basic_env):
+        client, _, _ = _get_client()
+        login_resp = client.post("/api/login", json={"username": "admin", "password": "testpass123"})
+        assert login_resp.status_code == 200
+        resp = client.get("/api/auth/check")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["authenticated"] is True
+        assert data["role"] == "master"
+
+
+class TestProxyAuthSecurity:
+    """Security-focused tests for proxy auth."""
+
+    def test_wrong_header_name_ignored(self, proxy_env):
+        client, _, _ = _get_client()
+        resp = client.get("/api/auth/check", headers={"X-Wrong-Header": "admin@example.com"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["authenticated"] is False
+
+    def test_whitespace_only_header_rejected(self, proxy_env):
+        client, _, _ = _get_client()
+        resp = client.get("/api/auth/check", headers={"Remote-User": "   "})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["authenticated"] is False
+
+    def test_proxy_auth_disabled_by_default(self):
+        """Without AUTH_PROXY_HEADER env var, proxy headers are ignored."""
+        with patch.dict(
+            os.environ,
+            {
+                "VIEWER_USERNAME": "admin",
+                "VIEWER_PASSWORD": "testpass123",
+                "AUTH_PROXY_HEADER": "",
+                "SECURE_COOKIES": "false",
+            },
+        ):
+            client, _, _ = _get_client()
+            resp = client.get("/api/auth/check", headers={"Remote-User": "admin@example.com"})
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["authenticated"] is False
+            assert data.get("proxy_auth") is None

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -1378,9 +1378,16 @@ class TestResolveSession(_WebTestBase):
 class TestRequireAuth(_WebTestBase):
     """Test require_auth dependency."""
 
+    def _mock_request(self, headers=None):
+        from unittest.mock import MagicMock
+
+        req = MagicMock()
+        req.headers = headers or {}
+        return req
+
     async def test_returns_anonymous_master_when_auth_disabled(self):
         """require_auth returns anonymous master only with explicit anonymous opt-in."""
-        result = await web_main.require_auth(auth_cookie=None)
+        result = await web_main.require_auth(request=self._mock_request(), auth_cookie=None)
         self.assertEqual(result.username, "anonymous")
         self.assertEqual(result.role, "master")
 
@@ -1390,7 +1397,7 @@ class TestRequireAuth(_WebTestBase):
         from fastapi import HTTPException
 
         with self.assertRaises(HTTPException) as ctx:
-            await web_main.require_auth(auth_cookie=None)
+            await web_main.require_auth(request=self._mock_request(), auth_cookie=None)
         self.assertEqual(ctx.exception.status_code, 503)
 
     async def test_raises_401_when_no_cookie(self):
@@ -1399,7 +1406,7 @@ class TestRequireAuth(_WebTestBase):
         from fastapi import HTTPException
 
         with self.assertRaises(HTTPException) as ctx:
-            await web_main.require_auth(auth_cookie=None)
+            await web_main.require_auth(request=self._mock_request(), auth_cookie=None)
         self.assertEqual(ctx.exception.status_code, 401)
 
     async def test_raises_401_for_invalid_session(self):
@@ -1408,7 +1415,7 @@ class TestRequireAuth(_WebTestBase):
         from fastapi import HTTPException
 
         with self.assertRaises(HTTPException) as ctx:
-            await web_main.require_auth(auth_cookie="bad-token")
+            await web_main.require_auth(request=self._mock_request(), auth_cookie="bad-token")
         self.assertEqual(ctx.exception.status_code, 401)
 
 


### PR DESCRIPTION
## Summary

- Adds trusted proxy header authentication for use behind Authelia, Authentik, Keycloak, or any reverse proxy that forwards authenticated user identity
- Proxy-authenticated admin users (via `AUTH_PROXY_ADMIN_USERS`) get master role with full access
- Non-admin users are auto-created as viewer accounts with configurable default access (`none` or `all`)
- Works standalone or combined with existing password-based auth
- Zero new dependencies

## Configuration

```env
AUTH_PROXY_HEADER=Remote-User
AUTH_PROXY_ADMIN_USERS=admin@example.com
AUTH_PROXY_DEFAULT_ACCESS=none
```

## How it works

1. Reverse proxy (Authelia/Authentik/Keycloak) authenticates the user via OIDC/LDAP/etc.
2. Proxy forwards identity in configured header (e.g., `Remote-User` or `X-Forwarded-User`)
3. Telegram Archive reads the header and resolves the user:
   - If username is in `AUTH_PROXY_ADMIN_USERS` → master role (full access)
   - If username exists as a ViewerAccount → uses existing permissions
   - If username is new → auto-creates ViewerAccount with `AUTH_PROXY_DEFAULT_ACCESS` permissions
4. Admin can then manage proxy-created users' chat permissions via the existing admin panel

## Security notes

- Header is ONLY trusted when `AUTH_PROXY_HEADER` is explicitly set (disabled by default)
- Users MUST ensure their reverse proxy strips the configured header from client requests to prevent spoofing
- WebSocket upgrade requests also respect proxy headers

## Test plan

- [ ] CI passes (lint + tests)
- [ ] Admin user via proxy header gets master role
- [ ] Non-admin user is auto-created with no permissions
- [ ] Existing viewer account is reused (not re-created)
- [ ] Disabled account is rejected
- [ ] Missing/empty header returns 401
- [ ] Combined with basic auth: proxy header takes priority, password login still works
- [ ] Wrong header name is ignored

Closes #159