### PR TITLE
fix: strip media root prefix from absolute file_path in media endpoint

### DIFF
--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1454,7 +1454,16 @@ async def get_chat_media(
             before_id=before_id or None,
         )
         for item in result["items"]:
-            file_path = item.get("file_path", "")
+            file_path = item.get("file_path", "") or ""
+            # Strip media root prefix for absolute paths stored in DB
+            if _media_root and file_path.startswith("/"):
+                media_root_str = str(_media_root) + "/"
+                if file_path.startswith(media_root_str):
+                    file_path = file_path[len(media_root_str) :]
+                else:
+                    item["thumb_url"] = None
+                    item.pop("file_path", None)
+                    continue
             if ".." in file_path.split("/") or file_path.startswith("/"):
                 item["thumb_url"] = None
                 item.pop("file_path", None)


### PR DESCRIPTION
## Summary
- Production DB stores `file_path` as absolute (`/data/backups/media/...`) which triggers the path traversal guard introduced in #162
- This strips the `_media_root` prefix before validation, producing relative paths for URL construction
- Fixes media gallery showing null `thumb_url` and `media_url` for all items

## Test plan
- [x] Verified on production viewer at srcanario.geiser.cloud
- [x] `get_media_counts` already worked (doesn't use file_path)
- [x] Path traversal protection remains active for truly malicious paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced media file path processing to more reliably validate and handle files, ensuring that invalid or missing path entries are gracefully filtered and don't interfere with media retrieval across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/Telegram-Archive/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->