### PR TITLE
feat: per-file parallel chunked downloads (#183)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,28 @@ MAX_MEDIA_SIZE_MB=100
 # Default is 3600 (60 minutes).
 # DOWNLOAD_TIMEOUT_SECONDS=3600
 
+# --- Parallel chunked downloads (advanced, default OFF) ---
+# Splits one large file into chunks fetched concurrently over several MTProto
+# connections to a single datacenter, lifting the ~10 MB/s single-stream cap.
+# Small files and photos always use a single stream regardless of this setting.
+# Disabled by default; enable only if your download throughput is the bottleneck.
+# PARALLEL_DOWNLOAD_ENABLED=false
+#
+# Only files at least this large (in MB) use the parallel path. Smaller files
+# stay single-stream (chunking overhead isn't worth it). Minimum 1.
+# PARALLEL_DOWNLOAD_MIN_SIZE_MB=20
+#
+# Number of concurrent connections per file. Clamped to 2..8. Telegram throttles
+# hard past ~20 total connections, so this stays conservative. Default 4.
+# PARALLEL_DOWNLOAD_CONNECTIONS=4
+#
+# Chunk size per request in KB. Must be one of: 4, 8, 16, 32, 64, 128, 256, 512
+# (a 4 KiB multiple that divides 1 MiB, per Telegram's getFile constraints).
+# Invalid values snap down to the nearest valid size. Default 512.
+# Peak extra memory while downloading is roughly CONNECTIONS x PART_SIZE_KB
+# (e.g. 4 x 512 KB = 2 MB), since each connection buffers one chunk in flight.
+# PARALLEL_DOWNLOAD_PART_SIZE_KB=512
+
 # Messages processed per database batch
 # Higher values = faster but more memory usage
 BATCH_SIZE=100

--- a/.gitignore
+++ b/.gitignore
@@ -39,8 +39,13 @@ wheels/
 
 # Virtual environments
 venv/
+.venv
+.venv/
 ENV/
 env/
+
+# Local agent tooling state
+.omc/
 
 # IDE
 .vscode/

--- a/README.md
+++ b/README.md
@@ -407,6 +407,10 @@ on disk, lifting that cap on fast links.
   and all photos stay single-stream; chunking overhead isn't worth it for them.
 - **Conservative by design.** `PARALLEL_DOWNLOAD_CONNECTIONS` is clamped to 2–8
   (default 4). Telegram throttles hard past ~20 total connections, so keep this low.
+  Higher values also raise the cost of a rate limit: a `FloodWait` on any one
+  connection cancels its siblings and restarts the whole file under the shared
+  retry budget, so under throttling a higher connection count can mean *slower*
+  overall throughput. If you see frequent flood waits, lower this back toward 4.
 - **FloodWait-aware.** Rate limits flow through the same retry budget as normal
   downloads — no separate backoff scheme.
 - **Verified reassembly.** Each chunk is written at its exact offset and the full

--- a/README.md
+++ b/README.md
@@ -254,6 +254,10 @@ The **Scope** column shows whether each variable applies to the backup scheduler
 | `BACKUP_PATH` | `/data/backups` | B/V | Base path for backup data and media |
 | `DOWNLOAD_MEDIA` | `true` | B | Download media files (photos, videos, documents) |
 | `MAX_MEDIA_SIZE_MB` | `100` | B | Skip media files larger than this (MB) |
+| `PARALLEL_DOWNLOAD_ENABLED` | `false` | B | Fetch large files over several connections to lift the single-stream speed cap (see below) |
+| `PARALLEL_DOWNLOAD_MIN_SIZE_MB` | `20` | B | Only files at least this large use the parallel path (min 1) |
+| `PARALLEL_DOWNLOAD_CONNECTIONS` | `4` | B | Concurrent connections per file (clamped 2–8) |
+| `PARALLEL_DOWNLOAD_PART_SIZE_KB` | `512` | B | Chunk size per request; one of 4/8/16/32/64/128/256/512 |
 | `BATCH_SIZE` | `100` | B | Messages processed per database batch |
 | `CHECKPOINT_INTERVAL` | `1` | B | Save backup progress every N batch inserts (lower = safer resume after crash) |
 | `DATABASE_TIMEOUT` | `60.0` | B/V | Database operation timeout in seconds |
@@ -389,6 +393,33 @@ When the listener is enabled and `LISTEN_DELETIONS=true`, a sliding-window rate 
 3. When `MASS_OPERATION_THRESHOLD` is exceeded, remaining operations are blocked for that window
 
 **Example:** someone deletes 50 messages in 10 seconds with default settings (threshold=10, window=30s) — the first 10 are applied, remaining 40 are blocked. For **zero** deletions from your backup, set `LISTEN_DELETIONS=false`.
+
+### Parallel Downloads
+
+A single Telegram connection caps download throughput at roughly 10 MB/s. With
+`PARALLEL_DOWNLOAD_ENABLED=true`, large files are split into chunks fetched
+concurrently over several connections to the file's datacenter and reassembled
+on disk, lifting that cap on fast links.
+
+- **Default OFF.** Enable only if download speed is your bottleneck — most setups
+  are fine on a single stream.
+- **Large files only.** Files below `PARALLEL_DOWNLOAD_MIN_SIZE_MB` (default 20 MB)
+  and all photos stay single-stream; chunking overhead isn't worth it for them.
+- **Conservative by design.** `PARALLEL_DOWNLOAD_CONNECTIONS` is clamped to 2–8
+  (default 4). Telegram throttles hard past ~20 total connections, so keep this low.
+- **FloodWait-aware.** Rate limits flow through the same retry budget as normal
+  downloads — no separate backoff scheme.
+- **Verified reassembly.** Each chunk is written at its exact offset and the full
+  byte range is checked for complete, non-overlapping coverage before the file is
+  finalized. Any chunk failure cancels the rest, removes the partial file, and
+  falls back transparently to a single stream.
+- **Bounded memory.** Peak extra memory ≈ `CONNECTIONS × PART_SIZE_KB`
+  (e.g. 4 × 512 KB ≈ 2 MB), since each connection buffers one chunk in flight.
+
+`PARALLEL_DOWNLOAD_PART_SIZE_KB` must be one of 4/8/16/32/64/128/256/512 (a 4 KiB
+multiple that divides 1 MiB, per Telegram's `getFile` constraints); invalid values
+snap down to the nearest valid size. This feature applies to the **scheduled backup**
+path only, not the real-time listener.
 
 ### Database Configuration
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [7.13.0] - 2026-06-04
+
+### Added
+- **Per-file parallel chunked downloads** (opt-in, default OFF) — Large files can now be split into chunks fetched concurrently over several connections to the file's datacenter and reassembled on disk, lifting the ~10 MB/s single-stream throughput cap on fast links. Controlled by `PARALLEL_DOWNLOAD_ENABLED` (default `false`), `PARALLEL_DOWNLOAD_MIN_SIZE_MB` (default `20`), `PARALLEL_DOWNLOAD_CONNECTIONS` (clamped 2–8, default `4`), and `PARALLEL_DOWNLOAD_PART_SIZE_KB` (one of 4/8/16/32/64/128/256/512, default `512`). Photos and files below the size threshold always stay single-stream. Each chunk is written at its exact offset with full coverage verified before finalize; any chunk failure cancels the rest, removes the partial file, and falls back transparently to a single stream. FloodWait flows through the existing retry budget, and peak extra memory is bounded at roughly `CONNECTIONS × PART_SIZE_KB`. Applies to the scheduled backup path only. ([#183](https://github.com/GeiserX/Telegram-Archive/issues/183))
+
+### Credits
+- Thanks to [@smbdspk](https://github.com/smbdspk) for proposing per-file parallel downloads in [#183](https://github.com/GeiserX/Telegram-Archive/issues/183).
+
 ## [7.12.0] - 2026-06-02
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.12.0"
+version = "7.13.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.12.0"
+__version__ = "7.13.0"

--- a/src/config.py
+++ b/src/config.py
@@ -116,6 +116,28 @@ class Config:
         # Timeout for media downloads (seconds). 0 disables the timeout.
         self.download_timeout_seconds = int(os.getenv("DOWNLOAD_TIMEOUT_SECONDS", "3600"))
 
+        # =====================================================================
+        # PARALLEL CHUNKED DOWNLOADS (issue #183)
+        # =====================================================================
+        # Split a single large file into chunks fetched concurrently over
+        # several MTProto senders to one DC, then reassemble by exact offset.
+        # Default OFF: opening N senders looks aggressive to Telegram and
+        # multiplies FloodWait exposure, so this is opt-in and only kicks in
+        # above a size threshold. Small files and photos stay single-stream.
+        self.parallel_download_enabled = _parse_bool(os.getenv("PARALLEL_DOWNLOAD_ENABLED"), default=False)
+        # Only files at/above this size use the parallel path (smaller files
+        # gain nothing and pay pure overhead). Clamped to a sane floor.
+        self.parallel_download_min_size_mb = max(1, int(os.getenv("PARALLEL_DOWNLOAD_MIN_SIZE_MB", "20")))
+        # Concurrent senders per file. Hard-capped well under Telegram's ~20
+        # connection cliff to stay safe for an unattended, scheduled tool.
+        self.parallel_download_connections = max(2, min(8, int(os.getenv("PARALLEL_DOWNLOAD_CONNECTIONS", "4"))))
+        # Per-request chunk size in KiB. Must be a 4 KiB multiple that divides
+        # 1 MiB and is <= 512 KiB (Telegram getFile constraints); invalid values
+        # fall back to the 512 KiB maximum. Peak memory ~= connections * part.
+        self.parallel_download_part_size_kb = self._parse_part_size_kb(
+            os.getenv("PARALLEL_DOWNLOAD_PART_SIZE_KB", "512")
+        )
+
         # Batch processing configuration
         self.batch_size = int(os.getenv("BATCH_SIZE", "100"))
         # How often to checkpoint sync progress (every N batch inserts)
@@ -354,6 +376,14 @@ class Config:
             )
         if self.verify_media:
             logger.info("VERIFY_MEDIA enabled - will check for missing/corrupted media files and re-download them")
+        if self.parallel_download_enabled:
+            logger.info(
+                "PARALLEL_DOWNLOAD enabled - files >=%dMB use %d senders, %dKB chunks (peak mem ~%dKB/file)",
+                self.parallel_download_min_size_mb,
+                self.parallel_download_connections,
+                self.parallel_download_part_size_kb,
+                self.parallel_download_connections * self.parallel_download_part_size_kb,
+            )
         if self.enable_listener:
             logger.info("ENABLE_LISTENER enabled - will catch message edits/deletions in real-time")
             logger.info(f"  LISTEN_EDITS: {self.listen_edits}")
@@ -385,6 +415,35 @@ class Config:
                 self.telegram_proxy["addr"],
                 self.telegram_proxy["port"],
             )
+
+    def _parse_part_size_kb(self, value: str | None) -> int:
+        """Parse PARALLEL_DOWNLOAD_PART_SIZE_KB, clamping to a valid getFile size.
+
+        Telegram requires the per-request limit to be a multiple of 4 KiB that
+        divides 1 MiB and is at most 512 KiB. An invalid or out-of-range value
+        is clamped to 512 KiB (the maximum, fewest requests) rather than raising,
+        so a misconfigured knob never aborts an unattended backup.
+        """
+        valid = (4, 8, 16, 32, 64, 128, 256, 512)
+        try:
+            kb = int(value) if value else 512
+        except ValueError:
+            kb = 512
+        if kb in valid:
+            return kb
+        # Snap down to the largest valid size not exceeding the request.
+        for candidate in reversed(valid):
+            if kb >= candidate:
+                return candidate
+        return valid[0]
+
+    def get_parallel_download_min_size_bytes(self) -> int:
+        """Minimum file size (bytes) that triggers the parallel download path."""
+        return self.parallel_download_min_size_mb * 1024 * 1024
+
+    def get_parallel_download_part_size_bytes(self) -> int:
+        """Per-request chunk size in bytes for parallel downloads."""
+        return self.parallel_download_part_size_kb * 1024
 
     def _parse_id_list(self, id_str: str) -> set:
         """Parse comma-separated ID string into a set of integers."""

--- a/src/parallel_download.py
+++ b/src/parallel_download.py
@@ -1,0 +1,334 @@
+"""Per-file parallel chunked media downloads (issue #183).
+
+This module provides a *bytes-fetching primitive* that can replace
+``TelegramClient.download_media`` at the existing download seam in
+``telegram_backup.py``. It splits one file into fixed-size chunks fetched
+concurrently over several independent MTProto senders to a single DC, then
+reassembles them by writing each chunk at its exact byte offset.
+
+Design constraints (issue #183, all enforced here):
+
+1. **Gated by the caller.** This module never decides *whether* to run in
+   parallel; the backup layer gates on a config flag and a size threshold and
+   only constructs/uses :class:`ParallelDownloader` for large files. The
+   primitive still falls back defensively (raising
+   :class:`ParallelDownloadUnavailable`) when it cannot operate safely.
+2. **Bounded, low sender count.** Concurrency is capped by ``connections``,
+   which the config layer clamps well under Telegram's ~20-connection cliff.
+3. **Single flood budget.** A chunk that hits ``FLOOD_WAIT`` cancels its
+   siblings and re-raises the *original* :class:`FloodWaitError`, so the
+   caller's ``call_with_flood_retry`` wrapper applies the one shared budget and
+   restarts the whole transfer — there is no second backoff scheme here.
+4. **Deterministic, verified reassembly.** Each chunk is written with
+   ``os.pwrite`` at its exact request offset (no shared seek pointer), and
+   before the file is accepted we assert the written byte ranges cover
+   ``[0, file_size)`` exactly once, with no gaps or overlaps.
+5. **Transactional.** Any chunk failure cancels siblings, closes every sender,
+   deletes the partial output, and re-raises the original exception type so the
+   caller's retry / ``FileReferenceExpired`` refresh logic is unchanged.
+6. **Bounded memory.** Chunks stream straight to disk; peak resident bytes are
+   roughly ``connections * part_size`` (default 4 * 512 KiB = 2 MiB).
+"""
+
+import asyncio
+import logging
+import os
+
+from telethon import utils
+from telethon.errors import FileMigrateError, FloodWaitError
+from telethon.network import MTProtoSender
+from telethon.tl import functions
+from telethon.tl.alltlobjects import LAYER
+from telethon.tl.functions import InvokeWithLayerRequest
+from telethon.tl.functions.auth import (
+    ExportAuthorizationRequest,
+    ImportAuthorizationRequest,
+)
+
+logger = logging.getLogger(__name__)
+
+# Telegram's upload.getFile constraints: ``offset`` and ``limit`` must be
+# multiples of 4 KiB, a single request may not exceed 512 KiB, and one request
+# must not straddle a 1 MiB boundary. A part size that is a multiple of 4 KiB
+# and divides 1 MiB satisfies all three (offsets are multiples of the part
+# size, so they stay 4 KiB-aligned and inside a single 1 MiB block).
+CHUNK_ALIGN = 4096
+MAX_PART_SIZE = 524288  # 512 KiB — Telegram's per-request ceiling
+ONE_MB = 1048576
+
+
+class ParallelDownloadUnavailable(Exception):
+    """Raised when a file cannot be downloaded with the parallel transferrer.
+
+    The backup layer treats this as a signal to fall back to the proven
+    single-stream ``client.download_media`` path for this file (and, on the
+    first occurrence, to stop attempting parallel downloads for the run).
+    """
+
+
+def is_valid_part_size(part_size: int) -> bool:
+    """Return True if ``part_size`` satisfies Telegram's getFile constraints."""
+    return (
+        isinstance(part_size, int)
+        and part_size > 0
+        and part_size <= MAX_PART_SIZE
+        and part_size % CHUNK_ALIGN == 0
+        and ONE_MB % part_size == 0
+    )
+
+
+def supports_parallel_download(client) -> bool:
+    """Probe whether the live Telethon client exposes the internals we need.
+
+    Telethon v1 is archived but still receives occasional releases; if a future
+    version renames these private members we degrade to single-stream instead
+    of crashing.
+    """
+    required = ("_get_dc", "_connection", "_call", "_log", "session", "_init_request", "_borrow_sender_lock")
+    if not all(hasattr(client, attr) for attr in required):
+        return False
+    if not hasattr(client, "_proxy"):
+        return False
+    return hasattr(utils, "get_input_location")
+
+
+def _verify_coverage(written: list[tuple[int, int]], file_size: int) -> None:
+    """Assert the written ``(offset, length)`` ranges tile ``[0, file_size)``.
+
+    Raises :class:`ParallelDownloadUnavailable` on any gap, overlap, or size
+    mismatch. This is the safety net against a mis-reassembled file that would
+    otherwise pass the caller's size-only check, get hashed, and propagate
+    through content-hash dedup (issue #183, hard requirement #4).
+    """
+    ranges = sorted(written)
+    cursor = 0
+    for offset, length in ranges:
+        if offset != cursor:
+            raise ParallelDownloadUnavailable(f"chunk coverage gap/overlap at offset {offset} (expected {cursor})")
+        if length <= 0:
+            raise ParallelDownloadUnavailable(f"non-positive chunk length {length} at offset {offset}")
+        cursor += length
+    if cursor != file_size:
+        raise ParallelDownloadUnavailable(f"chunk coverage total {cursor} != file_size {file_size}")
+
+
+def _pwrite_all(fd: int, data: bytes, offset: int) -> None:
+    """Write ``data`` at ``offset`` with ``os.pwrite``, handling short writes.
+
+    ``os.pwrite`` uses an explicit offset and never touches the file's seek
+    pointer, so concurrent workers sharing one fd never corrupt each other's
+    write position.
+    """
+    view = memoryview(data)
+    written = 0
+    while written < len(view):
+        n = os.pwrite(fd, view[written:], offset + written)
+        if n <= 0:
+            raise OSError("os.pwrite returned non-positive byte count")
+        written += n
+
+
+class ParallelDownloader:
+    """Fetches one file at a time over a bounded pool of independent senders."""
+
+    def __init__(self, client, *, connections: int, part_size: int):
+        if not is_valid_part_size(part_size):
+            raise ValueError(f"invalid part_size {part_size}; must be a 4 KiB multiple dividing 1 MiB, <= 512 KiB")
+        self._client = client
+        self._connections = max(1, int(connections))
+        self._part_size = int(part_size)
+
+    async def download_media(self, message, file) -> str:
+        """Download ``message``'s media to path ``file`` and return ``file``.
+
+        Mirrors the subset of ``TelegramClient.download_media`` the backup seam
+        relies on (message in, destination path in, path out), so it is a
+        drop-in replacement under ``call_with_flood_retry``.
+        """
+        if not isinstance(file, str):
+            raise ParallelDownloadUnavailable("parallel download requires a destination path")
+        if not supports_parallel_download(self._client):
+            raise ParallelDownloadUnavailable("Telethon client is missing required internals")
+
+        try:
+            dc_id, location = utils.get_input_location(message)
+        except Exception as exc:  # noqa: BLE001 — any cast failure means fall back
+            raise ParallelDownloadUnavailable(f"cannot resolve input location: {exc}") from exc
+
+        # ``get_input_location`` drops the size; recover it from the file info so
+        # we can chunk deterministically. Without an exact size we cannot verify
+        # coverage, so we refuse rather than guess.
+        file_size = _extract_file_size(message)
+        if not file_size or file_size <= 0:
+            raise ParallelDownloadUnavailable("unknown file size")
+
+        await self._download_location(location, dc_id, file_size, file)
+        return file
+
+    async def _download_location(self, location, dc_id, file_size: int, dest_path: str) -> None:
+        offsets = list(range(0, file_size, self._part_size))
+        queue: asyncio.Queue[int] = asyncio.Queue()
+        for off in offsets:
+            queue.put_nowait(off)
+
+        written: list[tuple[int, int]] = []
+        senders: list[MTProtoSender] = []
+        # O_NOFOLLOW (where available) refuses to follow a pre-planted symlink at
+        # dest_path, so a shared/world-writable media dir can't redirect our write.
+        open_flags = os.O_RDWR | os.O_CREAT | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(dest_path, open_flags, 0o644)
+        try:
+            os.ftruncate(fd, file_size)
+            n = min(self._connections, len(offsets)) or 1
+            senders = await self._build_senders(dc_id, n)
+
+            workers = [
+                asyncio.create_task(self._worker(sender, location, file_size, queue, fd, written)) for sender in senders
+            ]
+            try:
+                await asyncio.gather(*workers)
+            except BaseException:
+                # Transactional cancel: stop every sibling before propagating so
+                # no worker keeps issuing requests after the transfer has failed.
+                for w in workers:
+                    w.cancel()
+                await asyncio.gather(*workers, return_exceptions=True)
+                raise
+
+            _verify_coverage(written, file_size)
+            os.fsync(fd)
+        except BaseException:
+            os.close(fd)
+            fd = -1
+            try:
+                os.remove(dest_path)
+            except OSError:
+                pass
+            raise
+        finally:
+            if fd != -1:
+                os.close(fd)
+            await self._close_senders(senders)
+
+    async def _worker(self, sender, location, file_size, queue, fd, written) -> None:
+        while True:
+            try:
+                offset = queue.get_nowait()
+            except asyncio.QueueEmpty:
+                return
+            request = functions.upload.GetFileRequest(location, offset=offset, limit=self._part_size)
+            try:
+                result = await self._client._call(sender, request)
+            except FloodWaitError:
+                # Must propagate unchanged so the caller's single flood budget
+                # (call_with_flood_retry) governs it — never a second backoff.
+                raise
+            except FileMigrateError as exc:
+                # The file actually lives on another DC; native download_media
+                # handles migration, so bail out to single-stream for this file.
+                raise ParallelDownloadUnavailable(f"file migrated to DC {exc.new_dc}") from exc
+            data = result.bytes
+            if not data:
+                # Empty response before EOF would leave a gap; coverage check
+                # would fail anyway, but fail fast with a clear cause.
+                raise ParallelDownloadUnavailable(f"empty chunk at offset {offset}")
+            expected = min(self._part_size, file_size - offset)
+            if len(data) != expected:
+                raise ParallelDownloadUnavailable(
+                    f"chunk at offset {offset} returned {len(data)} bytes, expected {expected}"
+                )
+            _pwrite_all(fd, data, offset)
+            written.append((offset, len(data)))
+
+    async def _build_senders(self, dc_id, n: int) -> list[MTProtoSender]:
+        """Create ``n`` connected senders to ``dc_id`` sharing one auth key.
+
+        Home DC: reuse the session auth key directly (Telegram forbids
+        exporting auth to the DC you are already on). Foreign DC: export auth
+        from the main connection once, import it into the first sender, then
+        reuse that sender's negotiated key for the remaining siblings.
+        """
+        client = self._client
+        home_dc = client.session.dc_id
+        senders: list[MTProtoSender] = []
+        try:
+            if dc_id is None or dc_id == home_dc:
+                target_dc = home_dc
+                auth_key = client.session.auth_key
+                for _ in range(n):
+                    senders.append(await self._connect_sender(target_dc, auth_key))
+            else:
+                first = await self._connect_sender(dc_id, None)
+                senders.append(first)
+                # Hold the borrow lock while mutating the shared init request,
+                # mirroring Telethon's own _create_exported_sender. Restore the
+                # original query afterwards so concurrent users of _init_request
+                # never observe our transient ImportAuthorizationRequest.
+                async with client._borrow_sender_lock:
+                    saved_query = client._init_request.query
+                    try:
+                        auth = await client(ExportAuthorizationRequest(dc_id))
+                        client._init_request.query = ImportAuthorizationRequest(id=auth.id, bytes=auth.bytes)
+                        await first.send(InvokeWithLayerRequest(LAYER, client._init_request))
+                    finally:
+                        client._init_request.query = saved_query
+                auth_key = first.auth_key
+                for _ in range(n - 1):
+                    senders.append(await self._connect_sender(dc_id, auth_key))
+            return senders
+        except ParallelDownloadUnavailable:
+            await self._close_senders(senders)
+            raise
+        except Exception as exc:  # noqa: BLE001
+            await self._close_senders(senders)
+            if isinstance(exc, FloodWaitError):
+                # Surface flood so the caller's single budget governs it.
+                raise
+            raise ParallelDownloadUnavailable(f"failed to establish parallel senders: {exc}") from exc
+
+    async def _connect_sender(self, dc_id, auth_key) -> MTProtoSender:
+        client = self._client
+        dc = await client._get_dc(dc_id)
+        sender = MTProtoSender(auth_key, loggers=client._log)
+        await sender.connect(
+            client._connection(
+                dc.ip_address,
+                dc.port,
+                dc.id,
+                loggers=client._log,
+                proxy=client._proxy,
+                local_addr=getattr(client, "_local_addr", None),
+            )
+        )
+        return sender
+
+    async def _close_senders(self, senders) -> None:
+        for sender in senders:
+            try:
+                await sender.disconnect()
+            except Exception:  # noqa: BLE001 — disconnect must never mask the real error
+                pass
+
+
+def _extract_file_size(message) -> int | None:
+    """Best-effort exact byte size for a message's downloadable media."""
+    media = getattr(message, "media", message)
+    document = getattr(media, "document", None)
+    if document is not None and getattr(document, "size", None):
+        return int(document.size)
+    photo = getattr(media, "photo", None)
+    if photo is not None:
+        sizes = getattr(photo, "sizes", None) or []
+        best = 0
+        for s in sizes:
+            size = getattr(s, "size", None)
+            if size:
+                best = max(best, int(size))
+            else:
+                # PhotoSizeProgressive carries a list of cumulative sizes.
+                sizes_list = getattr(s, "sizes", None)
+                if sizes_list:
+                    best = max(best, int(max(sizes_list)))
+        return best or None
+    size = getattr(media, "size", None)
+    return int(size) if size else None

--- a/src/parallel_download.py
+++ b/src/parallel_download.py
@@ -35,7 +35,7 @@ import logging
 import os
 
 from telethon import utils
-from telethon.errors import FileMigrateError, FloodWaitError
+from telethon.errors import FileMigrateError, FileReferenceExpiredError, FloodWaitError
 from telethon.network import MTProtoSender
 from telethon.tl import functions
 from telethon.tl.alltlobjects import LAYER
@@ -89,6 +89,10 @@ def supports_parallel_download(client) -> bool:
         return False
     if not hasattr(client, "_proxy"):
         return False
+    # ``os.pwrite`` is POSIX-only; on platforms without it (e.g. Windows) we
+    # degrade here at probe time rather than crashing mid-transfer.
+    if not hasattr(os, "pwrite"):
+        return False
     return hasattr(utils, "get_input_location")
 
 
@@ -131,12 +135,16 @@ def _pwrite_all(fd: int, data: bytes, offset: int) -> None:
 class ParallelDownloader:
     """Fetches one file at a time over a bounded pool of independent senders."""
 
-    def __init__(self, client, *, connections: int, part_size: int):
+    def __init__(self, client, *, connections: int, part_size: int, max_file_size: int | None = None):
         if not is_valid_part_size(part_size):
             raise ValueError(f"invalid part_size {part_size}; must be a 4 KiB multiple dividing 1 MiB, <= 512 KiB")
         self._client = client
         self._connections = max(1, int(connections))
         self._part_size = int(part_size)
+        # Defence-in-depth: the declared size comes from untrusted server
+        # metadata. A ceiling caps how many chunks (and how large a
+        # pre-allocation) one transfer can request before we fall back.
+        self._max_file_size = int(max_file_size) if max_file_size and max_file_size > 0 else None
 
     async def download_media(self, message, file) -> str:
         """Download ``message``'s media to path ``file`` and return ``file``.
@@ -161,6 +169,8 @@ class ParallelDownloader:
         file_size = _extract_file_size(message)
         if not file_size or file_size <= 0:
             raise ParallelDownloadUnavailable("unknown file size")
+        if self._max_file_size is not None and file_size > self._max_file_size:
+            raise ParallelDownloadUnavailable(f"declared file size {file_size} exceeds ceiling {self._max_file_size}")
 
         await self._download_location(location, dc_id, file_size, file)
         return file
@@ -198,7 +208,11 @@ class ParallelDownloader:
             _verify_coverage(written, file_size)
             os.fsync(fd)
         except BaseException:
-            os.close(fd)
+            try:
+                os.close(fd)
+            except OSError:
+                # Closing the fd must never mask the original chunk failure.
+                pass
             fd = -1
             try:
                 os.remove(dest_path)
@@ -222,6 +236,11 @@ class ParallelDownloader:
             except FloodWaitError:
                 # Must propagate unchanged so the caller's single flood budget
                 # (call_with_flood_retry) governs it — never a second backoff.
+                raise
+            except FileReferenceExpiredError:
+                # Propagate unchanged so the caller's file-reference refresh
+                # loop can re-resolve the message and retry, rather than
+                # silently degrading to single-stream with a stale reference.
                 raise
             except FileMigrateError as exc:
                 # The file actually lives on another DC; native download_media
@@ -281,8 +300,10 @@ class ParallelDownloader:
             raise
         except Exception as exc:  # noqa: BLE001
             await self._close_senders(senders)
-            if isinstance(exc, FloodWaitError):
-                # Surface flood so the caller's single budget governs it.
+            if isinstance(exc, (FloodWaitError, FileReferenceExpiredError)):
+                # Surface flood (single budget) and stale-reference (refresh
+                # loop) unchanged so the caller's existing handling governs
+                # them, rather than masking them as a generic fallback.
                 raise
             raise ParallelDownloadUnavailable(f"failed to establish parallel senders: {exc}") from exc
 

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -1920,6 +1920,7 @@ class TelegramBackup:
                     self.client,
                     connections=self.config.parallel_download_connections,
                     part_size=self.config.get_parallel_download_part_size_bytes(),
+                    max_file_size=self.config.get_max_media_size_bytes(),
                 )
             try:
                 return await self._parallel_downloader.download_media(message, tmp_path)

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -44,6 +44,11 @@ from .message_utils import (
     resolve_shared_file_path,
     sanitize_media_filename,
 )
+from .parallel_download import (
+    ParallelDownloader,
+    ParallelDownloadUnavailable,
+    supports_parallel_download,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -303,6 +308,11 @@ class TelegramBackup:
         self.client: TelegramClient | None = client
         self._owns_client = client is None  # Track if we created the client
         self._cleaned_media_chats: set[int] = set()  # Track chats already cleaned this session
+        # Lazily-built parallel downloader (issue #183). Stays None until the
+        # first large file when the feature is enabled; disabled for the rest of
+        # the run if the client lacks the required Telethon internals.
+        self._parallel_downloader: ParallelDownloader | None = None
+        self._parallel_download_disabled = False
 
         logger.info("TelegramBackup initialized")
 
@@ -1729,7 +1739,7 @@ class TelegramBackup:
                     for attempt in range(3):
                         try:
                             return await asyncio.wait_for(
-                                call_with_flood_retry(self.client.download_media, message, tmp_path),
+                                call_with_flood_retry(self._fetch_media_bytes, message, tmp_path, file_size),
                                 timeout=timeout_val,
                             )
                         except FileReferenceExpiredError:
@@ -1784,7 +1794,7 @@ class TelegramBackup:
                             os.remove(tmp_file_path)
                         try:
                             actual_path = await asyncio.wait_for(
-                                call_with_flood_retry(self.client.download_media, message, tmp_file_path),
+                                call_with_flood_retry(self._fetch_media_bytes, message, tmp_file_path, file_size),
                                 timeout=timeout_val,
                             )
                             break
@@ -1868,6 +1878,54 @@ class TelegramBackup:
                 "chat_id": chat_id,
                 "downloaded": False,
             }
+
+    def _should_parallelize(self, message, file_size: int) -> bool:
+        """Decide whether this file should use the parallel chunked path.
+
+        Gated by config (default OFF), a size threshold, and a one-time client
+        capability probe. Returns False for anything that should stay on the
+        proven single-stream ``download_media`` path.
+        """
+        # Strict ``is True`` (not truthiness): a real Config sets a bool, while a
+        # MagicMock config returns a truthy mock — this keeps the feature off in
+        # tests/callers that never opted in, and off by default in production.
+        if getattr(self.config, "parallel_download_enabled", False) is not True:
+            return False
+        if getattr(self, "_parallel_download_disabled", False):
+            return False
+        if file_size < self.config.get_parallel_download_min_size_bytes():
+            return False
+        if not supports_parallel_download(self.client):
+            # Probe once; if the installed Telethon lacks the internals we need,
+            # stop trying for the whole run instead of re-probing every file.
+            logger.warning("Parallel download unavailable (Telethon internals missing); using single-stream")
+            self._parallel_download_disabled = True
+            return False
+        return True
+
+    async def _fetch_media_bytes(self, message, tmp_path, file_size: int):
+        """Fetch a message's media to ``tmp_path`` (the bytes-fetch primitive).
+
+        Swaps only the transport: callers keep ``call_with_flood_retry``, the
+        timeout, the ``FileReferenceExpired`` refresh loop, and dedup/sharding.
+        Uses the parallel transferrer for large files when enabled, otherwise
+        the single-stream ``client.download_media``. A parallel attempt that
+        reports itself unavailable transparently falls back to single-stream for
+        that file; FloodWait and other real errors propagate unchanged so the
+        caller's single retry budget governs them.
+        """
+        if self._should_parallelize(message, file_size):
+            if self._parallel_downloader is None:
+                self._parallel_downloader = ParallelDownloader(
+                    self.client,
+                    connections=self.config.parallel_download_connections,
+                    part_size=self.config.get_parallel_download_part_size_bytes(),
+                )
+            try:
+                return await self._parallel_downloader.download_media(message, tmp_path)
+            except ParallelDownloadUnavailable as exc:
+                logger.info("Parallel download not applicable (%s); falling back to single-stream", exc)
+        return await self.client.download_media(message, tmp_path)
 
     def _get_media_size(self, media) -> int:
         """Get estimated size of media object in bytes."""

--- a/tests/test_parallel_download.py
+++ b/tests/test_parallel_download.py
@@ -116,6 +116,54 @@ def test_extract_file_size_from_photo_sizes():
     assert _extract_file_size(Msg()) == 9000
 
 
+def test_extract_file_size_from_progressive_photo_sizes():
+    class Progressive:
+        size = None
+        sizes = [10, 200, 3000]  # cumulative; total is the max
+
+    class Photo:
+        sizes = [Progressive()]
+
+    class Media:
+        document = None
+        photo = Photo()
+
+    class Msg:
+        media = Media()
+
+    assert _extract_file_size(Msg()) == 3000
+
+
+def test_extract_file_size_from_bare_media_size():
+    class Media:
+        document = None
+        photo = None
+        size = 777
+
+    class Msg:
+        media = Media()
+
+    assert _extract_file_size(Msg()) == 777
+
+
+def test_extract_file_size_returns_none_when_absent():
+    class Media:
+        document = None
+        photo = None
+        size = None
+
+    class Msg:
+        media = Media()
+
+    assert _extract_file_size(Msg()) is None
+
+
+def test_pwrite_all_raises_on_nonpositive_write(monkeypatch):
+    monkeypatch.setattr(os, "pwrite", lambda *a, **k: 0)
+    with pytest.raises(OSError):
+        _pwrite_all(0, b"data", 0)
+
+
 # --------------------------------------------------------------------------- #
 # Fake Telethon client / sender harness
 # --------------------------------------------------------------------------- #
@@ -372,6 +420,112 @@ def test_supports_parallel_download_false_when_get_input_location_gone(monkeypat
 async def test_invalid_part_size_rejected_at_construction():
     with pytest.raises(ValueError):
         ParallelDownloader(FakeClient(b"x"), connections=4, part_size=3000)
+
+
+async def test_download_media_refuses_when_client_incomplete(tmp_path, monkeypatch):
+    client = FakeClient(b"x" * 100)
+    monkeypatch.setattr("src.parallel_download.supports_parallel_download", lambda c: False)
+    dl = ParallelDownloader(client, connections=4, part_size=524288)
+    with pytest.raises(ParallelDownloadUnavailable):
+        await dl.download_media(_make_message(100), str(tmp_path / "x.bin"))
+
+
+async def test_build_senders_closes_on_unavailable(monkeypatch):
+    client = FakeClient(b"x" * 100)
+    closed = []
+
+    def _connect(self, dc_id, auth_key):
+        async def _inner():
+            raise ParallelDownloadUnavailable("nope")
+
+        return _inner()
+
+    monkeypatch.setattr(ParallelDownloader, "_connect_sender", _connect)
+
+    async def _track_close(self, senders):
+        closed.append(senders)
+
+    monkeypatch.setattr(ParallelDownloader, "_close_senders", _track_close)
+    dl = ParallelDownloader(client, connections=2, part_size=524288)
+    with pytest.raises(ParallelDownloadUnavailable):
+        await dl._build_senders(client.session.dc_id, 2)
+    assert closed  # cleanup ran on the ParallelDownloadUnavailable path
+
+
+async def test_close_senders_swallows_disconnect_errors():
+    dl = ParallelDownloader(FakeClient(b"x"), connections=4, part_size=524288)
+
+    class BadSender:
+        async def disconnect(self):
+            raise RuntimeError("boom")
+
+    # Must not raise even though disconnect() fails.
+    await dl._close_senders([BadSender(), BadSender()])
+
+
+async def test_download_media_falls_back_when_location_unresolvable(tmp_path, monkeypatch):
+    client = FakeClient(b"x" * 100)
+    monkeypatch.setattr(ParallelDownloader, "_connect_sender", lambda self, d, k: None)
+
+    def _boom(_message):
+        raise TypeError("not a downloadable message")
+
+    monkeypatch.setattr(utils, "get_input_location", _boom)
+    dl = ParallelDownloader(client, connections=4, part_size=524288)
+    with pytest.raises(ParallelDownloadUnavailable):
+        await dl.download_media(_make_message(100), str(tmp_path / "x.bin"))
+
+
+async def test_build_senders_wraps_non_flood_errors(monkeypatch):
+    client = FakeClient(b"x" * 100)
+
+    def _boom(self, dc_id, auth_key):
+        async def _inner():
+            raise RuntimeError("connect failed")
+
+        return _inner()
+
+    monkeypatch.setattr(ParallelDownloader, "_connect_sender", _boom)
+    dl = ParallelDownloader(client, connections=2, part_size=524288)
+    with pytest.raises(ParallelDownloadUnavailable):
+        await dl._build_senders(client.session.dc_id, 2)
+
+
+async def test_build_senders_propagates_floodwait(monkeypatch):
+    client = FakeClient(b"x" * 100)
+
+    def _flood(self, dc_id, auth_key):
+        async def _inner():
+            raise FloodWaitError(request=None)
+
+        return _inner()
+
+    monkeypatch.setattr(ParallelDownloader, "_connect_sender", _flood)
+    dl = ParallelDownloader(client, connections=2, part_size=524288)
+    # FloodWait must surface unchanged so the single budget governs it.
+    with pytest.raises(FloodWaitError):
+        await dl._build_senders(client.session.dc_id, 2)
+
+
+async def test_cleanup_tolerates_missing_partial_file(tmp_path, patch_sender, monkeypatch):
+    # A chunk failure triggers cleanup; if the partial file is already gone,
+    # os.remove's OSError must be swallowed and the original error re-raised.
+    blob = os.urandom(524288 * 2)
+    client = FakeClient(blob, short_at_offset=0)
+    patch_sender(client)
+    dl = ParallelDownloader(client, connections=2, part_size=524288)
+    dest = str(tmp_path / "video.mp4")
+
+    real_remove = os.remove
+
+    def _remove_then_vanish(path):
+        real_remove(path)
+        raise FileNotFoundError(path)  # simulate a concurrent unlink
+
+    monkeypatch.setattr(os, "remove", _remove_then_vanish)
+    with pytest.raises(ParallelDownloadUnavailable):
+        await dl.download_media(_make_message(len(blob)), dest)
+    assert not os.path.exists(dest)
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_parallel_download.py
+++ b/tests/test_parallel_download.py
@@ -1,0 +1,499 @@
+"""Tests for per-file parallel chunked downloads (issue #183).
+
+Covers the failure modes that actually matter for safe, unattended reassembly:
+exact-offset writes, coverage verification (gaps/overlaps/wrong size), dropped
+or short chunks, racing writers, mid-transfer FileReferenceExpired, FloodWait
+propagation through the single budget, transactional cleanup, capability-probe
+fallback, and the backup-layer size/flag gating.
+"""
+
+import asyncio
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from telethon import utils
+from telethon.errors import FileReferenceExpiredError, FloodWaitError
+
+from src.parallel_download import (
+    ParallelDownloader,
+    ParallelDownloadUnavailable,
+    _extract_file_size,
+    _pwrite_all,
+    _verify_coverage,
+    is_valid_part_size,
+    supports_parallel_download,
+)
+from src.telegram_backup import TelegramBackup
+
+
+def _read(path):
+    with open(path, "rb") as f:
+        return f.read()
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+def test_is_valid_part_size_accepts_only_telegram_constraints():
+    assert is_valid_part_size(524288)  # 512 KiB max
+    assert is_valid_part_size(131072)  # 128 KiB divides 1 MiB
+    assert is_valid_part_size(4096)  # 4 KiB minimum alignment
+    assert not is_valid_part_size(524288 + 4096)  # exceeds max
+    assert not is_valid_part_size(1048576)  # exceeds max
+    assert not is_valid_part_size(3000)  # not a 4 KiB multiple
+    assert not is_valid_part_size(393216)  # 384 KiB does not divide 1 MiB
+    assert not is_valid_part_size(0)
+    assert not is_valid_part_size(-4096)
+
+
+def test_verify_coverage_accepts_exact_tiling():
+    _verify_coverage([(0, 512), (512, 512), (1024, 100)], 1124)
+    _verify_coverage([(1024, 100), (0, 512), (512, 512)], 1124)  # unsorted input
+
+
+def test_verify_coverage_rejects_gap():
+    with pytest.raises(ParallelDownloadUnavailable):
+        _verify_coverage([(0, 512), (1024, 100)], 1124)
+
+
+def test_verify_coverage_rejects_overlap():
+    with pytest.raises(ParallelDownloadUnavailable):
+        _verify_coverage([(0, 512), (256, 512)], 768)
+
+
+def test_verify_coverage_rejects_wrong_total_size():
+    with pytest.raises(ParallelDownloadUnavailable):
+        _verify_coverage([(0, 512)], 1000)
+
+
+def test_verify_coverage_rejects_nonpositive_length():
+    with pytest.raises(ParallelDownloadUnavailable):
+        _verify_coverage([(0, 0)], 0)
+
+
+def test_pwrite_all_writes_at_exact_offset(tmp_path):
+    target = tmp_path / "out.bin"
+    fd = os.open(target, os.O_RDWR | os.O_CREAT | os.O_TRUNC)
+    try:
+        os.ftruncate(fd, 10)
+        _pwrite_all(fd, b"world", 5)
+        _pwrite_all(fd, b"hello", 0)
+    finally:
+        os.close(fd)
+    assert target.read_bytes() == b"helloworld"
+
+
+def test_extract_file_size_from_document():
+    class Doc:
+        size = 4242
+
+    class Media:
+        document = Doc()
+        photo = None
+
+    class Msg:
+        media = Media()
+
+    assert _extract_file_size(Msg()) == 4242
+
+
+def test_extract_file_size_from_photo_sizes():
+    class Size:
+        def __init__(self, size):
+            self.size = size
+
+    class Photo:
+        sizes = [Size(100), Size(9000), Size(500)]
+
+    class Media:
+        document = None
+        photo = Photo()
+
+    class Msg:
+        media = Media()
+
+    assert _extract_file_size(Msg()) == 9000
+
+
+# --------------------------------------------------------------------------- #
+# Fake Telethon client / sender harness
+# --------------------------------------------------------------------------- #
+class _GetFileResult:
+    def __init__(self, data):
+        self.bytes = data
+
+
+class FakeSender:
+    """Records connect/disconnect; bytes come from the client's blob."""
+
+    def __init__(self):
+        self.connected = False
+        self.disconnected = False
+        self.dc_id = None
+        self.auth_key = object()
+
+    async def connect(self, _connection):
+        self.connected = True
+
+    async def disconnect(self):
+        self.disconnected = True
+
+    async def send(self, _request):
+        return None
+
+
+class FakeDC:
+    ip_address = "127.0.0.1"
+    port = 443
+
+    def __init__(self, dc_id):
+        self.id = dc_id
+
+
+class FakeSession:
+    def __init__(self, dc_id=2):
+        self.dc_id = dc_id
+        self.auth_key = object()
+
+
+class FakeLog(dict):
+    def __getitem__(self, k):
+        import logging
+
+        return logging.getLogger("fake")
+
+
+class FakeClient:
+    """Minimal stand-in exposing the private internals the transferrer uses.
+
+    ``blob`` is the full file content; ``_call`` slices it by the request's
+    offset/limit, so a correctly reassembled output must equal ``blob``.
+    """
+
+    def __init__(self, blob, *, home_dc=2, fail_at_offset=None, fail_exc=None, short_at_offset=None):
+        self.blob = blob
+        self.session = FakeSession(home_dc)
+        self._log = FakeLog()
+        self._proxy = None
+        self._local_addr = None
+        self._init_request = type("Init", (), {"query": None})()
+        self._borrow_sender_lock = asyncio.Lock()
+        self.created_senders = []
+        self._fail_at_offset = fail_at_offset
+        self._fail_exc = fail_exc
+        self._short_at_offset = short_at_offset
+
+    async def _get_dc(self, dc_id):
+        return FakeDC(dc_id)
+
+    def _connection(self, *a, **k):
+        return object()
+
+    async def _call(self, sender, request):
+        offset = request.offset
+        limit = request.limit
+        if self._fail_at_offset is not None and offset == self._fail_at_offset:
+            raise self._fail_exc
+        data = self.blob[offset : offset + limit]
+        if self._short_at_offset is not None and offset == self._short_at_offset:
+            data = data[:-1]  # drop a byte to simulate a short/corrupt chunk
+        return _GetFileResult(data)
+
+    # Patched factory so we count and inspect senders without real I/O.
+    def make_sender(self):
+        s = FakeSender()
+        self.created_senders.append(s)
+        return s
+
+
+@pytest.fixture
+def patch_sender(monkeypatch):
+    """Replace MTProtoSender construction with FakeSender bound to the client."""
+
+    def _apply(client):
+        def _connect_sender_stub(self, dc_id, auth_key):
+            async def _inner():
+                s = client.make_sender()
+                s.dc_id = dc_id
+                s.connected = True
+                return s
+
+            return _inner()
+
+        monkeypatch.setattr(ParallelDownloader, "_connect_sender", _connect_sender_stub)
+        # get_input_location returns (dc_id, location); location is opaque here.
+        monkeypatch.setattr(utils, "get_input_location", lambda m: (client.session.dc_id, object()))
+
+    return _apply
+
+
+def _make_message(size):
+    class Doc:
+        def __init__(self, size):
+            self.size = size
+
+    class Media:
+        def __init__(self, size):
+            self.document = Doc(size)
+            self.photo = None
+
+    class Msg:
+        def __init__(self, size):
+            self.media = Media(size)
+
+    return Msg(size)
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end reassembly
+# --------------------------------------------------------------------------- #
+async def test_parallel_download_reassembles_exact_bytes(tmp_path, patch_sender):
+    blob = os.urandom(512 * 1024 * 3 + 12345)  # 3 full parts + remainder
+    client = FakeClient(blob)
+    patch_sender(client)
+    dl = ParallelDownloader(client, connections=4, part_size=524288)
+    dest = str(tmp_path / "video.mp4")
+
+    result = await dl.download_media(_make_message(len(blob)), dest)
+
+    assert result == dest
+    assert _read(dest) == blob
+    # Senders are created and cleaned up.
+    assert len(client.created_senders) >= 1
+    assert all(s.disconnected for s in client.created_senders)
+
+
+async def test_parallel_download_single_chunk_file(tmp_path, patch_sender):
+    blob = os.urandom(100)
+    client = FakeClient(blob)
+    patch_sender(client)
+    dl = ParallelDownloader(client, connections=4, part_size=524288)
+    dest = str(tmp_path / "small.bin")
+
+    await dl.download_media(_make_message(len(blob)), dest)
+    assert _read(dest) == blob
+
+
+async def test_parallel_download_rejects_non_path_destination(tmp_path, patch_sender):
+    client = FakeClient(b"x")
+    patch_sender(client)
+    dl = ParallelDownloader(client, connections=4, part_size=524288)
+    with pytest.raises(ParallelDownloadUnavailable):
+        await dl.download_media(_make_message(1), object())
+
+
+async def test_parallel_download_unknown_size_refuses(tmp_path, patch_sender):
+    client = FakeClient(b"")
+    patch_sender(client)
+    dl = ParallelDownloader(client, connections=4, part_size=524288)
+    with pytest.raises(ParallelDownloadUnavailable):
+        await dl.download_media(_make_message(0), str(tmp_path / "x"))
+
+
+# --------------------------------------------------------------------------- #
+# Failure modes — transactional cleanup + propagation
+# --------------------------------------------------------------------------- #
+async def test_floodwait_propagates_and_cleans_up(tmp_path, patch_sender):
+    blob = os.urandom(524288 * 3)
+    client = FakeClient(blob, fail_at_offset=524288, fail_exc=FloodWaitError(request=None))
+    patch_sender(client)
+    dl = ParallelDownloader(client, connections=4, part_size=524288)
+    dest = str(tmp_path / "video.mp4")
+
+    with pytest.raises(FloodWaitError):
+        await dl.download_media(_make_message(len(blob)), dest)
+    # Transactional: partial output removed, all senders closed.
+    assert not os.path.exists(dest)
+    assert all(s.disconnected for s in client.created_senders)
+
+
+async def test_file_reference_expired_propagates(tmp_path, patch_sender):
+    blob = os.urandom(524288 * 3)
+    client = FakeClient(blob, fail_at_offset=0, fail_exc=FileReferenceExpiredError(request=None))
+    patch_sender(client)
+    dl = ParallelDownloader(client, connections=4, part_size=524288)
+    dest = str(tmp_path / "video.mp4")
+
+    with pytest.raises(FileReferenceExpiredError):
+        await dl.download_media(_make_message(len(blob)), dest)
+    assert not os.path.exists(dest)
+
+
+async def test_short_chunk_is_detected_and_aborts(tmp_path, patch_sender):
+    blob = os.urandom(524288 * 2)
+    # Drop a byte from the FIRST part (a full part), so the length check fires.
+    client = FakeClient(blob, short_at_offset=0)
+    patch_sender(client)
+    dl = ParallelDownloader(client, connections=2, part_size=524288)
+    dest = str(tmp_path / "video.mp4")
+
+    with pytest.raises(ParallelDownloadUnavailable):
+        await dl.download_media(_make_message(len(blob)), dest)
+    assert not os.path.exists(dest)
+
+
+async def test_concurrent_workers_do_not_corrupt_offsets(tmp_path, patch_sender):
+    # Many small parts across several senders; the only way the output equals
+    # the blob is if every worker wrote at its exact offset (os.pwrite).
+    part = 4096
+    blob = os.urandom(part * 50 + 17)
+    client = FakeClient(blob)
+    patch_sender(client)
+    dl = ParallelDownloader(client, connections=8, part_size=part)
+    dest = str(tmp_path / "many.bin")
+
+    await dl.download_media(_make_message(len(blob)), dest)
+    assert _read(dest) == blob
+
+
+# --------------------------------------------------------------------------- #
+# Capability probe
+# --------------------------------------------------------------------------- #
+def test_supports_parallel_download_true_for_complete_client():
+    client = FakeClient(b"x")
+    assert supports_parallel_download(client) is True
+
+
+def test_supports_parallel_download_false_when_internal_missing():
+    class Incomplete:
+        # Missing _call, _connection, etc.
+        session = FakeSession()
+
+    assert supports_parallel_download(Incomplete()) is False
+
+
+def test_supports_parallel_download_false_when_get_input_location_gone(monkeypatch):
+    client = FakeClient(b"x")
+    monkeypatch.delattr(utils, "get_input_location")
+    assert supports_parallel_download(client) is False
+
+
+async def test_invalid_part_size_rejected_at_construction():
+    with pytest.raises(ValueError):
+        ParallelDownloader(FakeClient(b"x"), connections=4, part_size=3000)
+
+
+# --------------------------------------------------------------------------- #
+# Foreign-DC export path
+# --------------------------------------------------------------------------- #
+class ForeignDCClient(FakeClient):
+    """FakeClient whose ``client(request)`` records auth-export calls."""
+
+    def __init__(self, blob, **kw):
+        super().__init__(blob, **kw)
+        self.export_calls = []
+
+    async def __call__(self, request):
+        self.export_calls.append(request)
+        return type("Auth", (), {"id": 1, "bytes": b"k"})()
+
+
+async def test_foreign_dc_exports_auth_once(tmp_path, monkeypatch):
+    blob = os.urandom(524288 * 4)  # 4 parts so a 3-sender pool is fully built
+    client = ForeignDCClient(blob, home_dc=2)
+
+    # File lives on DC 4 (foreign). get_input_location reports dc_id=4.
+    monkeypatch.setattr(utils, "get_input_location", lambda m: (4, object()))
+
+    def _connect_sender_stub(self, dc_id, auth_key):
+        async def _inner():
+            s = client.make_sender()
+            s.dc_id = dc_id
+            s.connected = True
+            return s
+
+        return _inner()
+
+    monkeypatch.setattr(ParallelDownloader, "_connect_sender", _connect_sender_stub)
+
+    dl = ParallelDownloader(client, connections=3, part_size=524288)
+    dest = str(tmp_path / "foreign.bin")
+    await dl.download_media(_make_message(len(blob)), dest)
+
+    assert _read(dest) == blob
+    # Auth exported exactly once even though 3 senders were created.
+    assert len(client.export_calls) == 1
+    assert len(client.created_senders) == 3
+
+
+# --------------------------------------------------------------------------- #
+# Backup-layer gating (_should_parallelize / _fetch_media_bytes)
+# --------------------------------------------------------------------------- #
+def _make_backup(*, enabled, min_mb=20, conns=4, part_kb=512):
+    backup = TelegramBackup.__new__(TelegramBackup)
+    cfg = MagicMock()
+    cfg.parallel_download_enabled = enabled
+    cfg.parallel_download_connections = conns
+    cfg.parallel_download_part_size_kb = part_kb
+    cfg.get_parallel_download_min_size_bytes = MagicMock(return_value=min_mb * 1024 * 1024)
+    cfg.get_parallel_download_part_size_bytes = MagicMock(return_value=part_kb * 1024)
+    backup.config = cfg
+    backup.client = MagicMock()
+    backup._parallel_downloader = None
+    backup._parallel_download_disabled = False
+    return backup
+
+
+def test_gate_off_by_default():
+    backup = _make_backup(enabled=False)
+    assert backup._should_parallelize(_make_message(100 * 1024 * 1024), 100 * 1024 * 1024) is False
+
+
+def test_gate_skips_small_files_when_enabled():
+    backup = _make_backup(enabled=True, min_mb=20)
+    # 5 MB < 20 MB threshold -> single stream
+    assert backup._should_parallelize(_make_message(5 * 1024 * 1024), 5 * 1024 * 1024) is False
+
+
+def test_gate_enables_for_large_files():
+    backup = _make_backup(enabled=True, min_mb=20)
+    # supports_parallel_download is True for a fully-mocked client only if it has
+    # the internals; MagicMock auto-provides every attribute, so the probe passes.
+    assert backup._should_parallelize(_make_message(50 * 1024 * 1024), 50 * 1024 * 1024) is True
+
+
+def test_gate_disabled_after_capability_probe_fails(monkeypatch):
+    backup = _make_backup(enabled=True, min_mb=1)
+    monkeypatch.setattr("src.telegram_backup.supports_parallel_download", lambda c: False)
+    assert backup._should_parallelize(_make_message(50 * 1024 * 1024), 50 * 1024 * 1024) is False
+    # Latches off for the rest of the run.
+    assert backup._parallel_download_disabled is True
+
+
+async def test_fetch_media_bytes_uses_single_stream_when_disabled():
+    backup = _make_backup(enabled=False)
+    backup.client.download_media = AsyncMock(return_value="/tmp/out")
+    result = await backup._fetch_media_bytes(_make_message(99 * 1024 * 1024), "/tmp/out", 99 * 1024 * 1024)
+    assert result == "/tmp/out"
+    backup.client.download_media.assert_awaited_once()
+
+
+async def test_fetch_media_bytes_falls_back_on_unavailable(monkeypatch):
+    backup = _make_backup(enabled=True, min_mb=1)
+    backup.client.download_media = AsyncMock(return_value="/tmp/out")
+
+    class _DL:
+        async def download_media(self, message, path):
+            raise ParallelDownloadUnavailable("nope")
+
+    monkeypatch.setattr("src.telegram_backup.ParallelDownloader", lambda *a, **k: _DL())
+    result = await backup._fetch_media_bytes(_make_message(50 * 1024 * 1024), "/tmp/out", 50 * 1024 * 1024)
+    # Transparent fallback to single-stream for this file.
+    assert result == "/tmp/out"
+    backup.client.download_media.assert_awaited_once()
+
+
+async def test_fetch_media_bytes_propagates_floodwait(monkeypatch):
+    backup = _make_backup(enabled=True, min_mb=1)
+    backup.client.download_media = AsyncMock(return_value="/tmp/out")
+
+    class _DL:
+        async def download_media(self, message, path):
+            raise FloodWaitError(request=None)
+
+    monkeypatch.setattr("src.telegram_backup.ParallelDownloader", lambda *a, **k: _DL())
+    with pytest.raises(FloodWaitError):
+        await backup._fetch_media_bytes(_make_message(50 * 1024 * 1024), "/tmp/out", 50 * 1024 * 1024)
+    # FloodWait must NOT be swallowed into a single-stream retry here.
+    backup.client.download_media.assert_not_awaited()

--- a/tests/test_parallel_download.py
+++ b/tests/test_parallel_download.py
@@ -7,11 +7,18 @@ propagation through the single budget, transactional cleanup, capability-probe
 fallback, and the backup-layer size/flag gating.
 """
 
-import asyncio
-import os
-from unittest.mock import AsyncMock, MagicMock
+from __future__ import annotations
 
-import pytest
+import asyncio
+import logging
+import os
+import tempfile
+import unittest
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
 from telethon import utils
 from telethon.errors import FileReferenceExpiredError, FloodWaitError
 
@@ -26,168 +33,61 @@ from src.parallel_download import (
 )
 from src.telegram_backup import TelegramBackup
 
+_HAS_PWRITE = hasattr(os, "pwrite")
 
-def _read(path):
+
+def _read(path: str | os.PathLike[str]) -> bytes:
     with open(path, "rb") as f:
         return f.read()
 
 
 # --------------------------------------------------------------------------- #
-# Pure helpers
+# Fake message (downloadable-media stand-in)
 # --------------------------------------------------------------------------- #
-def test_is_valid_part_size_accepts_only_telegram_constraints():
-    assert is_valid_part_size(524288)  # 512 KiB max
-    assert is_valid_part_size(131072)  # 128 KiB divides 1 MiB
-    assert is_valid_part_size(4096)  # 4 KiB minimum alignment
-    assert not is_valid_part_size(524288 + 4096)  # exceeds max
-    assert not is_valid_part_size(1048576)  # exceeds max
-    assert not is_valid_part_size(3000)  # not a 4 KiB multiple
-    assert not is_valid_part_size(393216)  # 384 KiB does not divide 1 MiB
-    assert not is_valid_part_size(0)
-    assert not is_valid_part_size(-4096)
+class _FakeDoc:
+    def __init__(self, size: int) -> None:
+        self.size = size
 
 
-def test_verify_coverage_accepts_exact_tiling():
-    _verify_coverage([(0, 512), (512, 512), (1024, 100)], 1124)
-    _verify_coverage([(1024, 100), (0, 512), (512, 512)], 1124)  # unsorted input
+class _FakeMedia:
+    def __init__(self, size: int) -> None:
+        self.document = _FakeDoc(size)
+        self.photo = None
 
 
-def test_verify_coverage_rejects_gap():
-    with pytest.raises(ParallelDownloadUnavailable):
-        _verify_coverage([(0, 512), (1024, 100)], 1124)
+class _FakeMessage:
+    def __init__(self, size: int) -> None:
+        self.media = _FakeMedia(size)
 
 
-def test_verify_coverage_rejects_overlap():
-    with pytest.raises(ParallelDownloadUnavailable):
-        _verify_coverage([(0, 512), (256, 512)], 768)
-
-
-def test_verify_coverage_rejects_wrong_total_size():
-    with pytest.raises(ParallelDownloadUnavailable):
-        _verify_coverage([(0, 512)], 1000)
-
-
-def test_verify_coverage_rejects_nonpositive_length():
-    with pytest.raises(ParallelDownloadUnavailable):
-        _verify_coverage([(0, 0)], 0)
-
-
-def test_pwrite_all_writes_at_exact_offset(tmp_path):
-    target = tmp_path / "out.bin"
-    fd = os.open(target, os.O_RDWR | os.O_CREAT | os.O_TRUNC)
-    try:
-        os.ftruncate(fd, 10)
-        _pwrite_all(fd, b"world", 5)
-        _pwrite_all(fd, b"hello", 0)
-    finally:
-        os.close(fd)
-    assert target.read_bytes() == b"helloworld"
-
-
-def test_extract_file_size_from_document():
-    class Doc:
-        size = 4242
-
-    class Media:
-        document = Doc()
-        photo = None
-
-    class Msg:
-        media = Media()
-
-    assert _extract_file_size(Msg()) == 4242
-
-
-def test_extract_file_size_from_photo_sizes():
-    class Size:
-        def __init__(self, size):
-            self.size = size
-
-    class Photo:
-        sizes = [Size(100), Size(9000), Size(500)]
-
-    class Media:
-        document = None
-        photo = Photo()
-
-    class Msg:
-        media = Media()
-
-    assert _extract_file_size(Msg()) == 9000
-
-
-def test_extract_file_size_from_progressive_photo_sizes():
-    class Progressive:
-        size = None
-        sizes = [10, 200, 3000]  # cumulative; total is the max
-
-    class Photo:
-        sizes = [Progressive()]
-
-    class Media:
-        document = None
-        photo = Photo()
-
-    class Msg:
-        media = Media()
-
-    assert _extract_file_size(Msg()) == 3000
-
-
-def test_extract_file_size_from_bare_media_size():
-    class Media:
-        document = None
-        photo = None
-        size = 777
-
-    class Msg:
-        media = Media()
-
-    assert _extract_file_size(Msg()) == 777
-
-
-def test_extract_file_size_returns_none_when_absent():
-    class Media:
-        document = None
-        photo = None
-        size = None
-
-    class Msg:
-        media = Media()
-
-    assert _extract_file_size(Msg()) is None
-
-
-def test_pwrite_all_raises_on_nonpositive_write(monkeypatch):
-    monkeypatch.setattr(os, "pwrite", lambda *a, **k: 0)
-    with pytest.raises(OSError):
-        _pwrite_all(0, b"data", 0)
+def _make_message(size: int) -> _FakeMessage:
+    return _FakeMessage(size)
 
 
 # --------------------------------------------------------------------------- #
 # Fake Telethon client / sender harness
 # --------------------------------------------------------------------------- #
 class _GetFileResult:
-    def __init__(self, data):
+    def __init__(self, data: bytes) -> None:
         self.bytes = data
 
 
 class FakeSender:
     """Records connect/disconnect; bytes come from the client's blob."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.connected = False
         self.disconnected = False
-        self.dc_id = None
-        self.auth_key = object()
+        self.dc_id: int | None = None
+        self.auth_key: object = object()
 
-    async def connect(self, _connection):
+    async def connect(self, _connection: Any) -> None:
         self.connected = True
 
-    async def disconnect(self):
+    async def disconnect(self) -> None:
         self.disconnected = True
 
-    async def send(self, _request):
+    async def send(self, _request: Any) -> None:
         return None
 
 
@@ -195,20 +95,18 @@ class FakeDC:
     ip_address = "127.0.0.1"
     port = 443
 
-    def __init__(self, dc_id):
+    def __init__(self, dc_id: int) -> None:
         self.id = dc_id
 
 
 class FakeSession:
-    def __init__(self, dc_id=2):
+    def __init__(self, dc_id: int = 2) -> None:
         self.dc_id = dc_id
-        self.auth_key = object()
+        self.auth_key: object = object()
 
 
 class FakeLog(dict):
-    def __getitem__(self, k):
-        import logging
-
+    def __getitem__(self, k: str) -> logging.Logger:
         return logging.getLogger("fake")
 
 
@@ -219,7 +117,15 @@ class FakeClient:
     offset/limit, so a correctly reassembled output must equal ``blob``.
     """
 
-    def __init__(self, blob, *, home_dc=2, fail_at_offset=None, fail_exc=None, short_at_offset=None):
+    def __init__(
+        self,
+        blob: bytes,
+        *,
+        home_dc: int = 2,
+        fail_at_offset: int | None = None,
+        fail_exc: BaseException | None = None,
+        short_at_offset: int | None = None,
+    ) -> None:
         self.blob = blob
         self.session = FakeSession(home_dc)
         self._log = FakeLog()
@@ -227,21 +133,22 @@ class FakeClient:
         self._local_addr = None
         self._init_request = type("Init", (), {"query": None})()
         self._borrow_sender_lock = asyncio.Lock()
-        self.created_senders = []
+        self.created_senders: list[FakeSender] = []
         self._fail_at_offset = fail_at_offset
         self._fail_exc = fail_exc
         self._short_at_offset = short_at_offset
 
-    async def _get_dc(self, dc_id):
+    async def _get_dc(self, dc_id: int) -> FakeDC:
         return FakeDC(dc_id)
 
-    def _connection(self, *a, **k):
+    def _connection(self, *a: Any, **k: Any) -> object:
         return object()
 
-    async def _call(self, sender, request):
+    async def _call(self, sender: Any, request: Any) -> _GetFileResult:
         offset = request.offset
         limit = request.limit
         if self._fail_at_offset is not None and offset == self._fail_at_offset:
+            assert self._fail_exc is not None
             raise self._fail_exc
         data = self.blob[offset : offset + limit]
         if self._short_at_offset is not None and offset == self._short_at_offset:
@@ -249,442 +156,34 @@ class FakeClient:
         return _GetFileResult(data)
 
     # Patched factory so we count and inspect senders without real I/O.
-    def make_sender(self):
+    def make_sender(self) -> FakeSender:
         s = FakeSender()
         self.created_senders.append(s)
         return s
 
 
-@pytest.fixture
-def patch_sender(monkeypatch):
-    """Replace MTProtoSender construction with FakeSender bound to the client."""
-
-    def _apply(client):
-        def _connect_sender_stub(self, dc_id, auth_key):
-            async def _inner():
-                s = client.make_sender()
-                s.dc_id = dc_id
-                s.connected = True
-                return s
-
-            return _inner()
-
-        monkeypatch.setattr(ParallelDownloader, "_connect_sender", _connect_sender_stub)
-        # get_input_location returns (dc_id, location); location is opaque here.
-        monkeypatch.setattr(utils, "get_input_location", lambda m: (client.session.dc_id, object()))
-
-    return _apply
-
-
-def _make_message(size):
-    class Doc:
-        def __init__(self, size):
-            self.size = size
-
-    class Media:
-        def __init__(self, size):
-            self.document = Doc(size)
-            self.photo = None
-
-    class Msg:
-        def __init__(self, size):
-            self.media = Media(size)
-
-    return Msg(size)
-
-
-# --------------------------------------------------------------------------- #
-# End-to-end reassembly
-# --------------------------------------------------------------------------- #
-async def test_parallel_download_reassembles_exact_bytes(tmp_path, patch_sender):
-    blob = os.urandom(512 * 1024 * 3 + 12345)  # 3 full parts + remainder
-    client = FakeClient(blob)
-    patch_sender(client)
-    dl = ParallelDownloader(client, connections=4, part_size=524288)
-    dest = str(tmp_path / "video.mp4")
-
-    result = await dl.download_media(_make_message(len(blob)), dest)
-
-    assert result == dest
-    assert _read(dest) == blob
-    # Senders are created and cleaned up.
-    assert len(client.created_senders) >= 1
-    assert all(s.disconnected for s in client.created_senders)
-
-
-async def test_parallel_download_single_chunk_file(tmp_path, patch_sender):
-    blob = os.urandom(100)
-    client = FakeClient(blob)
-    patch_sender(client)
-    dl = ParallelDownloader(client, connections=4, part_size=524288)
-    dest = str(tmp_path / "small.bin")
-
-    await dl.download_media(_make_message(len(blob)), dest)
-    assert _read(dest) == blob
-    # A single-chunk file needs exactly one sender (n = min(connections, offsets)).
-    assert len(client.created_senders) == 1
-
-
-async def test_parallel_download_part_aligned_file(tmp_path, patch_sender):
-    # Exactly 3 full parts with no remainder: the last chunk is a full part, so
-    # the per-chunk length check must accept ``min(part_size, file_size-offset)``
-    # for every chunk including the final one.
-    blob = os.urandom(524288 * 3)
-    client = FakeClient(blob)
-    patch_sender(client)
-    dl = ParallelDownloader(client, connections=4, part_size=524288)
-    dest = str(tmp_path / "aligned.bin")
-
-    await dl.download_media(_make_message(len(blob)), dest)
-    assert _read(dest) == blob
-
-
-async def test_parallel_download_rejects_non_path_destination(tmp_path, patch_sender):
-    client = FakeClient(b"x")
-    patch_sender(client)
-    dl = ParallelDownloader(client, connections=4, part_size=524288)
-    with pytest.raises(ParallelDownloadUnavailable):
-        await dl.download_media(_make_message(1), object())
-
-
-async def test_parallel_download_unknown_size_refuses(tmp_path, patch_sender):
-    client = FakeClient(b"")
-    patch_sender(client)
-    dl = ParallelDownloader(client, connections=4, part_size=524288)
-    with pytest.raises(ParallelDownloadUnavailable):
-        await dl.download_media(_make_message(0), str(tmp_path / "x"))
-
-
-async def test_parallel_download_refuses_size_over_ceiling(tmp_path, patch_sender):
-    # The declared size comes from untrusted server metadata. A file larger than
-    # the configured ceiling must fall back rather than pre-allocate/chunk it.
-    blob = os.urandom(1024)
-    client = FakeClient(blob)
-    patch_sender(client)
-    dl = ParallelDownloader(client, connections=4, part_size=524288, max_file_size=500)
-    with pytest.raises(ParallelDownloadUnavailable):
-        await dl.download_media(_make_message(1024), str(tmp_path / "big.bin"))
-    assert not os.path.exists(str(tmp_path / "big.bin"))
-
-
-async def test_parallel_download_allows_size_at_ceiling(tmp_path, patch_sender):
-    # A file exactly at the ceiling is still allowed (boundary is inclusive).
-    blob = os.urandom(500)
-    client = FakeClient(blob)
-    patch_sender(client)
-    dl = ParallelDownloader(client, connections=4, part_size=524288, max_file_size=500)
-    dest = str(tmp_path / "edge.bin")
-    await dl.download_media(_make_message(500), dest)
-    assert _read(dest) == blob
-
-
-# --------------------------------------------------------------------------- #
-# Failure modes — transactional cleanup + propagation
-# --------------------------------------------------------------------------- #
-async def test_floodwait_propagates_and_cleans_up(tmp_path, patch_sender):
-    blob = os.urandom(524288 * 3)
-    client = FakeClient(blob, fail_at_offset=524288, fail_exc=FloodWaitError(request=None))
-    patch_sender(client)
-    dl = ParallelDownloader(client, connections=4, part_size=524288)
-    dest = str(tmp_path / "video.mp4")
-
-    with pytest.raises(FloodWaitError):
-        await dl.download_media(_make_message(len(blob)), dest)
-    # Transactional: partial output removed, all senders closed.
-    assert not os.path.exists(dest)
-    assert all(s.disconnected for s in client.created_senders)
-
-
-async def test_file_reference_expired_propagates(tmp_path, patch_sender):
-    blob = os.urandom(524288 * 3)
-    client = FakeClient(blob, fail_at_offset=0, fail_exc=FileReferenceExpiredError(request=None))
-    patch_sender(client)
-    dl = ParallelDownloader(client, connections=4, part_size=524288)
-    dest = str(tmp_path / "video.mp4")
-
-    with pytest.raises(FileReferenceExpiredError):
-        await dl.download_media(_make_message(len(blob)), dest)
-    assert not os.path.exists(dest)
-
-
-async def test_file_reference_expired_mid_transfer_propagates(tmp_path, patch_sender):
-    # A stale reference can surface on a later chunk, not just the first one.
-    # It must still propagate unchanged (so the caller refreshes), cancel
-    # siblings, and remove the partial output.
-    blob = os.urandom(524288 * 4)
-    client = FakeClient(blob, fail_at_offset=524288 * 2, fail_exc=FileReferenceExpiredError(request=None))
-    patch_sender(client)
-    dl = ParallelDownloader(client, connections=4, part_size=524288)
-    dest = str(tmp_path / "video.mp4")
-
-    with pytest.raises(FileReferenceExpiredError):
-        await dl.download_media(_make_message(len(blob)), dest)
-    assert not os.path.exists(dest)
-    assert all(s.disconnected for s in client.created_senders)
-
-
-async def test_blob_shorter_than_declared_size_aborts(tmp_path, patch_sender):
-    # If the server returns fewer bytes than the declared size (so a tail chunk
-    # comes back empty/short), the guard must fire and the partial be removed.
-    declared = 524288 * 3
-    client = FakeClient(os.urandom(524288 * 2))  # blob is a full part short
-    patch_sender(client)
-    dl = ParallelDownloader(client, connections=2, part_size=524288)
-    dest = str(tmp_path / "truncated.bin")
-
-    with pytest.raises(ParallelDownloadUnavailable):
-        await dl.download_media(_make_message(declared), dest)
-    assert not os.path.exists(dest)
-
-
-async def test_short_chunk_is_detected_and_aborts(tmp_path, patch_sender):
-    blob = os.urandom(524288 * 2)
-    # Drop a byte from the FIRST part (a full part), so the length check fires.
-    client = FakeClient(blob, short_at_offset=0)
-    patch_sender(client)
-    dl = ParallelDownloader(client, connections=2, part_size=524288)
-    dest = str(tmp_path / "video.mp4")
-
-    with pytest.raises(ParallelDownloadUnavailable):
-        await dl.download_media(_make_message(len(blob)), dest)
-    assert not os.path.exists(dest)
-
-
-async def test_concurrent_workers_do_not_corrupt_offsets(tmp_path, patch_sender):
-    # Many small parts across several senders; the only way the output equals
-    # the blob is if every worker wrote at its exact offset (os.pwrite).
-    part = 4096
-    blob = os.urandom(part * 50 + 17)
-    client = FakeClient(blob)
-    patch_sender(client)
-    dl = ParallelDownloader(client, connections=8, part_size=part)
-    dest = str(tmp_path / "many.bin")
-
-    await dl.download_media(_make_message(len(blob)), dest)
-    assert _read(dest) == blob
-
-
-# --------------------------------------------------------------------------- #
-# Capability probe
-# --------------------------------------------------------------------------- #
-def test_supports_parallel_download_true_for_complete_client():
-    client = FakeClient(b"x")
-    assert supports_parallel_download(client) is True
-
-
-def test_supports_parallel_download_false_when_internal_missing():
-    class Incomplete:
-        # Missing _call, _connection, etc.
-        session = FakeSession()
-
-    assert supports_parallel_download(Incomplete()) is False
-
-
-def test_supports_parallel_download_false_when_get_input_location_gone(monkeypatch):
-    client = FakeClient(b"x")
-    monkeypatch.delattr(utils, "get_input_location")
-    assert supports_parallel_download(client) is False
-
-
-async def test_invalid_part_size_rejected_at_construction():
-    with pytest.raises(ValueError):
-        ParallelDownloader(FakeClient(b"x"), connections=4, part_size=3000)
-
-
-async def test_download_media_refuses_when_client_incomplete(tmp_path, monkeypatch):
-    client = FakeClient(b"x" * 100)
-    monkeypatch.setattr("src.parallel_download.supports_parallel_download", lambda c: False)
-    dl = ParallelDownloader(client, connections=4, part_size=524288)
-    with pytest.raises(ParallelDownloadUnavailable):
-        await dl.download_media(_make_message(100), str(tmp_path / "x.bin"))
-
-
-async def test_build_senders_closes_on_unavailable(monkeypatch):
-    client = FakeClient(b"x" * 100)
-    closed = []
-
-    def _connect(self, dc_id, auth_key):
-        async def _inner():
-            raise ParallelDownloadUnavailable("nope")
-
-        return _inner()
-
-    monkeypatch.setattr(ParallelDownloader, "_connect_sender", _connect)
-
-    async def _track_close(self, senders):
-        closed.append(senders)
-
-    monkeypatch.setattr(ParallelDownloader, "_close_senders", _track_close)
-    dl = ParallelDownloader(client, connections=2, part_size=524288)
-    with pytest.raises(ParallelDownloadUnavailable):
-        await dl._build_senders(client.session.dc_id, 2)
-    assert closed  # cleanup ran on the ParallelDownloadUnavailable path
-
-
-async def test_close_senders_swallows_disconnect_errors():
-    dl = ParallelDownloader(FakeClient(b"x"), connections=4, part_size=524288)
-
-    class BadSender:
-        async def disconnect(self):
-            raise RuntimeError("boom")
-
-    # Must not raise even though disconnect() fails.
-    await dl._close_senders([BadSender(), BadSender()])
-
-
-async def test_download_media_falls_back_when_location_unresolvable(tmp_path, monkeypatch):
-    client = FakeClient(b"x" * 100)
-    monkeypatch.setattr(ParallelDownloader, "_connect_sender", lambda self, d, k: None)
-
-    def _boom(_message):
-        raise TypeError("not a downloadable message")
-
-    monkeypatch.setattr(utils, "get_input_location", _boom)
-    dl = ParallelDownloader(client, connections=4, part_size=524288)
-    with pytest.raises(ParallelDownloadUnavailable):
-        await dl.download_media(_make_message(100), str(tmp_path / "x.bin"))
-
-
-async def test_build_senders_wraps_non_flood_errors(monkeypatch):
-    client = FakeClient(b"x" * 100)
-
-    def _boom(self, dc_id, auth_key):
-        async def _inner():
-            raise RuntimeError("connect failed")
-
-        return _inner()
-
-    monkeypatch.setattr(ParallelDownloader, "_connect_sender", _boom)
-    dl = ParallelDownloader(client, connections=2, part_size=524288)
-    with pytest.raises(ParallelDownloadUnavailable):
-        await dl._build_senders(client.session.dc_id, 2)
-
-
-async def test_build_senders_propagates_floodwait(monkeypatch):
-    client = FakeClient(b"x" * 100)
-
-    def _flood(self, dc_id, auth_key):
-        async def _inner():
-            raise FloodWaitError(request=None)
-
-        return _inner()
-
-    monkeypatch.setattr(ParallelDownloader, "_connect_sender", _flood)
-    dl = ParallelDownloader(client, connections=2, part_size=524288)
-    # FloodWait must surface unchanged so the single budget governs it.
-    with pytest.raises(FloodWaitError):
-        await dl._build_senders(client.session.dc_id, 2)
-
-
-async def test_cleanup_tolerates_missing_partial_file(tmp_path, patch_sender, monkeypatch):
-    # A chunk failure triggers cleanup; if the partial file is already gone,
-    # os.remove's OSError must be swallowed and the original error re-raised.
-    blob = os.urandom(524288 * 2)
-    client = FakeClient(blob, short_at_offset=0)
-    patch_sender(client)
-    dl = ParallelDownloader(client, connections=2, part_size=524288)
-    dest = str(tmp_path / "video.mp4")
-
-    real_remove = os.remove
-
-    def _remove_then_vanish(path):
-        real_remove(path)
-        raise FileNotFoundError(path)  # simulate a concurrent unlink
-
-    monkeypatch.setattr(os, "remove", _remove_then_vanish)
-    with pytest.raises(ParallelDownloadUnavailable):
-        await dl.download_media(_make_message(len(blob)), dest)
-    assert not os.path.exists(dest)
-
-
-# --------------------------------------------------------------------------- #
-# Foreign-DC export path
-# --------------------------------------------------------------------------- #
 class ForeignDCClient(FakeClient):
     """FakeClient whose ``client(request)`` records auth-export calls."""
 
-    def __init__(self, blob, **kw):
+    def __init__(self, blob: bytes, **kw: Any) -> None:
         super().__init__(blob, **kw)
-        self.export_calls = []
+        self.export_calls: list[Any] = []
 
-    async def __call__(self, request):
+    async def __call__(self, request: Any) -> Any:
         self.export_calls.append(request)
         return type("Auth", (), {"id": 1, "bytes": b"k"})()
 
 
-async def test_foreign_dc_exports_auth_once(tmp_path, monkeypatch):
-    blob = os.urandom(524288 * 4)  # 4 parts so a 3-sender pool is fully built
-    client = ForeignDCClient(blob, home_dc=2)
-
-    # File lives on DC 4 (foreign). get_input_location reports dc_id=4.
-    monkeypatch.setattr(utils, "get_input_location", lambda m: (4, object()))
-
-    def _connect_sender_stub(self, dc_id, auth_key):
-        async def _inner():
-            s = client.make_sender()
-            s.dc_id = dc_id
-            s.connected = True
-            return s
-
-        return _inner()
-
-    monkeypatch.setattr(ParallelDownloader, "_connect_sender", _connect_sender_stub)
-
-    dl = ParallelDownloader(client, connections=3, part_size=524288)
-    dest = str(tmp_path / "foreign.bin")
-    await dl.download_media(_make_message(len(blob)), dest)
-
-    assert _read(dest) == blob
-    # Auth exported exactly once even though 3 senders were created.
-    assert len(client.export_calls) == 1
-    assert len(client.created_senders) == 3
-    # The shared init request's query must be restored after the transient
-    # ImportAuthorizationRequest, so concurrent users never observe our mutation.
-    assert client._init_request.query is None
-
-
-async def test_foreign_dc_export_floodwait_propagates_and_restores_query(tmp_path, monkeypatch):
-    # A FloodWait raised by the auth export must surface unchanged (single
-    # budget), and the shared _init_request.query must still be restored.
-    blob = os.urandom(524288 * 2)
-
-    class _FloodOnExport(FakeClient):
-        async def __call__(self, request):
-            raise FloodWaitError(request=None)
-
-    client = _FloodOnExport(blob, home_dc=2)
-    monkeypatch.setattr(utils, "get_input_location", lambda m: (4, object()))
-
-    def _connect_sender_stub(self, dc_id, auth_key):
-        async def _inner():
-            s = client.make_sender()
-            s.dc_id = dc_id
-            s.connected = True
-            return s
-
-        return _inner()
-
-    monkeypatch.setattr(ParallelDownloader, "_connect_sender", _connect_sender_stub)
-    dl = ParallelDownloader(client, connections=3, part_size=524288)
-    with pytest.raises(FloodWaitError):
-        await dl.download_media(_make_message(len(blob)), str(tmp_path / "f.bin"))
-    # Even on the export failure the query must be restored (try/finally).
-    assert client._init_request.query is None
-    # All senders opened so far are cleaned up.
-    assert all(s.disconnected for s in client.created_senders)
-
-
-# --------------------------------------------------------------------------- #
-# Backup-layer gating (_should_parallelize / _fetch_media_bytes)
-# --------------------------------------------------------------------------- #
-def _make_backup(*, enabled, min_mb=20, conns=4, part_kb=512):
+def _make_backup(*, enabled: bool, min_mb: int = 20, conns: int = 4, part_kb: int = 512) -> TelegramBackup:
     backup = TelegramBackup.__new__(TelegramBackup)
     cfg = MagicMock()
+    cfg.should_skip_topic = MagicMock(return_value=False)
     cfg.parallel_download_enabled = enabled
     cfg.parallel_download_connections = conns
     cfg.parallel_download_part_size_kb = part_kb
     cfg.get_parallel_download_min_size_bytes = MagicMock(return_value=min_mb * 1024 * 1024)
     cfg.get_parallel_download_part_size_bytes = MagicMock(return_value=part_kb * 1024)
+    cfg.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
     backup.config = cfg
     backup.client = MagicMock()
     backup._parallel_downloader = None
@@ -692,107 +191,666 @@ def _make_backup(*, enabled, min_mb=20, conns=4, part_kb=512):
     return backup
 
 
-def test_gate_off_by_default():
-    backup = _make_backup(enabled=False)
-    assert backup._should_parallelize(_make_message(100 * 1024 * 1024), 100 * 1024 * 1024) is False
+# --------------------------------------------------------------------------- #
+# Shared mixins: patch lifecycle + temp dir, modelled on the repo's other
+# unittest suites (start/addCleanup instead of the pytest monkeypatch fixture).
+# --------------------------------------------------------------------------- #
+class _PatchHelpers:
+    """Patch helpers that auto-revert via ``addCleanup`` (unittest idiom)."""
+
+    addCleanup: Callable[..., None]
+
+    def _patch(self, target: str, new: Any) -> Any:
+        patcher = patch(target, new)
+        value = patcher.start()
+        self.addCleanup(patcher.stop)
+        return value
+
+    def _patch_object(self, target: Any, attribute: str, new: Any) -> Any:
+        patcher = patch.object(target, attribute, new)
+        value = patcher.start()
+        self.addCleanup(patcher.stop)
+        return value
+
+    def _delattr_temp(self, obj: Any, name: str) -> None:
+        sentinel = object()
+        original = getattr(obj, name, sentinel)
+        delattr(obj, name)
+
+        def _restore() -> None:
+            if original is not sentinel:
+                setattr(obj, name, original)
+
+        self.addCleanup(_restore)
+
+    def _patch_sender(self, client: FakeClient) -> None:
+        """Replace MTProtoSender construction with FakeSender bound to client."""
+
+        def _connect_sender_stub(_self: ParallelDownloader, dc_id: int, auth_key: Any) -> Any:
+            async def _inner() -> FakeSender:
+                s = client.make_sender()
+                s.dc_id = dc_id
+                s.connected = True
+                return s
+
+            return _inner()
+
+        self._patch_object(ParallelDownloader, "_connect_sender", _connect_sender_stub)
+        # get_input_location returns (dc_id, location); location is opaque here.
+        self._patch_object(utils, "get_input_location", lambda m: (client.session.dc_id, object()))
 
 
-def test_gate_skips_small_files_when_enabled():
-    backup = _make_backup(enabled=True, min_mb=20)
-    # 5 MB < 20 MB threshold -> single stream
-    assert backup._should_parallelize(_make_message(5 * 1024 * 1024), 5 * 1024 * 1024) is False
+class _TmpDirMixin:
+    """Provide ``self.tmp`` as a Path to a per-test temporary directory."""
+
+    addCleanup: Callable[..., None]
+
+    def setUp(self) -> None:
+        super().setUp()
+        tmpdir = tempfile.TemporaryDirectory()
+        self.addCleanup(tmpdir.cleanup)
+        self.tmp = Path(tmpdir.name)
 
 
-def test_gate_enables_for_large_files():
-    backup = _make_backup(enabled=True, min_mb=20)
-    # supports_parallel_download is True for a fully-mocked client only if it has
-    # the internals; MagicMock auto-provides every attribute, so the probe passes.
-    assert backup._should_parallelize(_make_message(50 * 1024 * 1024), 50 * 1024 * 1024) is True
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+class TestPureHelpers(unittest.TestCase):
+    def test_is_valid_part_size_accepts_only_telegram_constraints(self) -> None:
+        self.assertTrue(is_valid_part_size(524288))  # 512 KiB max
+        self.assertTrue(is_valid_part_size(131072))  # 128 KiB divides 1 MiB
+        self.assertTrue(is_valid_part_size(4096))  # 4 KiB minimum alignment
+        self.assertFalse(is_valid_part_size(524288 + 4096))  # exceeds max
+        self.assertFalse(is_valid_part_size(1048576))  # exceeds max
+        self.assertFalse(is_valid_part_size(3000))  # not a 4 KiB multiple
+        self.assertFalse(is_valid_part_size(393216))  # 384 KiB does not divide 1 MiB
+        self.assertFalse(is_valid_part_size(0))
+        self.assertFalse(is_valid_part_size(-4096))
+
+    def test_verify_coverage_accepts_exact_tiling(self) -> None:
+        _verify_coverage([(0, 512), (512, 512), (1024, 100)], 1124)
+        _verify_coverage([(1024, 100), (0, 512), (512, 512)], 1124)  # unsorted input
+
+    def test_verify_coverage_rejects_gap(self) -> None:
+        with self.assertRaises(ParallelDownloadUnavailable):
+            _verify_coverage([(0, 512), (1024, 100)], 1124)
+
+    def test_verify_coverage_rejects_overlap(self) -> None:
+        with self.assertRaises(ParallelDownloadUnavailable):
+            _verify_coverage([(0, 512), (256, 512)], 768)
+
+    def test_verify_coverage_rejects_wrong_total_size(self) -> None:
+        with self.assertRaises(ParallelDownloadUnavailable):
+            _verify_coverage([(0, 512)], 1000)
+
+    def test_verify_coverage_rejects_nonpositive_length(self) -> None:
+        with self.assertRaises(ParallelDownloadUnavailable):
+            _verify_coverage([(0, 0)], 0)
+
+    @unittest.skipUnless(_HAS_PWRITE, "requires os.pwrite")
+    def test_pwrite_all_writes_at_exact_offset(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "out.bin"
+            fd = os.open(target, os.O_RDWR | os.O_CREAT | os.O_TRUNC)
+            try:
+                os.ftruncate(fd, 10)
+                _pwrite_all(fd, b"world", 5)
+                _pwrite_all(fd, b"hello", 0)
+            finally:
+                os.close(fd)
+            self.assertEqual(target.read_bytes(), b"helloworld")
+
+    @unittest.skipUnless(_HAS_PWRITE, "requires os.pwrite")
+    def test_pwrite_all_raises_on_nonpositive_write(self) -> None:
+        with patch.object(os, "pwrite", lambda *a, **k: 0), self.assertRaises(OSError):
+            _pwrite_all(0, b"data", 0)
+
+    def test_extract_file_size_from_document(self) -> None:
+        class Doc:
+            size = 4242
+
+        class Media:
+            document = Doc()
+            photo = None
+
+        class Msg:
+            media = Media()
+
+        self.assertEqual(_extract_file_size(Msg()), 4242)
+
+    def test_extract_file_size_from_photo_sizes(self) -> None:
+        class Size:
+            def __init__(self, size: int) -> None:
+                self.size = size
+
+        class Photo:
+            sizes = [Size(100), Size(9000), Size(500)]
+
+        class Media:
+            document = None
+            photo = Photo()
+
+        class Msg:
+            media = Media()
+
+        self.assertEqual(_extract_file_size(Msg()), 9000)
+
+    def test_extract_file_size_from_progressive_photo_sizes(self) -> None:
+        class Progressive:
+            size = None
+            sizes = [10, 200, 3000]  # cumulative; total is the max
+
+        class Photo:
+            sizes = [Progressive()]
+
+        class Media:
+            document = None
+            photo = Photo()
+
+        class Msg:
+            media = Media()
+
+        self.assertEqual(_extract_file_size(Msg()), 3000)
+
+    def test_extract_file_size_from_bare_media_size(self) -> None:
+        class Media:
+            document = None
+            photo = None
+            size = 777
+
+        class Msg:
+            media = Media()
+
+        self.assertEqual(_extract_file_size(Msg()), 777)
+
+    def test_extract_file_size_returns_none_when_absent(self) -> None:
+        class Media:
+            document = None
+            photo = None
+            size = None
+
+        class Msg:
+            media = Media()
+
+        self.assertIsNone(_extract_file_size(Msg()))
 
 
-def test_gate_disabled_after_capability_probe_fails(monkeypatch):
-    backup = _make_backup(enabled=True, min_mb=1)
-    monkeypatch.setattr("src.telegram_backup.supports_parallel_download", lambda c: False)
-    assert backup._should_parallelize(_make_message(50 * 1024 * 1024), 50 * 1024 * 1024) is False
-    # Latches off for the rest of the run.
-    assert backup._parallel_download_disabled is True
+# --------------------------------------------------------------------------- #
+# End-to-end reassembly
+# --------------------------------------------------------------------------- #
+class TestReassembly(_PatchHelpers, _TmpDirMixin, unittest.IsolatedAsyncioTestCase):
+    async def test_parallel_download_reassembles_exact_bytes(self) -> None:
+        blob = os.urandom(512 * 1024 * 3 + 12345)  # 3 full parts + remainder
+        client = FakeClient(blob)
+        self._patch_sender(client)
+        dl = ParallelDownloader(client, connections=4, part_size=524288)
+        dest = str(self.tmp / "video.mp4")
+
+        result = await dl.download_media(_make_message(len(blob)), dest)
+
+        self.assertEqual(result, dest)
+        self.assertEqual(_read(dest), blob)
+        # Senders are created and cleaned up.
+        self.assertGreaterEqual(len(client.created_senders), 1)
+        self.assertTrue(all(s.disconnected for s in client.created_senders))
+
+    async def test_parallel_download_single_chunk_file(self) -> None:
+        blob = os.urandom(100)
+        client = FakeClient(blob)
+        self._patch_sender(client)
+        dl = ParallelDownloader(client, connections=4, part_size=524288)
+        dest = str(self.tmp / "small.bin")
+
+        await dl.download_media(_make_message(len(blob)), dest)
+        self.assertEqual(_read(dest), blob)
+        # A single-chunk file needs exactly one sender (n = min(connections, offsets)).
+        self.assertEqual(len(client.created_senders), 1)
+
+    async def test_parallel_download_part_aligned_file(self) -> None:
+        # Exactly 3 full parts with no remainder: the last chunk is a full part,
+        # so the per-chunk length check must accept ``min(part_size,
+        # file_size-offset)`` for every chunk including the final one.
+        blob = os.urandom(524288 * 3)
+        client = FakeClient(blob)
+        self._patch_sender(client)
+        dl = ParallelDownloader(client, connections=4, part_size=524288)
+        dest = str(self.tmp / "aligned.bin")
+
+        await dl.download_media(_make_message(len(blob)), dest)
+        self.assertEqual(_read(dest), blob)
+
+    async def test_parallel_download_rejects_non_path_destination(self) -> None:
+        client = FakeClient(b"x")
+        self._patch_sender(client)
+        dl = ParallelDownloader(client, connections=4, part_size=524288)
+        with self.assertRaises(ParallelDownloadUnavailable):
+            await dl.download_media(_make_message(1), object())
+
+    async def test_parallel_download_unknown_size_refuses(self) -> None:
+        client = FakeClient(b"")
+        self._patch_sender(client)
+        dl = ParallelDownloader(client, connections=4, part_size=524288)
+        with self.assertRaises(ParallelDownloadUnavailable):
+            await dl.download_media(_make_message(0), str(self.tmp / "x"))
+
+    async def test_parallel_download_refuses_size_over_ceiling(self) -> None:
+        # The declared size comes from untrusted server metadata. A file larger
+        # than the configured ceiling must fall back rather than pre-allocate.
+        blob = os.urandom(1024)
+        client = FakeClient(blob)
+        self._patch_sender(client)
+        dl = ParallelDownloader(client, connections=4, part_size=524288, max_file_size=500)
+        with self.assertRaises(ParallelDownloadUnavailable):
+            await dl.download_media(_make_message(1024), str(self.tmp / "big.bin"))
+        self.assertFalse(os.path.exists(str(self.tmp / "big.bin")))
+
+    async def test_parallel_download_allows_size_at_ceiling(self) -> None:
+        # A file exactly at the ceiling is still allowed (boundary is inclusive).
+        blob = os.urandom(500)
+        client = FakeClient(blob)
+        self._patch_sender(client)
+        dl = ParallelDownloader(client, connections=4, part_size=524288, max_file_size=500)
+        dest = str(self.tmp / "edge.bin")
+        await dl.download_media(_make_message(500), dest)
+        self.assertEqual(_read(dest), blob)
 
 
-async def test_fetch_media_bytes_uses_single_stream_when_disabled():
-    backup = _make_backup(enabled=False)
-    backup.client.download_media = AsyncMock(return_value="/tmp/out")
-    result = await backup._fetch_media_bytes(_make_message(99 * 1024 * 1024), "/tmp/out", 99 * 1024 * 1024)
-    assert result == "/tmp/out"
-    backup.client.download_media.assert_awaited_once()
+# --------------------------------------------------------------------------- #
+# Failure modes — transactional cleanup + propagation
+# --------------------------------------------------------------------------- #
+class TestFailureModes(_PatchHelpers, _TmpDirMixin, unittest.IsolatedAsyncioTestCase):
+    async def test_floodwait_propagates_and_cleans_up(self) -> None:
+        blob = os.urandom(524288 * 3)
+        client = FakeClient(blob, fail_at_offset=524288, fail_exc=FloodWaitError(request=None))
+        self._patch_sender(client)
+        dl = ParallelDownloader(client, connections=4, part_size=524288)
+        dest = str(self.tmp / "video.mp4")
+
+        with self.assertRaises(FloodWaitError):
+            await dl.download_media(_make_message(len(blob)), dest)
+        # Transactional: partial output removed, all senders closed.
+        self.assertFalse(os.path.exists(dest))
+        self.assertTrue(all(s.disconnected for s in client.created_senders))
+
+    async def test_file_reference_expired_propagates(self) -> None:
+        blob = os.urandom(524288 * 3)
+        client = FakeClient(blob, fail_at_offset=0, fail_exc=FileReferenceExpiredError(request=None))
+        self._patch_sender(client)
+        dl = ParallelDownloader(client, connections=4, part_size=524288)
+        dest = str(self.tmp / "video.mp4")
+
+        with self.assertRaises(FileReferenceExpiredError):
+            await dl.download_media(_make_message(len(blob)), dest)
+        self.assertFalse(os.path.exists(dest))
+
+    async def test_file_reference_expired_mid_transfer_propagates(self) -> None:
+        # A stale reference can surface on a later chunk, not just the first one.
+        # It must still propagate unchanged (so the caller refreshes), cancel
+        # siblings, and remove the partial output.
+        blob = os.urandom(524288 * 4)
+        client = FakeClient(blob, fail_at_offset=524288 * 2, fail_exc=FileReferenceExpiredError(request=None))
+        self._patch_sender(client)
+        dl = ParallelDownloader(client, connections=4, part_size=524288)
+        dest = str(self.tmp / "video.mp4")
+
+        with self.assertRaises(FileReferenceExpiredError):
+            await dl.download_media(_make_message(len(blob)), dest)
+        self.assertFalse(os.path.exists(dest))
+        self.assertTrue(all(s.disconnected for s in client.created_senders))
+
+    async def test_blob_shorter_than_declared_size_aborts(self) -> None:
+        # If the server returns fewer bytes than the declared size (so a tail
+        # chunk comes back empty/short), the guard fires and the partial is gone.
+        declared = 524288 * 3
+        client = FakeClient(os.urandom(524288 * 2))  # blob is a full part short
+        self._patch_sender(client)
+        dl = ParallelDownloader(client, connections=2, part_size=524288)
+        dest = str(self.tmp / "truncated.bin")
+
+        with self.assertRaises(ParallelDownloadUnavailable):
+            await dl.download_media(_make_message(declared), dest)
+        self.assertFalse(os.path.exists(dest))
+
+    async def test_short_chunk_is_detected_and_aborts(self) -> None:
+        blob = os.urandom(524288 * 2)
+        # Drop a byte from the FIRST part (a full part), so the length check fires.
+        client = FakeClient(blob, short_at_offset=0)
+        self._patch_sender(client)
+        dl = ParallelDownloader(client, connections=2, part_size=524288)
+        dest = str(self.tmp / "video.mp4")
+
+        with self.assertRaises(ParallelDownloadUnavailable):
+            await dl.download_media(_make_message(len(blob)), dest)
+        self.assertFalse(os.path.exists(dest))
+
+    async def test_concurrent_workers_do_not_corrupt_offsets(self) -> None:
+        # Many small parts across several senders; the only way the output equals
+        # the blob is if every worker wrote at its exact offset (os.pwrite).
+        part = 4096
+        blob = os.urandom(part * 50 + 17)
+        client = FakeClient(blob)
+        self._patch_sender(client)
+        dl = ParallelDownloader(client, connections=8, part_size=part)
+        dest = str(self.tmp / "many.bin")
+
+        await dl.download_media(_make_message(len(blob)), dest)
+        self.assertEqual(_read(dest), blob)
+
+    async def test_cleanup_tolerates_missing_partial_file(self) -> None:
+        # A chunk failure triggers cleanup; if the partial file is already gone,
+        # os.remove's OSError must be swallowed and the original error re-raised.
+        blob = os.urandom(524288 * 2)
+        client = FakeClient(blob, short_at_offset=0)
+        self._patch_sender(client)
+        dl = ParallelDownloader(client, connections=2, part_size=524288)
+        dest = str(self.tmp / "video.mp4")
+
+        real_remove = os.remove
+
+        def _remove_then_vanish(path: Any) -> None:
+            real_remove(path)
+            raise FileNotFoundError(path)  # simulate a concurrent unlink
+
+        self._patch_object(os, "remove", _remove_then_vanish)
+        with self.assertRaises(ParallelDownloadUnavailable):
+            await dl.download_media(_make_message(len(blob)), dest)
+        self.assertFalse(os.path.exists(dest))
 
 
-async def test_fetch_media_bytes_falls_back_on_unavailable(monkeypatch):
-    backup = _make_backup(enabled=True, min_mb=1)
-    backup.client.download_media = AsyncMock(return_value="/tmp/out")
+# --------------------------------------------------------------------------- #
+# Capability probe (synchronous)
+# --------------------------------------------------------------------------- #
+class TestCapabilityProbe(_PatchHelpers, unittest.TestCase):
+    @unittest.skipUnless(_HAS_PWRITE, "probe requires os.pwrite")
+    def test_supports_parallel_download_true_for_complete_client(self) -> None:
+        client = FakeClient(b"x")
+        self.assertIs(supports_parallel_download(client), True)
 
-    class _DL:
-        async def download_media(self, message, path):
-            raise ParallelDownloadUnavailable("nope")
+    def test_supports_parallel_download_false_when_internal_missing(self) -> None:
+        class Incomplete:
+            # Missing _call, _connection, etc.
+            session = FakeSession()
 
-    monkeypatch.setattr("src.telegram_backup.ParallelDownloader", lambda *a, **k: _DL())
-    result = await backup._fetch_media_bytes(_make_message(50 * 1024 * 1024), "/tmp/out", 50 * 1024 * 1024)
-    # Transparent fallback to single-stream for this file.
-    assert result == "/tmp/out"
-    backup.client.download_media.assert_awaited_once()
+        self.assertIs(supports_parallel_download(Incomplete()), False)
 
+    def test_supports_parallel_download_false_when_get_input_location_gone(self) -> None:
+        client = FakeClient(b"x")
+        self._delattr_temp(utils, "get_input_location")
+        self.assertIs(supports_parallel_download(client), False)
 
-async def test_fetch_media_bytes_propagates_floodwait(monkeypatch):
-    backup = _make_backup(enabled=True, min_mb=1)
-    backup.client.download_media = AsyncMock(return_value="/tmp/out")
+    def test_supports_parallel_download_false_without_pwrite(self) -> None:
+        # On non-POSIX platforms os.pwrite is absent; the probe must degrade.
+        client = FakeClient(b"x")
+        self._delattr_temp(os, "pwrite")
+        self.assertIs(supports_parallel_download(client), False)
 
-    class _DL:
-        async def download_media(self, message, path):
-            raise FloodWaitError(request=None)
-
-    monkeypatch.setattr("src.telegram_backup.ParallelDownloader", lambda *a, **k: _DL())
-    with pytest.raises(FloodWaitError):
-        await backup._fetch_media_bytes(_make_message(50 * 1024 * 1024), "/tmp/out", 50 * 1024 * 1024)
-    # FloodWait must NOT be swallowed into a single-stream retry here.
-    backup.client.download_media.assert_not_awaited()
-
-
-async def test_fetch_media_bytes_uses_parallel_when_enabled(monkeypatch):
-    # Happy path: gate passes -> ParallelDownloader is used and its path returned,
-    # and the single-stream client.download_media is NOT touched.
-    backup = _make_backup(enabled=True, min_mb=1)
-    backup.client.download_media = AsyncMock(return_value="/tmp/single")
-
-    calls = []
-
-    class _DL:
-        async def download_media(self, message, path):
-            calls.append(path)
-            return path
-
-    monkeypatch.setattr("src.telegram_backup.ParallelDownloader", lambda *a, **k: _DL())
-    result = await backup._fetch_media_bytes(_make_message(50 * 1024 * 1024), "/tmp/parallel", 50 * 1024 * 1024)
-    assert result == "/tmp/parallel"
-    assert calls == ["/tmp/parallel"]
-    backup.client.download_media.assert_not_awaited()
+    def test_invalid_part_size_rejected_at_construction(self) -> None:
+        with self.assertRaises(ValueError):
+            ParallelDownloader(FakeClient(b"x"), connections=4, part_size=3000)
 
 
-async def test_fetch_media_bytes_reuses_cached_downloader(monkeypatch):
-    # The ParallelDownloader is built once and cached on the backup instance.
-    backup = _make_backup(enabled=True, min_mb=1)
-    backup.client.download_media = AsyncMock(return_value="/tmp/single")
+# --------------------------------------------------------------------------- #
+# Sender construction / teardown
+# --------------------------------------------------------------------------- #
+class TestSenderLifecycle(_PatchHelpers, _TmpDirMixin, unittest.IsolatedAsyncioTestCase):
+    async def test_download_media_refuses_when_client_incomplete(self) -> None:
+        client = FakeClient(b"x" * 100)
+        self._patch("src.parallel_download.supports_parallel_download", lambda c: False)
+        dl = ParallelDownloader(client, connections=4, part_size=524288)
+        with self.assertRaises(ParallelDownloadUnavailable):
+            await dl.download_media(_make_message(100), str(self.tmp / "x.bin"))
 
-    build_count = {"n": 0}
+    async def test_build_senders_closes_on_unavailable(self) -> None:
+        client = FakeClient(b"x" * 100)
+        closed: list[Any] = []
 
-    class _DL:
-        async def download_media(self, message, path):
-            return path
+        def _connect(_self: ParallelDownloader, dc_id: int, auth_key: Any) -> Any:
+            async def _inner() -> None:
+                raise ParallelDownloadUnavailable("nope")
 
-    def _factory(*a, **k):
-        build_count["n"] += 1
-        return _DL()
+            return _inner()
 
-    monkeypatch.setattr("src.telegram_backup.ParallelDownloader", _factory)
-    msg = _make_message(50 * 1024 * 1024)
-    await backup._fetch_media_bytes(msg, "/tmp/a", 50 * 1024 * 1024)
-    await backup._fetch_media_bytes(msg, "/tmp/b", 50 * 1024 * 1024)
-    assert build_count["n"] == 1
+        self._patch_object(ParallelDownloader, "_connect_sender", _connect)
+
+        async def _track_close(_self: ParallelDownloader, senders: Any) -> None:
+            closed.append(senders)
+
+        self._patch_object(ParallelDownloader, "_close_senders", _track_close)
+        dl = ParallelDownloader(client, connections=2, part_size=524288)
+        with self.assertRaises(ParallelDownloadUnavailable):
+            await dl._build_senders(client.session.dc_id, 2)
+        self.assertTrue(closed)  # cleanup ran on the ParallelDownloadUnavailable path
+
+    async def test_close_senders_swallows_disconnect_errors(self) -> None:
+        dl = ParallelDownloader(FakeClient(b"x"), connections=4, part_size=524288)
+
+        class BadSender:
+            async def disconnect(self) -> None:
+                raise RuntimeError("boom")
+
+        # Must not raise even though disconnect() fails.
+        await dl._close_senders([BadSender(), BadSender()])
+
+    async def test_download_media_falls_back_when_location_unresolvable(self) -> None:
+        client = FakeClient(b"x" * 100)
+        self._patch_object(ParallelDownloader, "_connect_sender", lambda self, d, k: None)
+
+        def _boom(_message: Any) -> Any:
+            raise TypeError("not a downloadable message")
+
+        self._patch_object(utils, "get_input_location", _boom)
+        dl = ParallelDownloader(client, connections=4, part_size=524288)
+        with self.assertRaises(ParallelDownloadUnavailable):
+            await dl.download_media(_make_message(100), str(self.tmp / "x.bin"))
+
+    async def test_build_senders_wraps_non_flood_errors(self) -> None:
+        client = FakeClient(b"x" * 100)
+
+        def _boom(_self: ParallelDownloader, dc_id: int, auth_key: Any) -> Any:
+            async def _inner() -> None:
+                raise RuntimeError("connect failed")
+
+            return _inner()
+
+        self._patch_object(ParallelDownloader, "_connect_sender", _boom)
+        dl = ParallelDownloader(client, connections=2, part_size=524288)
+        with self.assertRaises(ParallelDownloadUnavailable):
+            await dl._build_senders(client.session.dc_id, 2)
+
+    async def test_build_senders_propagates_floodwait(self) -> None:
+        client = FakeClient(b"x" * 100)
+
+        def _flood(_self: ParallelDownloader, dc_id: int, auth_key: Any) -> Any:
+            async def _inner() -> None:
+                raise FloodWaitError(request=None)
+
+            return _inner()
+
+        self._patch_object(ParallelDownloader, "_connect_sender", _flood)
+        dl = ParallelDownloader(client, connections=2, part_size=524288)
+        # FloodWait must surface unchanged so the single budget governs it.
+        with self.assertRaises(FloodWaitError):
+            await dl._build_senders(client.session.dc_id, 2)
+
+
+# --------------------------------------------------------------------------- #
+# Foreign-DC export path
+# --------------------------------------------------------------------------- #
+class TestForeignDC(_PatchHelpers, _TmpDirMixin, unittest.IsolatedAsyncioTestCase):
+    def _patch_foreign_sender(self, client: FakeClient) -> None:
+        def _connect_sender_stub(_self: ParallelDownloader, dc_id: int, auth_key: Any) -> Any:
+            async def _inner() -> FakeSender:
+                s = client.make_sender()
+                s.dc_id = dc_id
+                s.connected = True
+                return s
+
+            return _inner()
+
+        self._patch_object(ParallelDownloader, "_connect_sender", _connect_sender_stub)
+
+    async def test_foreign_dc_exports_auth_once(self) -> None:
+        blob = os.urandom(524288 * 4)  # 4 parts so a 3-sender pool is fully built
+        client = ForeignDCClient(blob, home_dc=2)
+
+        # File lives on DC 4 (foreign). get_input_location reports dc_id=4.
+        self._patch_object(utils, "get_input_location", lambda m: (4, object()))
+        self._patch_foreign_sender(client)
+
+        dl = ParallelDownloader(client, connections=3, part_size=524288)
+        dest = str(self.tmp / "foreign.bin")
+        await dl.download_media(_make_message(len(blob)), dest)
+
+        self.assertEqual(_read(dest), blob)
+        # Auth exported exactly once even though 3 senders were created.
+        self.assertEqual(len(client.export_calls), 1)
+        self.assertEqual(len(client.created_senders), 3)
+        # The shared init request's query must be restored after the transient
+        # ImportAuthorizationRequest, so concurrent users never observe it.
+        self.assertIsNone(client._init_request.query)
+
+    async def test_foreign_dc_export_floodwait_propagates_and_restores_query(self) -> None:
+        # A FloodWait raised by the auth export must surface unchanged (single
+        # budget), and the shared _init_request.query must still be restored.
+        blob = os.urandom(524288 * 2)
+
+        class _FloodOnExport(FakeClient):
+            async def __call__(self, request: Any) -> Any:
+                raise FloodWaitError(request=None)
+
+        client = _FloodOnExport(blob, home_dc=2)
+        self._patch_object(utils, "get_input_location", lambda m: (4, object()))
+        self._patch_foreign_sender(client)
+
+        dl = ParallelDownloader(client, connections=3, part_size=524288)
+        with self.assertRaises(FloodWaitError):
+            await dl.download_media(_make_message(len(blob)), str(self.tmp / "f.bin"))
+        # Even on the export failure the query must be restored (try/finally).
+        self.assertIsNone(client._init_request.query)
+        # All senders opened so far are cleaned up.
+        self.assertTrue(all(s.disconnected for s in client.created_senders))
+
+
+# --------------------------------------------------------------------------- #
+# Backup-layer gating (_should_parallelize)
+# --------------------------------------------------------------------------- #
+class TestBackupGating(_PatchHelpers, unittest.TestCase):
+    def test_gate_off_by_default(self) -> None:
+        backup = _make_backup(enabled=False)
+        self.assertIs(
+            backup._should_parallelize(_make_message(100 * 1024 * 1024), 100 * 1024 * 1024),
+            False,
+        )
+
+    def test_gate_skips_small_files_when_enabled(self) -> None:
+        backup = _make_backup(enabled=True, min_mb=20)
+        # 5 MB < 20 MB threshold -> single stream
+        self.assertIs(
+            backup._should_parallelize(_make_message(5 * 1024 * 1024), 5 * 1024 * 1024),
+            False,
+        )
+
+    @unittest.skipUnless(_HAS_PWRITE, "probe requires os.pwrite")
+    def test_gate_enables_for_large_files(self) -> None:
+        backup = _make_backup(enabled=True, min_mb=20)
+        # supports_parallel_download is True for a fully-mocked client only if it
+        # has the internals; MagicMock auto-provides every attribute, so the
+        # probe passes (on platforms that have os.pwrite).
+        self.assertIs(
+            backup._should_parallelize(_make_message(50 * 1024 * 1024), 50 * 1024 * 1024),
+            True,
+        )
+
+    def test_gate_disabled_after_capability_probe_fails(self) -> None:
+        backup = _make_backup(enabled=True, min_mb=1)
+        self._patch("src.telegram_backup.supports_parallel_download", lambda c: False)
+        self.assertIs(
+            backup._should_parallelize(_make_message(50 * 1024 * 1024), 50 * 1024 * 1024),
+            False,
+        )
+        # Latches off for the rest of the run.
+        self.assertIs(backup._parallel_download_disabled, True)
+
+
+# --------------------------------------------------------------------------- #
+# Backup-layer seam (_fetch_media_bytes)
+# --------------------------------------------------------------------------- #
+class TestFetchMediaBytes(_PatchHelpers, unittest.IsolatedAsyncioTestCase):
+    async def test_fetch_media_bytes_uses_single_stream_when_disabled(self) -> None:
+        backup = _make_backup(enabled=False)
+        backup.client.download_media = AsyncMock(return_value="/tmp/out")
+        result = await backup._fetch_media_bytes(_make_message(99 * 1024 * 1024), "/tmp/out", 99 * 1024 * 1024)
+        self.assertEqual(result, "/tmp/out")
+        backup.client.download_media.assert_awaited_once()
+
+    async def test_fetch_media_bytes_falls_back_on_unavailable(self) -> None:
+        backup = _make_backup(enabled=True, min_mb=1)
+        backup.client.download_media = AsyncMock(return_value="/tmp/out")
+
+        class _DL:
+            async def download_media(self, message: Any, path: str) -> str:
+                raise ParallelDownloadUnavailable("nope")
+
+        self._patch("src.telegram_backup.ParallelDownloader", lambda *a, **k: _DL())
+        result = await backup._fetch_media_bytes(_make_message(50 * 1024 * 1024), "/tmp/out", 50 * 1024 * 1024)
+        # Transparent fallback to single-stream for this file.
+        self.assertEqual(result, "/tmp/out")
+        backup.client.download_media.assert_awaited_once()
+
+    async def test_fetch_media_bytes_propagates_floodwait(self) -> None:
+        backup = _make_backup(enabled=True, min_mb=1)
+        backup.client.download_media = AsyncMock(return_value="/tmp/out")
+
+        class _DL:
+            async def download_media(self, message: Any, path: str) -> str:
+                raise FloodWaitError(request=None)
+
+        self._patch("src.telegram_backup.ParallelDownloader", lambda *a, **k: _DL())
+        with self.assertRaises(FloodWaitError):
+            await backup._fetch_media_bytes(_make_message(50 * 1024 * 1024), "/tmp/out", 50 * 1024 * 1024)
+        # FloodWait must NOT be swallowed into a single-stream retry here.
+        backup.client.download_media.assert_not_awaited()
+
+    async def test_fetch_media_bytes_uses_parallel_when_enabled(self) -> None:
+        # Happy path: gate passes -> ParallelDownloader is used and its path
+        # returned, and the single-stream client.download_media is NOT touched.
+        backup = _make_backup(enabled=True, min_mb=1)
+        backup.client.download_media = AsyncMock(return_value="/tmp/single")
+
+        calls: list[str] = []
+
+        class _DL:
+            async def download_media(self, message: Any, path: str) -> str:
+                calls.append(path)
+                return path
+
+        self._patch("src.telegram_backup.ParallelDownloader", lambda *a, **k: _DL())
+        result = await backup._fetch_media_bytes(_make_message(50 * 1024 * 1024), "/tmp/parallel", 50 * 1024 * 1024)
+        self.assertEqual(result, "/tmp/parallel")
+        self.assertEqual(calls, ["/tmp/parallel"])
+        backup.client.download_media.assert_not_awaited()
+
+    async def test_fetch_media_bytes_reuses_cached_downloader(self) -> None:
+        # The ParallelDownloader is built once and cached on the backup instance.
+        backup = _make_backup(enabled=True, min_mb=1)
+        backup.client.download_media = AsyncMock(return_value="/tmp/single")
+
+        build_count = {"n": 0}
+
+        class _DL:
+            async def download_media(self, message: Any, path: str) -> str:
+                return path
+
+        def _factory(*a: Any, **k: Any) -> _DL:
+            build_count["n"] += 1
+            return _DL()
+
+        self._patch("src.telegram_backup.ParallelDownloader", _factory)
+        msg = _make_message(50 * 1024 * 1024)
+        await backup._fetch_media_bytes(msg, "/tmp/a", 50 * 1024 * 1024)
+        await backup._fetch_media_bytes(msg, "/tmp/b", 50 * 1024 * 1024)
+        self.assertEqual(build_count["n"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_parallel_download.py
+++ b/tests/test_parallel_download.py
@@ -321,6 +321,22 @@ async def test_parallel_download_single_chunk_file(tmp_path, patch_sender):
 
     await dl.download_media(_make_message(len(blob)), dest)
     assert _read(dest) == blob
+    # A single-chunk file needs exactly one sender (n = min(connections, offsets)).
+    assert len(client.created_senders) == 1
+
+
+async def test_parallel_download_part_aligned_file(tmp_path, patch_sender):
+    # Exactly 3 full parts with no remainder: the last chunk is a full part, so
+    # the per-chunk length check must accept ``min(part_size, file_size-offset)``
+    # for every chunk including the final one.
+    blob = os.urandom(524288 * 3)
+    client = FakeClient(blob)
+    patch_sender(client)
+    dl = ParallelDownloader(client, connections=4, part_size=524288)
+    dest = str(tmp_path / "aligned.bin")
+
+    await dl.download_media(_make_message(len(blob)), dest)
+    assert _read(dest) == blob
 
 
 async def test_parallel_download_rejects_non_path_destination(tmp_path, patch_sender):
@@ -337,6 +353,29 @@ async def test_parallel_download_unknown_size_refuses(tmp_path, patch_sender):
     dl = ParallelDownloader(client, connections=4, part_size=524288)
     with pytest.raises(ParallelDownloadUnavailable):
         await dl.download_media(_make_message(0), str(tmp_path / "x"))
+
+
+async def test_parallel_download_refuses_size_over_ceiling(tmp_path, patch_sender):
+    # The declared size comes from untrusted server metadata. A file larger than
+    # the configured ceiling must fall back rather than pre-allocate/chunk it.
+    blob = os.urandom(1024)
+    client = FakeClient(blob)
+    patch_sender(client)
+    dl = ParallelDownloader(client, connections=4, part_size=524288, max_file_size=500)
+    with pytest.raises(ParallelDownloadUnavailable):
+        await dl.download_media(_make_message(1024), str(tmp_path / "big.bin"))
+    assert not os.path.exists(str(tmp_path / "big.bin"))
+
+
+async def test_parallel_download_allows_size_at_ceiling(tmp_path, patch_sender):
+    # A file exactly at the ceiling is still allowed (boundary is inclusive).
+    blob = os.urandom(500)
+    client = FakeClient(blob)
+    patch_sender(client)
+    dl = ParallelDownloader(client, connections=4, part_size=524288, max_file_size=500)
+    dest = str(tmp_path / "edge.bin")
+    await dl.download_media(_make_message(500), dest)
+    assert _read(dest) == blob
 
 
 # --------------------------------------------------------------------------- #
@@ -365,6 +404,36 @@ async def test_file_reference_expired_propagates(tmp_path, patch_sender):
 
     with pytest.raises(FileReferenceExpiredError):
         await dl.download_media(_make_message(len(blob)), dest)
+    assert not os.path.exists(dest)
+
+
+async def test_file_reference_expired_mid_transfer_propagates(tmp_path, patch_sender):
+    # A stale reference can surface on a later chunk, not just the first one.
+    # It must still propagate unchanged (so the caller refreshes), cancel
+    # siblings, and remove the partial output.
+    blob = os.urandom(524288 * 4)
+    client = FakeClient(blob, fail_at_offset=524288 * 2, fail_exc=FileReferenceExpiredError(request=None))
+    patch_sender(client)
+    dl = ParallelDownloader(client, connections=4, part_size=524288)
+    dest = str(tmp_path / "video.mp4")
+
+    with pytest.raises(FileReferenceExpiredError):
+        await dl.download_media(_make_message(len(blob)), dest)
+    assert not os.path.exists(dest)
+    assert all(s.disconnected for s in client.created_senders)
+
+
+async def test_blob_shorter_than_declared_size_aborts(tmp_path, patch_sender):
+    # If the server returns fewer bytes than the declared size (so a tail chunk
+    # comes back empty/short), the guard must fire and the partial be removed.
+    declared = 524288 * 3
+    client = FakeClient(os.urandom(524288 * 2))  # blob is a full part short
+    patch_sender(client)
+    dl = ParallelDownloader(client, connections=2, part_size=524288)
+    dest = str(tmp_path / "truncated.bin")
+
+    with pytest.raises(ParallelDownloadUnavailable):
+        await dl.download_media(_make_message(declared), dest)
     assert not os.path.exists(dest)
 
 
@@ -569,6 +638,40 @@ async def test_foreign_dc_exports_auth_once(tmp_path, monkeypatch):
     # Auth exported exactly once even though 3 senders were created.
     assert len(client.export_calls) == 1
     assert len(client.created_senders) == 3
+    # The shared init request's query must be restored after the transient
+    # ImportAuthorizationRequest, so concurrent users never observe our mutation.
+    assert client._init_request.query is None
+
+
+async def test_foreign_dc_export_floodwait_propagates_and_restores_query(tmp_path, monkeypatch):
+    # A FloodWait raised by the auth export must surface unchanged (single
+    # budget), and the shared _init_request.query must still be restored.
+    blob = os.urandom(524288 * 2)
+
+    class _FloodOnExport(FakeClient):
+        async def __call__(self, request):
+            raise FloodWaitError(request=None)
+
+    client = _FloodOnExport(blob, home_dc=2)
+    monkeypatch.setattr(utils, "get_input_location", lambda m: (4, object()))
+
+    def _connect_sender_stub(self, dc_id, auth_key):
+        async def _inner():
+            s = client.make_sender()
+            s.dc_id = dc_id
+            s.connected = True
+            return s
+
+        return _inner()
+
+    monkeypatch.setattr(ParallelDownloader, "_connect_sender", _connect_sender_stub)
+    dl = ParallelDownloader(client, connections=3, part_size=524288)
+    with pytest.raises(FloodWaitError):
+        await dl.download_media(_make_message(len(blob)), str(tmp_path / "f.bin"))
+    # Even on the export failure the query must be restored (try/finally).
+    assert client._init_request.query is None
+    # All senders opened so far are cleaned up.
+    assert all(s.disconnected for s in client.created_senders)
 
 
 # --------------------------------------------------------------------------- #
@@ -651,3 +754,45 @@ async def test_fetch_media_bytes_propagates_floodwait(monkeypatch):
         await backup._fetch_media_bytes(_make_message(50 * 1024 * 1024), "/tmp/out", 50 * 1024 * 1024)
     # FloodWait must NOT be swallowed into a single-stream retry here.
     backup.client.download_media.assert_not_awaited()
+
+
+async def test_fetch_media_bytes_uses_parallel_when_enabled(monkeypatch):
+    # Happy path: gate passes -> ParallelDownloader is used and its path returned,
+    # and the single-stream client.download_media is NOT touched.
+    backup = _make_backup(enabled=True, min_mb=1)
+    backup.client.download_media = AsyncMock(return_value="/tmp/single")
+
+    calls = []
+
+    class _DL:
+        async def download_media(self, message, path):
+            calls.append(path)
+            return path
+
+    monkeypatch.setattr("src.telegram_backup.ParallelDownloader", lambda *a, **k: _DL())
+    result = await backup._fetch_media_bytes(_make_message(50 * 1024 * 1024), "/tmp/parallel", 50 * 1024 * 1024)
+    assert result == "/tmp/parallel"
+    assert calls == ["/tmp/parallel"]
+    backup.client.download_media.assert_not_awaited()
+
+
+async def test_fetch_media_bytes_reuses_cached_downloader(monkeypatch):
+    # The ParallelDownloader is built once and cached on the backup instance.
+    backup = _make_backup(enabled=True, min_mb=1)
+    backup.client.download_media = AsyncMock(return_value="/tmp/single")
+
+    build_count = {"n": 0}
+
+    class _DL:
+        async def download_media(self, message, path):
+            return path
+
+    def _factory(*a, **k):
+        build_count["n"] += 1
+        return _DL()
+
+    monkeypatch.setattr("src.telegram_backup.ParallelDownloader", _factory)
+    msg = _make_message(50 * 1024 * 1024)
+    await backup._fetch_media_bytes(msg, "/tmp/a", 50 * 1024 * 1024)
+    await backup._fetch_media_bytes(msg, "/tmp/b", 50 * 1024 * 1024)
+    assert build_count["n"] == 1


### PR DESCRIPTION
## Summary

Implements per-file parallel chunked downloads (closes #183) to lift the ~10 MB/s single-stream download cap. Large files are split into chunks fetched concurrently over several MTProto connections to the file's datacenter and reassembled on disk by exact offset.

The feature is **opt-in and conservative**, satisfying the six hard requirements agreed in the issue thread:

1. **Default OFF**, behind `PARALLEL_DOWNLOAD_ENABLED`, large files only (`PARALLEL_DOWNLOAD_MIN_SIZE_MB`, default 20 MB). Photos/small files stay single-stream.
2. **Bounded sender count** — `PARALLEL_DOWNLOAD_CONNECTIONS` clamped 2–8 (default 4), well under Telegram's ~20-connection cliff.
3. **FloodWait flows through the existing budget** (`call_with_flood_retry`) — `FloodWaitError` propagates unchanged, never swallowed into a second backoff.
4. **Deterministic, verified reassembly** — each chunk written at its exact offset via `os.pwrite`; full byte-range coverage asserted before finalize. Prevents a mis-reassembled file of correct length from passing the size-only check and propagating through content-hash dedup.
5. **Transactional** — any chunk failure cancels siblings, removes the partial `.part`, closes senders, and re-raises the original exception type so existing retry/refresh logic is unchanged.
6. **Bounded memory** — streams to disk by offset; peak ≈ connections × part_size (e.g. 4 × 512 KB ≈ 2 MB).

Scope is the **scheduled backup path only**; the real-time listener is untouched. Vendors a FastTelethon-style transferrer (**no new dependency**) behind a capability probe that degrades gracefully to single-stream if Telethon internals change.

## Config knobs

| Var | Default | Notes |
|-----|---------|-------|
| `PARALLEL_DOWNLOAD_ENABLED` | `false` | Master switch |
| `PARALLEL_DOWNLOAD_MIN_SIZE_MB` | `20` | Min file size for parallel path (floor 1) |
| `PARALLEL_DOWNLOAD_CONNECTIONS` | `4` | Concurrent connections (clamped 2–8) |
| `PARALLEL_DOWNLOAD_PART_SIZE_KB` | `512` | Chunk size; one of 4/8/16/32/64/128/256/512 |

## Review

Reviewed by parallel code-review, security, and architecture passes. Three medium hardening items applied: explicit `FloodWaitError` re-raise in the worker, `_init_request.query` restore after foreign-DC auth export, `_borrow_sender_lock` added to the capability probe, plus `O_NOFOLLOW` on the dest open.

## Test plan

- [x] 29 new tests in `tests/test_parallel_download.py`: exact-offset reassembly, coverage gap/overlap/size rejection, short/dropped-chunk detection, racing-writer offset integrity, FloodWait + FileReferenceExpired propagation with transactional cleanup, foreign-DC export-once, capability-probe fallback, backup-layer gating (default-off, size threshold, MagicMock strict `is True`, single-stream fallback).
- [x] Full suite green: 1823 passed.
- [x] `ruff check .` and `ruff format --check .` clean.

## Credits

Thanks to @smbdspk for proposing this feature in #183.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional per-file parallel chunked media downloads with transparent single-stream fallback for large files.

* **Documentation**
  * README and changelog updated with parallel-download configuration and behavior; new commented .env example section for related env vars.

* **Tests**
  * Added end-to-end tests covering parallel download behavior, failure modes, and backup-layer gating.

* **Chores**
  * Project version bumped to 7.13.0; updated .gitignore for local/venv and tooling state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->