### PR TITLE
fix(scheduler): survive transient listener disconnect instead of crashing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.11.6"
+version = "7.11.7"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.11.6"
+__version__ = "7.11.7"

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -208,6 +208,12 @@ class BackupScheduler:
                 await self._listener_task
             except asyncio.CancelledError:
                 pass
+            except Exception:
+                # Task already died (e.g. transient ConnectionError); its
+                # exception was logged by the restart loop. Awaiting a done
+                # task re-raises it, so swallow here to let teardown/restart
+                # proceed instead of crashing the process.
+                pass
             self._listener_task = None
 
         if self._listener:

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -471,6 +471,7 @@ class TestBackupSchedulerListener:
             from src.scheduler import BackupScheduler
 
             config = MagicMock()
+            config.should_skip_topic = MagicMock(return_value=False)
             scheduler = BackupScheduler(config)
 
             # A task that has already finished with a ConnectionError.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -458,6 +458,39 @@ class TestBackupSchedulerListener:
             assert scheduler._listener is None
             assert scheduler._listener_task is None
 
+    async def test_stop_listener_swallows_dead_task_exception(self):
+        """_stop_listener does not re-raise a dead task's stored exception.
+
+        Regression for the crash where a transient ConnectionError from
+        run_until_disconnected() became the listener task's stored exception;
+        awaiting that done task in _stop_listener re-raised it (only
+        CancelledError was caught), crashing run_forever -> main -> sys.exit(1)
+        -> container restart, instead of triggering the intended restart.
+        """
+        with patch("src.scheduler.signal.signal"):
+            from src.scheduler import BackupScheduler
+
+            config = MagicMock()
+            scheduler = BackupScheduler(config)
+
+            # A task that has already finished with a ConnectionError.
+            loop = asyncio.get_event_loop()
+            dead_task = loop.create_future()
+            dead_task.set_exception(ConnectionError("Cannot send requests while disconnected"))
+
+            mock_listener = AsyncMock()
+            mock_listener.close = AsyncMock()
+
+            scheduler._listener_task = dead_task
+            scheduler._listener = mock_listener
+
+            # Must not raise — teardown should proceed cleanly.
+            await scheduler._stop_listener()
+
+            mock_listener.close.assert_called_once()
+            assert scheduler._listener is None
+            assert scheduler._listener_task is None
+
     async def test_stop_listener_when_no_listener_is_noop(self):
         """_stop_listener is safe when no listener is running."""
         with patch("src.scheduler.signal.signal"):


### PR DESCRIPTION
## Summary

Fixes a crash reported in #175 where a **transient** Telegram disconnect escalated into a **fatal container restart**.

@zey0n confirmed the #175 media-extension repair now works, but shared a traceback showing the container crashing on a `ConnectionError: Cannot send requests while disconnected` — which also wiped the repair logs.

### Root cause

1. `listener.run()` wraps `run_until_disconnected()` but only catches `asyncio.CancelledError`. A transient `ConnectionError` propagates and becomes the listener task's **stored exception**.
2. The restart loop in `run_forever` correctly detects the dead task and logs it, then calls `_stop_listener()` to tear it down before restarting.
3. But `_stop_listener` does `await self._listener_task` on an already-done task, which **re-raises** the stored exception. Only `CancelledError` was caught, so the `ConnectionError` escaped → `run_forever` → `main()` → `sys.exit(1)` → **container restart**.

So the very teardown meant to enable a graceful restart crashed the process instead.

### Fix

Swallow non-cancellation exceptions when awaiting the task during teardown (it was already logged by the restart loop). The listener now restarts gracefully through the shared-connection reconnect path on transient disconnects.

## Changes

- `src/scheduler.py` — catch `Exception` (in addition to `CancelledError`) when awaiting a dead listener task in `_stop_listener`.
- `tests/test_scheduler.py` — regression test `test_stop_listener_swallows_dead_task_exception` (reproduces the exact crash; fails on old code, passes with fix).
- Version bump to **7.11.7** (`pyproject.toml`, `src/__init__.py`).

## Test plan

- [x] `ruff check .` + `ruff format --check .` pass
- [x] Full suite: 1788 passed
- [x] New test fails on unfixed code with `ConnectionError ... scheduler.py:208`, passes with fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved real-time listener shutdown reliability by preventing crashes when listener components terminate unexpectedly during teardown.

* **Chores**
  * Version bumped to 7.11.7.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->