### PR TITLE
feat: media gallery with per-chat grid view

### DIFF
--- a/alembic/versions/20260523_012_add_media_chat_type_index.py
+++ b/alembic/versions/20260523_012_add_media_chat_type_index.py
@@ -1,0 +1,27 @@
+"""Add composite index on media(chat_id, type) for gallery queries.
+
+Revision ID: 012
+Revises: 011
+Create Date: 2026-05-23
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "012"
+down_revision = "011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_indexes = {idx["name"] for idx in inspector.get_indexes("media")}
+    if "idx_media_chat_type" not in existing_indexes:
+        op.create_index("idx_media_chat_type", "media", ["chat_id", "type"])
+
+
+def downgrade():
+    op.drop_index("idx_media_chat_type", table_name="media")

--- a/alembic/versions/20260523_012_add_media_chat_type_index.py
+++ b/alembic/versions/20260523_012_add_media_chat_type_index.py
@@ -24,4 +24,8 @@ def upgrade():
 
 
 def downgrade():
-    op.drop_index("idx_media_chat_type", table_name="media")
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_indexes = {idx["name"] for idx in inspector.get_indexes("media")}
+    if "idx_media_chat_type" in existing_indexes:
+        op.drop_index("idx_media_chat_type", table_name="media")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [7.10.0] - 2026-05-23
+
+### Added
+- **Media Gallery**: Dedicated per-chat media page with grid view for photos/videos, list view for voice messages and files
+- **Media API**: New endpoints `GET /api/chats/{id}/media` and `GET /api/chats/{id}/media/counts` for paginated media browsing
+- **Thumbnail pre-generation**: Thumbnails are now generated during backup for instant gallery loading
+- **Thumbnail concurrency limit**: Semaphore prevents memory exhaustion when loading large grids
+- **Database index**: New composite index `idx_media_chat_type(chat_id, type)` for efficient media type filtering
+
 ## [7.7.0] - 2026-04-29
 
 ### Security

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,6 +30,8 @@ For version history and changes, see [CHANGELOG.md](./CHANGELOG.md).
 
 ### Viewer Polish
 
+- [x] Media Gallery Phase 1+2 (grid view for photos/videos, list view for voice/files) — v7.10.0
+- [ ] Media Gallery Phase 3: Links tab (shared URLs extracted from messages)
 - [ ] Custom themes (light mode, OLED dark, Telegram classic)
 - [ ] Voice message player with waveform visualization
 - [ ] Keyboard shortcuts (j/k navigation, Esc to close, etc.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.9.0"
+version = "7.10.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -92,6 +92,15 @@ if has_tables and not has_alembic:
             CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)
         );
     \"\"\")
+    # Check artifact from migration 012: idx_media_chat_type index
+    cur.execute(\"\"\"
+        SELECT EXISTS (
+            SELECT FROM pg_indexes
+            WHERE indexname = 'idx_media_chat_type'
+        );
+    \"\"\")
+    has_012_index = cur.fetchone()[0]
+
     # Check artifact from migration 011: media.content_hash column
     cur.execute(\"\"\"
         SELECT EXISTS (
@@ -189,7 +198,9 @@ if has_tables and not has_alembic:
     has_push_subs = cur.fetchone()[0]
 
     # Determine which version to stamp based on existing schema
-    if has_011_content_hash:
+    if has_012_index:
+        stamp_version = '012'
+    elif has_011_content_hash:
         stamp_version = '011'
     elif has_010_all:
         stamp_version = '010'
@@ -275,6 +286,10 @@ if has_tables and not has_alembic:
         )
     ''')
 
+    # Check artifact from migration 012: idx_media_chat_type index
+    cur.execute(\"SELECT name FROM sqlite_master WHERE type='index' AND name='idx_media_chat_type'\")
+    has_012_index = cur.fetchone() is not None
+
     # Check artifact from migration 011: media.content_hash column
     cur.execute(\"PRAGMA table_info(media)\")
     media_columns = {row[1] for row in cur.fetchall()}
@@ -321,7 +336,9 @@ if has_tables and not has_alembic:
     has_push_subs = cur.fetchone() is not None
 
     # Determine which version to stamp based on existing schema
-    if has_011_content_hash:
+    if has_012_index:
+        stamp_version = '012'
+    elif has_011_content_hash:
         stamp_version = '011'
     elif has_010_all:
         stamp_version = '010'

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.9.0"
+__version__ = "7.10.0"

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -716,6 +716,100 @@ class DatabaseAdapter:
                 for m in media_records
             ]
 
+    async def get_media_paginated(
+        self,
+        chat_id: int,
+        media_types: list[str] | None = None,
+        limit: int = 50,
+        before_id: str | None = None,
+        sort_desc: bool = True,
+    ) -> dict[str, Any]:
+        """
+        Get paginated media records for a chat with cursor-based pagination.
+
+        Args:
+            chat_id: Chat identifier
+            media_types: Optional list of media types to filter by
+            limit: Maximum number of items to return
+            before_id: Cursor for pagination (media id to paginate from)
+            sort_desc: Sort by message date descending if True
+
+        Returns:
+            Dict with 'items' list and 'has_more' boolean
+        """
+        async with self.db_manager.async_session_factory() as session:
+            stmt = select(Media, Message.date, Message.sender_name).join(
+                Message,
+                and_(
+                    Media.message_id == Message.id,
+                    Media.chat_id == Message.chat_id,
+                ),
+            )
+            stmt = stmt.where(and_(Media.chat_id == chat_id, Media.downloaded == 1))
+
+            if media_types:
+                stmt = stmt.where(Media.type.in_(media_types))
+
+            if before_id:
+                cursor_stmt = select(Media.message_id).where(Media.id == before_id)
+                cursor_result = await session.execute(cursor_stmt)
+                cursor_message_id = cursor_result.scalar_one_or_none()
+                if cursor_message_id is not None:
+                    if sort_desc:
+                        stmt = stmt.where(Media.message_id < cursor_message_id)
+                    else:
+                        stmt = stmt.where(Media.message_id > cursor_message_id)
+
+            if sort_desc:
+                stmt = stmt.order_by(Message.date.desc())
+            else:
+                stmt = stmt.order_by(Message.date.asc())
+
+            stmt = stmt.limit(limit + 1)
+            result = await session.execute(stmt)
+            rows = result.all()
+
+            has_more = len(rows) > limit
+            items = [
+                {
+                    "id": media.id,
+                    "message_id": media.message_id,
+                    "chat_id": media.chat_id,
+                    "type": media.type,
+                    "file_path": media.file_path,
+                    "file_name": media.file_name,
+                    "file_size": media.file_size,
+                    "mime_type": media.mime_type,
+                    "width": media.width,
+                    "height": media.height,
+                    "duration": media.duration,
+                    "message_date": message_date.isoformat() if message_date else None,
+                    "sender_name": sender_name,
+                }
+                for media, message_date, sender_name in rows[:limit]
+            ]
+
+            return {"items": items, "has_more": has_more}
+
+    async def get_media_counts(self, chat_id: int) -> dict[str, int]:
+        """
+        Get count of downloaded media grouped by type for a chat.
+
+        Args:
+            chat_id: Chat identifier
+
+        Returns:
+            Dict mapping media type to count (only types with count > 0)
+        """
+        async with self.db_manager.async_session_factory() as session:
+            stmt = (
+                select(Media.type, func.count())
+                .where(and_(Media.chat_id == chat_id, Media.downloaded == 1))
+                .group_by(Media.type)
+            )
+            result = await session.execute(stmt)
+            return {row[0]: row[1] for row in result.all()}
+
     async def delete_media_for_chat(self, chat_id: int) -> int:
         """
         Delete all media records for a specific chat.

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -722,28 +722,23 @@ class DatabaseAdapter:
         media_types: list[str] | None = None,
         limit: int = 50,
         before_id: str | None = None,
-        sort_desc: bool = True,
     ) -> dict[str, Any]:
         """
         Get paginated media records for a chat with cursor-based pagination.
 
-        Args:
-            chat_id: Chat identifier
-            media_types: Optional list of media types to filter by
-            limit: Maximum number of items to return
-            before_id: Cursor for pagination (media id to paginate from)
-            sort_desc: Sort by message date descending if True
-
-        Returns:
-            Dict with 'items' list and 'has_more' boolean
+        Uses composite cursor (Message.date, Media.id) for deterministic ordering.
         """
         async with self.db_manager.async_session_factory() as session:
