### PR TITLE
fix(media): harden #175 repair against transient FS/DB failures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.11.5"
+version = "7.11.6"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.11.5"
+__version__ = "7.11.6"

--- a/src/repair_media_extensions.py
+++ b/src/repair_media_extensions.py
@@ -191,18 +191,34 @@ def _iter_chat_dirs(media_path: str) -> list[str]:
     """Immediate sub-directories of ``media_path`` that hold chat media.
 
     Excludes ``_shared`` (the dedup blob store) and any non-directory entry.
+    Lets ``OSError`` propagate: a failure to scan the sweep root is transient
+    repairable work, so the caller must defer it (and withhold the marker)
+    rather than mistake an unreadable root for an empty one.
     """
     chat_dirs: list[str] = []
-    try:
-        with os.scandir(media_path) as it:
-            for entry in it:
-                if entry.name == "_shared":
-                    continue
-                if entry.is_dir(follow_symlinks=False):
-                    chat_dirs.append(entry.path)
-    except OSError:
-        pass
+    with os.scandir(media_path) as it:
+        for entry in it:
+            if entry.name == "_shared":
+                continue
+            if entry.is_dir(follow_symlinks=False):
+                chat_dirs.append(entry.path)
     return chat_dirs
+
+
+def _scan_chat_symlinks(chat_dir: str) -> list[str]:
+    """Symlink paths directly under ``chat_dir``.
+
+    Returns only string paths (not ``DirEntry`` objects) and closes the scandir
+    handle before returning, so the caller can mutate the directory (the repair
+    does ``unlink``/``symlink``) without iterating a live handle over a folder it
+    is changing. Collecting strings keeps memory bounded to the symlink count.
+    """
+    links: list[str] = []
+    with os.scandir(chat_dir) as it:
+        for entry in it:
+            if entry.is_symlink():
+                links.append(entry.path)
+    return links
 
 
 def _sweep_orphan_links_sync(media_path: str, shared_dir: str) -> tuple[int, int]:
