### PR TITLE
fix(web): fix lightbox black screen and add video thumbnails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ FROM python:3.14-slim
 # Set working directory
 WORKDIR /app
 
-# Install system dependencies
+# Install system dependencies (ffmpeg for video thumbnail extraction)
 RUN apt-get update && apt-get install -y \
     gcc \
+    ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv for fast, reproducible dependency installation

--- a/alembic/versions/20260524_013_fix_media_file_paths.py
+++ b/alembic/versions/20260524_013_fix_media_file_paths.py
@@ -23,7 +23,9 @@ down_revision = "012"
 branch_labels = None
 depends_on = None
 
-_BATCH_SIZE = 5000
+# Can't import from src.web.media_utils in migrations (different runtime context)
+# Define locally to keep migration self-contained
+_CHANNEL_ID_OFFSET = 1_000_000_000_000
 
 
 def _derive_stale_folder(chat_id: int) -> str | None:
@@ -36,71 +38,46 @@ def _derive_stale_folder(chat_id: int) -> str | None:
     if chat_id >= 0:
         return None
     raw = -chat_id
-    if raw > 1000000000000:
-        return str(raw - 1000000000000)
+    if raw > _CHANNEL_ID_OFFSET:
+        return str(raw - _CHANNEL_ID_OFFSET)
     return str(raw)
 
 
 def upgrade():
     conn = op.get_bind()
-    dialect = conn.dialect.name
 
-    if dialect == "postgresql":
-        # Get all distinct negative chat_ids that have media
-        result = conn.execute(sa.text("SELECT DISTINCT chat_id FROM media WHERE chat_id < 0 AND file_path IS NOT NULL"))
-        chat_ids = [row[0] for row in result]
+    # Get all distinct negative chat_ids that have media
+    result = conn.execute(sa.text("SELECT DISTINCT chat_id FROM media WHERE chat_id < 0 AND file_path IS NOT NULL"))
+    chat_ids = [row[0] for row in result]
 
-        for chat_id in chat_ids:
-            stale_folder = _derive_stale_folder(chat_id)
-            if stale_folder is None:
-                continue
-            correct_folder = str(chat_id)
+    for chat_id in chat_ids:
+        stale_folder = _derive_stale_folder(chat_id)
+        if stale_folder is None:
+            continue
+        correct_folder = str(chat_id)
 
-            # Only update rows where file_path contains the stale folder
-            # Use pattern: .../<stale_folder>/... → .../<correct_folder>/...
-            stale_pattern = f"%/{stale_folder}/%"
-            conn.execute(
-                sa.text(
-                    "UPDATE media SET file_path = REPLACE(file_path, :old_seg, :new_seg) "
-                    "WHERE chat_id = :cid AND file_path LIKE :pattern"
-                ),
-                {
-                    "old_seg": f"/{stale_folder}/",
-                    "new_seg": f"/{correct_folder}/",
-                    "cid": chat_id,
-                    "pattern": stale_pattern,
-                },
-            )
-
-    elif dialect == "sqlite":
-        result = conn.execute(sa.text("SELECT DISTINCT chat_id FROM media WHERE chat_id < 0 AND file_path IS NOT NULL"))
-        chat_ids = [row[0] for row in result]
-
-        for chat_id in chat_ids:
-            stale_folder = _derive_stale_folder(chat_id)
-            if stale_folder is None:
-                continue
-            correct_folder = str(chat_id)
-
-            stale_pattern = f"%/{stale_folder}/%"
-            conn.execute(
-                sa.text(
-                    "UPDATE media SET file_path = REPLACE(file_path, :old_seg, :new_seg) "
-                    "WHERE chat_id = :cid AND file_path LIKE :pattern"
-                ),
-                {
-                    "old_seg": f"/{stale_folder}/",
-                    "new_seg": f"/{correct_folder}/",
-                    "cid": chat_id,
-                    "pattern": stale_pattern,
-                },
-            )
+        # Only update rows where file_path contains the stale folder
+        # Use pattern: .../<stale_folder>/... → .../<correct_folder>/...
+        stale_pattern = f"%/{stale_folder}/%"
+        conn.execute(
+            sa.text(
+                "UPDATE media SET file_path = REPLACE(file_path, :old_seg, :new_seg) "
+                "WHERE chat_id = :cid AND file_path LIKE :pattern"
+            ),
+            {
+                "old_seg": f"/{stale_folder}/",
+                "new_seg": f"/{correct_folder}/",
+                "cid": chat_id,
+                "pattern": stale_pattern,
+            },
+        )
 
 
 def downgrade():
-    # Reversible: swap the folder components back
+    # WARNING: This reverses ALL negative-folder paths to positive, including rows
+    # created after the upgrade. This is intentional — old code expects positive
+    # folders in file_path. The runtime fallback handles disk resolution.
     conn = op.get_bind()
-    dialect = conn.dialect.name
 
     result = conn.execute(sa.text("SELECT DISTINCT chat_id FROM media WHERE chat_id < 0 AND file_path IS NOT NULL"))
     chat_ids = [row[0] for row in result]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.10.15"
+version = "7.11.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.10.14"
+version = "7.10.15"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -93,15 +93,24 @@ if has_tables and not has_alembic:
         );
     \"\"\")
     # Check artifact from migration 013: file_path values use negative chat_id folders
