### PR TITLE
fix(media): preserve correct file extension on download finalize (#175)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.11.2"
+version = "7.11.3"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.11.2"
+__version__ = "7.11.3"

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -895,6 +895,13 @@ class DatabaseAdapter:
             await session.execute(stmt)
             await session.commit()
 
+    async def update_media_file_path(self, media_id: str, file_path: str) -> None:
+        """Update the stored file_path for a single media record."""
+        async with self.db_manager.async_session_factory() as session:
+            stmt = update(Media).where(Media.id == media_id).values(file_path=file_path)
+            await session.execute(stmt)
+            await session.commit()
+
     # ========== Reaction Operations ==========
 
     @retry_on_locked()

--- a/src/listener.py
+++ b/src/listener.py
@@ -40,6 +40,7 @@ from .message_utils import (
     download_and_shard_media,
     extract_topic_id,
     finalize_atomic_download,
+    sanitize_media_filename,
 )
 from .realtime import NotificationType, RealtimeNotifier
 from .telegram_backup import call_with_flood_retry
@@ -543,8 +544,8 @@ class TelegramListener:
                 if hasattr(attr, "file_name") and attr.file_name:
                     # Use Telegram file ID + original name for deduplication
                     if telegram_file_id:
-                        return f"{telegram_file_id}_{attr.file_name}"
-                    return attr.file_name
+                        return sanitize_media_filename(f"{telegram_file_id}_{attr.file_name}")
+                    return sanitize_media_filename(attr.file_name)
 
         # Generate filename based on type
         extensions = {

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -108,18 +108,34 @@ def compute_file_hash(filepath: str, chunk_size: int = 65536) -> str | None:
 
 
 def finalize_atomic_download(actual_path: str | None, temporary_path: str, fallback_path: str) -> str | None:
-    """Move a temporary download into place while preserving Telethon's chosen extension."""
-    if actual_path and os.path.exists(actual_path):
-        final_path = actual_path[:-5] if actual_path.endswith(".part") else actual_path
-        if final_path != actual_path:
-            os.replace(actual_path, final_path)
-        return final_path if os.path.exists(final_path) else None
+    """Move a finished download to its intended filename.
 
-    if os.path.exists(temporary_path):
-        os.replace(temporary_path, fallback_path)
-        return fallback_path if os.path.exists(fallback_path) else None
+    The temp path carries a unique ``.{pid}.{task}.part`` suffix so concurrent
+    downloads never collide. Telethon's ``_get_proper_filename`` treats that
+    trailing ``.part`` as the file extension and returns the temp path verbatim,
+    so the produced file is always one of ``actual_path`` / ``temporary_path``.
+    We rename it to the caller-provided ``fallback_path`` (the intended clean
+    name, already carrying the correct extension), instead of deriving a name
+    from the temp path — stripping only ``.part`` left names like
+    ``video.mp4.7.140234567890`` on disk. See issue #175.
+    """
+    source = actual_path if (actual_path and os.path.exists(actual_path)) else None
+    if source is None and os.path.exists(temporary_path):
+        source = temporary_path
+    if source is None:
+        return None
 
-    return None
+    if source != fallback_path:
+        os.replace(source, fallback_path)
+
+    # Clean up a stale temp artifact if Telethon wrote the real file elsewhere.
+    if temporary_path not in (fallback_path, source) and os.path.exists(temporary_path):
+        try:
+            os.remove(temporary_path)
+        except OSError:
+            pass
+
+    return fallback_path if os.path.exists(fallback_path) else None
 
 
 async def download_and_shard_media(

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -8,6 +8,23 @@ import os
 logger = logging.getLogger(__name__)
 
 
+def sanitize_media_filename(name: str) -> str:
+    """Strip path components from an attacker-controlled media filename.
+
+    Telegram document ``file_name`` attributes are remote-controlled and may
+    contain ``/``, ``\\``, or ``..`` segments. Left unchecked these survive into
+    ``media.file_name`` and later into on-disk ``os.replace`` targets, allowing a
+    write outside the media store (#175 repair pass made this reachable). Collapse
+    to a bare basename and neutralise residual traversal/separators.
+    """
+    name = name.replace("\\", "/")
+    name = os.path.basename(name)
+    name = name.replace("\x00", "")
+    if name in ("", ".", ".."):
+        return "_"
+    return name
+
+
 def get_shared_file_path(shared_dir: str, file_name: str, content_hash: str | None) -> str:
     """Build the sharded path for a file in the shared store.
 

--- a/src/repair_media_extensions.py
+++ b/src/repair_media_extensions.py
@@ -1,0 +1,179 @@
+"""Repair media files corrupted by the pre-7.11.3 download finalize bug (#175).
+
+Before 7.11.3, downloads went to a temp path ``{file_name}.{pid}.{task_id}.part``.
+Telethon treats the trailing ``.part`` as the extension and returns that path
+verbatim, and the old finalize step stripped only ``.part`` — leaving files
+named like ``1234_video.mp4.7.140234567890`` on disk.
+
+The corruption appears two ways:
+
+* No-dedup installs: the chat-folder file itself carries the corrupt name and
+  ``media.file_path`` points at it.
+* Dedup installs (default): the chat-folder entry is a symlink with the clean
+  name pointing at ``_shared/<hh>/<clean>.<pid>.<task>`` (corrupt blob name);
+  ``media.file_path`` already stores the clean chat-folder path.
+
+This pass is anchored to the DB's clean ``file_name`` so detection has zero
+false positives: a path is only treated as corrupt when its basename equals
+``file_name`` plus a ``.<int>.<int>`` tail. It never deletes anything (per
+project safety rules) and is crash-safe and idempotent via a marker file.
+"""
+
+import logging
+import os
+import re
+
+from .message_utils import compute_file_hash
+
+logger = logging.getLogger(__name__)
+
+REPAIR_MARKER = ".repaired-175"
+
+# Secondary guard: pid is a small int, id()-derived task_id is large.
+_CORRUPT_TAIL = re.compile(r"\.\d{1,7}\.\d{4,}$")
+
+
+def _is_corrupt_basename(basename: str, clean_name: str) -> bool:
+    """True when ``basename`` is ``clean_name`` plus a ``.<pid>.<task>`` tail.
+
+    Anchored to the known-good clean name to avoid misclassifying legitimate
+    filenames that merely end in digits.
+    """
+    if basename == clean_name:
+        return False
+    prefix = clean_name + "."
+    if not basename.startswith(prefix):
+        return False
+    tail = basename[len(clean_name) :]  # includes leading dot, e.g. ".7.1402..."
+    return bool(_CORRUPT_TAIL.fullmatch(tail))
+
+
+def _repair_direct_file(corrupt_path: str, clean_path: str) -> bool:
+    """No-dedup case: rename the corrupt on-disk file to its clean name.
+
+    Returns True when ``clean_path`` ends up holding the intended content.
+    """
+    if os.path.lexists(clean_path):
+        # A clean file already exists. Keep it; only adopt it when content matches.
+        if os.path.isfile(clean_path) and os.path.isfile(corrupt_path):
+            if compute_file_hash(clean_path) == compute_file_hash(corrupt_path):
+                return True  # redundant corrupt copy; leave it untouched (no delete)
+        return False  # genuine distinct file or unreadable — do not clobber
+    os.replace(corrupt_path, clean_path)
+    return True
+
+
+def _repair_symlink_blob(link_path: str, shared_dir: str) -> bool:
+    """Dedup case: rename the corrupt shared blob and retarget the chat symlink.
+
+    The symlink basename is already clean; only its target blob name is corrupt.
+    Renames the blob FIRST (creating the clean truth), then retargets the link,
+    so a crash in between leaves a dangling link that re-resolves on the next
+    run (the clean blob is found and the link is simply re-pointed).
+    """
+    link_dir = os.path.dirname(link_path)
+    clean_name = os.path.basename(link_path)
+    target = os.readlink(link_path)
+    blob_path = os.path.normpath(os.path.join(link_dir, target))
+    blob_dir = os.path.dirname(blob_path)
+    blob_name = os.path.basename(blob_path)
+
+    if not _is_corrupt_basename(blob_name, clean_name):
+        return False
+
+    clean_blob = os.path.join(blob_dir, clean_name)
+
+    if os.path.lexists(clean_blob):
+        if os.path.isfile(clean_blob) and os.path.isfile(blob_path):
+            if compute_file_hash(clean_blob) != compute_file_hash(blob_path):
+                return False  # distinct content under the clean name — skip
+        # Clean blob already present (matching or our own prior run): just relink.
+    elif os.path.isfile(blob_path):
+        os.replace(blob_path, clean_blob)
+    else:
+        return False  # corrupt blob missing and no clean blob — nothing to do
+
+    new_rel = os.path.relpath(clean_blob, link_dir)
+    os.unlink(link_path)
+    os.symlink(new_rel, link_path)
+    return True
+
+
+async def repair_media_extensions(media_path: str, db: object) -> int:
+    """Repair files corrupted by #175. Returns the number of records repaired.
+
+    Idempotent: a marker under ``_shared/`` short-circuits subsequent runs.
+    Never deletes files; orphan ``.part`` artifacts are only counted/logged.
+    """
+    if not media_path or not os.path.isdir(media_path):
+        return 0
+
+    shared_dir = os.path.join(media_path, "_shared")
+    marker = os.path.join(shared_dir, REPAIR_MARKER)
+    if os.path.exists(marker):
+        return 0
+
+    try:
+        records = await db.get_media_for_verification()
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning(f"Media repair skipped — could not read media records: {e}")
+        return 0
+
+    repaired = 0
+    skipped = 0
+    for record in records:
+        file_path = record.get("file_path")
+        clean_name = record.get("file_name")
+        media_id = record.get("id")
+        if not file_path or not clean_name or media_id is None:
+            continue
+
+        try:
+            if os.path.islink(file_path):
+                # Dedup case: link name is clean, blob name may be corrupt.
+                if os.path.basename(file_path) != clean_name:
+                    continue
+                if _repair_symlink_blob(file_path, shared_dir):
+                    repaired += 1
+                continue
+
+            # No-dedup case: the recorded path itself may be corrupt.
+            if _is_corrupt_basename(os.path.basename(file_path), clean_name):
+                clean_path = os.path.join(os.path.dirname(file_path), clean_name)
+                if _repair_direct_file(file_path, clean_path):
+                    await db.update_media_file_path(media_id, clean_path)
+                    repaired += 1
+                else:
+                    skipped += 1
+        except OSError:
+            skipped += 1
+
+    orphan_parts = _count_orphan_parts(shared_dir)
+
+    if repaired or skipped or orphan_parts:
+        logger.info(
+            "Media extension repair: %d repaired, %d skipped, %d orphan .part files left in place",
+            repaired,
+            skipped,
+            orphan_parts,
+        )
+
+    _write_marker(marker)
+    return repaired
+
+
+def _count_orphan_parts(shared_dir: str) -> int:
+    """Count leftover ``.part`` artifacts without deleting them."""
+    count = 0
+    for _root, _dirs, files in os.walk(shared_dir):
+        count += sum(1 for f in files if f.endswith(".part"))
+    return count
+
+
+def _write_marker(marker_path: str) -> None:
+    try:
+        os.makedirs(os.path.dirname(marker_path), exist_ok=True)
+        with open(marker_path, "w") as f:
+            f.write("media extension repair (#175) complete\n")
+    except OSError as e:
+        logger.error(f"Failed to write repair marker: {e}")

--- a/src/repair_media_extensions.py
+++ b/src/repair_media_extensions.py
@@ -51,14 +51,21 @@ def _is_corrupt_basename(basename: str, clean_name: str) -> bool:
 def _repair_direct_file(corrupt_path: str, clean_path: str) -> bool:
     """No-dedup case: rename the corrupt on-disk file to its clean name.
 
-    Returns True when ``clean_path`` ends up holding the intended content.
+    Returns True when ``clean_path`` ends up holding the intended content,
+    which signals the caller to repoint ``media.file_path`` at it.
     """
     if os.path.lexists(clean_path):
-        # A clean file already exists. Keep it; only adopt it when content matches.
+        # A clean file already exists.
+        if not os.path.lexists(corrupt_path):
+            # The user already renamed it by hand (the #175 reporter's own
+            # workaround) — adopt the clean file so the DB row is corrected.
+            return True
         if os.path.isfile(clean_path) and os.path.isfile(corrupt_path):
             if compute_file_hash(clean_path) == compute_file_hash(corrupt_path):
                 return True  # redundant corrupt copy; leave it untouched (no delete)
         return False  # genuine distinct file or unreadable — do not clobber
+    if not os.path.lexists(corrupt_path):
+        return False  # nothing on disk under either name
     os.replace(corrupt_path, clean_path)
     return True
 
@@ -77,6 +84,12 @@ def _repair_symlink_blob(link_path: str, shared_dir: str) -> bool:
     blob_path = os.path.normpath(os.path.join(link_dir, target))
     blob_dir = os.path.dirname(blob_path)
     blob_name = os.path.basename(blob_path)
+
+    # Only ever rename blobs that live inside our own _shared store; never touch
+    # externally managed targets (e.g. git-annex) the symlink may point at.
+    shared_root = os.path.normpath(shared_dir)
+    if os.path.commonpath([shared_root, blob_path]) != shared_root:
+        return False
 
     if not _is_corrupt_basename(blob_name, clean_name):
         return False

--- a/src/repair_media_extensions.py
+++ b/src/repair_media_extensions.py
@@ -17,11 +17,18 @@ This pass is anchored to the DB's clean ``file_name`` so detection has zero
 false positives: a path is only treated as corrupt when its basename equals
 ``file_name`` plus a ``.<int>.<int>`` tail. It never deletes anything (per
 project safety rules) and is crash-safe and idempotent via a marker file.
+
+The marker is written only when no row was *deferred* — i.e. only when no
+transient failure (filesystem error, DB write error) left repairable work
+undone. Permanent no-ops (a genuinely distinct file already under the clean
+name) do not block the marker, since retrying them can never succeed.
 """
 
+import asyncio
 import logging
 import os
 import re
+from typing import Protocol
 
 from .message_utils import compute_file_hash
 
@@ -29,8 +36,18 @@ logger = logging.getLogger(__name__)
 
 REPAIR_MARKER = ".repaired-175"
 
-# Secondary guard: pid is a small int, id()-derived task_id is large.
-_CORRUPT_TAIL = re.compile(r"\.\d{1,7}\.\d{4,}$")
+# Secondary guard: the task_id (id()-derived) is always large; the pid may be
+# any positive int. Anchoring to the clean name is what guarantees zero false
+# positives, so the pid bound is intentionally permissive.
+_CORRUPT_TAIL = re.compile(r"\.\d+\.\d{4,}$")
+
+
+class _MediaRepairDB(Protocol):
+    """The narrow DB surface the repair pass depends on."""
+
+    async def get_media_for_verification(self) -> list[dict]: ...
+
+    async def update_media_file_path(self, media_id: object, file_path: str) -> None: ...
 
 
 def _is_corrupt_basename(basename: str, clean_name: str) -> bool:
@@ -52,7 +69,8 @@ def _repair_direct_file(corrupt_path: str, clean_path: str) -> bool:
     """No-dedup case: rename the corrupt on-disk file to its clean name.
 
     Returns True when ``clean_path`` ends up holding the intended content,
-    which signals the caller to repoint ``media.file_path`` at it.
+    which signals the caller to repoint ``media.file_path`` at it. Raises
+    ``OSError`` on a transient filesystem failure so the driver can defer it.
     """
     if os.path.lexists(clean_path):
         # A clean file already exists.
@@ -76,7 +94,11 @@ def _repair_symlink_blob(link_path: str, shared_dir: str) -> bool:
     The symlink basename is already clean; only its target blob name is corrupt.
     Renames the blob FIRST (creating the clean truth), then retargets the link,
     so a crash in between leaves a dangling link that re-resolves on the next
-    run (the clean blob is found and the link is simply re-pointed).
+    run (the clean blob is found and the link is simply re-pointed). The same
+    re-resolution heals sibling symlinks (other chats sharing the dedup'd blob)
+    whose targets still carry the old corrupt name after the blob was renamed.
+
+    Raises ``OSError`` on a transient filesystem failure so the driver defers it.
     """
     link_dir = os.path.dirname(link_path)
     clean_name = os.path.basename(link_path)
@@ -87,8 +109,11 @@ def _repair_symlink_blob(link_path: str, shared_dir: str) -> bool:
 
     # Only ever rename blobs that live inside our own _shared store; never touch
     # externally managed targets (e.g. git-annex) the symlink may point at.
-    shared_root = os.path.normpath(shared_dir)
-    if os.path.commonpath([shared_root, blob_path]) != shared_root:
+    # realpath (not normpath) so a symlinked path component can't smuggle the
+    # target outside _shared past the containment check.
+    shared_root = os.path.realpath(shared_dir)
+    real_blob_dir = os.path.realpath(blob_dir)
+    if real_blob_dir != shared_root and not real_blob_dir.startswith(shared_root + os.sep):
         return False
 
     if not _is_corrupt_basename(blob_name, clean_name):
@@ -100,7 +125,8 @@ def _repair_symlink_blob(link_path: str, shared_dir: str) -> bool:
         if os.path.isfile(clean_blob) and os.path.isfile(blob_path):
             if compute_file_hash(clean_blob) != compute_file_hash(blob_path):
                 return False  # distinct content under the clean name — skip
-        # Clean blob already present (matching or our own prior run): just relink.
+        # Clean blob already present (matching content, our own prior run, or a
+        # sibling symlink that already renamed it): just relink.
     elif os.path.isfile(blob_path):
         os.replace(blob_path, clean_blob)
     else:
@@ -112,28 +138,19 @@ def _repair_symlink_blob(link_path: str, shared_dir: str) -> bool:
     return True
 
 
-async def repair_media_extensions(media_path: str, db: object) -> int:
-    """Repair files corrupted by #175. Returns the number of records repaired.
+def _repair_records_sync(records: list[dict], shared_dir: str) -> tuple[int, int, list[tuple]]:
+    """Do the blocking filesystem repair work off the event loop.
 
-    Idempotent: a marker under ``_shared/`` short-circuits subsequent runs.
-    Never deletes files; orphan ``.part`` artifacts are only counted/logged.
+    Returns ``(repaired, deferred, pending_db_updates)`` where
+    ``pending_db_updates`` is a list of ``(media_id, clean_path)`` rows whose
+    ``media.file_path`` must be repointed by the async caller. ``deferred``
+    counts rows that hit a transient filesystem error and should be retried on
+    a later run (these block the idempotency marker).
     """
-    if not media_path or not os.path.isdir(media_path):
-        return 0
-
-    shared_dir = os.path.join(media_path, "_shared")
-    marker = os.path.join(shared_dir, REPAIR_MARKER)
-    if os.path.exists(marker):
-        return 0
-
-    try:
-        records = await db.get_media_for_verification()
-    except Exception as e:  # pragma: no cover - defensive
-        logger.warning(f"Media repair skipped — could not read media records: {e}")
-        return 0
-
     repaired = 0
-    skipped = 0
+    deferred = 0
+    pending_db_updates: list[tuple] = []
+
     for record in records:
         file_path = record.get("file_path")
         clean_name = record.get("file_name")
@@ -154,33 +171,63 @@ async def repair_media_extensions(media_path: str, db: object) -> int:
             if _is_corrupt_basename(os.path.basename(file_path), clean_name):
                 clean_path = os.path.join(os.path.dirname(file_path), clean_name)
                 if _repair_direct_file(file_path, clean_path):
-                    await db.update_media_file_path(media_id, clean_path)
+                    pending_db_updates.append((media_id, clean_path))
                     repaired += 1
-                else:
-                    skipped += 1
         except OSError:
-            skipped += 1
+            deferred += 1
 
-    orphan_parts = _count_orphan_parts(shared_dir)
+    return repaired, deferred, pending_db_updates
 
-    if repaired or skipped or orphan_parts:
+
+async def repair_media_extensions(media_path: str, db: _MediaRepairDB) -> int:
+    """Repair files corrupted by #175. Returns the number of records repaired.
+
+    Idempotent: a marker under ``_shared/`` short-circuits subsequent runs, but
+    is written only when nothing was deferred, so transient failures are retried
+    on the next run instead of being permanently suppressed. Never deletes files.
+    """
+    if not media_path or not os.path.isdir(media_path):
+        return 0
+
+    shared_dir = os.path.join(media_path, "_shared")
+    marker = os.path.join(shared_dir, REPAIR_MARKER)
+    if os.path.exists(marker):
+        return 0
+
+    try:
+        records = await db.get_media_for_verification()
+    except Exception as e:
+        logger.warning("Media repair skipped — could not read media records (%s)", type(e).__name__)
+        return 0
+
+    # Filesystem walks, hashing, and renames are blocking; keep them off the
+    # event loop so the concurrently-running listener is not starved.
+    repaired, deferred, pending_db_updates = await asyncio.to_thread(_repair_records_sync, records, shared_dir)
+
+    # Repoint media.file_path for the no-dedup rows we renamed. A failure here
+    # leaves the file renamed but the row stale; defer so the marker is withheld
+    # and the next run's adoption branch repoints it.
+    for media_id, clean_path in pending_db_updates:
+        try:
+            await db.update_media_file_path(media_id, clean_path)
+        except Exception as e:
+            logger.warning("Media repair: DB repoint failed for one record (%s)", type(e).__name__)
+            deferred += 1
+            repaired -= 1
+
+    if repaired or deferred:
         logger.info(
-            "Media extension repair: %d repaired, %d skipped, %d orphan .part files left in place",
+            "Media extension repair: %d repaired, %d deferred for retry",
             repaired,
-            skipped,
-            orphan_parts,
+            deferred,
         )
 
-    _write_marker(marker)
+    # Only seal the pass when no repairable work was left behind by a transient
+    # failure. Permanent no-ops (distinct content under the clean name) do not
+    # set ``deferred`` and therefore never block the marker.
+    if deferred == 0:
+        _write_marker(marker)
     return repaired
-
-
-def _count_orphan_parts(shared_dir: str) -> int:
-    """Count leftover ``.part`` artifacts without deleting them."""
-    count = 0
-    for _root, _dirs, files in os.walk(shared_dir):
-        count += sum(1 for f in files if f.endswith(".part"))
-    return count
 
 
 def _write_marker(marker_path: str) -> None:
@@ -189,4 +236,4 @@ def _write_marker(marker_path: str) -> None:
         with open(marker_path, "w") as f:
             f.write("media extension repair (#175) complete\n")
     except OSError as e:
-        logger.error(f"Failed to write repair marker: {e}")
+        logger.error("Failed to write repair marker (%s)", type(e).__name__)

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -2131,6 +2131,10 @@ async def run_backup(config: Config, client: TelegramClient | None = None):
     backup = await TelegramBackup.create(config, client=client)
     try:
         await backup.connect()
+        # One-time repair of media files corrupted by the pre-7.11.3 finalize bug (#175).
+        from .repair_media_extensions import repair_media_extensions
+
+        await repair_media_extensions(config.media_path, backup.db)
         await backup.backup_all()
     finally:
         await backup.disconnect()

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -39,6 +39,7 @@ from .message_utils import (
     extract_topic_id,
     finalize_atomic_download,
     resolve_shared_file_path,
+    sanitize_media_filename,
 )
 
 logger = logging.getLogger(__name__)
@@ -1821,7 +1822,7 @@ class TelegramBackup:
         # If we have original filename, use it (with file_id prefix for uniqueness)
         if original_name and telegram_file_id:
             safe_id = str(telegram_file_id).replace("/", "_").replace("\\", "_")
-            return f"{safe_id}_{original_name}"
+            return sanitize_media_filename(f"{safe_id}_{original_name}")
 
         # Determine extension from mime_type, then fall back to media_type
         extension = None

--- a/tests/test_atomic_download_helpers.py
+++ b/tests/test_atomic_download_helpers.py
@@ -16,16 +16,53 @@ def test_finalize_atomic_download_uses_temporary_fallback(tmp_path):
     assert not temporary_path.exists()
 
 
-def test_finalize_atomic_download_strips_part_suffix(tmp_path):
-    """When Telethon returns a .part path, remove the suffix atomically."""
+def test_finalize_atomic_download_renames_actual_to_intended_name(tmp_path):
+    """Telethon returns the temp path verbatim; finalize moves it to the clean name."""
     actual_path = tmp_path / "chosen.jpg.part"
     actual_path.write_bytes(b"image")
     fallback_path = tmp_path / "fallback.jpg"
 
     result = finalize_atomic_download(str(actual_path), str(actual_path), str(fallback_path))
 
-    assert result == str(tmp_path / "chosen.jpg")
-    assert (tmp_path / "chosen.jpg").read_bytes() == b"image"
+    assert result == str(fallback_path)
+    assert fallback_path.read_bytes() == b"image"
+    assert not actual_path.exists()
+
+
+def test_finalize_atomic_download_does_not_leak_unique_temp_suffix(tmp_path):
+    """Regression for #175: the unique .{pid}.{task}.part temp name must never reach disk.
+
+    Telethon treats the trailing .part as the extension and returns our exact temp
+    path. Finalize must produce the clean intended name, not video.mp4.<pid>.<task>.
+    """
+    intended = tmp_path / "1234567890.mp4"
+    temp_path = tmp_path / "1234567890.mp4.7.140234567890.part"
+    temp_path.write_bytes(b"video-bytes")
+
+    # Telethon returns the temp path it was handed, untouched.
+    result = finalize_atomic_download(str(temp_path), str(temp_path), str(intended))
+
+    assert result == str(intended)
+    assert intended.read_bytes() == b"video-bytes"
+    assert not temp_path.exists()
+    # No corrupted siblings left behind.
+    leftovers = [p.name for p in tmp_path.iterdir()]
+    assert leftovers == ["1234567890.mp4"], leftovers
+
+
+def test_finalize_atomic_download_cleans_stale_temp_when_real_file_elsewhere(tmp_path):
+    """If Telethon writes the real file at a different path, the temp stub is removed."""
+    actual_path = tmp_path / "real.mp4"
+    actual_path.write_bytes(b"video")
+    temp_path = tmp_path / "real.mp4.7.99.part"
+    temp_path.write_bytes(b"")  # stale zero-byte stub
+    intended = tmp_path / "real.mp4.final"
+
+    result = finalize_atomic_download(str(actual_path), str(temp_path), str(intended))
+
+    assert result == str(intended)
+    assert intended.read_bytes() == b"video"
+    assert not temp_path.exists()
     assert not actual_path.exists()
 
 

--- a/tests/test_atomic_download_helpers.py
+++ b/tests/test_atomic_download_helpers.py
@@ -1,6 +1,6 @@
 """Tests for shared atomic media download finalization helpers."""
 
-from src.message_utils import finalize_atomic_download
+from src.message_utils import finalize_atomic_download, sanitize_media_filename
 
 
 def test_finalize_atomic_download_uses_temporary_fallback(tmp_path):
@@ -73,3 +73,34 @@ def test_finalize_atomic_download_returns_none_when_no_file_was_created(tmp_path
 
     assert finalize_atomic_download(None, str(missing_temp), str(fallback_path)) is None
     assert not fallback_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# sanitize_media_filename — attacker-controlled Telegram document file names
+# ---------------------------------------------------------------------------
+
+
+def test_sanitize_strips_posix_traversal():
+    assert sanitize_media_filename("../../etc/passwd") == "passwd"
+
+
+def test_sanitize_strips_windows_traversal():
+    assert sanitize_media_filename("..\\..\\windows\\system32\\evil.dll") == "evil.dll"
+
+
+def test_sanitize_collapses_leading_path_to_basename():
+    assert sanitize_media_filename("/abs/path/movie.mp4") == "movie.mp4"
+
+
+def test_sanitize_passes_clean_names_through():
+    assert sanitize_media_filename("1234_video.mp4") == "1234_video.mp4"
+
+
+def test_sanitize_neutralises_pure_traversal_tokens():
+    assert sanitize_media_filename("..") == "_"
+    assert sanitize_media_filename("") == "_"
+    assert sanitize_media_filename(".") == "_"
+
+
+def test_sanitize_drops_nul_byte():
+    assert "\x00" not in sanitize_media_filename("evil\x00.mp4")

--- a/tests/test_repair_media_extensions.py
+++ b/tests/test_repair_media_extensions.py
@@ -95,6 +95,28 @@ async def test_repair_no_dedup_skips_when_clean_exists_with_different_content(tm
     assert "m1" not in db.updates
 
 
+async def test_repair_no_dedup_adopts_manually_renamed_file(tmp_path):
+    """The #175 reporter renamed files by hand; repair must still fix the DB row.
+
+    Clean file exists, corrupt path is already gone -> adopt the clean file and
+    repoint media.file_path (otherwise the marker suppresses any later retry).
+    """
+    media = _media_root(tmp_path)
+    chat = media / "-100123"
+    chat.mkdir()
+    clean = chat / "abc.mp4"
+    clean.write_bytes(b"video")
+    corrupt_recorded = chat / "abc.mp4.7.140234567890"  # in DB, no longer on disk
+
+    db = _FakeDB([{"id": "m1", "file_name": "abc.mp4", "file_path": str(corrupt_recorded)}])
+
+    repaired = await repair_media_extensions(str(media), db)
+
+    assert repaired == 1
+    assert db.updates["m1"] == str(clean)
+    assert clean.read_bytes() == b"video"
+
+
 async def test_repair_no_dedup_adopts_clean_when_content_matches(tmp_path):
     media = _media_root(tmp_path)
     chat = media / "-100123"
@@ -165,6 +187,30 @@ async def test_repair_dedup_relinks_when_clean_blob_already_present(tmp_path):
     assert repaired == 1
     assert os.path.realpath(link) == str(clean_blob)
     assert clean_blob.read_bytes() == b"video"
+
+
+async def test_repair_dedup_never_renames_blob_outside_shared(tmp_path):
+    """A symlink pointing at an externally managed store must not be touched."""
+    media = _media_root(tmp_path)
+    external = tmp_path / "external_store"
+    external.mkdir()
+    external_blob = external / "abc.mp4.7.140234567890"
+    external_blob.write_bytes(b"managed-elsewhere")
+
+    chat = media / "-100123"
+    chat.mkdir()
+    link = chat / "abc.mp4"
+    link.symlink_to(os.path.relpath(external_blob, chat))
+
+    db = _FakeDB([{"id": "m1", "file_name": "abc.mp4", "file_path": str(link)}])
+
+    repaired = await repair_media_extensions(str(media), db)
+
+    assert repaired == 0
+    # External file untouched; no clean sibling created next to it.
+    assert external_blob.exists()
+    assert not (external / "abc.mp4").exists()
+    assert os.readlink(link) == os.path.relpath(external_blob, chat)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_repair_media_extensions.py
+++ b/tests/test_repair_media_extensions.py
@@ -1,10 +1,12 @@
 """Tests for the #175 media extension repair pass."""
 
 import os
+from unittest import mock
 
 from src.repair_media_extensions import (
     REPAIR_MARKER,
     _is_corrupt_basename,
+    _repair_records_sync,
     repair_media_extensions,
 )
 
@@ -12,14 +14,17 @@ from src.repair_media_extensions import (
 class _FakeDB:
     """Minimal async stand-in for the DatabaseAdapter media surface."""
 
-    def __init__(self, records):
+    def __init__(self, records, fail_update_ids=None):
         self._records = records
         self.updates = {}
+        self._fail_update_ids = set(fail_update_ids or ())
 
     async def get_media_for_verification(self):
         return list(self._records)
 
     async def update_media_file_path(self, media_id, file_path):
+        if media_id in self._fail_update_ids:
+            raise RuntimeError("simulated DB write failure")
         self.updates[media_id] = file_path
 
 
@@ -269,3 +274,247 @@ async def test_repair_is_idempotent_via_marker(tmp_path):
 async def test_repair_noop_when_media_path_missing(tmp_path):
     db = _FakeDB([])
     assert await repair_media_extensions(str(tmp_path / "nope"), db) == 0
+
+
+# ---------------------------------------------------------------------------
+# Marker is withheld on transient failure, so retries are not suppressed
+# ---------------------------------------------------------------------------
+
+
+async def test_repair_withholds_marker_when_db_repoint_fails(tmp_path):
+    """A DB write failure AFTER the on-disk rename must not seal the pass.
+
+    The file is renamed but the row is stale; the marker must be withheld so the
+    next run's adoption branch repoints media.file_path instead of suppressing it.
+    """
+    media = _media_root(tmp_path)
+    chat = media / "-100123"
+    chat.mkdir()
+    corrupt = chat / "abc.mp4.7.140234567890"
+    corrupt.write_bytes(b"video")
+
+    db = _FakeDB(
+        [{"id": "m1", "file_name": "abc.mp4", "file_path": str(corrupt)}],
+        fail_update_ids={"m1"},
+    )
+
+    repaired = await repair_media_extensions(str(media), db)
+
+    # Rename happened on disk, but the DB repoint failed -> not counted, marker withheld.
+    assert repaired == 0
+    assert (chat / "abc.mp4").read_bytes() == b"video"
+    assert not (media / "_shared" / REPAIR_MARKER).exists()
+
+    # Next run adopts the manually-present clean file and repoints the row.
+    db2 = _FakeDB([{"id": "m1", "file_name": "abc.mp4", "file_path": str(corrupt)}])
+    second = await repair_media_extensions(str(media), db2)
+    assert second == 1
+    assert db2.updates["m1"] == str(chat / "abc.mp4")
+    assert (media / "_shared" / REPAIR_MARKER).exists()
+
+
+async def test_repair_writes_marker_when_only_permanent_noops(tmp_path):
+    """A genuinely distinct clean file is a permanent no-op, not a deferral.
+
+    It must NOT block the marker — retrying can never resolve it.
+    """
+    media = _media_root(tmp_path)
+    chat = media / "-100123"
+    chat.mkdir()
+    corrupt = chat / "abc.mp4.7.140234567890"
+    corrupt.write_bytes(b"corrupt-copy")
+    clean = chat / "abc.mp4"
+    clean.write_bytes(b"distinct-real-file")
+
+    db = _FakeDB([{"id": "m1", "file_name": "abc.mp4", "file_path": str(corrupt)}])
+
+    repaired = await repair_media_extensions(str(media), db)
+
+    assert repaired == 0
+    assert (media / "_shared" / REPAIR_MARKER).exists()
+
+
+# ---------------------------------------------------------------------------
+# Multi-symlink dedup: sibling links self-heal after the blob is renamed
+# ---------------------------------------------------------------------------
+
+
+async def test_repair_dedup_heals_sibling_symlinks_to_renamed_blob(tmp_path):
+    """Two chats share one dedup'd blob. After the first link renames the blob,
+    the sibling link (still pointing at the old corrupt name) must be retargeted
+    to the clean blob in the same pass."""
+    media = _media_root(tmp_path)
+    shared = media / "_shared" / "ab"
+    shared.mkdir()
+    corrupt_blob = shared / "abc.mp4.7.140234567890"
+    corrupt_blob.write_bytes(b"video")
+
+    chat_a = media / "-100111"
+    chat_b = media / "-100222"
+    chat_a.mkdir()
+    chat_b.mkdir()
+    link_a = chat_a / "abc.mp4"
+    link_b = chat_b / "abc.mp4"
+    link_a.symlink_to(os.path.relpath(corrupt_blob, chat_a))
+    link_b.symlink_to(os.path.relpath(corrupt_blob, chat_b))
+
+    db = _FakeDB(
+        [
+            {"id": "m1", "file_name": "abc.mp4", "file_path": str(link_a)},
+            {"id": "m2", "file_name": "abc.mp4", "file_path": str(link_b)},
+        ]
+    )
+
+    repaired = await repair_media_extensions(str(media), db)
+
+    assert repaired == 2
+    clean_blob = shared / "abc.mp4"
+    assert clean_blob.read_bytes() == b"video"
+    assert not corrupt_blob.exists()
+    assert os.path.realpath(link_a) == str(clean_blob)
+    assert os.path.realpath(link_b) == str(clean_blob)
+
+
+# ---------------------------------------------------------------------------
+# Skip paths
+# ---------------------------------------------------------------------------
+
+
+async def test_repair_skips_symlink_when_basename_differs_from_clean_name(tmp_path):
+    """A symlink whose basename doesn't match file_name is left untouched."""
+    media = _media_root(tmp_path)
+    shared = media / "_shared" / "ab"
+    shared.mkdir()
+    corrupt_blob = shared / "abc.mp4.7.140234567890"
+    corrupt_blob.write_bytes(b"video")
+
+    chat = media / "-100123"
+    chat.mkdir()
+    # Link basename "renamed.mp4" != DB file_name "abc.mp4" -> skip.
+    link = chat / "renamed.mp4"
+    link.symlink_to(os.path.relpath(corrupt_blob, chat))
+
+    db = _FakeDB([{"id": "m1", "file_name": "abc.mp4", "file_path": str(link)}])
+
+    repaired = await repair_media_extensions(str(media), db)
+
+    assert repaired == 0
+    assert corrupt_blob.exists()
+    assert os.readlink(link) == os.path.relpath(corrupt_blob, chat)
+
+
+async def test_repair_defers_and_withholds_marker_on_replace_oserror(tmp_path):
+    """A transient os.replace failure during a no-dedup rename defers the row.
+
+    The marker must be withheld so the next run retries instead of suppressing.
+    """
+    media = _media_root(tmp_path)
+    chat = media / "-100123"
+    chat.mkdir()
+    corrupt = chat / "abc.mp4.7.140234567890"
+    corrupt.write_bytes(b"video")
+
+    db = _FakeDB([{"id": "m1", "file_name": "abc.mp4", "file_path": str(corrupt)}])
+
+    with mock.patch("src.repair_media_extensions.os.replace", side_effect=OSError("EIO")):
+        repaired = await repair_media_extensions(str(media), db)
+
+    assert repaired == 0
+    assert "m1" not in db.updates
+    assert not (media / "_shared" / REPAIR_MARKER).exists()
+
+
+async def test_repair_realpath_guard_blocks_symlinked_blob_dir(tmp_path):
+    """A blob dir that is itself a symlink resolving outside _shared is rejected.
+
+    normpath would be fooled; realpath is not. The link must be left untouched.
+    """
+    media = _media_root(tmp_path)
+    external = tmp_path / "external_store"
+    external.mkdir()
+    external_blob = external / "abc.mp4.7.140234567890"
+    external_blob.write_bytes(b"managed-elsewhere")
+
+    # _shared/sneaky -> ../external_store (a symlinked bucket pointing outside)
+    sneaky = media / "_shared" / "sneaky"
+    sneaky.symlink_to(os.path.relpath(external, media / "_shared"))
+
+    chat = media / "-100123"
+    chat.mkdir()
+    link = chat / "abc.mp4"
+    # Link target goes through the in-_shared symlink, so normpath stays "inside".
+    link.symlink_to(os.path.relpath(sneaky / "abc.mp4.7.140234567890", chat))
+
+    db = _FakeDB([{"id": "m1", "file_name": "abc.mp4", "file_path": str(link)}])
+
+    repaired = await repair_media_extensions(str(media), db)
+
+    assert repaired == 0
+    assert external_blob.exists()
+    assert not (external / "abc.mp4").exists()
+
+
+# ---------------------------------------------------------------------------
+# _repair_records_sync — the off-loop worker contract
+# ---------------------------------------------------------------------------
+
+
+def test_repair_records_sync_returns_pending_update_for_direct_file(tmp_path):
+    media = _media_root(tmp_path)
+    chat = media / "-100123"
+    chat.mkdir()
+    corrupt = chat / "abc.mp4.7.140234567890"
+    corrupt.write_bytes(b"video")
+
+    records = [{"id": "m1", "file_name": "abc.mp4", "file_path": str(corrupt)}]
+    repaired, deferred, pending = _repair_records_sync(records, str(media / "_shared"))
+
+    assert repaired == 1
+    assert deferred == 0
+    assert pending == [("m1", str(chat / "abc.mp4"))]
+    assert (chat / "abc.mp4").read_bytes() == b"video"
+
+
+def test_repair_records_sync_counts_oserror_as_deferred(tmp_path):
+    media = _media_root(tmp_path)
+    chat = media / "-100123"
+    chat.mkdir()
+    corrupt = chat / "abc.mp4.7.140234567890"
+    corrupt.write_bytes(b"video")
+
+    records = [{"id": "m1", "file_name": "abc.mp4", "file_path": str(corrupt)}]
+    with mock.patch("src.repair_media_extensions.os.replace", side_effect=OSError("EIO")):
+        repaired, deferred, pending = _repair_records_sync(records, str(media / "_shared"))
+
+    assert repaired == 0
+    assert deferred == 1
+    assert pending == []
+
+
+def test_repair_records_sync_skips_incomplete_records(tmp_path):
+    media = _media_root(tmp_path)
+    records = [
+        {"id": None, "file_name": "abc.mp4", "file_path": "/x"},
+        {"id": "m2", "file_name": None, "file_path": "/x"},
+        {"id": "m3", "file_name": "abc.mp4", "file_path": None},
+    ]
+    repaired, deferred, pending = _repair_records_sync(records, str(media / "_shared"))
+    assert (repaired, deferred, pending) == (0, 0, [])
+
+
+async def test_repair_offloads_fs_work_to_thread(tmp_path):
+    """repair_media_extensions runs the blocking sweep via asyncio.to_thread."""
+    media = _media_root(tmp_path)
+    db = _FakeDB([])
+
+    with mock.patch(
+        "src.repair_media_extensions.asyncio.to_thread",
+        new_callable=mock.AsyncMock,
+        return_value=(0, 0, []),
+    ) as to_thread:
+        await repair_media_extensions(str(media), db)
+
+    to_thread.assert_awaited_once()
+    args = to_thread.await_args.args
+    assert args[0] is _repair_records_sync
+    assert args[2] == str(media / "_shared")

--- a/tests/test_repair_media_extensions.py
+++ b/tests/test_repair_media_extensions.py
@@ -1,0 +1,225 @@
+"""Tests for the #175 media extension repair pass."""
+
+import os
+
+from src.repair_media_extensions import (
+    REPAIR_MARKER,
+    _is_corrupt_basename,
+    repair_media_extensions,
+)
+
+
+class _FakeDB:
+    """Minimal async stand-in for the DatabaseAdapter media surface."""
+
+    def __init__(self, records):
+        self._records = records
+        self.updates = {}
+
+    async def get_media_for_verification(self):
+        return list(self._records)
+
+    async def update_media_file_path(self, media_id, file_path):
+        self.updates[media_id] = file_path
+
+
+def _media_root(tmp_path):
+    media = tmp_path / "media"
+    (media / "_shared").mkdir(parents=True)
+    return media
+
+
+# ---------------------------------------------------------------------------
+# Detection
+# ---------------------------------------------------------------------------
+
+
+def test_is_corrupt_basename_matches_pid_task_tail():
+    assert _is_corrupt_basename("123.mp4.7.140234567890", "123.mp4")
+
+
+def test_is_corrupt_basename_rejects_clean_name():
+    assert not _is_corrupt_basename("123.mp4", "123.mp4")
+
+
+def test_is_corrupt_basename_rejects_legit_digit_names():
+    # A real filename that merely ends in digits must not be flagged.
+    assert not _is_corrupt_basename("backup_2024.7z", "backup_2024.7z")
+    assert not _is_corrupt_basename("report.v2", "report.v2")
+
+
+def test_is_corrupt_basename_requires_clean_prefix():
+    assert not _is_corrupt_basename("other.mp4.7.999999", "123.mp4")
+
+
+# ---------------------------------------------------------------------------
+# No-dedup repair: corrupt file recorded directly in DB
+# ---------------------------------------------------------------------------
+
+
+async def test_repair_no_dedup_renames_file_and_updates_db(tmp_path):
+    media = _media_root(tmp_path)
+    chat = media / "-100123"
+    chat.mkdir()
+    corrupt = chat / "abc.mp4.7.140234567890"
+    corrupt.write_bytes(b"video")
+
+    db = _FakeDB([{"id": "m1", "file_name": "abc.mp4", "file_path": str(corrupt)}])
+
+    repaired = await repair_media_extensions(str(media), db)
+
+    assert repaired == 1
+    clean = chat / "abc.mp4"
+    assert clean.read_bytes() == b"video"
+    assert not corrupt.exists()
+    assert db.updates["m1"] == str(clean)
+
+
+async def test_repair_no_dedup_skips_when_clean_exists_with_different_content(tmp_path):
+    media = _media_root(tmp_path)
+    chat = media / "-100123"
+    chat.mkdir()
+    corrupt = chat / "abc.mp4.7.140234567890"
+    corrupt.write_bytes(b"corrupt-copy")
+    clean = chat / "abc.mp4"
+    clean.write_bytes(b"the-real-distinct-file")
+
+    db = _FakeDB([{"id": "m1", "file_name": "abc.mp4", "file_path": str(corrupt)}])
+
+    repaired = await repair_media_extensions(str(media), db)
+
+    assert repaired == 0
+    # Neither file is destroyed.
+    assert clean.read_bytes() == b"the-real-distinct-file"
+    assert corrupt.read_bytes() == b"corrupt-copy"
+    assert "m1" not in db.updates
+
+
+async def test_repair_no_dedup_adopts_clean_when_content_matches(tmp_path):
+    media = _media_root(tmp_path)
+    chat = media / "-100123"
+    chat.mkdir()
+    corrupt = chat / "abc.mp4.7.140234567890"
+    corrupt.write_bytes(b"same")
+    clean = chat / "abc.mp4"
+    clean.write_bytes(b"same")
+
+    db = _FakeDB([{"id": "m1", "file_name": "abc.mp4", "file_path": str(corrupt)}])
+
+    repaired = await repair_media_extensions(str(media), db)
+
+    # Treated as repaired (clean copy already holds the content); DB row points clean.
+    assert repaired == 1
+    assert db.updates["m1"] == str(clean)
+    assert clean.read_bytes() == b"same"
+
+
+# ---------------------------------------------------------------------------
+# Dedup repair: clean symlink -> corrupt shared blob
+# ---------------------------------------------------------------------------
+
+
+async def test_repair_dedup_renames_blob_and_retargets_symlink(tmp_path):
+    media = _media_root(tmp_path)
+    shared = media / "_shared" / "ab"
+    shared.mkdir()
+    corrupt_blob = shared / "abc.mp4.7.140234567890"
+    corrupt_blob.write_bytes(b"video")
+
+    chat = media / "-100123"
+    chat.mkdir()
+    link = chat / "abc.mp4"
+    link.symlink_to(os.path.relpath(corrupt_blob, chat))
+
+    db = _FakeDB([{"id": "m1", "file_name": "abc.mp4", "file_path": str(link)}])
+
+    repaired = await repair_media_extensions(str(media), db)
+
+    assert repaired == 1
+    clean_blob = shared / "abc.mp4"
+    assert clean_blob.read_bytes() == b"video"
+    assert not corrupt_blob.exists()
+    # Symlink still resolves, now to the clean blob.
+    assert os.path.islink(link)
+    assert os.path.realpath(link) == str(clean_blob)
+
+
+async def test_repair_dedup_relinks_when_clean_blob_already_present(tmp_path):
+    media = _media_root(tmp_path)
+    shared = media / "_shared" / "ab"
+    shared.mkdir()
+    corrupt_blob = shared / "abc.mp4.7.140234567890"
+    corrupt_blob.write_bytes(b"video")
+    clean_blob = shared / "abc.mp4"
+    clean_blob.write_bytes(b"video")  # identical content
+
+    chat = media / "-100123"
+    chat.mkdir()
+    link = chat / "abc.mp4"
+    link.symlink_to(os.path.relpath(corrupt_blob, chat))
+
+    db = _FakeDB([{"id": "m1", "file_name": "abc.mp4", "file_path": str(link)}])
+
+    repaired = await repair_media_extensions(str(media), db)
+
+    assert repaired == 1
+    assert os.path.realpath(link) == str(clean_blob)
+    assert clean_blob.read_bytes() == b"video"
+
+
+# ---------------------------------------------------------------------------
+# Safety / idempotency
+# ---------------------------------------------------------------------------
+
+
+async def test_repair_leaves_clean_records_untouched(tmp_path):
+    media = _media_root(tmp_path)
+    chat = media / "-100123"
+    chat.mkdir()
+    clean = chat / "abc.mp4"
+    clean.write_bytes(b"video")
+
+    db = _FakeDB([{"id": "m1", "file_name": "abc.mp4", "file_path": str(clean)}])
+
+    repaired = await repair_media_extensions(str(media), db)
+
+    assert repaired == 0
+    assert "m1" not in db.updates
+    assert clean.read_bytes() == b"video"
+
+
+async def test_repair_never_deletes_orphan_part_files(tmp_path):
+    media = _media_root(tmp_path)
+    orphan = media / "_shared" / "leftover.mp4.7.99.part"
+    orphan.write_bytes(b"partial")
+
+    db = _FakeDB([])
+
+    await repair_media_extensions(str(media), db)
+
+    assert orphan.exists()  # counted, not deleted
+
+
+async def test_repair_is_idempotent_via_marker(tmp_path):
+    media = _media_root(tmp_path)
+    chat = media / "-100123"
+    chat.mkdir()
+    corrupt = chat / "abc.mp4.7.140234567890"
+    corrupt.write_bytes(b"video")
+
+    db = _FakeDB([{"id": "m1", "file_name": "abc.mp4", "file_path": str(corrupt)}])
+
+    first = await repair_media_extensions(str(media), db)
+    assert first == 1
+    assert (media / "_shared" / REPAIR_MARKER).exists()
+
+    # Second run short-circuits on the marker.
+    db2 = _FakeDB([{"id": "m1", "file_name": "abc.mp4", "file_path": str(corrupt)}])
+    second = await repair_media_extensions(str(media), db2)
+    assert second == 0
+    assert db2.updates == {}
+
+
+async def test_repair_noop_when_media_path_missing(tmp_path):
+    db = _FakeDB([])
+    assert await repair_media_extensions(str(tmp_path / "nope"), db) == 0

--- a/tests/test_symlink_dedup.py
+++ b/tests/test_symlink_dedup.py
@@ -166,12 +166,12 @@ class TestDownloadReturnValueCapture(unittest.TestCase):
         # clean filename — finalize renames the download to file_name regardless
         # of the path Telethon returned (regression guard for #175).
         chat_link = os.path.join(chat_dir, "fileid123.bin")
-        if os.path.lexists(chat_link):
-            resolved = os.path.realpath(chat_link)
-            self.assertTrue(os.path.exists(resolved))
-            self.assertEqual(os.path.basename(resolved), "fileid123.bin")
-            with open(resolved, "rb") as f:
-                self.assertEqual(f.read(), b"video data")
+        self.assertTrue(os.path.lexists(chat_link), "chat-dir symlink was never created")
+        resolved = os.path.realpath(chat_link)
+        self.assertTrue(os.path.exists(resolved))
+        self.assertEqual(os.path.basename(resolved), "fileid123.bin")
+        with open(resolved, "rb") as f:
+            self.assertEqual(f.read(), b"video data")
 
 
 class TestProcessMediaDedupSymlink(unittest.TestCase):
@@ -241,12 +241,12 @@ class TestProcessMediaDedupSymlink(unittest.TestCase):
         # The chat-dir symlink should resolve to the intended clean filename;
         # finalize renames the download to file_name (regression guard for #175).
         chat_file = os.path.join(chat_dir, "photo_abc")
-        if os.path.lexists(chat_file):
-            resolved = os.path.realpath(chat_file)
-            self.assertTrue(os.path.exists(resolved))
-            self.assertEqual(os.path.basename(resolved), "photo_abc")
-            with open(resolved, "rb") as f:
-                self.assertEqual(f.read(), b"mp4 content here")
+        self.assertTrue(os.path.lexists(chat_file), "chat-dir symlink was never created")
+        resolved = os.path.realpath(chat_file)
+        self.assertTrue(os.path.exists(resolved))
+        self.assertEqual(os.path.basename(resolved), "photo_abc")
+        with open(resolved, "rb") as f:
+            self.assertEqual(f.read(), b"mp4 content here")
 
     def test_process_media_preserves_existing_symlink(self):
         """An existing symlink at file_path short-circuits the download path.
@@ -682,12 +682,12 @@ class TestListenerDownloadMediaDedup(unittest.TestCase):
         # Symlink should resolve to the intended clean filename; finalize renames
         # the download to file_name, not the path Telethon returned (#175 guard).
         chat_file = os.path.join(chat_dir, file_name)
-        if os.path.lexists(chat_file):
-            resolved = os.path.realpath(chat_file)
-            self.assertTrue(os.path.exists(resolved))
-            self.assertEqual(os.path.basename(resolved), file_name)
-            with open(resolved, "rb") as f:
-                self.assertEqual(f.read(), b"video content")
+        self.assertTrue(os.path.lexists(chat_file), "chat-dir symlink was never created")
+        resolved = os.path.realpath(chat_file)
+        self.assertTrue(os.path.exists(resolved))
+        self.assertEqual(os.path.basename(resolved), file_name)
+        with open(resolved, "rb") as f:
+            self.assertEqual(f.read(), b"video content")
 
     def test_listener_dedup_preserves_existing_symlink(self):
         """Listener leaves an existing chat-dir symlink alone, even when broken.

--- a/tests/test_symlink_dedup.py
+++ b/tests/test_symlink_dedup.py
@@ -162,13 +162,16 @@ class TestDownloadReturnValueCapture(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertTrue(result["downloaded"])
 
-        # The symlink in the chat dir should exist and point to the .mp4 file
+        # The symlink in the chat dir should exist and resolve to the intended
+        # clean filename — finalize renames the download to file_name regardless
+        # of the path Telethon returned (regression guard for #175).
         chat_link = os.path.join(chat_dir, "fileid123.bin")
         if os.path.lexists(chat_link):
             resolved = os.path.realpath(chat_link)
-            # File is sharded but retains Telethon's .mp4 extension
             self.assertTrue(os.path.exists(resolved))
-            self.assertTrue(resolved.endswith("fileid123.mp4"))
+            self.assertEqual(os.path.basename(resolved), "fileid123.bin")
+            with open(resolved, "rb") as f:
+                self.assertEqual(f.read(), b"video data")
 
 
 class TestProcessMediaDedupSymlink(unittest.TestCase):
@@ -235,12 +238,15 @@ class TestProcessMediaDedupSymlink(unittest.TestCase):
         self.assertIsNotNone(result)
         self.assertTrue(result["downloaded"])
 
-        # The chat-dir symlink should resolve to the .mp4 file
+        # The chat-dir symlink should resolve to the intended clean filename;
+        # finalize renames the download to file_name (regression guard for #175).
         chat_file = os.path.join(chat_dir, "photo_abc")
         if os.path.lexists(chat_file):
             resolved = os.path.realpath(chat_file)
             self.assertTrue(os.path.exists(resolved))
-            self.assertTrue(resolved.endswith("photo_abc.mp4"))
+            self.assertEqual(os.path.basename(resolved), "photo_abc")
+            with open(resolved, "rb") as f:
+                self.assertEqual(f.read(), b"mp4 content here")
 
     def test_process_media_preserves_existing_symlink(self):
         """An existing symlink at file_path short-circuits the download path.
@@ -673,12 +679,15 @@ class TestListenerDownloadMediaDedup(unittest.TestCase):
         result = self._run(self.listener._download_media(msg, chat_id))
 
         self.assertIsNotNone(result)
-        # Symlink should point to the .mp4 path returned by Telethon
+        # Symlink should resolve to the intended clean filename; finalize renames
+        # the download to file_name, not the path Telethon returned (#175 guard).
         chat_file = os.path.join(chat_dir, file_name)
         if os.path.lexists(chat_file):
             resolved = os.path.realpath(chat_file)
             self.assertTrue(os.path.exists(resolved))
-            self.assertTrue(resolved.endswith("video_xyz.mp4"))
+            self.assertEqual(os.path.basename(resolved), file_name)
+            with open(resolved, "rb") as f:
+                self.assertEqual(f.read(), b"video content")
 
     def test_listener_dedup_preserves_existing_symlink(self):
         """Listener leaves an existing chat-dir symlink alone, even when broken.

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -1710,6 +1710,25 @@ class TestRunBackup(unittest.TestCase):
         mock_backup.backup_all.assert_awaited_once()
         mock_backup.disconnect.assert_awaited_once()
 
+    @patch("src.repair_media_extensions.repair_media_extensions", new_callable=AsyncMock)
+    @patch("src.telegram_backup.TelegramBackup.create", new_callable=AsyncMock)
+    def test_run_backup_runs_media_repair_before_backup(self, mock_create, mock_repair):
+        """run_backup awaits the #175 media repair pass before backing up."""
+        mock_backup = AsyncMock()
+        mock_create.return_value = mock_backup
+
+        config = MagicMock()
+        config.media_path = "/tmp/media-path"
+
+        order = []
+        mock_repair.side_effect = lambda *a, **k: order.append("repair")
+        mock_backup.backup_all.side_effect = lambda *a, **k: order.append("backup")
+
+        _run(run_backup(config))
+
+        mock_repair.assert_awaited_once_with(config.media_path, mock_backup.db)
+        self.assertEqual(order, ["repair", "backup"])
+
     @patch("src.telegram_backup.TelegramBackup.create", new_callable=AsyncMock)
     def test_run_backup_disconnects_on_error(self, mock_create):
         """run_backup calls disconnect even when backup_all raises."""


### PR DESCRIPTION
## Summary

Fixes #175 — media files saved on disk with names like `filename.mp4.<random-numbers>` and orphan `.part` files.

**Root cause:** Downloads go to a unique temp path `{file_name}.{pid}.{task_id}.part` (so concurrent downloads never collide). Telethon's `_get_proper_filename` does `splitext()` and, seeing the trailing `.part` as a non-empty extension, returns our temp path verbatim. The old `finalize_atomic_download` then stripped only the 5-char `.part`, leaving `video.mp4.7.140234567890` on disk. Leftover `.part` files are downloads interrupted before finalize ran. File **content** was always intact — only the name/extension was wrong, which matches the reporter's finding that renaming made the files work.

## Changes

- **Forward fix** (`src/message_utils.py`): `finalize_atomic_download` now renames the finished download to the caller-provided clean target name (already the correct extension at all three call sites) instead of string-stripping `.part`. Also cleans a stale temp stub if Telethon wrote the real file elsewhere.
- **One-time repair pass** (`src/repair_media_extensions.py`): idempotent startup pass (marker file under `_shared/`) that repairs already-corrupted files for both layouts:
  - **no-dedup**: renames the corrupt on-disk file to its clean name and updates `media.file_path`.
  - **dedup**: renames the corrupt `_shared/<hh>/` blob to its clean name and retargets the chat symlink (blob-rename first → crash-safe).
  - Detection is anchored to the DB's clean `file_name` (corrupt iff basename == `file_name` + `.<int>.<int>` tail), giving **zero false positives** on legitimate digit-ending filenames.
  - Content-hash collision guard: never clobbers an existing distinct clean file.
  - **Never deletes** anything (per project safety rules) — orphan `.part` files are only counted and logged. Logs counts only (no PII).
- `update_media_file_path` adapter method; wired into `run_backup` startup.

## Test plan

- [x] `tests/test_atomic_download_helpers.py` — finalize renames to clean name; regression test proving the `.<pid>.<task>` suffix never reaches disk
- [x] `tests/test_repair_media_extensions.py` — no-dedup + dedup repair, collision (matching/distinct content), false-positive avoidance, orphan `.part` never deleted, idempotency via marker
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI (Python 3.14): full suite incl. web/listener tests that need FastAPI/pydantic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed media file download corruption issue from a previous version
  * Added automatic one-time repair process to restore previously corrupted media files
  * Improved download finalization logic to ensure correct filenames are used

* **Chores**
  * Version bumped to 7.11.3

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GeiserX/Telegram-Archive/pull/176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->