### PR TITLE
fix(web): enforce media ACL on request path, not resolved symlink

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.11.1"
+version = "7.11.2"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.11.1"
+__version__ = "7.11.2"

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -947,7 +947,9 @@ async def serve_media(path: str, download: int = Query(0), user: UserContext = D
     if not resolved.is_relative_to(_media_root):
         raise HTTPException(status_code=403, detail="Access denied")
 
-    _enforce_media_acl(str(resolved.relative_to(_media_root)), user)
+    # ACL uses the original request path (chat folder), not the resolved symlink
+    # target — symlinks into _shared/ don't carry chat folder context.
+    _enforce_media_acl(path, user)
 
     if not resolved.is_file():
         raise HTTPException(status_code=404, detail="File not found")

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -268,10 +268,10 @@
     </script>
 </head>
 
-<body class="bg-gradient-to-br from-blue-600 via-blue-700 to-blue-800 text-white h-screen overflow-hidden">
+<body class="bg-slate-900 text-white h-screen overflow-hidden">
     <div id="app" class="w-full h-full">
         <!-- Login Page -->
-        <div v-if="!isAuthenticated" class="w-full h-full flex items-center justify-center">
+        <div v-if="!isAuthenticated" class="w-full h-full flex items-center justify-center bg-gradient-to-br from-blue-600 via-blue-700 to-blue-800">
             <div
                 class="bg-white/10 backdrop-blur-lg rounded-2xl shadow-2xl p-10 w-full max-w-md border border-white/20">
                 <!-- Telegram Logo -->


### PR DESCRIPTION
## Summary
- **Media ACL fix**: Restricted users got 403 on ALL media because symlinks resolve to `_shared/` folder. ACL tried to parse `_shared` as a chat ID → ValueError → 403. Admin was unaffected (unrestricted users skip ACL).
- **Mobile Safari fix**: Body had a blue gradient showing through safe-area padding on iOS. Moved gradient to login page only; app uses dark slate-900 everywhere.

## Root Cause (media)
Sharding migration created symlinks: `-1002240913478/file.jpg → ../_shared/03/file.jpg`
`resolve(strict=True)` follows the symlink, so `resolved.relative_to(media_root)` = `_shared/03/file.jpg`
ACL then does `int("_shared")` → ValueError → 403

## Test plan
- [ ] Restricted user can view media in their allowed chat
- [ ] Admin still works as before
- [ ] Path traversal protection still works (containment check on resolved path)
- [ ] Mobile Safari shows dark top/bottom (no bright blue)
- [ ] Login page still shows blue gradient