### PR TITLE
fix(viewer): prevent 'Authentication is disabled' flash on load

### DIFF
--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -287,7 +287,7 @@
                 <p class="text-sm text-amber-200 mb-8 text-center" v-else-if="authCheckFailed">
                     ⚠️ Could not verify authentication. Try opening in your browser instead of in-app.
                 </p>
-                <p class="text-sm text-blue-100 mb-8 text-center" v-else>
+                <p class="text-sm text-blue-100 mb-8 text-center" v-else-if="!loadingAuth">
                     Authentication is disabled
                 </p>
 


### PR DESCRIPTION
## Summary
- Before the `/api/auth/check` call resolves, `authRequired` is `false` and `authCheckFailed` is `false`, so the `v-else` branch briefly flashes "Authentication is disabled"
- Fix: gate the message with `!loadingAuth` so it only shows after auth check completes and confirms auth is truly disabled
- Pre-existing bug, not introduced by v7.10.0

## Test plan
- [x] Load page with auth enabled — should show "Sign in to access your backup" (no flash)
- [x] Load page with auth disabled — should show "Authentication is disabled" after check resolves