### PR TITLE
fix(media): stream #175 repair in batches to avoid OOM crash loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.11.3"
+version = "7.11.4"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.11.3"
+__version__ = "7.11.4"

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -857,6 +857,33 @@ class DatabaseAdapter:
                 for m in result.scalars()
             ]
 
+    async def iter_media_paths_for_repair(self, batch_size: int = 500):
+        """Yield ``(id, file_path, file_name)`` batches for the #175 repair pass.
+
+        Keyset-paginated on the primary key and projecting only the three columns
+        the repair needs, so memory stays bounded regardless of table size. The
+        full-table materialization in ``get_media_for_verification`` OOM-killed
+        the 256m backup container on large archives; this streams instead.
+        """
+        last_id: str | None = None
+        while True:
+            async with self.db_manager.async_session_factory() as session:
+                stmt = (
+                    select(Media.id, Media.file_path, Media.file_name)
+                    .where(or_(Media.downloaded == 1, Media.file_path.isnot(None)))
+                    .order_by(Media.id)
+                    .limit(batch_size)
+                )
+                if last_id is not None:
+                    stmt = stmt.where(Media.id > last_id)
+                rows = (await session.execute(stmt)).all()
+            if not rows:
+                return
+            yield [{"id": r[0], "file_path": r[1], "file_name": r[2]} for r in rows]
+            last_id = rows[-1][0]
+            if len(rows) < batch_size:
+                return
+
     async def get_pending_media_downloads(self, max_media_size_bytes: int | None = None) -> list[dict[str, Any]]:
         """Get media records that failed to download and need retry.
 

--- a/src/repair_media_extensions.py
+++ b/src/repair_media_extensions.py
@@ -28,6 +28,7 @@ import asyncio
 import logging
 import os
 import re
+from collections.abc import AsyncIterator
 from typing import Protocol
 
 from .message_utils import compute_file_hash
@@ -45,7 +46,7 @@ _CORRUPT_TAIL = re.compile(r"\.\d+\.\d{4,}$")
 class _MediaRepairDB(Protocol):
     """The narrow DB surface the repair pass depends on."""
 
-    async def get_media_for_verification(self) -> list[dict]: ...
+    def iter_media_paths_for_repair(self, batch_size: int = ...) -> AsyncIterator[list[dict]]: ...
 
     async def update_media_file_path(self, media_id: object, file_path: str) -> None: ...
 
@@ -194,26 +195,36 @@ async def repair_media_extensions(media_path: str, db: _MediaRepairDB) -> int:
     if os.path.exists(marker):
         return 0
 
+    repaired = 0
+    deferred = 0
+
+    # Stream the media table in keyset-paginated batches. Materializing the whole
+    # table OOM-killed the 256m backup container on large archives (#175 v7.11.3
+    # crash loop), so we hold only one batch in memory at a time.
     try:
-        records = await db.get_media_for_verification()
+        batches = db.iter_media_paths_for_repair()
+        async for records in batches:
+            # Filesystem walks, hashing, and renames are blocking; keep them off
+            # the event loop so the concurrently-running listener is not starved.
+            batch_repaired, batch_deferred, pending_db_updates = await asyncio.to_thread(
+                _repair_records_sync, records, shared_dir
+            )
+            repaired += batch_repaired
+            deferred += batch_deferred
+
+            # Repoint media.file_path for the no-dedup rows we renamed. A failure
+            # here leaves the file renamed but the row stale; defer so the marker
+            # is withheld and the next run's adoption branch repoints it.
+            for media_id, clean_path in pending_db_updates:
+                try:
+                    await db.update_media_file_path(media_id, clean_path)
+                except Exception as e:
+                    logger.warning("Media repair: DB repoint failed for one record (%s)", type(e).__name__)
+                    deferred += 1
+                    repaired -= 1
     except Exception as e:
-        logger.warning("Media repair skipped — could not read media records (%s)", type(e).__name__)
-        return 0
-
-    # Filesystem walks, hashing, and renames are blocking; keep them off the
-    # event loop so the concurrently-running listener is not starved.
-    repaired, deferred, pending_db_updates = await asyncio.to_thread(_repair_records_sync, records, shared_dir)
-
-    # Repoint media.file_path for the no-dedup rows we renamed. A failure here
-    # leaves the file renamed but the row stale; defer so the marker is withheld
-    # and the next run's adoption branch repoints it.
-    for media_id, clean_path in pending_db_updates:
-        try:
-            await db.update_media_file_path(media_id, clean_path)
-        except Exception as e:
-            logger.warning("Media repair: DB repoint failed for one record (%s)", type(e).__name__)
-            deferred += 1
-            repaired -= 1
+        logger.warning("Media repair aborted — could not read media records (%s)", type(e).__name__)
+        return repaired
 
     if repaired or deferred:
         logger.info(

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -3198,3 +3198,62 @@ class TestUpsertChatFolderPostgres:
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()
+
+
+# ============================================================
+# iter_media_paths_for_repair — real-SQLite keyset pagination (#175 OOM fix)
+# ============================================================
+
+
+class TestIterMediaPathsForRepair:
+    """Verify the repair-pass streaming query against a real SQLite database.
+
+    The v7.11.3 crash loop was an OOM: the repair loaded the entire media table
+    at once. This method must keyset-paginate so memory stays bounded, while
+    still returning every downloaded/file-bearing row exactly once, in id order.
+    """
+
+    @pytest.mark.asyncio
+    async def test_streams_all_rows_in_id_order_across_batches(self, tmp_path):
+        from src.db.base import DatabaseManager
+
+        db_manager = DatabaseManager(f"sqlite:///{tmp_path / 'repair.db'}")
+        await db_manager.init()
+        adapter = DatabaseAdapter(db_manager)
+        try:
+            for i in range(5):
+                await adapter.insert_media(
+                    {
+                        "id": f"id{i}",
+                        "type": "photo",
+                        "file_name": f"f{i}.jpg",
+                        "file_path": f"/data/f{i}.jpg",
+                        "downloaded": True,
+                    }
+                )
+            # A row with downloaded=0 AND no file_path must be excluded.
+            await adapter.insert_media({"id": "skip", "type": "photo", "downloaded": False})
+
+            batches = [b async for b in adapter.iter_media_paths_for_repair(batch_size=2)]
+
+            # 5 matching rows in batches of 2 -> sizes [2, 2, 1].
+            assert [len(b) for b in batches] == [2, 2, 1]
+            flat = [r for b in batches for r in b]
+            assert [r["id"] for r in flat] == ["id0", "id1", "id2", "id3", "id4"]
+            assert flat[0] == {"id": "id0", "file_path": "/data/f0.jpg", "file_name": "f0.jpg"}
+            assert all(r["id"] != "skip" for r in flat)
+        finally:
+            await db_manager.close()
+
+    @pytest.mark.asyncio
+    async def test_empty_table_yields_no_batches(self, tmp_path):
+        from src.db.base import DatabaseManager
+
+        db_manager = DatabaseManager(f"sqlite:///{tmp_path / 'empty.db'}")
+        await db_manager.init()
+        adapter = DatabaseAdapter(db_manager)
+        try:
+            batches = [b async for b in adapter.iter_media_paths_for_repair()]
+            assert batches == []
+        finally:
+            await db_manager.close()

--- a/tests/test_repair_media_extensions.py
+++ b/tests/test_repair_media_extensions.py
@@ -1,5 +1,6 @@
 """Tests for the #175 media extension repair pass."""
 