-            stmt = select(Media, Message.date, Message.sender_name).join(
-                Message,
-                and_(
-                    Media.message_id == Message.id,
-                    Media.chat_id == Message.chat_id,
-                ),
+            stmt = (
+                select(Media, Message.date, User.first_name, User.last_name)
+                .join(
+                    Message,
+                    and_(
+                        Media.message_id == Message.id,
+                        Media.chat_id == Message.chat_id,
+                    ),
+                )
+                .outerjoin(User, Message.sender_id == User.id)
             )
             stmt = stmt.where(and_(Media.chat_id == chat_id, Media.downloaded == 1))
 
@@ -751,20 +746,27 @@ class DatabaseAdapter:
                 stmt = stmt.where(Media.type.in_(media_types))
 
             if before_id:
-                cursor_stmt = select(Media.message_id).where(Media.id == before_id)
+                cursor_stmt = (
+                    select(Media.id, Message.date)
+                    .join(
+                        Message,
+                        and_(Media.message_id == Message.id, Media.chat_id == Message.chat_id),
+                    )
+                    .where(Media.id == before_id)
+                )
                 cursor_result = await session.execute(cursor_stmt)
-                cursor_message_id = cursor_result.scalar_one_or_none()
-                if cursor_message_id is not None:
-                    if sort_desc:
-                        stmt = stmt.where(Media.message_id < cursor_message_id)
-                    else:
-                        stmt = stmt.where(Media.message_id > cursor_message_id)
+                cursor_row = cursor_result.one_or_none()
+                if cursor_row is None:
+                    return {"items": [], "has_more": False}
+                cursor_media_id, cursor_date = cursor_row
+                stmt = stmt.where(
+                    or_(
+                        Message.date < cursor_date,
+                        and_(Message.date == cursor_date, Media.id < cursor_media_id),
+                    )
+                )
 
-            if sort_desc:
-                stmt = stmt.order_by(Message.date.desc())
-            else:
-                stmt = stmt.order_by(Message.date.asc())
-
+            stmt = stmt.order_by(Message.date.desc(), Media.id.desc())
             stmt = stmt.limit(limit + 1)
             result = await session.execute(stmt)
             rows = result.all()
@@ -783,10 +785,10 @@ class DatabaseAdapter:
                     "width": media.width,
                     "height": media.height,
                     "duration": media.duration,
-                    "message_date": message_date.isoformat() if message_date else None,
-                    "sender_name": sender_name,
+                    "message_date": msg_date.isoformat() if msg_date else None,
+                    "sender_name": f"{first_name or ''} {last_name or ''}".strip() or None,
                 }
-                for media, message_date, sender_name in rows[:limit]
+                for media, msg_date, first_name, last_name in rows[:limit]
             ]
 
             return {"items": items, "has_more": has_more}

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -182,6 +182,7 @@ class Media(Base):
         Index("idx_media_downloaded", "chat_id", "downloaded"),
         Index("idx_media_type", "type"),
         Index("idx_media_content_hash", "content_hash"),
+        Index("idx_media_chat_type", "chat_id", "type"),
     )
 
 

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -66,25 +66,32 @@ def _pre_generate_thumbnail(source_path: str, media_root: str) -> None:
 
         from PIL import Image
 
+        from src.web.thumbnails import (
+            _IMAGE_EXTENSIONS,
+            _MAX_SOURCE_BYTES,
+            WEBP_QUALITY,
+            _thumb_path,
+        )
+
+        Image.MAX_IMAGE_PIXELS = 50_000_000
+
         source = Path(source_path)
         if not source.exists():
             return
 
-        # Only for images
-        image_extensions = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff"}
-        if source.suffix.lower() not in image_extensions:
+        if source.suffix.lower() not in _IMAGE_EXTENSIONS:
             return
 
-        # Skip large files (>50MB)
-        if source.stat().st_size > 50 * 1024 * 1024:
+        if source.stat().st_size > _MAX_SOURCE_BYTES:
             return
 
-        # Determine thumbnail path: {media_root}/.thumbs/200/{folder}/{stem}.webp
         media_root_path = Path(media_root)
+        if not source.is_relative_to(media_root_path):
+            return
+
         rel = source.relative_to(media_root_path)
         folder = str(rel.parent)
-        stem = source.stem
-        dest = media_root_path / ".thumbs" / "200" / folder / f"{stem}.webp"
+        dest = _thumb_path(media_root_path, 200, folder, source.name)
 
         if dest.exists():
             return
@@ -92,9 +99,9 @@ def _pre_generate_thumbnail(source_path: str, media_root: str) -> None:
         dest.parent.mkdir(parents=True, exist_ok=True)
         with Image.open(source) as img:
             img.thumbnail((200, 200), Image.LANCZOS)
-            img.save(dest, "WEBP", quality=80)
+            img.save(dest, "WEBP", quality=WEBP_QUALITY)
     except Exception:
-        pass  # Non-critical, viewer will generate on-demand as fallback
+        pass
 
 
 async def call_with_flood_retry(coro_fn, *args, max_retries=MAX_FLOOD_RETRIES, **kwargs):

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -59,6 +59,44 @@ MAX_FLOOD_RETRIES = _get_int_env("MAX_FLOOD_RETRIES", 5)
 MAX_FLOOD_WAIT_SECONDS = _get_int_env("MAX_FLOOD_WAIT_SECONDS", 3600)
 
 
+def _pre_generate_thumbnail(source_path: str, media_root: str) -> None:
+    """Pre-generate 200px WebP thumbnail for gallery grid view."""
+    try:
+        from pathlib import Path
+
+        from PIL import Image
+
+        source = Path(source_path)
+        if not source.exists():
+            return
+
+        # Only for images
+        image_extensions = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff"}
+        if source.suffix.lower() not in image_extensions:
+            return
+
+        # Skip large files (>50MB)
+        if source.stat().st_size > 50 * 1024 * 1024:
+            return
+
+        # Determine thumbnail path: {media_root}/.thumbs/200/{folder}/{stem}.webp
+        media_root_path = Path(media_root)
+        rel = source.relative_to(media_root_path)
+        folder = str(rel.parent)
+        stem = source.stem
+        dest = media_root_path / ".thumbs" / "200" / folder / f"{stem}.webp"
+
+        if dest.exists():
+            return
+
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with Image.open(source) as img:
+            img.thumbnail((200, 200), Image.LANCZOS)
+            img.save(dest, "WEBP", quality=80)
+    except Exception:
+        pass  # Non-critical, viewer will generate on-demand as fallback
+
+
 async def call_with_flood_retry(coro_fn, *args, max_retries=MAX_FLOOD_RETRIES, **kwargs):
     """Retry a single async call on FloodWaitError with bounded sleep.
 
@@ -1679,6 +1717,12 @@ class TelegramBackup:
                         media_data["height"] = attr.h
                     if hasattr(attr, "duration"):
                         media_data["duration"] = attr.duration
+
+            # Pre-generate thumbnail for instant gallery loading
+            try:
+                _pre_generate_thumbnail(file_path, self.config.media_path)
+            except Exception:
+                pass  # Non-critical, viewer generates on-demand as fallback
 
             # Return media data - caller is responsible for inserting to database
             # (to ensure message exists before media FK constraint)

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1428,6 +1428,78 @@ async def get_pinned_messages(chat_id: int, user: UserContext = Depends(require_
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+@app.get("/api/chats/{chat_id}/media")
+async def get_chat_media(
+    chat_id: int,
+    types: str = Query(default=""),
+    limit: int = Query(default=50, ge=1, le=200),
+    before_id: str = Query(default=""),
+    sort: str = Query(default="desc"),
+    user: UserContext = Depends(require_auth),
+):
+    """Get paginated media items for a chat, with optional type filtering."""
+    allowed = get_user_chat_ids(user)
+    if allowed is not None and chat_id not in allowed:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    if not db:
+        raise HTTPException(status_code=503, detail="Database not available")
+
+    media_types = [t.strip() for t in types.split(",") if t.strip()] or None
+
+    try:
+        result = await db.get_media_paginated(
+            chat_id,
+            media_types=media_types,
+            limit=limit,
+            before_id=before_id or None,
+            sort_desc=(sort == "desc"),
+        )
+        for item in result["items"]:
+            file_path = item.get("file_path", "")
+            parts = file_path.split("/", 1)
+            if len(parts) == 2:
+                folder, filename = parts
+                item["thumb_url"] = f"/media/thumb/200/{folder}/{filename}"
+            else:
+                item["thumb_url"] = None
+
+            if user.no_download:
+                item.pop("file_path", None)
+            else:
+                item["media_url"] = f"/media/{file_path}"
+
+        return result
+    except Exception as e:
+        logger.error(f"Error fetching chat media: {e}", exc_info=True)
+        if _is_db_connection_error(e):
+            raise HTTPException(status_code=503, detail="Database temporarily unavailable")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
+@app.get("/api/chats/{chat_id}/media/counts")
+async def get_chat_media_counts(
+    chat_id: int,
+    user: UserContext = Depends(require_auth),
+):
+    """Get media type counts for a chat."""
+    allowed = get_user_chat_ids(user)
+    if allowed is not None and chat_id not in allowed:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    if not db:
+        raise HTTPException(status_code=503, detail="Database not available")
+
+    try:
+        counts = await db.get_media_counts(chat_id)
+        return counts
+    except Exception as e:
+        logger.error(f"Error fetching media counts: {e}", exc_info=True)
+        if _is_db_connection_error(e):
+            raise HTTPException(status_code=503, detail="Database temporarily unavailable")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
 @app.get("/api/folders")
 async def get_folders(user: UserContext = Depends(require_auth)):
     """Get all chat folders with their chat counts.

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1434,7 +1434,6 @@ async def get_chat_media(
     types: str = Query(default=""),
     limit: int = Query(default=50, ge=1, le=200),
     before_id: str = Query(default=""),
-    sort: str = Query(default="desc"),
     user: UserContext = Depends(require_auth),
 ):
     """Get paginated media items for a chat, with optional type filtering."""
