### PR TITLE
fix(media): sweep orphan corrupt blobs and surface repair logs (#175)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.11.4"
+version = "7.11.5"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.11.4"
+__version__ = "7.11.5"

--- a/src/repair_media_extensions.py
+++ b/src/repair_media_extensions.py
@@ -18,10 +18,17 @@ false positives: a path is only treated as corrupt when its basename equals
 ``file_name`` plus a ``.<int>.<int>`` tail. It never deletes anything (per
 project safety rules) and is crash-safe and idempotent via a marker file.
 
+After the DB-driven pass, a filesystem sweep walks the chat-folder symlinks
+directly to catch corrupt blobs whose ``media`` row is missing (the DB pass
+never visits them). The sweep is anchored to each symlink's own clean basename,
+so it keeps the same zero-false-positive guarantee.
+
 The marker is written only when no row was *deferred* — i.e. only when no
 transient failure (filesystem error, DB write error) left repairable work
 undone. Permanent no-ops (a genuinely distinct file already under the clean
-name) do not block the marker, since retrying them can never succeed.
+name) do not block the marker, since retrying them can never succeed. The
+marker name is versioned (``-v2``) so installs sealed by the DB-only v7.11.4
+pass re-run once to pick up the new orphan sweep.
 """
 
 import asyncio
@@ -35,7 +42,7 @@ from .message_utils import compute_file_hash
 
 logger = logging.getLogger(__name__)
 
-REPAIR_MARKER = ".repaired-175"
+REPAIR_MARKER = ".repaired-175-v2"
 
 # Secondary guard: the task_id (id()-derived) is always large; the pid may be
 # any positive int. Anchoring to the clean name is what guarantees zero false
@@ -180,6 +187,61 @@ def _repair_records_sync(records: list[dict], shared_dir: str) -> tuple[int, int
     return repaired, deferred, pending_db_updates
 
 
+def _iter_chat_dirs(media_path: str) -> list[str]:
+    """Immediate sub-directories of ``media_path`` that hold chat media.
+
+    Excludes ``_shared`` (the dedup blob store) and any non-directory entry.
+    """
+    chat_dirs: list[str] = []
+    try:
+        with os.scandir(media_path) as it:
+            for entry in it:
+                if entry.name == "_shared":
+                    continue
+                if entry.is_dir(follow_symlinks=False):
+                    chat_dirs.append(entry.path)
+    except OSError:
+        pass
+    return chat_dirs
+
+
+def _sweep_orphan_links_sync(media_path: str, shared_dir: str) -> tuple[int, int]:
+    """Filesystem-driven sweep for corrupt blobs that have NO ``media`` row.
+
+    The DB-driven pass only visits paths recorded in ``media``; dedup symlinks
+    whose row was never written (or was pruned) are invisible to it, so their
+    corrupt-named ``_shared`` blob is never renamed (#175 zey0n residue).
+
+    This sweep walks every chat-folder symlink and reuses ``_repair_symlink_blob``,
+    which is anchored to the *symlink's own clean basename* — the same
+    zero-false-positive guarantee the DB ``file_name`` gave the primary pass. It
+    renames the corrupt blob (only inside ``_shared``) and retargets the link;
+    sibling links self-heal once the blob is clean. Never deletes anything.
+
+    Returns ``(repaired, deferred)``; ``deferred`` counts transient OS errors so
+    the idempotency marker is withheld and the sweep retries on the next run.
+    """
+    repaired = 0
+    deferred = 0
+
+    for chat_dir in _iter_chat_dirs(media_path):
+        try:
+            entries = list(os.scandir(chat_dir))
+        except OSError:
+            deferred += 1
+            continue
+        for entry in entries:
+            try:
+                if not entry.is_symlink():
+                    continue
+                if _repair_symlink_blob(entry.path, shared_dir):
+                    repaired += 1
+            except OSError:
+                deferred += 1
+
+    return repaired, deferred
+
+
 async def repair_media_extensions(media_path: str, db: _MediaRepairDB) -> int:
     """Repair files corrupted by #175. Returns the number of records repaired.
 
@@ -226,12 +288,29 @@ async def repair_media_extensions(media_path: str, db: _MediaRepairDB) -> int:
         logger.warning("Media repair aborted — could not read media records (%s)", type(e).__name__)
         return repaired
 
+    # Filesystem-driven sweep for corrupt blobs whose media row is missing, so
+    # the DB-driven pass above never reaches them (#175 residue reported by a
+    # user on v7.11.4). Reuses the symlink-blob repair, anchored to each link's
+    # own clean basename, so it is just as false-positive-free.
+    try:
+        sweep_repaired, sweep_deferred = await asyncio.to_thread(_sweep_orphan_links_sync, media_path, shared_dir)
+        repaired += sweep_repaired
+        deferred += sweep_deferred
+    except Exception as e:
+        logger.warning("Media repair: orphan-link sweep failed (%s)", type(e).__name__)
+        deferred += 1
+
+    # Logged at WARNING (not INFO) so deployments running LOG_LEVEL=warn still
+    # get visible confirmation the pass ran — the absence of this line was what
+    # made the v7.11.4 repair look like a no-op to a user (#175).
     if repaired or deferred:
-        logger.info(
-            "Media extension repair: %d repaired, %d deferred for retry",
+        logger.warning(
+            "Media extension repair (#175): %d repaired, %d deferred for retry",
             repaired,
             deferred,
         )
+    else:
+        logger.warning("Media extension repair (#175): nothing to repair")
 
     # Only seal the pass when no repairable work was left behind by a transient
     # failure. Permanent no-ops (distinct content under the clean name) do not

--- a/tests/test_repair_media_extensions.py
+++ b/tests/test_repair_media_extensions.py
@@ -7,7 +7,9 @@ from unittest import mock
 from src.repair_media_extensions import (
     REPAIR_MARKER,
     _is_corrupt_basename,
+    _iter_chat_dirs,
     _repair_records_sync,
+    _sweep_orphan_links_sync,
     repair_media_extensions,
 )
 
@@ -507,21 +509,29 @@ def test_repair_records_sync_skips_incomplete_records(tmp_path):
 
 
 async def test_repair_offloads_fs_work_to_thread(tmp_path):
-    """repair_media_extensions runs the blocking sweep via asyncio.to_thread."""
+    """repair_media_extensions runs the blocking sweeps via asyncio.to_thread.
+
+    Two off-loop calls now happen: the DB-driven record repair, then the
+    filesystem-driven orphan-link sweep.
+    """
     media = _media_root(tmp_path)
     db = _FakeDB([{"id": "m1", "file_name": "abc.mp4", "file_path": "/x/abc.mp4"}])
 
     with mock.patch(
         "src.repair_media_extensions.asyncio.to_thread",
         new_callable=mock.AsyncMock,
-        return_value=(0, 0, []),
+        side_effect=[(0, 0, []), (0, 0)],
     ) as to_thread:
         await repair_media_extensions(str(media), db)
 
-    to_thread.assert_awaited_once()
-    args = to_thread.await_args.args
-    assert args[0] is _repair_records_sync
-    assert args[2] == str(media / "_shared")
+    assert to_thread.await_count == 2
+    record_call = to_thread.await_args_list[0].args
+    assert record_call[0] is _repair_records_sync
+    assert record_call[2] == str(media / "_shared")
+    sweep_call = to_thread.await_args_list[1].args
+    assert sweep_call[0] is _sweep_orphan_links_sync
+    assert sweep_call[1] == str(media)
+    assert sweep_call[2] == str(media / "_shared")
 
 
 async def test_repair_streams_in_batches_without_loading_whole_table(tmp_path):
@@ -547,7 +557,8 @@ async def test_repair_streams_in_batches_without_loading_whole_table(tmp_path):
         repaired = await repair_media_extensions(str(media), db)
 
     assert repaired == 3
-    assert to_thread.await_count == 2  # ceil(3 / 2) batches
+    # ceil(3 / 2) record batches + 1 orphan-link sweep.
+    assert to_thread.await_count == 3
     for i in range(3):
         assert (chat / f"file{i}.mp4").read_bytes() == b"video"
         assert db.updates[f"m{i}"] == str(chat / f"file{i}.mp4")
@@ -563,3 +574,143 @@ async def test_repair_writes_marker_on_empty_table(tmp_path):
 
     assert repaired == 0
     assert (media / "_shared" / REPAIR_MARKER).exists()
+
+
+# ---------------------------------------------------------------------------
+# Orphan-link filesystem sweep: corrupt blobs whose media row is missing
+# ---------------------------------------------------------------------------
+
+
+def test_iter_chat_dirs_excludes_shared_and_files(tmp_path):
+    media = _media_root(tmp_path)
+    (media / "-100111").mkdir()
+    (media / "-100222").mkdir()
+    (media / "loose.txt").write_bytes(b"x")  # a stray file, not a chat dir
+
+    chat_dirs = set(_iter_chat_dirs(str(media)))
+
+    assert chat_dirs == {str(media / "-100111"), str(media / "-100222")}
+    assert str(media / "_shared") not in chat_dirs
+
+
+def test_iter_chat_dirs_returns_empty_for_missing_root(tmp_path):
+    assert _iter_chat_dirs(str(tmp_path / "nope")) == []
+
+
+def test_sweep_heals_orphan_link_with_no_db_row(tmp_path):
+    """The #175 v7.11.4 residue: a dedup symlink whose media row is gone.
+
+    The DB-driven pass never sees it, so the orphan sweep must rename the blob
+    and retarget the link on its own.
+    """
+    media = _media_root(tmp_path)
+    shared = media / "_shared" / "ab"
+    shared.mkdir()
+    corrupt_blob = shared / "abc.mp4.7.140234567890"
+    corrupt_blob.write_bytes(b"video")
+
+    chat = media / "-100123"
+    chat.mkdir()
+    link = chat / "abc.mp4"  # clean link name, no DB row references it
+    link.symlink_to(os.path.relpath(corrupt_blob, chat))
+
+    repaired, deferred = _sweep_orphan_links_sync(str(media), str(media / "_shared"))
+
+    assert (repaired, deferred) == (1, 0)
+    clean_blob = shared / "abc.mp4"
+    assert clean_blob.read_bytes() == b"video"
+    assert not corrupt_blob.exists()
+    assert os.path.realpath(link) == str(clean_blob)
+
+
+def test_sweep_leaves_clean_links_untouched(tmp_path):
+    media = _media_root(tmp_path)
+    shared = media / "_shared" / "ab"
+    shared.mkdir()
+    clean_blob = shared / "abc.mp4"
+    clean_blob.write_bytes(b"video")
+
+    chat = media / "-100123"
+    chat.mkdir()
+    link = chat / "abc.mp4"
+    link.symlink_to(os.path.relpath(clean_blob, chat))
+
+    repaired, deferred = _sweep_orphan_links_sync(str(media), str(media / "_shared"))
+
+    assert (repaired, deferred) == (0, 0)
+    assert os.path.realpath(link) == str(clean_blob)
+
+
+def test_sweep_never_renames_blob_outside_shared(tmp_path):
+    media = _media_root(tmp_path)
+    external = tmp_path / "external_store"
+    external.mkdir()
+    external_blob = external / "abc.mp4.7.140234567890"
+    external_blob.write_bytes(b"managed-elsewhere")
+
+    chat = media / "-100123"
+    chat.mkdir()
+    link = chat / "abc.mp4"
+    link.symlink_to(os.path.relpath(external_blob, chat))
+
+    repaired, deferred = _sweep_orphan_links_sync(str(media), str(media / "_shared"))
+
+    assert (repaired, deferred) == (0, 0)
+    assert external_blob.exists()
+    assert not (external / "abc.mp4").exists()
+
+
+def test_sweep_ignores_non_symlink_files_in_chat_dir(tmp_path):
+    """A real (non-symlink) corrupt-named file in a chat dir is a no-dedup row;
+    the DB pass owns it, so the orphan-link sweep must skip it."""
+    media = _media_root(tmp_path)
+    chat = media / "-100123"
+    chat.mkdir()
+    corrupt = chat / "abc.mp4.7.140234567890"
+    corrupt.write_bytes(b"video")
+
+    repaired, deferred = _sweep_orphan_links_sync(str(media), str(media / "_shared"))
+
+    assert (repaired, deferred) == (0, 0)
+    assert corrupt.exists()
+
+
+async def test_repair_end_to_end_heals_orphan_link_after_db_pass(tmp_path):
+    """Full driver: an orphan dedup link (no DB row) is healed by the sweep,
+    and the versioned marker is written so the pass is idempotent afterward."""
+    media = _media_root(tmp_path)
+    shared = media / "_shared" / "ab"
+    shared.mkdir()
+    corrupt_blob = shared / "abc.mp4.7.140234567890"
+    corrupt_blob.write_bytes(b"video")
+
+    chat = media / "-100123"
+    chat.mkdir()
+    link = chat / "abc.mp4"
+    link.symlink_to(os.path.relpath(corrupt_blob, chat))
+
+    db = _FakeDB([])  # no media rows at all -> DB pass repairs nothing
+
+    repaired = await repair_media_extensions(str(media), db)
+
+    assert repaired == 1
+    assert (shared / "abc.mp4").read_bytes() == b"video"
+    assert not corrupt_blob.exists()
+    assert os.path.realpath(link) == str(shared / "abc.mp4")
+    assert (media / "_shared" / REPAIR_MARKER).exists()
+
+
+async def test_repair_summary_logged_at_warning_level(tmp_path, caplog):
+    """LOG_LEVEL=warn users must see the repair ran (#175 zey0n: 'no logs')."""
+    import logging
+
+    media = _media_root(tmp_path)
+    db = _FakeDB([])
+
+    with caplog.at_level(logging.WARNING, logger="src.repair_media_extensions"):
+        await repair_media_extensions(str(media), db)
+
+    assert any(
+        record.levelno == logging.WARNING and "Media extension repair (#175)" in record.getMessage()
+        for record in caplog.records
+    )

--- a/tests/test_repair_media_extensions.py
+++ b/tests/test_repair_media_extensions.py
@@ -700,6 +700,66 @@ async def test_repair_end_to_end_heals_orphan_link_after_db_pass(tmp_path):
     assert (media / "_shared" / REPAIR_MARKER).exists()
 
 
+def test_sweep_defers_when_chat_dir_unreadable(tmp_path):
+    """A chat dir that can't be scanned is deferred, not crashed past."""
+    media = _media_root(tmp_path)
+    chat = media / "-100123"
+    chat.mkdir()
+
+    real_scandir = os.scandir
+
+    def scandir(path):
+        if path == str(chat):
+            raise OSError("EIO")  # the in-dir scan fails
+        return real_scandir(path)  # the chat-dir enumeration succeeds
+
+    with mock.patch("src.repair_media_extensions.os.scandir", side_effect=scandir):
+        repaired, deferred = _sweep_orphan_links_sync(str(media), str(media / "_shared"))
+
+    assert (repaired, deferred) == (0, 1)
+
+
+def test_sweep_defers_on_per_entry_oserror(tmp_path):
+    """A symlink whose repair raises OSError increments deferred, not repaired."""
+    media = _media_root(tmp_path)
+    shared = media / "_shared" / "ab"
+    shared.mkdir()
+    corrupt_blob = shared / "abc.mp4.7.140234567890"
+    corrupt_blob.write_bytes(b"video")
+
+    chat = media / "-100123"
+    chat.mkdir()
+    link = chat / "abc.mp4"
+    link.symlink_to(os.path.relpath(corrupt_blob, chat))
+
+    with mock.patch(
+        "src.repair_media_extensions._repair_symlink_blob",
+        side_effect=OSError("EIO"),
+    ):
+        repaired, deferred = _sweep_orphan_links_sync(str(media), str(media / "_shared"))
+
+    assert (repaired, deferred) == (0, 1)
+
+
+async def test_repair_defers_when_sweep_raises(tmp_path):
+    """A non-OSError escaping the sweep is caught: deferred++, marker withheld."""
+    media = _media_root(tmp_path)
+    db = _FakeDB([])
+
+    real_to_thread = asyncio.to_thread
+
+    async def flaky(func, *args):
+        if func is _sweep_orphan_links_sync:
+            raise RuntimeError("boom")
+        return await real_to_thread(func, *args)
+
+    with mock.patch("src.repair_media_extensions.asyncio.to_thread", side_effect=flaky):
+        repaired = await repair_media_extensions(str(media), db)
+
+    assert repaired == 0
+    assert not (media / "_shared" / REPAIR_MARKER).exists()
+
+
 async def test_repair_summary_logged_at_warning_level(tmp_path, caplog):
     """LOG_LEVEL=warn users must see the repair ran (#175 zey0n: 'no logs')."""
     import logging


### PR DESCRIPTION
## Summary

Follow-up to #177 (v7.11.4), addressing the residue a user reported on v7.11.4: old corrupt-named media files remained and no repair logs appeared.

Two fixes:

- **Orphan-blob filesystem sweep.** The v7.11.4 repair is DB-driven — it only visits files recorded in the `media` table. Dedup symlinks whose `media` row was never written (or was pruned) are invisible to it, so their corrupt-named `_shared` blob is never renamed. This adds a filesystem sweep that walks chat-folder symlinks directly and reuses the existing `_repair_symlink_blob`, anchored to each link's own clean basename (same zero-false-positive guarantee, never deletes, `realpath`-guarded within `_shared`). The marker is bumped to `.repaired-175-v2` so installs already sealed by the DB-only pass re-run the sweep exactly once.
- **WARN-visible repair summary.** The summary was logged at `INFO`, so `LOG_LEVEL=warn` deployments saw no confirmation the pass ran — it looked like a no-op. It now logs at `WARNING` (counts only, PII-safe).

## Test plan

- [x] `pytest tests/test_repair_media_extensions.py` — 35 pass (added orphan-sweep + WARN-logging regressions)
- [x] `pytest tests/test_db_adapter.py tests/test_repair_media_extensions.py tests/test_atomic_download_helpers.py` — 216 pass
- [x] `ruff check .` && `ruff format --check .` — clean
- [ ] CI green
- [ ] Deploy to geiserback, confirm residual orphan blobs are renamed and a WARN repair line appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Media repair now includes an additional filesystem sweep to find and heal orphaned media files not present in the database.

* **Bug Fixes**
  * Improved detection and repair of corrupted media blob names and symlink targets; more robust handling of partial failures.

* **Tests**
  * Expanded test coverage for the media repair sweep and its failure/deferral behaviors.

* **Chores**
  * Package version bumped to 7.11.5; repair will re-run on existing installs to apply the enhanced fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->