### PR TITLE
feat(web): video thumbnails, lightbox fix, and review hardening

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,10 @@ FROM python:3.14-slim
 # Set working directory
 WORKDIR /app
 
-# Install system dependencies
+# Install system dependencies (ffmpeg for video thumbnail extraction)
 RUN apt-get update && apt-get install -y \
     gcc \
+    ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv for fast, reproducible dependency installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.10.15"
+version = "7.11.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.10.15"
+__version__ = "7.11.0"

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1505,7 +1505,22 @@ async def get_chat_media(
             if len(parts) == 2:
                 folder, filename = parts
                 ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
-                if ext in ("jpg", "jpeg", "png", "gif", "webp", "bmp", "tiff"):
+                if ext in (
+                    "jpg",
+                    "jpeg",
+                    "png",
+                    "gif",
+                    "webp",
+                    "bmp",
+                    "tiff",
+                    "mp4",
+                    "mkv",
+                    "avi",
+                    "mov",
+                    "webm",
+                    "m4v",
+                    "3gp",
+                ):
                     item["thumb_url"] = f"/media/thumb/200/{folder}/{filename}"
                 else:
                     item["thumb_url"] = None

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -31,7 +31,7 @@ from fastapi.staticfiles import StaticFiles
 from ..config import Config
 from ..db import DatabaseAdapter, close_database, get_db_manager, init_database
 from ..realtime import RealtimeListener
-from .media_utils import legacy_folder_alternates, legacy_marked_chat_ids
+from .media_utils import THUMBNAIL_EXTENSIONS, legacy_folder_alternates, legacy_marked_chat_ids
 
 if TYPE_CHECKING:
     from .push import PushNotificationManager
@@ -1505,22 +1505,7 @@ async def get_chat_media(
             if len(parts) == 2:
                 folder, filename = parts
                 ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
-                if ext in (
-                    "jpg",
-                    "jpeg",
-                    "png",
-                    "gif",
-                    "webp",
-                    "bmp",
-                    "tiff",
-                    "mp4",
-                    "mkv",
-                    "avi",
-                    "mov",
-                    "webm",
-                    "m4v",
-                    "3gp",
-                ):
+                if ext in THUMBNAIL_EXTENSIONS:
                     item["thumb_url"] = f"/media/thumb/200/{folder}/{filename}"
                 else:
                     item["thumb_url"] = None

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -818,7 +818,7 @@ def _enforce_media_acl(path: str, user: UserContext, *, thumbnail: bool = False)
     try:
         media_chat_id = int(parts[0])
     except ValueError:
-        logger.warning("Blocked restricted media request for non-chat folder: %s", parts[0])
+        logger.warning("Blocked restricted media request for non-numeric folder")
         raise HTTPException(status_code=403, detail="Access denied")
     if media_chat_id not in user_chat_ids:
         # Legacy fallback: positive folder may correspond to negative marked ID

--- a/src/web/media_utils.py
+++ b/src/web/media_utils.py
@@ -6,6 +6,10 @@ and used consistently across serve_media, thumbnails, and ACL checks.
 
 CHANNEL_ID_OFFSET: int = 1_000_000_000_000
 
+IMAGE_EXTENSIONS: set[str] = {"jpg", "jpeg", "png", "gif", "webp", "bmp", "tiff"}
+VIDEO_EXTENSIONS: set[str] = {"mp4", "mkv", "avi", "mov", "webm", "m4v", "3gp"}
+THUMBNAIL_EXTENSIONS: set[str] = IMAGE_EXTENSIONS | VIDEO_EXTENSIONS
+
 
 def legacy_folder_alternates(folder: str) -> list[str]:
     """Return alternate folder names for legacy positive/negative ID paths.
@@ -47,6 +51,8 @@ def derive_stale_folder(chat_id: int) -> str | None:
     Basic groups: chat_id = -X  →  old folder = "X"
     Channels:     chat_id = -(10^12 + X)  →  old folder = "X"
     Users:        chat_id > 0  →  no mismatch possible, return None
+
+    Used by migration 013 and tests (not imported at web runtime).
     """
     if chat_id >= 0:
         return None

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1291,7 +1291,7 @@
             </button>
 
             <!-- Next Button -->
-            <button v-if="lightboxIndex < mediaMessages.length - 1" @click.stop="lightboxNext"
+            <button v-if="lightboxIndex < (lightboxList.length || mediaMessages.length) - 1" @click.stop="lightboxNext"
                 class="absolute right-4 top-1/2 -translate-y-1/2 z-60 p-3 text-white/70 hover:text-white bg-black/30 hover:bg-black/50 rounded-full transition">
                 <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/>
@@ -1314,9 +1314,9 @@
 
             <!-- Media Info -->
             <div v-if="lightboxMedia" class="absolute bottom-4 left-1/2 -translate-x-1/2 text-white/70 text-sm bg-black/50 px-4 py-2 rounded-full">
-                {{ formatDateFull(lightboxMedia.date) }} {{ formatTime(lightboxMedia.date) }}
-                <span v-if="mediaMessages.length > 1" class="ml-2 opacity-70">
-                    {{ lightboxIndex + 1 }} / {{ mediaMessages.length }}
+                <template v-if="lightboxMedia.date">{{ formatDateFull(lightboxMedia.date) }} {{ formatTime(lightboxMedia.date) }}</template>
+                <span v-if="(lightboxList.length || mediaMessages.length) > 1" class="ml-2 opacity-70">
+                    {{ lightboxIndex + 1 }} / {{ lightboxList.length || mediaMessages.length }}
                 </span>
             </div>
         </div>
@@ -1614,7 +1614,8 @@
                 // Lightbox state
                 const lightboxOpen = ref(false)
                 const lightboxMedia = ref(null)  // Current media being viewed
-                const lightboxIndex = ref(0)    // Index in mediaMessages array
+                const lightboxIndex = ref(0)    // Index in lightboxList array
+                const lightboxList = ref([])    // Current set of items for prev/next navigation
 
                 // Get all viewable media messages (photos, videos, animations) for lightbox navigation
                 const mediaMessages = computed(() => {
@@ -2698,13 +2699,11 @@
 
                 const openMediaItem = (item) => {
                     if (item.type === 'photo' || item.type === 'video' || item.type === 'animation') {
-                        // Open in lightbox — reuse existing lightbox infrastructure
                         const mediaList = mediaGalleryItems.value.filter(m =>
                             m.type === 'photo' || m.type === 'video' || m.type === 'animation'
                         )
                         const idx = mediaList.indexOf(item)
-                        // Map to the format the existing lightbox expects
-                        lightboxMedia.value = mediaList.map(m => ({
+                        const mapped = mediaList.map(m => ({
                             media: {
                                 type: m.type,
                                 file_path: m.file_path,
@@ -2714,9 +2713,14 @@
                                 mime_type: m.mime_type,
                             },
                             id: m.message_id,
+                            date: m.date,
                         }))
-                        lightboxIndex.value = idx >= 0 ? idx : 0
+                        lightboxList.value = mapped
+                        const startIdx = idx >= 0 ? idx : 0
+                        lightboxIndex.value = startIdx
+                        lightboxMedia.value = mapped[startIdx]
                         lightboxOpen.value = true
+                        document.addEventListener('keydown', handleLightboxKeydown)
                     }
                 }
 
@@ -3533,13 +3537,12 @@
                 }
 
                 const openMedia = (msg) => {
-                    // Open lightbox for images and videos, direct link for other media
                     if (msg.media?.type === 'photo' || msg.media?.type === 'video' || msg.media?.type === 'animation' ||
                         (msg.media?.type === 'document' && isImageDocument(msg))) {
+                        lightboxList.value = []
                         lightboxMedia.value = msg
                         lightboxIndex.value = mediaMessages.value.findIndex(m => m.id === msg.id && m.chat_id === msg.chat_id)
                         lightboxOpen.value = true
-                        // Add keyboard listener
                         document.addEventListener('keydown', handleLightboxKeydown)
                     } else {
                         window.open(getMediaUrl(msg), '_blank')
@@ -3549,20 +3552,23 @@
                 const closeLightbox = () => {
                     lightboxOpen.value = false
                     lightboxMedia.value = null
+                    lightboxList.value = []
                     document.removeEventListener('keydown', handleLightboxKeydown)
                 }
 
                 const lightboxPrev = () => {
+                    const list = lightboxList.value.length > 0 ? lightboxList.value : mediaMessages.value
                     if (lightboxIndex.value > 0) {
                         lightboxIndex.value--
-                        lightboxMedia.value = mediaMessages.value[lightboxIndex.value]
+                        lightboxMedia.value = list[lightboxIndex.value]
                     }
                 }
 
                 const lightboxNext = () => {
-                    if (lightboxIndex.value < mediaMessages.value.length - 1) {
+                    const list = lightboxList.value.length > 0 ? lightboxList.value : mediaMessages.value
+                    if (lightboxIndex.value < list.length - 1) {
                         lightboxIndex.value++
-                        lightboxMedia.value = mediaMessages.value[lightboxIndex.value]
+                        lightboxMedia.value = list[lightboxIndex.value]
                     }
                 }
 
@@ -4026,6 +4032,7 @@
                     lightboxOpen,
                     lightboxMedia,
                     lightboxIndex,
+                    lightboxList,
                     mediaMessages,
                     closeLightbox,
                     lightboxPrev,

--- a/src/web/thumbnails.py
+++ b/src/web/thumbnails.py
@@ -140,7 +140,7 @@ def _generate_sync(source: Path, dest: Path, size: int) -> bool:
     """Blocking thumbnail generation -- meant for run_in_executor."""
     try:
         if source.stat().st_size > _MAX_SOURCE_BYTES:
-            logger.warning("Source too large for thumbnail: %s (%d bytes)", source, source.stat().st_size)
+            logger.warning("Source too large for thumbnail (%d bytes)", source.stat().st_size)
             return False
         dest.parent.mkdir(parents=True, exist_ok=True)
         with Image.open(source) as img:
@@ -148,7 +148,7 @@ def _generate_sync(source: Path, dest: Path, size: int) -> bool:
             img.save(dest, "WEBP", quality=WEBP_QUALITY)
         return True
     except Exception as e:
-        logger.warning("Thumbnail generation failed for %s: %s", source, e)
+        logger.warning("Thumbnail generation failed: %s", e)
         return False
 
 

--- a/src/web/thumbnails.py
+++ b/src/web/thumbnails.py
@@ -18,7 +18,7 @@ from pathlib import Path
 
 from PIL import Image
 
-from .media_utils import legacy_folder_alternates
+from .media_utils import IMAGE_EXTENSIONS, VIDEO_EXTENSIONS, legacy_folder_alternates
 
 logger = logging.getLogger(__name__)
 
@@ -29,11 +29,13 @@ ALLOWED_SIZES: set[int] = {200, 400}
 WEBP_QUALITY = 80
 _MAX_SOURCE_BYTES = 50 * 1024 * 1024  # 50 MB
 
-_IMAGE_EXTENSIONS: set[str] = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff"}
-_VIDEO_EXTENSIONS: set[str] = {".mp4", ".mkv", ".avi", ".mov", ".webm", ".m4v", ".3gp"}
+_IMAGE_EXTENSIONS: set[str] = {f".{ext}" for ext in IMAGE_EXTENSIONS}
+_VIDEO_EXTENSIONS: set[str] = {f".{ext}" for ext in VIDEO_EXTENSIONS}
 
 # Limit concurrent thumbnail generations to cap peak memory (~15MB per decode)
 _generation_semaphore = asyncio.Semaphore(8)
+# Video thumbnails are heavier (ffmpeg subprocess) — lower concurrency limit
+_video_semaphore = asyncio.Semaphore(2)
 
 _DEFAULT_CACHE_DIR = "/tmp/telegram-archive-thumbs"
 
@@ -96,31 +98,36 @@ def _generate_video_sync(source: Path, dest: Path, size: int) -> bool:
         with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
             tmp_path = tmp.name
         try:
-            subprocess.run(
-                [
-                    "ffmpeg",
-                    "-y",
-                    "-i",
-                    str(source),
-                    "-ss",
-                    "00:00:01",
-                    "-frames:v",
-                    "1",
-                    "-vf",
-                    f"scale={size}:{size}:force_original_aspect_ratio=decrease",
-                    tmp_path,
-                ],
-                capture_output=True,
-                timeout=15,
-                check=True,
-            )
+            # Try at 1s first; fall back to first frame for very short videos
+            for seek_time in ("00:00:01", "00:00:00"):
+                result = subprocess.run(
+                    [
+                        "ffmpeg",
+                        "-y",
+                        "-ss",
+                        seek_time,
+                        "-i",
+                        str(source),
+                        "-frames:v",
+                        "1",
+                        "-vf",
+                        f"scale={size}:{size}:force_original_aspect_ratio=decrease",
+                        tmp_path,
+                    ],
+                    capture_output=True,
+                    timeout=15,
+                )
+                if result.returncode == 0 and Path(tmp_path).stat().st_size > 0:
+                    break
+            else:
+                return False
             with Image.open(tmp_path) as img:
                 img.save(dest, "WEBP", quality=WEBP_QUALITY)
             return True
         finally:
             Path(tmp_path).unlink(missing_ok=True)
     except Exception as e:
-        logger.warning("Video thumbnail failed for %s: %s", source, e)
+        logger.warning("Video thumbnail generation failed: %s", e)
         return False
 
 
@@ -205,7 +212,8 @@ async def ensure_thumbnail(
         if not found:
             return None
 
-    async with _generation_semaphore:
+    sem = _video_semaphore if is_vid else _generation_semaphore
+    async with sem:
         loop = asyncio.get_running_loop()
         gen_fn = _generate_video_sync if is_vid else _generate_sync
         ok = await loop.run_in_executor(None, gen_fn, source, dest, size)

--- a/src/web/thumbnails.py
+++ b/src/web/thumbnails.py
@@ -11,6 +11,9 @@ even when the media volume is mounted read-only.
 import asyncio
 import logging
 import os
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 
 from PIL import Image
@@ -27,6 +30,7 @@ WEBP_QUALITY = 80
 _MAX_SOURCE_BYTES = 50 * 1024 * 1024  # 50 MB
 
 _IMAGE_EXTENSIONS: set[str] = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".tiff"}
+_VIDEO_EXTENSIONS: set[str] = {".mp4", ".mkv", ".avi", ".mov", ".webm", ".m4v", ".3gp"}
 
 # Limit concurrent thumbnail generations to cap peak memory (~15MB per decode)
 _generation_semaphore = asyncio.Semaphore(8)
@@ -66,6 +70,60 @@ def _is_image(filename: str) -> bool:
     return Path(filename).suffix.lower() in _IMAGE_EXTENSIONS
 
 
+def _is_video(filename: str) -> bool:
+    return Path(filename).suffix.lower() in _VIDEO_EXTENSIONS
+
+
+_FFMPEG_AVAILABLE: bool | None = None
+
+
+def _check_ffmpeg() -> bool:
+    global _FFMPEG_AVAILABLE
+    if _FFMPEG_AVAILABLE is None:
+        _FFMPEG_AVAILABLE = shutil.which("ffmpeg") is not None
+    return _FFMPEG_AVAILABLE
+
+
+def _generate_video_sync(source: Path, dest: Path, size: int) -> bool:
+    """Extract a frame from video and create thumbnail — blocking."""
+    try:
+        if source.stat().st_size > _MAX_SOURCE_BYTES * 4:
+            return False
+        if not _check_ffmpeg():
+            logger.debug("ffmpeg not available for video thumbnails")
+            return False
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
+            tmp_path = tmp.name
+        try:
+            subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-i",
+                    str(source),
+                    "-ss",
+                    "00:00:01",
+                    "-frames:v",
+                    "1",
+                    "-vf",
+                    f"scale={size}:{size}:force_original_aspect_ratio=decrease",
+                    tmp_path,
+                ],
+                capture_output=True,
+                timeout=15,
+                check=True,
+            )
+            with Image.open(tmp_path) as img:
+                img.save(dest, "WEBP", quality=WEBP_QUALITY)
+            return True
+        finally:
+            Path(tmp_path).unlink(missing_ok=True)
+    except Exception as e:
+        logger.warning("Video thumbnail failed for %s: %s", source, e)
+        return False
+
+
 def _thumb_path(media_root: Path, size: int, folder: str, filename: str) -> Path:
     stem = Path(filename).stem
     return media_root / ".thumbs" / str(size) / folder / f"{stem}.webp"
@@ -102,7 +160,9 @@ async def ensure_thumbnail(
     if size not in ALLOWED_SIZES:
         return None
 
-    if not _is_image(filename):
+    is_img = _is_image(filename)
+    is_vid = _is_video(filename)
+    if not is_img and not is_vid:
         return None
 
     # Path traversal protection: resolve and verify containment
@@ -147,5 +207,6 @@ async def ensure_thumbnail(
 
     async with _generation_semaphore:
         loop = asyncio.get_running_loop()
-        ok = await loop.run_in_executor(None, _generate_sync, source, dest, size)
+        gen_fn = _generate_video_sync if is_vid else _generate_sync
+        ok = await loop.run_in_executor(None, gen_fn, source, dest, size)
     return (dest, resolved_folder) if ok else None

--- a/tests/test_web_thumbnails.py
+++ b/tests/test_web_thumbnails.py
@@ -8,10 +8,14 @@ from unittest.mock import MagicMock, patch
 from src.web.thumbnails import (
     _IMAGE_EXTENSIONS,
     _MAX_SOURCE_BYTES,
+    _VIDEO_EXTENSIONS,
     ALLOWED_SIZES,
     WEBP_QUALITY,
+    _check_ffmpeg,
     _generate_sync,
+    _generate_video_sync,
     _is_image,
+    _is_video,
     _thumb_path,
     ensure_thumbnail,
 )
@@ -68,6 +72,83 @@ class TestIsImage(unittest.TestCase):
     def test_no_extension_returns_false(self):
         """_is_image returns False for files without extension."""
         self.assertFalse(_is_image("noext"))
+
+
+class TestIsVideo(unittest.TestCase):
+    """Test _is_video file extension detection."""
+
+    def test_recognizes_mp4(self):
+        self.assertTrue(_is_video("clip.mp4"))
+
+    def test_recognizes_mkv(self):
+        self.assertTrue(_is_video("movie.mkv"))
+
+    def test_recognizes_webm(self):
+        self.assertTrue(_is_video("anim.webm"))
+
+    def test_recognizes_mov(self):
+        self.assertTrue(_is_video("video.mov"))
+
+    def test_rejects_jpg(self):
+        self.assertFalse(_is_video("photo.jpg"))
+
+    def test_rejects_txt(self):
+        self.assertFalse(_is_video("readme.txt"))
+
+    def test_case_insensitive(self):
+        self.assertTrue(_is_video("CLIP.MP4"))
+        self.assertTrue(_is_video("Video.MKV"))
+
+    def test_no_extension_returns_false(self):
+        self.assertFalse(_is_video("noext"))
+
+
+class TestCheckFfmpeg(unittest.TestCase):
+    """Test _check_ffmpeg detection."""
+
+    @patch("src.web.thumbnails.shutil.which", return_value="/usr/bin/ffmpeg")
+    def test_returns_true_when_available(self, _mock):
+        import src.web.thumbnails as mod
+
+        mod._FFMPEG_AVAILABLE = None
+        self.assertTrue(_check_ffmpeg())
+
+    @patch("src.web.thumbnails.shutil.which", return_value=None)
+    def test_returns_false_when_missing(self, _mock):
+        import src.web.thumbnails as mod
+
+        mod._FFMPEG_AVAILABLE = None
+        self.assertFalse(_check_ffmpeg())
+
+
+class TestGenerateVideoSync(unittest.TestCase):
+    """Test _generate_video_sync."""
+
+    def test_returns_false_when_source_too_large(self):
+        with tempfile.NamedTemporaryFile(suffix=".mp4") as src:
+            source = Path(src.name)
+            dest = Path(tempfile.mkdtemp()) / "out.webp"
+            with patch.object(Path, "stat") as mock_stat:
+                mock_stat.return_value = MagicMock(st_size=_MAX_SOURCE_BYTES * 4 + 1)
+                result = _generate_video_sync(source, dest, 200)
+            self.assertFalse(result)
+
+    @patch("src.web.thumbnails._check_ffmpeg", return_value=False)
+    def test_returns_false_when_ffmpeg_missing(self, _mock):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "clip.mp4"
+            source.write_bytes(b"\x00" * 100)
+            dest = Path(tmpdir) / "out.webp"
+            result = _generate_video_sync(source, dest, 200)
+            self.assertFalse(result)
+
+    def test_returns_false_on_invalid_video(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "corrupt.mp4"
+            source.write_text("not a video")
+            dest = Path(tmpdir) / "out.webp"
+            result = _generate_video_sync(source, dest, 200)
+            self.assertFalse(result)
 
 
 class TestThumbPath(unittest.TestCase):
@@ -184,10 +265,22 @@ class TestEnsureThumbnail(unittest.IsolatedAsyncioTestCase):
         result = await ensure_thumbnail(Path("/tmp"), 999, "folder", "img.jpg")
         self.assertIsNone(result)
 
-    async def test_rejects_non_image_file(self):
-        """ensure_thumbnail returns None for non-image files."""
-        result = await ensure_thumbnail(Path("/tmp"), 200, "folder", "video.mp4")
+    async def test_rejects_unsupported_file(self):
+        """ensure_thumbnail returns None for unsupported file types."""
+        result = await ensure_thumbnail(Path("/tmp"), 200, "folder", "doc.pdf")
         self.assertIsNone(result)
+
+    async def test_accepts_video_file_extension(self):
+        """ensure_thumbnail does not reject video files by extension."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            folder = "chat1"
+            (media_root / folder).mkdir()
+            source = media_root / folder / "clip.mp4"
+            source.write_bytes(b"\x00" * 100)
+            result = await ensure_thumbnail(media_root, 200, folder, "clip.mp4")
+            # Returns None because ffmpeg can't decode garbage, but doesn't reject on extension
+            self.assertIsNone(result)
 
     async def test_rejects_path_traversal_in_source(self):
         """ensure_thumbnail returns None when source escapes media_root."""

--- a/tests/test_web_thumbnails.py
+++ b/tests/test_web_thumbnails.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock, patch
 from src.web.thumbnails import (
     _IMAGE_EXTENSIONS,
     _MAX_SOURCE_BYTES,
-    _VIDEO_EXTENSIONS,
     ALLOWED_SIZES,
     WEBP_QUALITY,
     _check_ffmpeg,


### PR DESCRIPTION
## Summary
- Fix gallery lightbox black screen: `openMediaItem()` was setting `lightboxMedia` to array instead of single object
- Add video thumbnail generation via ffmpeg frame extraction
- Add ffmpeg to Docker image
- Consolidate extension lists into `media_utils.py` (single source of truth)
- Separate video semaphore (limit 2) to prevent resource pressure
- Fix ffmpeg to seek before input and fallback to first frame for short videos

## Test plan
- [x] Gallery lightbox displays photos/videos correctly
- [x] Prev/next navigation works in gallery and chat mode
- [x] Video files show thumbnail previews in gallery
- [x] 72 tests pass locally, CI green