### PR TITLE
fix: PR #180 follow-up tidy-ups + release v7.12.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [7.12.0] - 2026-06-02
+
+### Added
+- **Configurable download timeout** — Media downloads are now wrapped in `asyncio.wait_for` with a `DOWNLOAD_TIMEOUT_SECONDS` budget (default `3600`, `0` disables), so a single stalled download can no longer hang a backup indefinitely.
+- **Tunable backoff for transient errors** — `BACKOFF_MIN_SECONDS` and `BACKOFF_MAX_SECONDS` control exponential backoff with jitter for FloodWait and transient network retries, and `FLOOD_WAIT_LOG_THRESHOLD` tunes how chatty FloodWait logging is.
+
+### Fixed
+- **Transient network errors no longer abort one-shot API calls** — `call_with_flood_retry` now retries `TimeoutError`/`ConnectionError`/`OSError`/`RPCError` with bounded exponential backoff, while still re-raising terminal errors (FloodWait, FileReferenceExpired, ChannelPrivate, ChatForbidden, UserBanned) immediately.
+- **Expired file references are refreshed mid-download** — Downloads that hit `FileReferenceExpiredError` now re-fetch the message and retry instead of failing the media.
+- **Concurrent symlink creation is race-safe** — Deduplicated media symlinks tolerate `EEXIST` from concurrent tasks instead of crashing.
+- **`upsert_user` and `insert_media` retry on locked DB** — Both now use `@retry_on_locked()` for resilience under concurrent SQLite access.
+- **Windows-friendly auth help** — `setup_auth` no longer calls `os.getuid()`/`os.getgid()` unconditionally.
+
+### Credits
+- Thanks to [@smbdspk](https://github.com/smbdspk) for the download-resilience work in [#180](https://github.com/GeiserX/Telegram-Archive/pull/180).
+
 ## [7.10.10] - 2026-05-24
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.11.7"
+version = "7.12.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.11.7"
+__version__ = "7.12.0"

--- a/src/config.py
+++ b/src/config.py
@@ -128,10 +128,6 @@ class Config:
         # Default increased to 60s for better resilience with concurrent access (backup + web viewer).
         self.database_timeout = float(os.getenv("DATABASE_TIMEOUT", "60.0"))
 
-        # Backoff intervals for connection/timeout retries.
-        self.backoff_min = float(os.getenv("BACKOFF_MIN_SECONDS", "2.0"))
-        self.backoff_max = float(os.getenv("BACKOFF_MAX_SECONDS", "300.0"))
-
         # =====================================================================
         # CHAT FILTERING - Two Modes
         # =====================================================================

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1119,7 +1119,7 @@ class DatabaseAdapter:
 
             try:
                 result.update(json.loads(cached_stats))
-            except json.JSONDecodeError:
+            except json.JSONDecodeError, TypeError:
                 pass
 
         if last_backup_time:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -1743,7 +1743,7 @@ class TelegramBackup:
                             raise
                         except TimeoutError:
                             logger.error(
-                                f"Download timed out after {self.config.download_timeout_seconds} seconds for message {message.id} (attempt {attempt + 1}/3)"
+                                f"Download timed out after {timeout} seconds for message {message.id} (attempt {attempt + 1}/3)"
                             )
                             if attempt == 2:
                                 raise
@@ -1776,11 +1776,12 @@ class TelegramBackup:
                 if not os.path.lexists(file_path):
                     task_id = id(asyncio.current_task()) if asyncio.current_task() else 0
                     tmp_file_path = f"{file_path}.{os.getpid()}.{task_id}.part"
-                    if os.path.exists(tmp_file_path):
-                        os.remove(tmp_file_path)
                     timeout = getattr(self.config, "download_timeout_seconds", 3600)
                     timeout_val = timeout if isinstance(timeout, int) and timeout > 0 else None
                     for attempt in range(3):
+                        # Clear any partial file from a prior attempt so each retry starts clean.
+                        if os.path.exists(tmp_file_path):
+                            os.remove(tmp_file_path)
                         try:
                             actual_path = await asyncio.wait_for(
                                 call_with_flood_retry(self.client.download_media, message, tmp_file_path),
@@ -1798,7 +1799,7 @@ class TelegramBackup:
                             raise
                         except TimeoutError:
                             logger.error(
-                                f"Download timed out after {self.config.download_timeout_seconds} seconds for message {message.id} (attempt {attempt + 1}/3)"
+                                f"Download timed out after {timeout} seconds for message {message.id} (attempt {attempt + 1}/3)"
                             )
                             if attempt == 2:
                                 raise


### PR DESCRIPTION
Follow-up to #180 (merged). Applies the small punch-list items from the review and cuts the v7.12.0 release.

## Changes
1. **Remove dead config** — `config.backoff_min` / `config.backoff_max` were never read; the backoff math uses the module-level `BACKOFF_*` globals.
2. **Restore TypeError arm** — `get_stats` cached-stats parse is back to `except (json.JSONDecodeError, TypeError)` so non-str/bytes cached values stay caught.
3. **`.part` cleanup inside the retry loop** — the stale partial is now removed at the start of each download attempt instead of once before the loop, so retries (incl. FileReference refresh) start clean.
4. **Log the resolved timeout** — timeout log lines use the in-scope `timeout` local (getattr default) instead of re-reading `self.config.download_timeout_seconds`.

## Release
- Bump `pyproject.toml` + `src/__init__.py` to **7.12.0** (minor — #180 added `DOWNLOAD_TIMEOUT_SECONDS`, `BACKOFF_MIN/MAX_SECONDS`, `FLOOD_WAIT_LOG_THRESHOLD`).
- `docs/CHANGELOG.md` entry crediting @smbdspk.

## Verification
- 1794 tests pass, ruff + format clean locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable media download timeout settings
  * Introduced tunable exponential backoff parameters for retry behavior

* **Bug Fixes**
  * Improved resilience for download retries with partial file cleanup
  * Enhanced Telegram file reference refresh during downloads
  * Fixed concurrent symlink creation handling
  * Improved database operation retry logic
  * Resolved Windows compatibility issue in authentication setup

* **Documentation**
  * Updated changelog for v7.12.0 release with new configuration options and fixes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->