+import asyncio
 import os
 from unittest import mock
 
@@ -14,13 +15,16 @@ from src.repair_media_extensions import (
 class _FakeDB:
     """Minimal async stand-in for the DatabaseAdapter media surface."""
 
-    def __init__(self, records, fail_update_ids=None):
+    def __init__(self, records, fail_update_ids=None, batch_size=500):
         self._records = records
         self.updates = {}
         self._fail_update_ids = set(fail_update_ids or ())
+        self._batch_size = batch_size
 
-    async def get_media_for_verification(self):
-        return list(self._records)
+    async def iter_media_paths_for_repair(self, batch_size=None):
+        size = batch_size or self._batch_size
+        for start in range(0, len(self._records), size):
+            yield [dict(r) for r in self._records[start : start + size]]
 
     async def update_media_file_path(self, media_id, file_path):
         if media_id in self._fail_update_ids:
@@ -505,7 +509,7 @@ def test_repair_records_sync_skips_incomplete_records(tmp_path):
 async def test_repair_offloads_fs_work_to_thread(tmp_path):
     """repair_media_extensions runs the blocking sweep via asyncio.to_thread."""
     media = _media_root(tmp_path)
-    db = _FakeDB([])
+    db = _FakeDB([{"id": "m1", "file_name": "abc.mp4", "file_path": "/x/abc.mp4"}])
 
     with mock.patch(
         "src.repair_media_extensions.asyncio.to_thread",
@@ -518,3 +522,44 @@ async def test_repair_offloads_fs_work_to_thread(tmp_path):
     args = to_thread.await_args.args
     assert args[0] is _repair_records_sync
     assert args[2] == str(media / "_shared")
+
+
+async def test_repair_streams_in_batches_without_loading_whole_table(tmp_path):
+    """Regression for the v7.11.3 OOM crash loop (#175).
+
+    The repair must consume the media table in bounded batches, not materialize
+    it all at once. Here three corrupt files span two batches of size 2; all
+    must be repaired and the worker must be invoked once per non-empty batch.
+    """
+    media = _media_root(tmp_path)
+    chat = media / "-100123"
+    chat.mkdir()
+    records = []
+    for i in range(3):
+        corrupt = chat / f"file{i}.mp4.7.140234567890"
+        corrupt.write_bytes(b"video")
+        records.append({"id": f"m{i}", "file_name": f"file{i}.mp4", "file_path": str(corrupt)})
+
+    db = _FakeDB(records, batch_size=2)
+
+    real_to_thread = asyncio.to_thread
+    with mock.patch("src.repair_media_extensions.asyncio.to_thread", side_effect=real_to_thread) as to_thread:
+        repaired = await repair_media_extensions(str(media), db)
+
+    assert repaired == 3
+    assert to_thread.await_count == 2  # ceil(3 / 2) batches
+    for i in range(3):
+        assert (chat / f"file{i}.mp4").read_bytes() == b"video"
+        assert db.updates[f"m{i}"] == str(chat / f"file{i}.mp4")
+    assert (media / "_shared" / REPAIR_MARKER).exists()
+
+
+async def test_repair_writes_marker_on_empty_table(tmp_path):
+    """An archive with no media rows still seals the pass so it never re-runs."""
+    media = _media_root(tmp_path)
+    db = _FakeDB([])
+
+    repaired = await repair_media_extensions(str(media), db)
+
+    assert repaired == 0
+    assert (media / "_shared" / REPAIR_MARKER).exists()


### PR DESCRIPTION
## Summary

v7.11.3 shipped the #175 media-extension repair pass, but it crash-looped both backup containers in production (exit 137 / OOM-killed, RestartCount climbing) immediately after the "Running initial backup on startup" step.

**Root cause:** `repair_media_extensions` called `db.get_media_for_verification()`, which materializes the *entire* media table into a list of dicts. On large archives this blew past the container's `mem_limit: 256m`.

**Fix:** Add `DatabaseAdapter.iter_media_paths_for_repair()` — a keyset-paginated query (ordered by PK, `WHERE id > last_id LIMIT batch`) that projects only the three columns the repair needs (`id`, `file_path`, `file_name`). The repair driver now consumes one bounded batch at a time, offloads each batch's blocking filesystem work to a thread, and applies DB repoints incrementally. Memory stays flat regardless of table size.

`get_media_for_verification()` is retained — it's still used by the separate `VERIFY_MEDIA` path.

## Test plan

- [x] `test_db_adapter.py::TestIterMediaPathsForRepair` — real-SQLite integration: streams every downloaded/file-bearing row exactly once in id order across batches; excludes non-downloaded rows; empty table yields no batches.
- [x] `test_repair_media_extensions.py` — multi-batch streaming repairs all rows; empty-table seals the marker; all prior dedup/no-dedup/defer/marker cases still pass (27 tests).
- [x] `ruff check .` + `ruff format --check .` clean.
- [ ] Deploy to isolated test stack on geiserback, confirm repair runs to completion (marker written, corrupt-file count drops) with bounded memory before promoting to the sergio/annais production containers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced media repair functionality with updated processing mechanism.

* **Chores**
  * Package version bumped to 7.11.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->