### PR TITLE
fix(docker): add ffmpeg to viewer image for video thumbnails

### DIFF
--- a/Dockerfile.viewer
+++ b/Dockerfile.viewer
@@ -3,9 +3,10 @@ FROM python:3.14-slim
 # Set working directory
 WORKDIR /app
 
-# Install system libraries for Pillow (thumbnail generation)
+# Install system libraries for Pillow + ffmpeg for video thumbnail extraction
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libjpeg62-turbo libwebp7 libwebpmux3 zlib1g \
+    ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv for fast, reproducible dependency installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.11.0"
+version = "7.11.1"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.11.0"
+__version__ = "7.11.1"


### PR DESCRIPTION
## Summary
- Adds `ffmpeg` to `Dockerfile.viewer` so video thumbnail generation works in the viewer container
- The backup container already had ffmpeg, but the viewer (which actually serves thumbnails) was missing it
- All video thumb requests were returning 404 because `_check_ffmpeg()` returned False

## Test plan
- [ ] Verify viewer container has ffmpeg after rebuild
- [ ] Verify video thumbnails generate on first request
- [ ] Verify .MOV and .mp4 files show thumbnails in gallery

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Video thumbnail extraction capability is now available.
* **Chores**
  * Patch version update to 7.11.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/Telegram-Archive/pull/172?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->