@@ -1453,10 +1452,14 @@ async def get_chat_media(
             media_types=media_types,
             limit=limit,
             before_id=before_id or None,
-            sort_desc=(sort == "desc"),
         )
         for item in result["items"]:
             file_path = item.get("file_path", "")
+            if ".." in file_path.split("/") or file_path.startswith("/"):
+                item["thumb_url"] = None
+                item.pop("file_path", None)
+                continue
+
             parts = file_path.split("/", 1)
             if len(parts) == 2:
                 folder, filename = parts

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -758,6 +758,16 @@
                                 </svg>
                             </div>
 
+                            <!-- Media Gallery Button -->
+                            <button @click="showMediaGallery = true"
+                                class="p-1.5 sm:p-2 text-gray-400 hover:text-white rounded-lg hover:bg-white/10 transition shrink-0"
+                                title="Shared Media Gallery">
+                                <svg class="w-4 h-4 sm:w-5 sm:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                        d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"></path>
+                                </svg>
+                            </button>
+
                             <!-- Export Button - always visible -->
                             <button @click="exportChat"
                                 class="p-1.5 sm:p-2 text-gray-400 hover:text-white rounded-lg hover:bg-white/10 transition shrink-0"
@@ -827,7 +837,119 @@
                         </div>
                     </div>
 
+                    <!-- Media Gallery View (replaces message area when active) -->
+                    <template v-if="showMediaGallery">
+                    <div class="flex flex-col h-full flex-1 min-h-0">
+                        <!-- Header with back button -->
+                        <div class="flex items-center gap-3 px-4 py-3 border-b border-gray-700">
+                            <button @click="showMediaGallery = false" class="text-gray-400 hover:text-white">
+                                <i class="fas fa-arrow-left"></i>
+                            </button>
+                            <h3 class="text-white font-medium">Shared Media</h3>
+                        </div>
+
+                        <!-- Tab bar -->
+                        <div class="flex gap-1 px-4 py-2 border-b border-gray-700">
+                            <button v-for="tab in mediaTabs" :key="tab.id"
+                                @click="switchMediaTab(tab.id)"
+                                :class="mediaGalleryTab === tab.id ? 'bg-blue-600 text-white' : 'bg-gray-700/50 text-gray-400 hover:text-white'"
+                                class="px-3 py-1.5 rounded-lg text-sm font-medium transition">
+                                {{ tab.label }}
+                                <span v-if="mediaGalleryCounts[tab.id]" class="ml-1 text-xs opacity-75">
+                                    ({{ mediaGalleryCounts[tab.id] }})
+                                </span>
+                            </button>
+                        </div>
+
+                        <!-- Content area -->
+                        <div class="flex-1 overflow-y-auto p-2">
+                            <!-- Loading state -->
+                            <div v-if="mediaGalleryLoading && mediaGalleryItems.length === 0" class="grid grid-cols-3 md:grid-cols-4 gap-1">
+                                <div v-for="i in 12" :key="i" class="aspect-square bg-gray-700 rounded animate-pulse"></div>
+                            </div>
+
+                            <!-- Photos/Videos Grid -->
+                            <template v-if="mediaGalleryTab === 'photos'">
+                                <div class="grid grid-cols-3 md:grid-cols-4 gap-1">
+                                    <div v-for="item in mediaGalleryItems" :key="item.id"
+                                        @click="openMediaItem(item)"
+                                        class="aspect-square relative cursor-pointer group overflow-hidden rounded">
+                                        <img :src="item.thumb_url" :alt="item.file_name"
+                                            class="w-full h-full object-cover" loading="lazy" decoding="async">
+                                        <!-- Video overlay -->
+                                        <div v-if="item.type === 'video' || item.type === 'animation'"
+                                            class="absolute bottom-1 left-1 bg-black/70 text-white text-xs px-1 rounded">
+                                            <i class="fas fa-play text-[10px] mr-0.5"></i>
+                                            {{ formatDuration(item.duration) }}
+                                        </div>
+                                        <!-- Hover overlay -->
+                                        <div class="absolute inset-0 bg-black/0 group-hover:bg-black/20 transition"></div>
+                                    </div>
+                                </div>
+                            </template>
+
+                            <!-- Voice/Audio List -->
+                            <template v-else-if="mediaGalleryTab === 'voice'">
+                                <div class="space-y-1">
+                                    <div v-for="item in mediaGalleryItems" :key="item.id"
+                                        class="flex items-center gap-3 p-3 rounded-lg bg-gray-800/50 hover:bg-gray-700/50 cursor-pointer"
+                                        @click="jumpToMessage(item)">
+                                        <div class="w-10 h-10 rounded-full bg-blue-600 flex items-center justify-center flex-shrink-0">
+                                            <i class="fas fa-play text-white text-sm"></i>
+                                        </div>
+                                        <div class="flex-1 min-w-0">
+                                            <div class="text-sm text-white">{{ item.sender_name || 'Unknown' }}</div>
+                                            <div class="text-xs text-gray-400">{{ formatDuration(item.duration) }}</div>
+                                        </div>
+                                        <div class="text-xs text-gray-500">{{ formatMediaDate(item.message_date) }}</div>
+                                    </div>
+                                </div>
+                            </template>
+
+                            <!-- Files List -->
+                            <template v-else-if="mediaGalleryTab === 'files'">
+                                <div class="space-y-1">
+                                    <div v-for="item in mediaGalleryItems" :key="item.id"
+                                        class="flex items-center gap-3 p-3 rounded-lg bg-gray-800/50 hover:bg-gray-700/50">
+                                        <div class="w-10 h-10 rounded-lg bg-gray-700 flex items-center justify-center flex-shrink-0">
+                                            <i class="fas fa-file text-gray-400"></i>
+                                        </div>
+                                        <div class="flex-1 min-w-0">
+                                            <div class="text-sm text-white truncate">{{ item.file_name }}</div>
+                                            <div class="text-xs text-gray-400">{{ formatFileSize(item.file_size) }} &middot; {{ formatMediaDate(item.message_date) }}</div>
+                                        </div>
+                                        <div class="flex items-center gap-2">
+                                            <button v-if="item.media_url && !noDownload" @click.stop="downloadMedia(item)"
+                                                class="text-gray-400 hover:text-white p-1">
+                                                <i class="fas fa-download"></i>
+                                            </button>
+                                            <button @click.stop="jumpToMessage(item)" class="text-gray-400 hover:text-white p-1" title="Go to message">
+                                                <i class="fas fa-crosshairs"></i>
+                                            </button>
+                                        </div>
+                                    </div>
+                                </div>
+                            </template>
+
+                            <!-- Empty state -->
+                            <div v-if="!mediaGalleryLoading && mediaGalleryItems.length === 0" class="flex flex-col items-center justify-center py-20 text-gray-500">
+                                <i class="fas fa-photo-film text-4xl mb-3"></i>
+                                <p>No media found</p>
+                            </div>
+
+                            <!-- Load more -->
+                            <div v-if="mediaGalleryHasMore && mediaGalleryItems.length > 0" class="flex justify-center py-4">
+                                <button @click="loadMoreMedia" :disabled="mediaGalleryLoading"
+                                    class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg text-sm disabled:opacity-50">
+                                    {{ mediaGalleryLoading ? 'Loading...' : 'Load more' }}
+                                </button>
+                            </div>
+                        </div>
+                    </div>
+                    </template>
+
                     <!-- Messages - uses flex-col-reverse for instant scroll-to-bottom -->
