### PR TITLE
fix(viewer): remove auth disabled flash message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.10.4"
+version = "7.10.5"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.10.4"
+__version__ = "7.10.5"

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -272,7 +272,7 @@
 </head>
 
 <body class="bg-gradient-to-br from-blue-600 via-blue-700 to-blue-800 text-white h-screen overflow-hidden">
-    <div id="app" v-cloak class="w-full h-full">
+    <div id="app" v-cloak class="w-full h-full" hidden>
         <!-- Login Page -->
         <div v-if="!isAuthenticated" class="w-full h-full flex items-center justify-center">
             <div
@@ -285,14 +285,17 @@
                 </div>
 
                 <h1 class="text-3xl font-bold mb-2 text-center text-white">Telegram Archive</h1>
-                <p class="text-sm text-blue-100 mb-8 text-center" v-if="authRequired">
+                <div v-if="loadingAuth" class="flex justify-center mb-8">
+                    <svg class="w-6 h-6 animate-spin text-blue-200" fill="none" viewBox="0 0 24 24">
+                        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+                    </svg>
+                </div>
+                <p class="text-sm text-blue-100 mb-8 text-center" v-else-if="authRequired">
                     Sign in to access your backup
                 </p>
                 <p class="text-sm text-amber-200 mb-8 text-center" v-else-if="authCheckFailed">
                     ⚠️ Could not verify authentication. Try opening in your browser instead of in-app.
-                </p>
-                <p class="text-sm text-blue-100 mb-8 text-center" v-else-if="!loadingAuth">
-                    Authentication is disabled
                 </p>
 
                 <form @submit.prevent="performLogin" class="space-y-5" v-if="authRequired || authCheckFailed">
@@ -4160,6 +4163,7 @@
                 }
             }
         }).mount('#app')
+        document.getElementById('app').removeAttribute('hidden')
     </script>
 </body>
 


### PR DESCRIPTION
## Summary
- Removes the "Authentication is disabled" text from the login page entirely — it had no valid production use case
- Replaces with a loading spinner while the auth check is in-flight
- Root cause: Chrome DevTools Protocol testing confirmed Vue renders this text when `/api/auth/check` fetch hasn't resolved or fails — there is no server state where this message is correct

## Root Cause Analysis
Using Chrome headless `--dump-dom` and CDP `Runtime.evaluate`, confirmed:
1. Vue mounts successfully (`data-v-app=""` present)
2. The `hidden` attribute is properly removed after mount
3. But the fetch to `/api/auth/check` inside the browser either hasn't resolved yet or fails silently
4. This leaves `authRequired=false, authCheckFailed=false, loadingAuth=false` — triggering the `v-else-if="!loadingAuth"` branch

The message was a dead-end with no valid path:
- Auth disabled + anonymous → auto-authenticated, never sees login page
- Auth enabled → "Sign in" shows
- Auth check fails → "Could not verify" shows

## Test plan
- [ ] CI passes (lint + tests)
- [ ] Deploy v7.10.5 to annais viewer, verify login page shows spinner then "Sign in"
- [ ] Deploy to sergio viewer, same verification
- [ ] Confirm "Authentication is disabled" never appears in any browser