-    # If any media row for a negative chat_id has a correctly-negative folder, 013 has run
+    # Guard: media table may not exist on very old databases
     cur.execute(\"\"\"
         SELECT EXISTS (
-            SELECT 1 FROM media
-            WHERE chat_id < 0 AND file_path LIKE '%/' || CAST(chat_id AS TEXT) || '/%'
-            LIMIT 1
+            SELECT FROM information_schema.tables
+            WHERE table_name = 'media'
         );
     \"\"\")
-    has_013_paths = cur.fetchone()[0]
+    has_media_table = cur.fetchone()[0]
+    has_013_paths = False
+    if has_media_table:
+        cur.execute(\"\"\"
+            SELECT EXISTS (
+                SELECT 1 FROM media
+                WHERE chat_id < 0 AND file_path LIKE '%/' || CAST(chat_id AS TEXT) || '/%'
+                LIMIT 1
+            );
+        \"\"\")
+        has_013_paths = cur.fetchone()[0]
 
     # Check artifact from migration 012: idx_media_chat_type index
     cur.execute(\"\"\"
@@ -300,8 +309,13 @@ if has_tables and not has_alembic:
     ''')
 
     # Check artifact from migration 013: file_path values use negative chat_id folders
-    cur.execute(\"SELECT EXISTS(SELECT 1 FROM media WHERE chat_id < 0 AND file_path LIKE '%/' || CAST(chat_id AS TEXT) || '/%' LIMIT 1)\")
-    has_013_paths = cur.fetchone()[0]
+    # Guard: media table may not exist on very old databases
+    cur.execute(\"SELECT name FROM sqlite_master WHERE type='table' AND name='media'\")
+    has_media_table = cur.fetchone() is not None
+    has_013_paths = False
+    if has_media_table:
+        cur.execute(\"SELECT EXISTS(SELECT 1 FROM media WHERE chat_id < 0 AND file_path LIKE '%/' || CAST(chat_id AS TEXT) || '/%' LIMIT 1)\")
+        has_013_paths = cur.fetchone()[0]
 
     # Check artifact from migration 012: idx_media_chat_type index
     cur.execute(\"SELECT name FROM sqlite_master WHERE type='index' AND name='idx_media_chat_type'\")

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.10.15"
+__version__ = "7.11.0"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.10.14"
+__version__ = "7.10.15"

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -823,7 +823,7 @@ def _enforce_media_acl(path: str, user: UserContext, *, thumbnail: bool = False)
     if media_chat_id not in user_chat_ids:
         # Legacy fallback: positive folder may correspond to negative marked ID
         if media_chat_id > 0 and any(mid in user_chat_ids for mid in legacy_marked_chat_ids(media_chat_id)):
-            logger.debug("ACL legacy grant: positive folder %d mapped to allowed chat", media_chat_id)
+            logger.debug("ACL legacy grant: positive folder mapped to allowed chat via marked-ID convention")
         else:
             raise HTTPException(status_code=403, detail="Access denied")
 
@@ -886,18 +886,18 @@ async def serve_thumbnail(size: int, folder: str, filename: str, user: UserConte
     if user.no_download and not folder.startswith("avatars/"):
         raise HTTPException(status_code=403, detail="Downloads disabled for this account")
 
-    # Chat-level access check
-    _enforce_media_acl(f"{folder}/{filename}", user, thumbnail=True)
-
     from .thumbnails import ensure_thumbnail, resolve_cache_dir
 
     global _thumb_cache_dir
     if _thumb_cache_dir is None:
         _thumb_cache_dir = resolve_cache_dir(_media_root)
 
-    thumb_path = await ensure_thumbnail(_media_root, size, folder, filename, cache_dir=_thumb_cache_dir)
-    if not thumb_path:
+    result = await ensure_thumbnail(_media_root, size, folder, filename, cache_dir=_thumb_cache_dir)
+    if not result:
         raise HTTPException(status_code=404, detail="Thumbnail not available")
+
+    thumb_path, resolved_folder = result
+    _enforce_media_acl(f"{resolved_folder}/{filename}", user, thumbnail=True)
 
     return FileResponse(thumb_path, media_type="image/webp", headers={"Cache-Control": "public, max-age=86400"})
 
@@ -933,7 +933,7 @@ async def serve_media(path: str, download: int = Query(0), user: UserContext = D
             for alt in alt_folders:
                 try:
                     resolved = (_media_root / alt / rest).resolve(strict=True)
-                    logger.debug("Legacy fallback: served %s via alt folder %s", path, alt)
+                    logger.debug("Legacy fallback: served media via alternate folder resolution")
                     break
                 except OSError, ValueError, RuntimeError:
                     continue
@@ -942,9 +942,7 @@ async def serve_media(path: str, download: int = Query(0), user: UserContext = D
     if not resolved.is_relative_to(_media_root):
         raise HTTPException(status_code=403, detail="Access denied")
 
-    resolved_relative = resolved.relative_to(_media_root)
-    resolved_folder = str(resolved_relative.parts[0])
-    _enforce_media_acl(f"{resolved_folder}/{'/'.join(str(p) for p in resolved_relative.parts[1:])}", user)
+    _enforce_media_acl(str(resolved.relative_to(_media_root)), user)
 
     if not resolved.is_file():
         raise HTTPException(status_code=404, detail="File not found")

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1505,7 +1505,22 @@ async def get_chat_media(
             if len(parts) == 2:
                 folder, filename = parts
                 ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
-                if ext in ("jpg", "jpeg", "png", "gif", "webp", "bmp", "tiff"):
+                if ext in (
+                    "jpg",
+                    "jpeg",
+                    "png",
+                    "gif",
+                    "webp",
+                    "bmp",
+                    "tiff",
+                    "mp4",
+                    "mkv",
+                    "avi",
+                    "mov",
+                    "webm",
+                    "m4v",
+                    "3gp",
+                ):
                     item["thumb_url"] = f"/media/thumb/200/{folder}/{filename}"
                 else:
                     item["thumb_url"] = None

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -31,7 +31,7 @@ from fastapi.staticfiles import StaticFiles
 from ..config import Config
 from ..db import DatabaseAdapter, close_database, get_db_manager, init_database
 from ..realtime import RealtimeListener
-from .media_utils import legacy_folder_alternates, legacy_marked_chat_ids
+from .media_utils import THUMBNAIL_EXTENSIONS, legacy_folder_alternates, legacy_marked_chat_ids
 
 if TYPE_CHECKING:
     from .push import PushNotificationManager
@@ -1505,22 +1505,7 @@ async def get_chat_media(
             if len(parts) == 2:
                 folder, filename = parts
                 ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
-                if ext in (
-                    "jpg",
-                    "jpeg",
-                    "png",
-                    "gif",
-                    "webp",
-                    "bmp",
-                    "tiff",
-                    "mp4",
-                    "mkv",
-                    "avi",
-                    "mov",
-                    "webm",
-                    "m4v",
-                    "3gp",
-                ):
+                if ext in THUMBNAIL_EXTENSIONS:
                     item["thumb_url"] = f"/media/thumb/200/{folder}/{filename}"
                 else:
                     item["thumb_url"] = None

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -31,6 +31,7 @@ from fastapi.staticfiles import StaticFiles
 from ..config import Config
 from ..db import DatabaseAdapter, close_database, get_db_manager, init_database
 from ..realtime import RealtimeListener
+from .media_utils import legacy_folder_alternates, legacy_marked_chat_ids
 
 if TYPE_CHECKING:
     from .push import PushNotificationManager
@@ -821,8 +822,8 @@ def _enforce_media_acl(path: str, user: UserContext, *, thumbnail: bool = False)
         raise HTTPException(status_code=403, detail="Access denied")
     if media_chat_id not in user_chat_ids:
         # Legacy fallback: positive folder may correspond to negative marked ID
-        if media_chat_id > 0 and (-media_chat_id in user_chat_ids or -(1000000000000 + media_chat_id) in user_chat_ids):
-            pass
+        if media_chat_id > 0 and any(mid in user_chat_ids for mid in legacy_marked_chat_ids(media_chat_id)):
+            logger.debug("ACL legacy grant: positive folder %d mapped to allowed chat", media_chat_id)
         else:
             raise HTTPException(status_code=403, detail="Access denied")
 
@@ -928,23 +929,22 @@ async def serve_media(path: str, download: int = Query(0), user: UserContext = D
         resolved = None
         if len(parts) == 2:
             folder, rest = parts
-            alt_folders = []
-            if not folder.startswith("-"):
-                alt_folders = [f"-{folder}", f"-100{folder}"]
-            else:
-                alt_folders = [folder[1:]]
+            alt_folders = legacy_folder_alternates(folder)
             for alt in alt_folders:
                 try:
                     resolved = (_media_root / alt / rest).resolve(strict=True)
+                    logger.debug("Legacy fallback: served %s via alt folder %s", path, alt)
                     break
-                except OSError, ValueError:
+                except OSError, ValueError, RuntimeError:
                     continue
         if resolved is None:
             raise HTTPException(status_code=404, detail="File not found")
     if not resolved.is_relative_to(_media_root):
         raise HTTPException(status_code=403, detail="Access denied")
 
-    _enforce_media_acl(path, user)
+    resolved_relative = resolved.relative_to(_media_root)
+    resolved_folder = str(resolved_relative.parts[0])
+    _enforce_media_acl(f"{resolved_folder}/{'/'.join(str(p) for p in resolved_relative.parts[1:])}", user)
 
     if not resolved.is_file():
         raise HTTPException(status_code=404, detail="File not found")

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -886,6 +886,9 @@ async def serve_thumbnail(size: int, folder: str, filename: str, user: UserConte
     if user.no_download and not folder.startswith("avatars/"):
         raise HTTPException(status_code=403, detail="Downloads disabled for this account")
 
+    # Early ACL check on requested path (prevents existence leakage)
+    _enforce_media_acl(f"{folder}/{filename}", user, thumbnail=True)
+
     from .thumbnails import ensure_thumbnail, resolve_cache_dir
 
     global _thumb_cache_dir
@@ -897,7 +900,9 @@ async def serve_thumbnail(size: int, folder: str, filename: str, user: UserConte
         raise HTTPException(status_code=404, detail="Thumbnail not available")
 
     thumb_path, resolved_folder = result
-    _enforce_media_acl(f"{resolved_folder}/{filename}", user, thumbnail=True)
+    # Secondary ACL on resolved path if it differs (prevents bypass via legacy fallback)
+    if resolved_folder != folder:
+        _enforce_media_acl(f"{resolved_folder}/{filename}", user, thumbnail=True)
 
     return FileResponse(thumb_path, media_type="image/webp", headers={"Cache-Control": "public, max-age=86400"})
 

--- a/src/web/media_utils.py
+++ b/src/web/media_utils.py
@@ -17,10 +17,13 @@ def legacy_folder_alternates(folder: str) -> list[str]:
         "-1234567890"    → ["1234567890"]           (basic group)
         "-1001234567890" → ["1234567890"]           (channel)
     """
-    if not folder.startswith("-"):
+    try:
+        if not folder.startswith("-"):
+            folder_int = int(folder)
+            return [f"-{folder}", str(-(CHANNEL_ID_OFFSET + folder_int))]
         folder_int = int(folder)
-        return [f"-{folder}", str(-(CHANNEL_ID_OFFSET + folder_int))]
-    folder_int = int(folder)
+    except ValueError:
+        return []
     raw = -folder_int
     if raw > CHANNEL_ID_OFFSET:
         return [str(raw - CHANNEL_ID_OFFSET)]

--- a/src/web/media_utils.py
+++ b/src/web/media_utils.py
@@ -20,6 +20,8 @@ def legacy_folder_alternates(folder: str) -> list[str]:
     try:
         if not folder.startswith("-"):
             folder_int = int(folder)
+            if folder_int <= 0:
+                return []
             return [f"-{folder}", str(-(CHANNEL_ID_OFFSET + folder_int))]
         folder_int = int(folder)
     except ValueError:

--- a/src/web/media_utils.py
+++ b/src/web/media_utils.py
@@ -6,6 +6,10 @@ and used consistently across serve_media, thumbnails, and ACL checks.
 
 CHANNEL_ID_OFFSET: int = 1_000_000_000_000
 
+IMAGE_EXTENSIONS: set[str] = {"jpg", "jpeg", "png", "gif", "webp", "bmp", "tiff"}
+VIDEO_EXTENSIONS: set[str] = {"mp4", "mkv", "avi", "mov", "webm", "m4v", "3gp"}
+THUMBNAIL_EXTENSIONS: set[str] = IMAGE_EXTENSIONS | VIDEO_EXTENSIONS
+
 
 def legacy_folder_alternates(folder: str) -> list[str]:
     """Return alternate folder names for legacy positive/negative ID paths.
@@ -47,6 +51,8 @@ def derive_stale_folder(chat_id: int) -> str | None:
     Basic groups: chat_id = -X  →  old folder = "X"
     Channels:     chat_id = -(10^12 + X)  →  old folder = "X"
     Users:        chat_id > 0  →  no mismatch possible, return None
+
+    Used by migration 013 and tests (not imported at web runtime).
     """
     if chat_id >= 0:
         return None

--- a/src/web/media_utils.py
+++ b/src/web/media_utils.py
@@ -1,0 +1,51 @@
+"""Shared utilities for legacy media path resolution.
+
+Centralizes the Telegram marked-ID convention so it's defined once
+and used consistently across serve_media, thumbnails, and ACL checks.
+"""
+
+CHANNEL_ID_OFFSET: int = 1_000_000_000_000
+
+
+def legacy_folder_alternates(folder: str) -> list[str]:
+    """Return alternate folder names for legacy positive/negative ID paths.
+
+    Forward (positive folder → possible negative marked IDs on disk):
+        "1234567890" → ["-1234567890", "-1001234567890"]
+
+    Reverse (negative folder → possible old positive folder on disk):
+        "-1234567890"    → ["1234567890"]           (basic group)
+        "-1001234567890" → ["1234567890"]           (channel)
+    """
+    if not folder.startswith("-"):
+        folder_int = int(folder)
+        return [f"-{folder}", str(-(CHANNEL_ID_OFFSET + folder_int))]
+    folder_int = int(folder)
+    raw = -folder_int
+    if raw > CHANNEL_ID_OFFSET:
+        return [str(raw - CHANNEL_ID_OFFSET)]
+    return [str(raw)]
+
+
+def legacy_marked_chat_ids(positive_id: int) -> list[int]:
+    """Return possible marked chat_ids for a legacy positive folder ID.
+
+    Used by ACL checks to determine if a user has access to a chat
+    referenced by its old positive folder name.
+    """
+    return [-positive_id, -(CHANNEL_ID_OFFSET + positive_id)]
+
+
+def derive_stale_folder(chat_id: int) -> str | None:
+    """Derive the old positive folder name from a marked chat_id.
+
+    Basic groups: chat_id = -X  →  old folder = "X"
+    Channels:     chat_id = -(10^12 + X)  →  old folder = "X"
+    Users:        chat_id > 0  →  no mismatch possible, return None
+    """
+    if chat_id >= 0:
+        return None
+    raw = -chat_id
+    if raw > CHANNEL_ID_OFFSET:
+        return str(raw - CHANNEL_ID_OFFSET)
+    return str(raw)

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1291,7 +1291,7 @@
             </button>
 
             <!-- Next Button -->
-            <button v-if="lightboxIndex < mediaMessages.length - 1" @click.stop="lightboxNext"
+            <button v-if="lightboxIndex < (lightboxList.length || mediaMessages.length) - 1" @click.stop="lightboxNext"
                 class="absolute right-4 top-1/2 -translate-y-1/2 z-60 p-3 text-white/70 hover:text-white bg-black/30 hover:bg-black/50 rounded-full transition">
                 <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
@@ -1314,9 +1314,9 @@
 
             <!-- Media Info -->
             <div v-if="lightboxMedia" class="absolute bottom-4 left-1/2 -translate-x-1/2 text-white/70 text-sm bg-black/50 px-4 py-2 rounded-full">
-                {{ formatDateFull(lightboxMedia.date) }} {{ formatTime(lightboxMedia.date) }}
-                <span v-if="mediaMessages.length > 1" class="ml-2 opacity-70">
-                    {{ lightboxIndex + 1 }} / {{ mediaMessages.length }}
+                <template v-if="lightboxMedia.date">{{ formatDateFull(lightboxMedia.date) }} {{ formatTime(lightboxMedia.date) }}</template>
+                <span v-if="(lightboxList.length || mediaMessages.length) > 1" class="ml-2 opacity-70">
+                    {{ lightboxIndex + 1 }} / {{ lightboxList.length || mediaMessages.length }}
                 </span>
             </div>
         </div>
@@ -1614,7 +1614,8 @@
                 // Lightbox state
                 const lightboxOpen = ref(false)
                 const lightboxMedia = ref(null)  // Current media being viewed
-                const lightboxIndex = ref(0)    // Index in mediaMessages array
+                const lightboxIndex = ref(0)    // Index in lightboxList array
+                const lightboxList = ref([])    // Current set of items for prev/next navigation
 
                 // Get all viewable media messages (photos, videos, animations) for lightbox navigation
                 const mediaMessages = computed(() => {
@@ -2698,13 +2699,11 @@
 
                 const openMediaItem = (item) => {
                     if (item.type === 'photo' || item.type === 'video' || item.type === 'animation') {
-                        // Open in lightbox — reuse existing lightbox infrastructure
                         const mediaList = mediaGalleryItems.value.filter(m =>
                             m.type === 'photo' || m.type === 'video' || m.type === 'animation'
                         )
                         const idx = mediaList.indexOf(item)
-                        // Map to the format the existing lightbox expects
-                        lightboxMedia.value = mediaList.map(m => ({
+                        const mapped = mediaList.map(m => ({
                             media: {
                                 type: m.type,
                                 file_path: m.file_path,
@@ -2714,9 +2713,14 @@
                                 mime_type: m.mime_type,
                             },
                             id: m.message_id,
+                            date: m.date,
                         }))
-                        lightboxIndex.value = idx >= 0 ? idx : 0
+                        lightboxList.value = mapped
+                        const startIdx = idx >= 0 ? idx : 0
+                        lightboxIndex.value = startIdx
+                        lightboxMedia.value = mapped[startIdx]
                         lightboxOpen.value = true
+                        document.addEventListener('keydown', handleLightboxKeydown)
                     }
                 }
 
@@ -3533,13 +3537,12 @@
                 }
 
                 const openMedia = (msg) => {
-                    // Open lightbox for images and videos, direct link for other media
                     if (msg.media?.type === 'photo' || msg.media?.type === 'video' || msg.media?.type === 'animation' ||
                         (msg.media?.type === 'document' && isImageDocument(msg))) {
+                        lightboxList.value = []
                         lightboxMedia.value = msg
                         lightboxIndex.value = mediaMessages.value.findIndex(m => m.id === msg.id && m.chat_id === msg.chat_id)
                         lightboxOpen.value = true
-                        // Add keyboard listener
                         document.addEventListener('keydown', handleLightboxKeydown)
                     } else {
                         window.open(getMediaUrl(msg), '_blank')
@@ -3549,20 +3552,23 @@
                 const closeLightbox = () => {
                     lightboxOpen.value = false
                     lightboxMedia.value = null
+                    lightboxList.value = []
                     document.removeEventListener('keydown', handleLightboxKeydown)
                 }
 
                 const lightboxPrev = () => {
+                    const list = lightboxList.value.length > 0 ? lightboxList.value : mediaMessages.value
                     if (lightboxIndex.value > 0) {
                         lightboxIndex.value--
-                        lightboxMedia.value = mediaMessages.value[lightboxIndex.value]
+                        lightboxMedia.value = list[lightboxIndex.value]
                     }
                 }
 
                 const lightboxNext = () => {
-                    if (lightboxIndex.value < mediaMessages.value.length - 1) {
+                    const list = lightboxList.value.length > 0 ? lightboxList.value : mediaMessages.value
+                    if (lightboxIndex.value < list.length - 1) {
                         lightboxIndex.value++
-                        lightboxMedia.value = mediaMessages.value[lightboxIndex.value]
+                        lightboxMedia.value = list[lightboxIndex.value]
                     }
                 }
 
@@ -4026,6 +4032,7 @@
                     lightboxOpen,
                     lightboxMedia,
                     lightboxIndex,
+                    lightboxList,
                     mediaMessages,
                     closeLightbox,
                     lightboxPrev,

--- a/src/web/thumbnails.py
+++ b/src/web/thumbnails.py
@@ -15,7 +15,7 @@ from pathlib import Path
 
 from PIL import Image
 
-from src.web.media_utils import legacy_folder_alternates
+from .media_utils import legacy_folder_alternates
 
 logger = logging.getLogger(__name__)
 
@@ -89,11 +89,12 @@ def _generate_sync(source: Path, dest: Path, size: int) -> bool:
 
 async def ensure_thumbnail(
     media_root: Path, size: int, folder: str, filename: str, *, cache_dir: Path | None = None
-) -> Path | None:
-    """Return the path to a cached thumbnail, generating it if needed.
+) -> tuple[Path, str] | None:
+    """Return (thumb_path, resolved_folder) or None.
 
-    Returns None when the request is invalid or generation fails.
-    Includes path traversal protection.
+    resolved_folder is the actual folder the source was found in (may differ
+    from the requested folder due to legacy ID fallback). Callers use this
+    for ACL enforcement on the resolved path.
 
     When cache_dir is provided, thumbnails are written there instead of
     under {media_root}/.thumbs/ — this supports read-only media volumes.
@@ -122,20 +123,21 @@ async def ensure_thumbnail(
         if not dest.is_relative_to(thumbs_root):
             return None
 
+    resolved_folder = folder
+
     if dest.exists():
-        return dest
+        return dest, resolved_folder
 
     if not source.exists():
-        # Legacy fallback: pre-v4.0.5 paths used positive IDs, disk uses negative marked IDs.
-        # Try alternate folder names: X→-X (basic group), X→-100X (channel/supergroup)
         alt_folders = legacy_folder_alternates(folder)
         found = False
         for alt in alt_folders:
             try:
                 alt_source = (media_root / alt / filename).resolve()
                 if alt_source.is_relative_to(media_root_resolved) and alt_source.exists():
-                    logger.debug("Thumbnail legacy fallback: %s/%s via alt folder %s", folder, filename, alt)
+                    logger.debug("Thumbnail legacy fallback resolved via alternate folder")
                     source = alt_source
+                    resolved_folder = alt
                     found = True
                     break
             except OSError, RuntimeError:
@@ -146,4 +148,4 @@ async def ensure_thumbnail(
     async with _generation_semaphore:
         loop = asyncio.get_running_loop()
         ok = await loop.run_in_executor(None, _generate_sync, source, dest, size)
-    return dest if ok else None
+    return (dest, resolved_folder) if ok else None

--- a/src/web/thumbnails.py
+++ b/src/web/thumbnails.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 from PIL import Image
 
-from .media_utils import legacy_folder_alternates
+from .media_utils import IMAGE_EXTENSIONS, VIDEO_EXTENSIONS, legacy_folder_alternates
 
 logger = logging.getLogger(__name__)
 
@@ -29,11 +29,13 @@ ALLOWED_SIZES: set[int] = {200, 400}
 WEBP_QUALITY = 80
 _MAX_SOURCE_BYTES = 50 * 1024 * 1024  # 50 MB
 
-_IMAGE_EXTENSIONS: set[str] = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff"}
-_VIDEO_EXTENSIONS: set[str] = {".mp4", ".mkv", ".avi", ".mov", ".webm", ".m4v", ".3gp"}
+_IMAGE_EXTENSIONS: set[str] = {f".{ext}" for ext in IMAGE_EXTENSIONS}
+_VIDEO_EXTENSIONS: set[str] = {f".{ext}" for ext in VIDEO_EXTENSIONS}
 
 # Limit concurrent thumbnail generations to cap peak memory (~15MB per decode)
 _generation_semaphore = asyncio.Semaphore(8)
+# Video thumbnails are heavier (ffmpeg subprocess) — lower concurrency limit
+_video_semaphore = asyncio.Semaphore(2)
 
 _DEFAULT_CACHE_DIR = "/tmp/telegram-archive-thumbs"
 
@@ -96,31 +98,36 @@ def _generate_video_sync(source: Path, dest: Path, size: int) -> bool:
         with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
             tmp_path = tmp.name
         try:
-            subprocess.run(
-                [
-                    "ffmpeg",
-                    "-y",
-                    "-i",
-                    str(source),
-                    "-ss",
-                    "00:00:01",
-                    "-frames:v",
-                    "1",
-                    "-vf",
-                    f"scale={size}:{size}:force_original_aspect_ratio=decrease",
-                    tmp_path,
-                ],
-                capture_output=True,
-                timeout=15,
-                check=True,
-            )
+            # Try at 1s first; fall back to first frame for very short videos
+            for seek_time in ("00:00:01", "00:00:00"):
+                result = subprocess.run(
+                    [
+                        "ffmpeg",
+                        "-y",
+                        "-ss",
+                        seek_time,
+                        "-i",
+                        str(source),
+                        "-frames:v",
+                        "1",
+                        "-vf",
+                        f"scale={size}:{size}:force_original_aspect_ratio=decrease",
+                        tmp_path,
+                    ],
+                    capture_output=True,
+                    timeout=15,
+                )
+                if result.returncode == 0 and Path(tmp_path).stat().st_size > 0:
+                    break
+            else:
+                return False
             with Image.open(tmp_path) as img:
                 img.save(dest, "WEBP", quality=WEBP_QUALITY)
             return True
         finally:
             Path(tmp_path).unlink(missing_ok=True)
     except Exception as e:
-        logger.warning("Video thumbnail failed for %s: %s", source, e)
+        logger.warning("Video thumbnail generation failed: %s", e)
         return False
 
 
@@ -205,7 +212,8 @@ async def ensure_thumbnail(
         if not found:
             return None
 
-    async with _generation_semaphore:
+    sem = _video_semaphore if is_vid else _generation_semaphore
+    async with sem:
         loop = asyncio.get_running_loop()
         gen_fn = _generate_video_sync if is_vid else _generate_sync
         ok = await loop.run_in_executor(None, gen_fn, source, dest, size)

--- a/src/web/thumbnails.py
+++ b/src/web/thumbnails.py
@@ -11,6 +11,9 @@ even when the media volume is mounted read-only.
 import asyncio
 import logging
 import os
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 
 from PIL import Image
@@ -27,6 +30,7 @@ WEBP_QUALITY = 80
 _MAX_SOURCE_BYTES = 50 * 1024 * 1024  # 50 MB
 
 _IMAGE_EXTENSIONS: set[str] = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff"}
+_VIDEO_EXTENSIONS: set[str] = {".mp4", ".mkv", ".avi", ".mov", ".webm", ".m4v", ".3gp"}
 
 # Limit concurrent thumbnail generations to cap peak memory (~15MB per decode)
 _generation_semaphore = asyncio.Semaphore(8)
@@ -66,6 +70,60 @@ def _is_image(filename: str) -> bool:
     return Path(filename).suffix.lower() in _IMAGE_EXTENSIONS
 
 
+def _is_video(filename: str) -> bool:
+    return Path(filename).suffix.lower() in _VIDEO_EXTENSIONS
+
+
+_FFMPEG_AVAILABLE: bool | None = None
+
+
+def _check_ffmpeg() -> bool:
+    global _FFMPEG_AVAILABLE
+    if _FFMPEG_AVAILABLE is None:
+        _FFMPEG_AVAILABLE = shutil.which("ffmpeg") is not None
+    return _FFMPEG_AVAILABLE
+
+
+def _generate_video_sync(source: Path, dest: Path, size: int) -> bool:
+    """Extract a frame from video and create thumbnail — blocking."""
+    try:
+        if source.stat().st_size > _MAX_SOURCE_BYTES * 4:
+            return False
+        if not _check_ffmpeg():
+            logger.debug("ffmpeg not available for video thumbnails")
+            return False
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
+            tmp_path = tmp.name
+        try:
+            subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-i",
+                    str(source),
+                    "-ss",
+                    "00:00:01",
+                    "-frames:v",
+                    "1",
+                    "-vf",
+                    f"scale={size}:{size}:force_original_aspect_ratio=decrease",
+                    tmp_path,
+                ],
+                capture_output=True,
+                timeout=15,
+                check=True,
+            )
+            with Image.open(tmp_path) as img:
+                img.save(dest, "WEBP", quality=WEBP_QUALITY)
+            return True
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+    except Exception as e:
+        logger.warning("Video thumbnail failed for %s: %s", source, e)
+        return False
+
+
 def _thumb_path(media_root: Path, size: int, folder: str, filename: str) -> Path:
     stem = Path(filename).stem
     return media_root / ".thumbs" / str(size) / folder / f"{stem}.webp"
@@ -102,7 +160,9 @@ async def ensure_thumbnail(
     if size not in ALLOWED_SIZES:
         return None
 
-    if not _is_image(filename):
+    is_img = _is_image(filename)
+    is_vid = _is_video(filename)
+    if not is_img and not is_vid:
         return None
 
     # Path traversal protection: resolve and verify containment
@@ -147,5 +207,6 @@ async def ensure_thumbnail(
 
     async with _generation_semaphore:
         loop = asyncio.get_running_loop()
-        ok = await loop.run_in_executor(None, _generate_sync, source, dest, size)
+        gen_fn = _generate_video_sync if is_vid else _generate_sync
+        ok = await loop.run_in_executor(None, gen_fn, source, dest, size)
     return (dest, resolved_folder) if ok else None

--- a/src/web/thumbnails.py
+++ b/src/web/thumbnails.py
@@ -15,6 +15,8 @@ from pathlib import Path
 
 from PIL import Image
 
+from src.web.media_utils import legacy_folder_alternates
+
 logger = logging.getLogger(__name__)
 
 # Limit decompression to prevent pixel-bomb OOM attacks (~50 megapixels)
@@ -126,18 +128,18 @@ async def ensure_thumbnail(
     if not source.exists():
         # Legacy fallback: pre-v4.0.5 paths used positive IDs, disk uses negative marked IDs.
         # Try alternate folder names: X→-X (basic group), X→-100X (channel/supergroup)
-        alt_folders = []
-        if not folder.startswith("-"):
-            alt_folders = [f"-{folder}", f"-100{folder}"]
-        else:
-            alt_folders = [folder[1:]]
+        alt_folders = legacy_folder_alternates(folder)
         found = False
         for alt in alt_folders:
-            alt_source = (media_root / alt / filename).resolve()
-            if alt_source.is_relative_to(media_root_resolved) and alt_source.exists():
-                source = alt_source
-                found = True
-                break
+            try:
+                alt_source = (media_root / alt / filename).resolve()
+                if alt_source.is_relative_to(media_root_resolved) and alt_source.exists():
+                    logger.debug("Thumbnail legacy fallback: %s/%s via alt folder %s", folder, filename, alt)
+                    source = alt_source
+                    found = True
+                    break
+            except OSError, RuntimeError:
+                continue
         if not found:
             return None
 

--- a/tests/test_media_utils.py
+++ b/tests/test_media_utils.py
@@ -44,7 +44,6 @@ class TestLegacyFolderAlternatesForward(unittest.TestCase):
         result = legacy_folder_alternates("42")
         self.assertEqual(len(result), 2)
 
-
     def test_non_numeric_folder_returns_empty_list(self):
         """Non-numeric folder names return empty list (no alternates possible)."""
         self.assertEqual(legacy_folder_alternates("chat1"), [])

--- a/tests/test_media_utils.py
+++ b/tests/test_media_utils.py
@@ -50,6 +50,10 @@ class TestLegacyFolderAlternatesForward(unittest.TestCase):
         self.assertEqual(legacy_folder_alternates("photos"), [])
         self.assertEqual(legacy_folder_alternates("-abc"), [])
 
+    def test_zero_folder_returns_empty_list(self):
+        """Folder '0' is not a valid Telegram entity ID."""
+        self.assertEqual(legacy_folder_alternates("0"), [])
+
 
 class TestLegacyFolderAlternatesReverse(unittest.TestCase):
     """Reverse resolution: negative folder -> possible old positive folder."""
@@ -68,6 +72,11 @@ class TestLegacyFolderAlternatesReverse(unittest.TestCase):
         """Smallest channel ID -1000000000001 resolves to 1."""
         result = legacy_folder_alternates("-1000000000001")
         self.assertEqual(result, ["1"])
+
+    def test_reverse_exact_offset_treated_as_basic_group(self):
+        """Exact CHANNEL_ID_OFFSET boundary is treated as basic group (not channel)."""
+        result = legacy_folder_alternates(str(-CHANNEL_ID_OFFSET))
+        self.assertEqual(result, [str(CHANNEL_ID_OFFSET)])
 
     def test_reverse_always_returns_one_alternate(self):
         """Reverse resolution always returns exactly one alternate."""
@@ -129,6 +138,10 @@ class TestDeriveStaleFolder(unittest.TestCase):
     def test_boundary_smallest_channel(self):
         """Smallest channel ID -1000000000001 derives folder 1."""
         self.assertEqual(derive_stale_folder(-1000000000001), "1")
+
+    def test_exact_offset_treated_as_basic_group(self):
+        """Exact -CHANNEL_ID_OFFSET is basic group, not channel (raw == offset, not >)."""
+        self.assertEqual(derive_stale_folder(-CHANNEL_ID_OFFSET), str(CHANNEL_ID_OFFSET))
 
     def test_result_is_string_when_not_none(self):
         """Non-None results are strings."""

--- a/tests/test_media_utils.py
+++ b/tests/test_media_utils.py
@@ -45,6 +45,13 @@ class TestLegacyFolderAlternatesForward(unittest.TestCase):
         self.assertEqual(len(result), 2)
 
 
+    def test_non_numeric_folder_returns_empty_list(self):
+        """Non-numeric folder names return empty list (no alternates possible)."""
+        self.assertEqual(legacy_folder_alternates("chat1"), [])
+        self.assertEqual(legacy_folder_alternates("photos"), [])
+        self.assertEqual(legacy_folder_alternates("-abc"), [])
+
+
 class TestLegacyFolderAlternatesReverse(unittest.TestCase):
     """Reverse resolution: negative folder -> possible old positive folder."""
 

--- a/tests/test_media_utils.py
+++ b/tests/test_media_utils.py
@@ -1,0 +1,173 @@
+"""Tests for shared media path utilities (media_utils.py).
+
+Verifies the Telegram marked-ID convention logic used for legacy
+folder resolution across serve_media, thumbnails, and ACL checks.
+"""
+
+import unittest
+
+from src.web.media_utils import (
+    CHANNEL_ID_OFFSET,
+    derive_stale_folder,
+    legacy_folder_alternates,
+    legacy_marked_chat_ids,
+)
+
+
+class TestLegacyFolderAlternatesForward(unittest.TestCase):
+    """Forward resolution: positive folder -> possible negative marked IDs."""
+
+    def test_forward_10_digit_channel_id(self):
+        """Positive 10-digit folder produces basic-group and channel negatives."""
+        result = legacy_folder_alternates("1234567890")
+        self.assertEqual(result, ["-1234567890", "-1001234567890"])
+
+    def test_forward_9_digit_channel_id_pads_correctly(self):
+        """9-digit folder must produce -100_0_123456789, not -100_123456789."""
+        result = legacy_folder_alternates("123456789")
+        # CHANNEL_ID_OFFSET is 1_000_000_000_000, so 1000000000000 + 123456789 = 1000123456789
+        self.assertEqual(result, ["-123456789", "-1000123456789"])
+
+    def test_forward_small_basic_group_id(self):
+        """Small group ID produces correct channel-offset alternate."""
+        result = legacy_folder_alternates("54321")
+        self.assertEqual(result, ["-54321", "-1000000054321"])
+
+    def test_forward_result_types_are_strings(self):
+        """All returned alternates are strings."""
+        result = legacy_folder_alternates("999")
+        for item in result:
+            self.assertIsInstance(item, str)
+
+    def test_forward_always_returns_two_alternates(self):
+        """Forward resolution always returns exactly two alternates."""
+        result = legacy_folder_alternates("42")
+        self.assertEqual(len(result), 2)
+
+
+class TestLegacyFolderAlternatesReverse(unittest.TestCase):
+    """Reverse resolution: negative folder -> possible old positive folder."""
+
+    def test_reverse_channel_folder(self):
+        """Channel folder -1001234567890 resolves to positive 1234567890."""
+        result = legacy_folder_alternates("-1001234567890")
+        self.assertEqual(result, ["1234567890"])
+
+    def test_reverse_basic_group_folder(self):
+        """Basic group folder -54321 resolves to positive 54321."""
+        result = legacy_folder_alternates("-54321")
+        self.assertEqual(result, ["54321"])
+
+    def test_reverse_boundary_smallest_channel(self):
+        """Smallest channel ID -1000000000001 resolves to 1."""
+        result = legacy_folder_alternates("-1000000000001")
+        self.assertEqual(result, ["1"])
+
+    def test_reverse_always_returns_one_alternate(self):
+        """Reverse resolution always returns exactly one alternate."""
+        result = legacy_folder_alternates("-999")
+        self.assertEqual(len(result), 1)
+
+    def test_reverse_result_types_are_strings(self):
+        """Reverse alternates are strings."""
+        result = legacy_folder_alternates("-1001234567890")
+        for item in result:
+            self.assertIsInstance(item, str)
+
+
+class TestLegacyMarkedChatIds(unittest.TestCase):
+    """Marked chat ID generation from positive folder IDs."""
+
+    def test_returns_basic_group_and_channel_forms(self):
+        """Returns both -id and -(offset + id) for a given positive ID."""
+        result = legacy_marked_chat_ids(1234567890)
+        self.assertEqual(result, [-1234567890, -1001234567890])
+
+    def test_small_id_produces_correct_pair(self):
+        """Small IDs still offset correctly."""
+        result = legacy_marked_chat_ids(1)
+        self.assertEqual(result, [-1, -(CHANNEL_ID_OFFSET + 1)])
+
+    def test_returns_list_of_two_integers(self):
+        """Always returns exactly two integers."""
+        result = legacy_marked_chat_ids(42)
+        self.assertEqual(len(result), 2)
+        for item in result:
+            self.assertIsInstance(item, int)
+
+    def test_both_results_are_negative(self):
+        """Both marked IDs are negative."""
+        result = legacy_marked_chat_ids(99999)
+        self.assertTrue(all(x < 0 for x in result))
+
+
+class TestDeriveStaleFolder(unittest.TestCase):
+    """Derive old positive folder name from marked chat_id."""
+
+    def test_positive_chat_id_returns_none(self):
+        """User chat_id (positive) has no stale folder."""
+        self.assertIsNone(derive_stale_folder(12345))
+
+    def test_zero_returns_none(self):
+        """Zero chat_id returns None."""
+        self.assertIsNone(derive_stale_folder(0))
+
+    def test_basic_group_negative(self):
+        """Basic group -54321 derives folder 54321."""
+        self.assertEqual(derive_stale_folder(-54321), "54321")
+
+    def test_channel_negative(self):
+        """Channel -1001234567890 derives folder 1234567890."""
+        self.assertEqual(derive_stale_folder(-1001234567890), "1234567890")
+
+    def test_boundary_smallest_channel(self):
+        """Smallest channel ID -1000000000001 derives folder 1."""
+        self.assertEqual(derive_stale_folder(-1000000000001), "1")
+
+    def test_result_is_string_when_not_none(self):
+        """Non-None results are strings."""
+        result = derive_stale_folder(-999)
+        self.assertIsInstance(result, str)
+
+
+class TestMediaUtilsConsistency(unittest.TestCase):
+    """Cross-function consistency: forward and reverse are inverses."""
+
+    def test_channel_roundtrip_derive_then_reverse(self):
+        """derive_stale_folder output fed to legacy_folder_alternates reverse
+        produces the original chat_id's folder as an alternate."""
+        chat_id = -1001234567890
+        folder = derive_stale_folder(chat_id)
+        # folder is "1234567890", forward alternates include str(chat_id)
+        alternates = legacy_folder_alternates(folder)
+        self.assertIn(str(chat_id), alternates)
+
+    def test_basic_group_roundtrip_derive_then_reverse(self):
+        """Basic group derive -> forward alternates includes original chat_id."""
+        chat_id = -54321
+        folder = derive_stale_folder(chat_id)
+        alternates = legacy_folder_alternates(folder)
+        self.assertIn(str(chat_id), alternates)
+
+    def test_marked_ids_match_forward_alternates(self):
+        """legacy_marked_chat_ids output matches legacy_folder_alternates (as ints)."""
+        positive_id = 7777
+        marked = legacy_marked_chat_ids(positive_id)
+        alternates = legacy_folder_alternates(str(positive_id))
+        # alternates are strings of the marked IDs
+        self.assertEqual(sorted(str(m) for m in marked), sorted(alternates))
+
+    def test_channel_reverse_then_forward_contains_original(self):
+        """Reverse a channel folder, then forward it, original appears."""
+        channel_folder = "-1001234567890"
+        reversed_folders = legacy_folder_alternates(channel_folder)
+        # reversed_folders = ["1234567890"]
+        forward_again = legacy_folder_alternates(reversed_folders[0])
+        self.assertIn(channel_folder, forward_again)
+
+    def test_basic_group_reverse_then_forward_contains_original(self):
+        """Reverse a basic group folder, then forward it, original appears."""
+        group_folder = "-54321"
+        reversed_folders = legacy_folder_alternates(group_folder)
+        forward_again = legacy_folder_alternates(reversed_folders[0])
+        self.assertIn(group_folder, forward_again)

--- a/tests/test_web_coverage.py
+++ b/tests/test_web_coverage.py
@@ -348,6 +348,45 @@ class TestServeMedia(_WebTestBase):
                 resp = await client.get("/media/123/photo.jpg", cookies={"viewer_auth": token})
             self.assertEqual(resp.status_code, 403)
 
+    async def test_media_acl_enforced_on_resolved_path_not_url(self):
+        """ACL bypass prevention: user requests positive folder, file resolves to
+        a negative folder the user does NOT have access to — must deny."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = web_main.Path(tmpdir).resolve()
+            web_main._media_root = media_root
+            # File lives under negative folder -999 (the actual chat folder on disk)
+            denied_dir = os.path.join(tmpdir, "-999")
+            os.makedirs(denied_dir)
+            with open(os.path.join(denied_dir, "secret.jpg"), "w") as f:
+                f.write("secret")
+
+            web_main.AUTH_ENABLED = True
+            token = "acl-bypass-test"
+            # User only has access to chat 555, NOT -999
+            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={555})
+            # Request via positive folder "999" — legacy fallback resolves to "-999"
+            async with self._client() as client:
+                resp = await client.get("/media/999/secret.jpg", cookies={"viewer_auth": token})
+            self.assertEqual(resp.status_code, 403)
+
+    async def test_media_acl_allows_resolved_path_when_authorized(self):
+        """User with access to the resolved negative chat can access via positive folder."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = web_main.Path(tmpdir).resolve()
+            web_main._media_root = media_root
+            denied_dir = os.path.join(tmpdir, "-999")
+            os.makedirs(denied_dir)
+            with open(os.path.join(denied_dir, "photo.jpg"), "w") as f:
+                f.write("img")
+
+            web_main.AUTH_ENABLED = True
+            token = "acl-allow-test"
+            # User has access to -999 (the resolved folder)
+            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={-999})
+            async with self._client() as client:
+                resp = await client.get("/media/999/photo.jpg", cookies={"viewer_auth": token})
+            self.assertEqual(resp.status_code, 200)
+
     async def test_media_rejects_shared_folder_for_restricted_user(self):
         """Restricted users cannot fetch deduplicated _shared files directly."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -513,7 +552,7 @@ class TestServeThumbnail(_WebTestBase):
             with patch(
                 "src.web.thumbnails.ensure_thumbnail",
                 new_callable=AsyncMock,
-                return_value=web_main.Path(thumb_file),
+                return_value=(web_main.Path(thumb_file), "123"),
             ):
                 async with self._client() as client:
                     resp = await client.get("/media/thumb/200/123/photo.jpg")

--- a/tests/test_web_thumbnails.py
+++ b/tests/test_web_thumbnails.py
@@ -214,7 +214,9 @@ class TestEnsureThumbnail(unittest.IsolatedAsyncioTestCase):
 
             result = await ensure_thumbnail(media_root, 200, folder, "img.jpg")
             self.assertIsNotNone(result)
-            self.assertEqual(result, thumb.resolve())
+            thumb_path, resolved_folder = result
+            self.assertEqual(thumb_path, thumb.resolve())
+            self.assertEqual(resolved_folder, folder)
 
     async def test_returns_none_when_source_does_not_exist(self):
         """ensure_thumbnail returns None when source file is missing."""
@@ -238,8 +240,10 @@ class TestEnsureThumbnail(unittest.IsolatedAsyncioTestCase):
 
             result = await ensure_thumbnail(media_root, 200, folder, "photo.png")
             self.assertIsNotNone(result)
-            self.assertTrue(result.exists())
-            self.assertEqual(result.suffix, ".webp")
+            thumb_path, resolved_folder = result
+            self.assertTrue(thumb_path.exists())
+            self.assertEqual(thumb_path.suffix, ".webp")
+            self.assertEqual(resolved_folder, folder)
 
 
 if __name__ == "__main__":

--- a/tests/test_web_thumbnails.py
+++ b/tests/test_web_thumbnails.py
@@ -8,10 +8,14 @@ from unittest.mock import MagicMock, patch
 from src.web.thumbnails import (
     _IMAGE_EXTENSIONS,
     _MAX_SOURCE_BYTES,
+    _VIDEO_EXTENSIONS,
     ALLOWED_SIZES,
     WEBP_QUALITY,
+    _check_ffmpeg,
     _generate_sync,
+    _generate_video_sync,
     _is_image,
+    _is_video,
     _thumb_path,
     ensure_thumbnail,
 )
@@ -68,6 +72,83 @@ class TestIsImage(unittest.TestCase):
     def test_no_extension_returns_false(self):
         """_is_image returns False for files without extension."""
         self.assertFalse(_is_image("noext"))
+
+
+class TestIsVideo(unittest.TestCase):
+    """Test _is_video file extension detection."""
+
+    def test_recognizes_mp4(self):
+        self.assertTrue(_is_video("clip.mp4"))
+
+    def test_recognizes_mkv(self):
+        self.assertTrue(_is_video("movie.mkv"))
+
+    def test_recognizes_webm(self):
+        self.assertTrue(_is_video("anim.webm"))
+
+    def test_recognizes_mov(self):
+        self.assertTrue(_is_video("video.mov"))
+
+    def test_rejects_jpg(self):
+        self.assertFalse(_is_video("photo.jpg"))
+
+    def test_rejects_txt(self):
+        self.assertFalse(_is_video("readme.txt"))
+
+    def test_case_insensitive(self):
+        self.assertTrue(_is_video("CLIP.MP4"))
+        self.assertTrue(_is_video("Video.MKV"))
+
+    def test_no_extension_returns_false(self):
+        self.assertFalse(_is_video("noext"))
+
+
+class TestCheckFfmpeg(unittest.TestCase):
+    """Test _check_ffmpeg detection."""
+
+    @patch("src.web.thumbnails.shutil.which", return_value="/usr/bin/ffmpeg")
+    def test_returns_true_when_available(self, _mock):
+        import src.web.thumbnails as mod
+
+        mod._FFMPEG_AVAILABLE = None
+        self.assertTrue(_check_ffmpeg())
+
+    @patch("src.web.thumbnails.shutil.which", return_value=None)
+    def test_returns_false_when_missing(self, _mock):
+        import src.web.thumbnails as mod
+
+        mod._FFMPEG_AVAILABLE = None
+        self.assertFalse(_check_ffmpeg())
+
+
+class TestGenerateVideoSync(unittest.TestCase):
+    """Test _generate_video_sync."""
+
+    def test_returns_false_when_source_too_large(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as src:
+            source = Path(src.name)
+            dest = Path(tempfile.mkdtemp()) / "out.webp"
+            with patch.object(Path, "stat") as mock_stat:
+                mock_stat.return_value = MagicMock(st_size=_MAX_SOURCE_BYTES * 4 + 1)
+                result = _generate_video_sync(source, dest, 200)
+            self.assertFalse(result)
+
+    @patch("src.web.thumbnails._check_ffmpeg", return_value=False)
+    def test_returns_false_when_ffmpeg_missing(self, _mock):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "clip.mp4"
+            source.write_bytes(b"\x00" * 100)
+            dest = Path(tmpdir) / "out.webp"
+            result = _generate_video_sync(source, dest, 200)
+            self.assertFalse(result)
+
+    def test_returns_false_on_invalid_video(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "corrupt.mp4"
+            source.write_text("not a video")
+            dest = Path(tmpdir) / "out.webp"
+            result = _generate_video_sync(source, dest, 200)
+            self.assertFalse(result)
 
 
 class TestThumbPath(unittest.TestCase):
@@ -184,10 +265,22 @@ class TestEnsureThumbnail(unittest.IsolatedAsyncioTestCase):
         result = await ensure_thumbnail(Path("/tmp"), 999, "folder", "img.jpg")
         self.assertIsNone(result)
 
-    async def test_rejects_non_image_file(self):
-        """ensure_thumbnail returns None for non-image files."""
-        result = await ensure_thumbnail(Path("/tmp"), 200, "folder", "video.mp4")
+    async def test_rejects_unsupported_file(self):
+        """ensure_thumbnail returns None for unsupported file types."""
+        result = await ensure_thumbnail(Path("/tmp"), 200, "folder", "doc.pdf")
         self.assertIsNone(result)
+
+    async def test_accepts_video_file_extension(self):
+        """ensure_thumbnail does not reject video files by extension."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            folder = "chat1"
+            (media_root / folder).mkdir()
+            source = media_root / folder / "clip.mp4"
+            source.write_bytes(b"\x00" * 100)
+            result = await ensure_thumbnail(media_root, 200, folder, "clip.mp4")
+            # Returns None because ffmpeg can't decode garbage, but doesn't reject on extension
+            self.assertIsNone(result)
 
     async def test_rejects_path_traversal_in_source(self):
         """ensure_thumbnail returns None when source escapes media_root."""


### PR DESCRIPTION
## Summary
- Fix gallery lightbox showing black screen: `openMediaItem()` was setting `lightboxMedia` to an array instead of a single object
- Add video thumbnail generation using ffmpeg (extract frame at 1s)
- Add ffmpeg to Docker image for video thumbnail support
- Gallery endpoint now assigns `thumb_url` for video files (mp4, mkv, avi, etc.)

## Test plan
- [ ] Open gallery, click any photo — should display in lightbox (no black screen)
- [ ] Navigate prev/next in gallery lightbox
- [ ] Video files in gallery show thumbnail previews
- [ ] Open video from gallery lightbox — plays correctly
- [ ] Chat view lightbox still works (prev/next navigation via mediaMessages)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * On-demand video thumbnails now generated as WebP; thumbnail logic returns source resolution info.
  * Media gallery lightbox supports gallery-scoped navigation and correct indexing.
  * New legacy media resolution utilities to handle legacy folder/ID conventions.

* **Bug Fixes**
  * Avoid startup errors on very old databases missing media table.
  * Tightened access-control checks to prevent legacy-folder thumbnail bypasses.

* **Tests**
  * Added and expanded unit tests covering legacy media utilities, thumbnail/video paths, and ACL behavior.

* **Chores**
  * Added ffmpeg to system dependencies.
  * Project version bumped.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/Telegram-Archive/pull/170?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->