+                    <template v-else>
                     <div class="flex-1 relative min-h-0">
                     <div ref="messagesContainer" class="h-full overflow-y-auto p-4 flex flex-col-reverse gap-1 messages-scroll" @scroll="handleScroll">
                         <div v-if="loading && messages.length === 0" class="text-center py-4 text-tg-muted">
@@ -1102,6 +1224,7 @@
                         </svg>
                     </button>
                     </div>
+                    </template>
                 </template>
             </div>
         </div>
@@ -1756,6 +1879,7 @@
                     pinnedMessages.value = []
                     currentPinnedIndex.value = 0
                     showPinnedOnly.value = false
+                    showMediaGallery.value = false
                     await loadMessages()
                     if (chatVersion !== myVersion) return
                     await loadChatStats(chat.id)
@@ -2489,6 +2613,154 @@
                     showAdminPanel.value = false
                 }
 
+                // Media Gallery methods (v7.10.0)
+                const loadMediaGallery = async (append = false) => {
+                    if (!selectedChat.value) return
+                    mediaGalleryLoading.value = true
+                    try {
+                        const typeMap = {
+                            photos: 'photo,video,animation',
+                            voice: 'voice,audio',
+                            files: 'document',
+                        }
+                        const types = typeMap[mediaGalleryTab.value] || ''
+                        const lastItem = append && mediaGalleryItems.value.length > 0
+                            ? mediaGalleryItems.value[mediaGalleryItems.value.length - 1]
+                            : null
+                        const params = new URLSearchParams({
+                            types,
+                            limit: '50',
+                        })
+                        if (lastItem) params.set('before_id', lastItem.id)
+
+                        const res = await fetch(`/api/chats/${selectedChat.value.id}/media?${params}`, {
+                            credentials: 'include'
+                        })
+                        if (!res.ok) throw new Error('Failed to load media')
+                        const data = await res.json()
+                        if (append) {
+                            mediaGalleryItems.value.push(...data.items)
+                        } else {
+                            mediaGalleryItems.value = data.items
+                        }
+                        mediaGalleryHasMore.value = data.has_more
+                    } catch (e) {
+                        console.error('Failed to load media gallery:', e)
+                    } finally {
+                        mediaGalleryLoading.value = false
+                    }
+                }
+
+                const loadMediaCounts = async () => {
+                    if (!selectedChat.value) return
+                    try {
+                        const res = await fetch(`/api/chats/${selectedChat.value.id}/media/counts`, {
+                            credentials: 'include'
+                        })
+                        if (res.ok) {
+                            const data = await res.json()
+                            mediaGalleryCounts.value = {
+                                photos: (data.photo || 0) + (data.video || 0) + (data.animation || 0),
+                                voice: (data.voice || 0) + (data.audio || 0),
+                                files: data.document || 0,
+                            }
+                        }
+                    } catch (e) {
+                        console.error('Failed to load media counts:', e)
+                    }
+                }
+
+                const switchMediaTab = (tabId) => {
+                    mediaGalleryTab.value = tabId
+                    mediaGalleryItems.value = []
+                    mediaGalleryHasMore.value = true
+                    loadMediaGallery()
+                }
+
+                const loadMoreMedia = () => {
+                    loadMediaGallery(true)
+                }
+
+                const openMediaItem = (item) => {
+                    if (item.type === 'photo' || item.type === 'video' || item.type === 'animation') {
+                        // Open in lightbox — reuse existing lightbox infrastructure
+                        const mediaList = mediaGalleryItems.value.filter(m =>
+                            m.type === 'photo' || m.type === 'video' || m.type === 'animation'
+                        )
+                        const idx = mediaList.indexOf(item)
+                        // Map to the format the existing lightbox expects
+                        lightboxMedia.value = mediaList.map(m => ({
+                            media: {
+                                type: m.type,
+                                file_path: m.file_path,
+                                file_name: m.file_name,
+                                width: m.width,
+                                height: m.height,
+                                mime_type: m.mime_type,
+                            },
+                            id: m.message_id,
+                        }))
+                        lightboxIndex.value = idx >= 0 ? idx : 0
+                        lightboxOpen.value = true
+                    }
+                }
+
+                const jumpToMessage = async (item) => {
+                    showMediaGallery.value = false
+                    await loadMessagesAroundId(item.message_id)
+                }
+
+                const downloadMedia = (item) => {
+                    if (item.media_url) {
+                        window.open(item.media_url + '?download=1', '_blank')
+                    }
+                }
+
+                const formatDuration = (seconds) => {
+                    if (!seconds) return '0:00'
+                    const m = Math.floor(seconds / 60)
+                    const s = seconds % 60
+                    return `${m}:${s.toString().padStart(2, '0')}`
+                }
+
+                const formatMediaDate = (dateStr) => {
+                    if (!dateStr) return ''
+                    const d = new Date(dateStr)
+                    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
+                }
+
+                const formatFileSize = (bytes) => {
+                    if (!bytes) return ''
+                    if (bytes < 1024) return bytes + ' B'
+                    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB'
+                    return (bytes / (1024 * 1024)).toFixed(1) + ' MB'
+                }
+
+                const loadMessagesAroundId = async (messageId) => {
+                    if (!selectedChat.value) return
+                    const res = await fetch(`/api/chats/${selectedChat.value.id}/messages?before_id=${messageId + 1}&limit=50`, {
+                        credentials: 'include'
+                    })
+                    if (res.ok) {
+                        const data = await res.json()
+                        messages.value = data.messages || data
+                        await nextTick()
+                        const el = document.querySelector(`[data-msg-id="${messageId}"]`)
+                        if (el) {
+                            el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                            el.classList.add('bg-yellow-500/10')
+                            setTimeout(() => el.classList.remove('bg-yellow-500/10'), 2000)
+                        }
+                    }
+                }
+
+                watch(showMediaGallery, (val) => {
+                    if (val) {
+                        loadMediaGallery()
+                        loadMediaCounts()
+                    }
+                })
+
                 const filteredChats = computed(() => {
                     // If searching, use server-side search results
                     if (searchQuery.value.trim()) {
@@ -2589,6 +2861,20 @@
                 const currentPinnedIndex = ref(0)  // Which pinned message is currently shown in banner
                 const showPinnedOnly = ref(false)  // Whether we're in "pinned messages only" view
 
+                // Media Gallery state (v7.10.0)
+                const showMediaGallery = ref(false)
+                const mediaGalleryTab = ref('photos')
+                const mediaGalleryItems = ref([])
+                const mediaGalleryLoading = ref(false)
+                const mediaGalleryHasMore = ref(true)
+                const mediaGalleryCounts = ref({})
+
+                const mediaTabs = [
+                    { id: 'photos', label: 'Photos & Videos' },
+                    { id: 'voice', label: 'Voice' },
+                    { id: 'files', label: 'Files' },
+                ]
+
                 // Computed: current pinned message to display in banner
                 const pinnedMessage = computed(() => {
                     if (pinnedMessages.value.length === 0) return null
@@ -2678,6 +2964,7 @@
                     pinnedMessages.value = []  // Reset pinned messages when changing chat
                     currentPinnedIndex.value = 0
                     showPinnedOnly.value = false  // Exit pinned-only view when changing chat
+                    showMediaGallery.value = false  // Exit media gallery when changing chat
                     await loadMessages()
                     if (chatVersion !== myVersion) return  // Another chat was selected, abort
                     await loadChatStats(chat.id)  // Load stats for this chat
@@ -3690,6 +3977,25 @@
                     handlePinnedClick,
                     openPinnedView,
                     closePinnedView,
+                    // Media Gallery (v7.10.0)
+                    showMediaGallery,
+                    mediaGalleryTab,
+                    mediaGalleryItems,
+                    mediaGalleryLoading,
+                    mediaGalleryHasMore,
+                    mediaGalleryCounts,
+                    mediaTabs,
+                    loadMediaGallery,
+                    loadMediaCounts,
+                    switchMediaTab,
+                    loadMoreMedia,
+                    openMediaItem,
+                    jumpToMessage,
+                    downloadMedia,
+                    formatDuration,
+                    formatMediaDate,
+                    formatFileSize,
+                    loadMessagesAroundId,
                     searchMessages,
                     isOwnMessage,
                     getSenderName,

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -2616,6 +2616,7 @@
                 // Media Gallery methods (v7.10.0)
                 const loadMediaGallery = async (append = false) => {
                     if (!selectedChat.value) return
+                    if (mediaGalleryLoading.value) return
                     mediaGalleryLoading.value = true
                     try {
                         const typeMap = {

--- a/src/web/thumbnails.py
+++ b/src/web/thumbnails.py
@@ -22,6 +22,9 @@ _MAX_SOURCE_BYTES = 50 * 1024 * 1024  # 50 MB
 
 _IMAGE_EXTENSIONS: set[str] = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff"}
 
+# Limit concurrent thumbnail generations to cap peak memory (~15MB per decode)
+_generation_semaphore = asyncio.Semaphore(8)
+
 
 def _is_image(filename: str) -> bool:
     return Path(filename).suffix.lower() in _IMAGE_EXTENSIONS
@@ -78,6 +81,7 @@ async def ensure_thumbnail(media_root: Path, size: int, folder: str, filename: s
     if not source.exists():
         return None
 
-    loop = asyncio.get_running_loop()
-    ok = await loop.run_in_executor(None, _generate_sync, source, dest, size)
+    async with _generation_semaphore:
+        loop = asyncio.get_running_loop()
+        ok = await loop.run_in_executor(None, _generate_sync, source, dest, size)
     return dest if ok else None

--- a/tests/test_media_adapter.py
+++ b/tests/test_media_adapter.py
@@ -1,0 +1,263 @@
+"""Integration tests for media gallery adapter methods (get_media_paginated, get_media_counts).
+
+Uses real in-memory SQLite to exercise the actual SQL queries.
+"""
+
+import os
+import sys
+from datetime import datetime
+
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Base, Chat, Media, Message, User
+
+
+@pytest_asyncio.fixture
+async def adapter():
+    """In-memory SQLite with seeded media data."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db_manager = DatabaseManager.__new__(DatabaseManager)
+    db_manager.engine = engine
+    db_manager.database_url = "sqlite+aiosqlite://"
+    db_manager._is_sqlite = True
+    db_manager.async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    chat_id = -1001
+
+    async with db_manager.async_session_factory() as session:
+        session.add(Chat(id=chat_id, type="channel", title="Test Chat"))
+        session.add(User(id=100, first_name="Alice", last_name="Smith", username="alice"))
+        session.add(User(id=200, first_name="Bob", last_name=None, username="bob"))
+
+        # Messages with different dates
+        session.add(Message(id=1, chat_id=chat_id, sender_id=100, date=datetime(2026, 1, 1, 10), text="photo msg"))
+        session.add(Message(id=2, chat_id=chat_id, sender_id=100, date=datetime(2026, 1, 2, 10), text="album msg"))
+        session.add(Message(id=3, chat_id=chat_id, sender_id=200, date=datetime(2026, 1, 3, 10), text="video msg"))
+        session.add(Message(id=4, chat_id=chat_id, sender_id=None, date=datetime(2026, 1, 4, 10), text="channel post"))
+
+        # Media items — including album (multiple media per message)
+        session.add(
+            Media(
+                id="photo_1",
+                message_id=1,
+                chat_id=chat_id,
+                type="photo",
+                file_path="-1001/photo_1.jpg",
+                file_name="photo_1.jpg",
+                file_size=100000,
+                mime_type="image/jpeg",
+                width=1920,
+                height=1080,
+                downloaded=1,
+            )
+        )
+        session.add(
+            Media(
+                id="photo_2a",
+                message_id=2,
+                chat_id=chat_id,
+                type="photo",
+                file_path="-1001/photo_2a.jpg",
+                file_name="photo_2a.jpg",
+                file_size=200000,
+                mime_type="image/jpeg",
+                width=1920,
+                height=1080,
+                downloaded=1,
+            )
+        )
+        session.add(
+            Media(
+                id="photo_2b",
+                message_id=2,
+                chat_id=chat_id,
+                type="photo",
+                file_path="-1001/photo_2b.jpg",
+                file_name="photo_2b.jpg",
+                file_size=150000,
+                mime_type="image/jpeg",
+                width=1920,
+                height=1080,
+                downloaded=1,
+            )
+        )
+        session.add(
+            Media(
+                id="video_3",
+                message_id=3,
+                chat_id=chat_id,
+                type="video",
+                file_path="-1001/video_3.mp4",
+                file_name="video_3.mp4",
+                file_size=5000000,
+                mime_type="video/mp4",
+                width=1280,
+                height=720,
+                duration=30,
+                downloaded=1,
+            )
+        )
+        session.add(
+            Media(
+                id="doc_4",
+                message_id=4,
+                chat_id=chat_id,
+                type="document",
+                file_path="-1001/report.pdf",
+                file_name="report.pdf",
+                file_size=50000,
+                mime_type="application/pdf",
+                downloaded=1,
+            )
+        )
+        # Undownloaded media — should not appear
+        session.add(
+            Media(
+                id="photo_hidden",
+                message_id=1,
+                chat_id=chat_id,
+                type="photo",
+                file_path=None,
+                file_name=None,
+                file_size=None,
+                mime_type="image/jpeg",
+                downloaded=0,
+            )
+        )
+        await session.commit()
+
+    db_adapter = DatabaseAdapter(db_manager)
+    return db_adapter
+
+
+class TestGetMediaPaginated:
+    """Tests for get_media_paginated with real SQLite."""
+
+    async def test_returns_all_downloaded_media(self, adapter):
+        result = await adapter.get_media_paginated(-1001)
+        assert len(result["items"]) == 5
+        assert result["has_more"] is False
+
+    async def test_excludes_undownloaded_media(self, adapter):
+        result = await adapter.get_media_paginated(-1001)
+        ids = [item["id"] for item in result["items"]]
+        assert "photo_hidden" not in ids
+
+    async def test_filters_by_media_type(self, adapter):
+        result = await adapter.get_media_paginated(-1001, media_types=["photo"])
+        assert len(result["items"]) == 3
+        for item in result["items"]:
+            assert item["type"] == "photo"
+
+    async def test_filters_multiple_types(self, adapter):
+        result = await adapter.get_media_paginated(-1001, media_types=["photo", "video"])
+        assert len(result["items"]) == 4
+        types = {item["type"] for item in result["items"]}
+        assert types == {"photo", "video"}
+
+    async def test_orders_by_date_desc(self, adapter):
+        result = await adapter.get_media_paginated(-1001)
+        dates = [item["message_date"] for item in result["items"]]
+        assert dates == sorted(dates, reverse=True)
+
+    async def test_resolves_sender_name_from_user(self, adapter):
+        result = await adapter.get_media_paginated(-1001, media_types=["photo"])
+        # All photos belong to message_id 1 or 2, sender_id=100 (Alice Smith)
+        for item in result["items"]:
+            assert item["sender_name"] == "Alice Smith"
+
+    async def test_sender_name_without_last_name(self, adapter):
+        result = await adapter.get_media_paginated(-1001, media_types=["video"])
+        assert result["items"][0]["sender_name"] == "Bob"
+
+    async def test_sender_name_null_for_no_user(self, adapter):
+        result = await adapter.get_media_paginated(-1001, media_types=["document"])
+        assert result["items"][0]["sender_name"] is None
+
+    async def test_limit_works(self, adapter):
+        result = await adapter.get_media_paginated(-1001, limit=2)
+        assert len(result["items"]) == 2
+        assert result["has_more"] is True
+
+    async def test_cursor_pagination_no_duplicates(self, adapter):
+        """Fetching page 1 then page 2 returns all items with no overlap."""
+        page1 = await adapter.get_media_paginated(-1001, limit=3)
+        assert len(page1["items"]) == 3
+        assert page1["has_more"] is True
+
+        last_id = page1["items"][-1]["id"]
+        page2 = await adapter.get_media_paginated(-1001, limit=3, before_id=last_id)
+
+        all_ids = [item["id"] for item in page1["items"]] + [item["id"] for item in page2["items"]]
+        assert len(all_ids) == len(set(all_ids)), "Duplicate items across pages"
+        assert len(all_ids) == 5
+
+    async def test_cursor_with_album_messages(self, adapter):
+        """Album messages (multiple media per message_id) paginate correctly."""
+        # Get page with limit=1 starting from newest
+        page1 = await adapter.get_media_paginated(-1001, limit=1)
+        page2 = await adapter.get_media_paginated(-1001, limit=1, before_id=page1["items"][0]["id"])
+        page3 = await adapter.get_media_paginated(-1001, limit=1, before_id=page2["items"][0]["id"])
+
+        ids = [page1["items"][0]["id"], page2["items"][0]["id"], page3["items"][0]["id"]]
+        assert len(ids) == len(set(ids)), "Duplicate items when paginating through album"
+
+    async def test_cursor_not_found_returns_empty(self, adapter):
+        result = await adapter.get_media_paginated(-1001, before_id="nonexistent_id")
+        assert result["items"] == []
+        assert result["has_more"] is False
+
+    async def test_empty_chat_returns_empty(self, adapter):
+        result = await adapter.get_media_paginated(-9999)
+        assert result["items"] == []
+        assert result["has_more"] is False
+
+    async def test_item_fields_complete(self, adapter):
+        result = await adapter.get_media_paginated(-1001, media_types=["video"])
+        item = result["items"][0]
+        assert item["id"] == "video_3"
+        assert item["message_id"] == 3
+        assert item["chat_id"] == -1001
+        assert item["type"] == "video"
+        assert item["file_path"] == "-1001/video_3.mp4"
+        assert item["file_name"] == "video_3.mp4"
+        assert item["file_size"] == 5000000
+        assert item["mime_type"] == "video/mp4"
+        assert item["width"] == 1280
+        assert item["height"] == 720
+        assert item["duration"] == 30
+        assert item["message_date"] is not None
+        assert item["sender_name"] == "Bob"
+
+
+class TestGetMediaCounts:
+    """Tests for get_media_counts with real SQLite."""
+
+    async def test_returns_counts_by_type(self, adapter):
+        counts = await adapter.get_media_counts(-1001)
+        assert counts["photo"] == 3
+        assert counts["video"] == 1
+        assert counts["document"] == 1
+
+    async def test_excludes_undownloaded(self, adapter):
+        counts = await adapter.get_media_counts(-1001)
+        total = sum(counts.values())
+        assert total == 5  # not 6 (excludes the undownloaded one)
+
+    async def test_empty_chat_returns_empty_dict(self, adapter):
+        counts = await adapter.get_media_counts(-9999)
+        assert counts == {}

--- a/tests/test_media_page.py
+++ b/tests/test_media_page.py
@@ -1,0 +1,309 @@
+"""Integration tests for media gallery endpoints (v7.10.0)."""
+
+import json
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _reset_auth_module():
+    """Reset auth module state between tests."""
+    import src.web.main as main_mod
+
+    main_mod._sessions.clear()
+    main_mod._login_attempts.clear()
+    yield
+    main_mod._sessions.clear()
+    main_mod._login_attempts.clear()
+
+
+def _make_mock_db():
+    db = AsyncMock()
+    db.get_all_chats = AsyncMock(
+        return_value=[
+            {"id": -1001, "title": "Chat A", "type": "channel"},
+        ]
+    )
+    db.get_chat_count = AsyncMock(return_value=1)
+    db.get_cached_statistics = AsyncMock(return_value={"total_chats": 1})
+    db.get_metadata = AsyncMock(return_value=None)
+    db.get_viewer_by_username = AsyncMock(return_value=None)
+    db.get_viewer_account = AsyncMock(return_value=None)
+    db.get_all_viewer_accounts = AsyncMock(return_value=[])
+    db.create_audit_log = AsyncMock()
+    db.get_all_folders = AsyncMock(return_value=[])
+    db.get_archived_chat_count = AsyncMock(return_value=0)
+    db.get_session = AsyncMock(return_value=None)
+    db.save_session = AsyncMock()
+    db.delete_session = AsyncMock()
+    # Media-specific mocks
+    db.get_media_paginated = AsyncMock(
+        return_value=[
+            {
+                "id": "file_abc123",
+                "message_id": 100,
+                "chat_id": -1001,
+                "type": "photo",
+                "file_path": "-1001/photo_123.jpg",
+                "file_name": "photo_123.jpg",
+                "file_size": 245000,
+                "mime_type": "image/jpeg",
+                "width": 1920,
+                "height": 1080,
+                "duration": None,
+                "message_date": "2026-01-15T10:30:00",
+                "sender_name": "TestUser",
+            },
+        ]
+    )
+    db.get_media_counts = AsyncMock(
+        return_value={
+            "photo": 10,
+            "video": 5,
+            "animation": 2,
+            "voice": 3,
+            "document": 8,
+        }
+    )
+    return db
+
+
+@pytest.fixture
+def auth_env():
+    with patch.dict(
+        os.environ,
+        {
+            "VIEWER_USERNAME": "admin",
+            "VIEWER_PASSWORD": "testpass123",
+            "AUTH_SESSION_DAYS": "1",
+            "SECURE_COOKIES": "false",
+        },
+    ):
+        yield
+
+
+@pytest.fixture
+def anon_env():
+    with patch.dict(
+        os.environ,
+        {
+            "VIEWER_USERNAME": "",
+            "VIEWER_PASSWORD": "",
+            "ALLOW_ANONYMOUS_VIEWER": "true",
+        },
+    ):
+        yield
+
+
+def _get_client(mock_db=None):
+    """Create a fresh TestClient by reloading the module with current env."""
+    import importlib
+
+    import src.web.main as main_mod
+
+    importlib.reload(main_mod)
+
+    if mock_db is None:
+        mock_db = _make_mock_db()
+    main_mod.db = mock_db
+
+    return TestClient(main_mod.app, raise_server_exceptions=False), main_mod, mock_db
+
+
+def _login(client, username="admin", password="testpass123"):
+    """Helper to login and get authenticated client."""
+    resp = client.post("/api/login", json={"username": username, "password": password})
+    assert resp.status_code == 200
+    return client
+
+
+class TestMediaEndpointAuth:
+    """Tests for media endpoint authentication requirements."""
+
+    def test_requires_authentication(self, auth_env):
+        client, _, _ = _get_client()
+        resp = client.get("/api/chats/-1001/media")
+        assert resp.status_code == 401
+
+    def test_works_when_authenticated(self, auth_env):
+        client, _, _ = _get_client()
+        login_resp = client.post("/api/login", json={"username": "admin", "password": "testpass123"})
+        cookie = login_resp.cookies.get("viewer_auth")
+        resp = client.get("/api/chats/-1001/media", cookies={"viewer_auth": cookie})
+        assert resp.status_code == 200
+
+    def test_works_anonymous_mode(self, anon_env):
+        client, _, _ = _get_client()
+        resp = client.get("/api/chats/-1001/media")
+        assert resp.status_code == 200
+
+
+class TestMediaPaginated:
+    """Tests for paginated media list endpoint."""
+
+    def test_returns_media_items(self, anon_env):
+        client, _, mock_db = _get_client()
+        resp = client.get("/api/chats/-1001/media")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert isinstance(data, list)
+        assert len(data) == 1
+        assert data[0]["id"] == "file_abc123"
+
+    def test_passes_types_filter(self, anon_env):
+        client, _, mock_db = _get_client()
+        client.get("/api/chats/-1001/media?types=photo,video")
+        mock_db.get_media_paginated.assert_called_once_with(
+            -1001,
+            media_types=["photo", "video"],
+            limit=50,
+            before_id=None,
+            sort_desc=True,
+        )
+
+    def test_passes_limit(self, anon_env):
+        client, _, mock_db = _get_client()
+        client.get("/api/chats/-1001/media?limit=20")
+        mock_db.get_media_paginated.assert_called_once_with(
+            -1001,
+            media_types=None,
+            limit=20,
+            before_id=None,
+            sort_desc=True,
+        )
+
+    def test_passes_before_id(self, anon_env):
+        client, _, mock_db = _get_client()
+        client.get("/api/chats/-1001/media?before_id=abc")
+        mock_db.get_media_paginated.assert_called_once_with(
+            -1001,
+            media_types=None,
+            limit=50,
+            before_id="abc",
+            sort_desc=True,
+        )
+
+    def test_empty_types_means_all(self, anon_env):
+        client, _, mock_db = _get_client()
+        client.get("/api/chats/-1001/media")
+        mock_db.get_media_paginated.assert_called_once_with(
+            -1001,
+            media_types=None,
+            limit=50,
+            before_id=None,
+            sort_desc=True,
+        )
+
+    def test_items_include_thumb_url(self, anon_env):
+        client, _, _ = _get_client()
+        resp = client.get("/api/chats/-1001/media")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data[0]["thumb_url"] == "/media/thumb/200/-1001/photo_123.jpg"
+
+    def test_no_download_strips_media_url(self, auth_env):
+        import src.web.main as main_mod
+
+        mock_db = _make_mock_db()
+        salt = "abc123"
+        pw_hash = main_mod._hash_password("vpass", salt)
+        mock_db.get_viewer_by_username = AsyncMock(
+            return_value={
+                "id": 1,
+                "username": "restricted",
+                "password_hash": pw_hash,
+                "salt": salt,
+                "allowed_chat_ids": json.dumps([-1001]),
+                "is_active": 1,
+                "no_download": 1,
+                "created_by": "admin",
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+            }
+        )
+        client, _, _ = _get_client(mock_db)
+
+        login_resp = client.post("/api/login", json={"username": "restricted", "password": "vpass"})
+        cookie = login_resp.cookies.get("viewer_auth")
+        resp = client.get("/api/chats/-1001/media", cookies={"viewer_auth": cookie})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "media_url" not in data[0]
+        assert "file_path" not in data[0]
+
+
+class TestMediaCounts:
+    """Tests for media type counts endpoint."""
+
+    def test_returns_counts(self, anon_env):
+        client, _, _ = _get_client()
+        resp = client.get("/api/chats/-1001/media/counts")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["photo"] == 10
+        assert data["video"] == 5
+        assert data["animation"] == 2
+        assert data["voice"] == 3
+        assert data["document"] == 8
+
+    def test_forbidden_for_restricted_user(self, auth_env):
+        import src.web.main as main_mod
+
+        mock_db = _make_mock_db()
+        salt = "abc123"
+        pw_hash = main_mod._hash_password("vpass", salt)
+        mock_db.get_viewer_by_username = AsyncMock(
+            return_value={
+                "id": 1,
+                "username": "restricted",
+                "password_hash": pw_hash,
+                "salt": salt,
+                "allowed_chat_ids": json.dumps([-1002]),
+                "is_active": 1,
+                "created_by": "admin",
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+            }
+        )
+        client, _, _ = _get_client(mock_db)
+
+        login_resp = client.post("/api/login", json={"username": "restricted", "password": "vpass"})
+        cookie = login_resp.cookies.get("viewer_auth")
+        resp = client.get("/api/chats/-1001/media/counts", cookies={"viewer_auth": cookie})
+        assert resp.status_code == 403
+
+
+class TestMediaACL:
+    """Tests for media access control list enforcement."""
+
+    def test_forbidden_chat_returns_403(self, auth_env):
+        import src.web.main as main_mod
+
+        mock_db = _make_mock_db()
+        salt = "abc123"
+        pw_hash = main_mod._hash_password("vpass", salt)
+        mock_db.get_viewer_by_username = AsyncMock(
+            return_value={
+                "id": 1,
+                "username": "restricted",
+                "password_hash": pw_hash,
+                "salt": salt,
+                "allowed_chat_ids": json.dumps([-1002]),
+                "is_active": 1,
+                "created_by": "admin",
+                "created_at": "2026-01-01T00:00:00",
+                "updated_at": "2026-01-01T00:00:00",
+            }
+        )
+        client, _, _ = _get_client(mock_db)
+
+        login_resp = client.post("/api/login", json={"username": "restricted", "password": "vpass"})
+        cookie = login_resp.cookies.get("viewer_auth")
+        resp = client.get("/api/chats/-1001/media", cookies={"viewer_auth": cookie})
+        assert resp.status_code == 403

--- a/tests/test_media_page.py
+++ b/tests/test_media_page.py
@@ -44,23 +44,26 @@ def _make_mock_db():
     db.delete_session = AsyncMock()
     # Media-specific mocks
     db.get_media_paginated = AsyncMock(
-        return_value=[
-            {
-                "id": "file_abc123",
-                "message_id": 100,
-                "chat_id": -1001,
-                "type": "photo",
-                "file_path": "-1001/photo_123.jpg",
-                "file_name": "photo_123.jpg",
-                "file_size": 245000,
-                "mime_type": "image/jpeg",
-                "width": 1920,
-                "height": 1080,
-                "duration": None,
-                "message_date": "2026-01-15T10:30:00",
-                "sender_name": "TestUser",
-            },
-        ]
+        return_value={
+            "items": [
+                {
+                    "id": "file_abc123",
+                    "message_id": 100,
+                    "chat_id": -1001,
+                    "type": "photo",
+                    "file_path": "-1001/photo_123.jpg",
+                    "file_name": "photo_123.jpg",
+                    "file_size": 245000,
+                    "mime_type": "image/jpeg",
+                    "width": 1920,
+                    "height": 1080,
+                    "duration": None,
+                    "message_date": "2026-01-15T10:30:00",
+                    "sender_name": "TestUser",
+                },
+            ],
+            "has_more": False,
+        }
     )
     db.get_media_counts = AsyncMock(
         return_value={
@@ -152,9 +155,10 @@ class TestMediaPaginated:
         resp = client.get("/api/chats/-1001/media")
         assert resp.status_code == 200
         data = resp.json()
-        assert isinstance(data, list)
-        assert len(data) == 1
-        assert data[0]["id"] == "file_abc123"
+        assert "items" in data
+        assert "has_more" in data
+        assert len(data["items"]) == 1
+        assert data["items"][0]["id"] == "file_abc123"
 
     def test_passes_types_filter(self, anon_env):
         client, _, mock_db = _get_client()
@@ -205,7 +209,7 @@ class TestMediaPaginated:
         resp = client.get("/api/chats/-1001/media")
         assert resp.status_code == 200
         data = resp.json()
-        assert data[0]["thumb_url"] == "/media/thumb/200/-1001/photo_123.jpg"
+        assert data["items"][0]["thumb_url"] == "/media/thumb/200/-1001/photo_123.jpg"
 
     def test_no_download_strips_media_url(self, auth_env):
         import src.web.main as main_mod
@@ -234,8 +238,8 @@ class TestMediaPaginated:
         resp = client.get("/api/chats/-1001/media", cookies={"viewer_auth": cookie})
         assert resp.status_code == 200
         data = resp.json()
-        assert "media_url" not in data[0]
-        assert "file_path" not in data[0]
+        assert "media_url" not in data["items"][0]
+        assert "file_path" not in data["items"][0]
 
 
 class TestMediaCounts:

--- a/tests/test_media_page.py
+++ b/tests/test_media_page.py
@@ -283,6 +283,79 @@ class TestMediaCounts:
         assert resp.status_code == 403
 
 
+class TestMediaPathValidation:
+    """Tests for path traversal protection and URL generation."""
+
+    def test_traversal_path_gets_null_thumb_url(self, anon_env):
+        mock_db = _make_mock_db()
+        mock_db.get_media_paginated = AsyncMock(
+            return_value={
+                "items": [
+                    {
+                        "id": "file_evil",
+                        "message_id": 1,
+                        "chat_id": -1001,
+                        "type": "photo",
+                        "file_path": "../../../etc/passwd",
+                        "file_name": "passwd",
+                        "file_size": 100,
+                        "mime_type": "image/jpeg",
+                        "width": 100,
+                        "height": 100,
+                        "duration": None,
+                        "message_date": "2026-01-01T00:00:00",
+                        "sender_name": "Attacker",
+                    },
+                ],
+                "has_more": False,
+            }
+        )
+        client, _, _ = _get_client(mock_db)
+        resp = client.get("/api/chats/-1001/media")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["items"][0]["thumb_url"] is None
+        assert "file_path" not in data["items"][0]
+
+    def test_absolute_path_gets_null_thumb_url(self, anon_env):
+        mock_db = _make_mock_db()
+        mock_db.get_media_paginated = AsyncMock(
+            return_value={
+                "items": [
+                    {
+                        "id": "file_abs",
+                        "message_id": 2,
+                        "chat_id": -1001,
+                        "type": "photo",
+                        "file_path": "/etc/shadow",
+                        "file_name": "shadow",
+                        "file_size": 100,
+                        "mime_type": "text/plain",
+                        "width": None,
+                        "height": None,
+                        "duration": None,
+                        "message_date": "2026-01-01T00:00:00",
+                        "sender_name": None,
+                    },
+                ],
+                "has_more": False,
+            }
+        )
+        client, _, _ = _get_client(mock_db)
+        resp = client.get("/api/chats/-1001/media")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["items"][0]["thumb_url"] is None
+        assert "file_path" not in data["items"][0]
+
+    def test_valid_path_includes_media_url(self, anon_env):
+        client, _, _ = _get_client()
+        resp = client.get("/api/chats/-1001/media")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["items"][0]["media_url"] == "/media/-1001/photo_123.jpg"
+
+
 class TestMediaACL:
     """Tests for media access control list enforcement."""
 

--- a/tests/test_media_page.py
+++ b/tests/test_media_page.py
@@ -162,46 +162,46 @@ class TestMediaPaginated:
 
     def test_passes_types_filter(self, anon_env):
         client, _, mock_db = _get_client()
-        client.get("/api/chats/-1001/media?types=photo,video")
+        resp = client.get("/api/chats/-1001/media?types=photo,video")
+        assert resp.status_code == 200
         mock_db.get_media_paginated.assert_called_once_with(
             -1001,
             media_types=["photo", "video"],
             limit=50,
             before_id=None,
-            sort_desc=True,
         )
 
     def test_passes_limit(self, anon_env):
         client, _, mock_db = _get_client()
-        client.get("/api/chats/-1001/media?limit=20")
+        resp = client.get("/api/chats/-1001/media?limit=20")
+        assert resp.status_code == 200
         mock_db.get_media_paginated.assert_called_once_with(
             -1001,
             media_types=None,
             limit=20,
             before_id=None,
-            sort_desc=True,
         )
 
     def test_passes_before_id(self, anon_env):
         client, _, mock_db = _get_client()
-        client.get("/api/chats/-1001/media?before_id=abc")
+        resp = client.get("/api/chats/-1001/media?before_id=abc")
+        assert resp.status_code == 200
         mock_db.get_media_paginated.assert_called_once_with(
             -1001,
             media_types=None,
             limit=50,
             before_id="abc",
-            sort_desc=True,
         )
 
     def test_empty_types_means_all(self, anon_env):
         client, _, mock_db = _get_client()
-        client.get("/api/chats/-1001/media")
+        resp = client.get("/api/chats/-1001/media")
+        assert resp.status_code == 200
         mock_db.get_media_paginated.assert_called_once_with(
             -1001,
             media_types=None,
             limit=50,
             before_id=None,
-            sort_desc=True,
         )
 
     def test_items_include_thumb_url(self, anon_env):

--- a/tests/test_pre_generate_thumbnail.py
+++ b/tests/test_pre_generate_thumbnail.py
@@ -1,0 +1,122 @@
+"""Tests for _pre_generate_thumbnail in telegram_backup.py."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from PIL import Image as PILImage
+
+from src.telegram_backup import _pre_generate_thumbnail
+
+
+class TestPreGenerateThumbnail(unittest.TestCase):
+    """Test pre-generation of thumbnails during backup."""
+
+    def _make_image(self, path: Path, size=(300, 300)):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        img = PILImage.new("RGB", size, "red")
+        img.save(path)
+
+    def test_generates_thumbnail_for_valid_image(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            source = media_root / "chat1" / "photo.jpg"
+            self._make_image(source)
+
+            _pre_generate_thumbnail(str(source), str(media_root))
+
+            dest = media_root / ".thumbs" / "200" / "chat1" / "photo.webp"
+            self.assertTrue(dest.exists())
+            with PILImage.open(dest) as thumb:
+                self.assertEqual(thumb.format, "WEBP")
+                self.assertLessEqual(thumb.width, 200)
+                self.assertLessEqual(thumb.height, 200)
+
+    def test_skips_non_image_extension(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            source = media_root / "chat1" / "document.pdf"
+            source.parent.mkdir(parents=True)
+            source.write_text("not an image")
+
+            _pre_generate_thumbnail(str(source), str(media_root))
+
+            dest = media_root / ".thumbs" / "200" / "chat1" / "document.webp"
+            self.assertFalse(dest.exists())
+
+    def test_skips_nonexistent_source(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            _pre_generate_thumbnail(str(media_root / "missing.jpg"), str(media_root))
+            # Should not raise, just return silently
+
+    def test_skips_file_exceeding_size_limit(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            source = media_root / "chat1" / "huge.jpg"
+            self._make_image(source)
+
+            from unittest.mock import MagicMock, patch
+
+            with patch("pathlib.Path.stat") as mock_stat:
+                mock_stat.return_value = MagicMock(st_size=51 * 1024 * 1024)
+                _pre_generate_thumbnail(str(source), str(media_root))
+
+            dest = media_root / ".thumbs" / "200" / "chat1" / "huge.webp"
+            self.assertFalse(dest.exists())
+
+    def test_skips_source_outside_media_root(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir) / "media"
+            media_root.mkdir()
+            outside = Path(tmpdir) / "outside" / "photo.jpg"
+            self._make_image(outside)
+
+            _pre_generate_thumbnail(str(outside), str(media_root))
+
+            # No thumbnail generated anywhere under media_root
+            thumbs_dir = media_root / ".thumbs"
+            self.assertFalse(thumbs_dir.exists())
+
+    def test_skips_if_thumbnail_already_exists(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            source = media_root / "chat1" / "photo.png"
+            self._make_image(source)
+
+            dest = media_root / ".thumbs" / "200" / "chat1" / "photo.webp"
+            dest.parent.mkdir(parents=True)
+            dest.write_text("existing")
+
+            _pre_generate_thumbnail(str(source), str(media_root))
+
+            # Should not overwrite
+            self.assertEqual(dest.read_text(), "existing")
+
+    def test_handles_nested_folder_structure(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            source = media_root / "deep" / "nested" / "dir" / "img.png"
+            self._make_image(source)
+
+            _pre_generate_thumbnail(str(source), str(media_root))
+
+            dest = media_root / ".thumbs" / "200" / "deep" / "nested" / "dir" / "img.webp"
+            self.assertTrue(dest.exists())
+
+    def test_handles_corrupt_image_gracefully(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            source = media_root / "chat1" / "corrupt.jpg"
+            source.parent.mkdir(parents=True)
+            source.write_bytes(b"not a valid image file content")
+
+            # Should not raise
+            _pre_generate_thumbnail(str(source), str(media_root))
+
+            dest = media_root / ".thumbs" / "200" / "chat1" / "corrupt.webp"
+            self.assertFalse(dest.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds a dedicated media page per chat (grid icon in chat header) with tabs for Photos/Videos, Voice/Audio, and Files
- New API endpoints for paginated media browsing with type filtering and cursor-based pagination
- Thumbnail pre-generation during backup for instant gallery loading
- Memory-safe concurrent thumbnail generation via semaphore
- Alembic migration for composite index `(chat_id, type)` enabling efficient media queries

## Configuration

No new env vars required. The feature works out of the box with existing installations.

## Architecture

- **Backend**: `GET /api/chats/{id}/media?types=photo,video&limit=50&before_id=X` + `GET /api/chats/{id}/media/counts`
- **DB**: New `get_media_paginated` (cursor pagination via message_id) + `get_media_counts` (GROUP BY type)
- **Frontend**: New gallery view using `showMediaGallery` state (same pattern as pinned messages toggle)
- **Thumbnails**: Pre-generated at 200px during backup + Semaphore(8) for cold-cache protection

## Deferred (Phase 3)

- Links tab (requires URL extraction pipeline + new table, planned for v8.x/v9.x)
- Virtual scrolling for extreme chats (10K+ media, documented in roadmap)

## Test plan

- [ ] CI passes (lint + tests + CodeQL)
- [ ] Photos/videos grid loads with thumbnails
- [ ] Voice messages tab shows list with duration
- [ ] Files tab shows list with size and download button
- [ ] Tab badges show correct counts
- [ ] "Jump to message" navigates to source message
- [ ] Per-user ACL enforced (restricted users can't access other chats' media)
- [ ] Lightbox opens from photo grid
- [ ] Pagination ("Load more") works
- [ ] Gallery resets on chat change
- [ ] no_download users don't see download buttons or media URLs

Closes #160