@@ -224,17 +240,22 @@ def _sweep_orphan_links_sync(media_path: str, shared_dir: str) -> tuple[int, int
     repaired = 0
     deferred = 0
 
-    for chat_dir in _iter_chat_dirs(media_path):
+    try:
+        chat_dirs = _iter_chat_dirs(media_path)
+    except OSError:
+        # Could not enumerate chat dirs (transient root-scan failure). Defer so
+        # the marker is withheld and the whole sweep retries next run.
+        return 0, 1
+
+    for chat_dir in chat_dirs:
         try:
-            entries = list(os.scandir(chat_dir))
+            links = _scan_chat_symlinks(chat_dir)
         except OSError:
             deferred += 1
             continue
-        for entry in entries:
+        for link_path in links:
             try:
-                if not entry.is_symlink():
-                    continue
-                if _repair_symlink_blob(entry.path, shared_dir):
+                if _repair_symlink_blob(link_path, shared_dir):
                     repaired += 1
             except OSError:
                 deferred += 1
@@ -285,8 +306,12 @@ async def repair_media_extensions(media_path: str, db: _MediaRepairDB) -> int:
                     deferred += 1
                     repaired -= 1
     except Exception as e:
-        logger.warning("Media repair aborted — could not read media records (%s)", type(e).__name__)
-        return repaired
+        # A DB read failure must NOT skip the filesystem sweep below: the sweep
+        # is DB-independent and is exactly what heals corrupt blobs whose media
+        # row is missing. Count the DB failure as deferred (so the marker is
+        # withheld and the next run retries the DB pass) and fall through.
+        logger.warning("Media repair: could not read media records, running sweep only (%s)", type(e).__name__)
+        deferred += 1
 
     # Filesystem-driven sweep for corrupt blobs whose media row is missing, so
     # the DB-driven pass above never reaches them (#175 residue reported by a

--- a/tests/test_repair_media_extensions.py
+++ b/tests/test_repair_media_extensions.py
@@ -9,6 +9,7 @@ from src.repair_media_extensions import (
     _is_corrupt_basename,
     _iter_chat_dirs,
     _repair_records_sync,
+    _scan_chat_symlinks,
     _sweep_orphan_links_sync,
     repair_media_extensions,
 )
@@ -593,8 +594,40 @@ def test_iter_chat_dirs_excludes_shared_and_files(tmp_path):
     assert str(media / "_shared") not in chat_dirs
 
 
-def test_iter_chat_dirs_returns_empty_for_missing_root(tmp_path):
-    assert _iter_chat_dirs(str(tmp_path / "nope")) == []
+def test_iter_chat_dirs_raises_on_missing_root(tmp_path):
+    """A failed root scan must surface, not be mistaken for an empty dir, so the
+    sweep can defer it and withhold the marker."""
+    import pytest
+
+    with pytest.raises(OSError):
+        _iter_chat_dirs(str(tmp_path / "nope"))
+
+
+def test_scan_chat_symlinks_returns_only_symlink_strings(tmp_path):
+    """The helper returns string paths (not DirEntry) and skips real files, so the
+    caller can mutate the directory after the scandir handle is closed."""
+    chat = tmp_path / "-100123"
+    chat.mkdir()
+    target = tmp_path / "blob.bin"
+    target.write_bytes(b"x")
+    (chat / "real.txt").write_bytes(b"y")  # a real file, not a symlink
+    link = chat / "abc.mp4"
+    link.symlink_to(os.path.relpath(target, chat))
+
+    result = _scan_chat_symlinks(str(chat))
+
+    assert result == [str(link)]
+    assert all(isinstance(p, str) for p in result)
+
+
+def test_sweep_defers_when_root_unreadable(tmp_path):
+    """A transient failure enumerating chat dirs defers the whole sweep."""
+    media = _media_root(tmp_path)
+
+    with mock.patch("src.repair_media_extensions._iter_chat_dirs", side_effect=OSError("EIO")):
+        repaired, deferred = _sweep_orphan_links_sync(str(media), str(media / "_shared"))
+
+    assert (repaired, deferred) == (0, 1)
 
 
 def test_sweep_heals_orphan_link_with_no_db_row(tmp_path):
@@ -755,6 +788,67 @@ async def test_repair_defers_when_sweep_raises(tmp_path):
 
     with mock.patch("src.repair_media_extensions.asyncio.to_thread", side_effect=flaky):
         repaired = await repair_media_extensions(str(media), db)
+
+    assert repaired == 0
+    assert not (media / "_shared" / REPAIR_MARKER).exists()
+
+
+class _ReadFailDB:
+    """A DB whose media-table read fails, to exercise the sweep-only fallback."""
+
+    def __init__(self):
+        self.updates = {}
+
+    async def iter_media_paths_for_repair(self, batch_size=None):
+        raise RuntimeError("simulated DB read failure")
+        yield  # pragma: no cover - makes this an async generator
+
+    async def update_media_file_path(self, media_id, file_path):  # pragma: no cover
+        self.updates[media_id] = file_path
+
+
+async def test_repair_runs_sweep_even_when_db_read_fails(tmp_path):
+    """A DB read failure must not skip the DB-independent orphan sweep.
+
+    The sweep is exactly what heals corrupt blobs whose media row is missing, so
+    a transient DB outage must still let it run. The DB failure is deferred, so
+    the marker is withheld and the DB pass retries next run.
+    """
+    media = _media_root(tmp_path)
+    shared = media / "_shared" / "ab"
+    shared.mkdir()
+    corrupt_blob = shared / "abc.mp4.7.140234567890"
+    corrupt_blob.write_bytes(b"video")
+
+    chat = media / "-100123"
+    chat.mkdir()
+    link = chat / "abc.mp4"
+    link.symlink_to(os.path.relpath(corrupt_blob, chat))
+
+    repaired = await repair_media_extensions(str(media), _ReadFailDB())
+
+    # Sweep healed the orphan even though the DB read blew up.
+    assert repaired == 1
+    assert (shared / "abc.mp4").read_bytes() == b"video"
+    assert not corrupt_blob.exists()
+    assert os.path.realpath(link) == str(shared / "abc.mp4")
+    # DB failure was deferred -> marker withheld so the DB pass retries.
+    assert not (media / "_shared" / REPAIR_MARKER).exists()
+
+
+async def test_repair_withholds_marker_when_db_read_fails_and_sweep_empty(tmp_path):
+    """DB outage on an archive with no orphan residue must still withhold the marker.
+
+    This isolates the marker invariant from sweep success: the sweep repairs
+    nothing (repaired==0) yet the deferred DB read must keep the marker unwritten
+    so the DB pass retries next run. Writing it here would permanently seal the
+    pass after a transient DB failure on a clean archive (#175 deferred-marker).
+    """
+    media = _media_root(tmp_path)
+    # A clean chat dir with nothing corrupt: the sweep finds no work.
+    (media / "-100123").mkdir()
+
+    repaired = await repair_media_extensions(str(media), _ReadFailDB())
 
     assert repaired == 0
     assert not (media / "_shared" / REPAIR_MARKER).exists()


### PR DESCRIPTION
## Summary

Three robustness fixes to the #175 orphan-blob repair sweep, raised by CodeRabbit on #178. Released as **v7.11.6**.

- **`_iter_chat_dirs` propagates `OSError`** instead of returning `[]`. A transient root-scan failure is now deferred (marker withheld) rather than mistaken for an empty tree — previously this could permanently seal the repair pass after a transient FS error.
- **New `_scan_chat_symlinks` helper** collects symlink path *strings* and closes the `scandir` handle **before** the caller mutates the directory (`unlink`+`symlink`). Avoids iterating a live handle over a folder being changed (CodeRabbit's original suggestion to iterate the live handle would itself hit unspecified POSIX mutation-during-iteration behavior).
- **DB read failure now defers and falls through to the sweep** instead of returning early. The orphan sweep is DB-independent and is exactly what heals corrupt blobs whose `media` row is missing, so a transient DB outage must not skip it.

The deferred/marker invariant is preserved on every path: transient failures (`deferred > 0`) withhold the idempotency marker so the next run retries; permanent no-ops do not block it. Never deletes files.

## Test plan

- [x] `pytest tests/test_db_adapter.py tests/test_repair_media_extensions.py tests/test_atomic_download_helpers.py` — 223 passed
- [x] `ruff check .` && `ruff format --check .` — clean
- [x] New tests: `_iter_chat_dirs` raise + sweep defer; `_scan_chat_symlinks` returns strings/symlinks-only; DB read failure still runs sweep; **marker withheld when DB read fails on a clean archive (`repaired==0`)**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 7.11.6

* **Bug Fixes**
  * Improved media extension repair robustness: repair processes now gracefully handle database read failures and continue with orphan symlink cleanup instead of aborting, ensuring filesystem-based healing occurs even when database operations encounter transient issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->