### PR TITLE
ci: trigger test and ruff on uv.lock changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,10 +3,10 @@ name: Lint
 on:
   push:
     branches: [main, master]
-    paths: ['src/**', 'tests/**', 'scripts/**', 'alembic/**', '*.py', 'pyproject.toml', 'requirements*.txt', '.github/workflows/lint.yml']
+    paths: ['src/**', 'tests/**', 'scripts/**', 'alembic/**', '*.py', 'pyproject.toml', 'requirements*.txt', 'uv.lock', '.github/workflows/lint.yml']
   pull_request:
     branches: [main, master]
-    paths: ['src/**', 'tests/**', 'scripts/**', 'alembic/**', '*.py', 'pyproject.toml', 'requirements*.txt', '.github/workflows/lint.yml']
+    paths: ['src/**', 'tests/**', 'scripts/**', 'alembic/**', '*.py', 'pyproject.toml', 'requirements*.txt', 'uv.lock', '.github/workflows/lint.yml']
 
 jobs:
   ruff:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
   push:
     branches: [main, master]
-    paths: ['src/**', 'tests/**', 'scripts/**', 'alembic/**', '*.py', 'pyproject.toml', 'requirements*.txt', 'Dockerfile*', 'docker-compose.yml', '.github/workflows/tests.yml']
+    paths: ['src/**', 'tests/**', 'scripts/**', 'alembic/**', '*.py', 'pyproject.toml', 'requirements*.txt', 'uv.lock', 'Dockerfile*', 'docker-compose.yml', '.github/workflows/tests.yml']
   pull_request:
     branches: [main, master]
-    paths: ['src/**', 'tests/**', 'scripts/**', 'alembic/**', '*.py', 'pyproject.toml', 'requirements*.txt', 'Dockerfile*', 'docker-compose.yml', '.github/workflows/tests.yml']
+    paths: ['src/**', 'tests/**', 'scripts/**', 'alembic/**', '*.py', 'pyproject.toml', 'requirements*.txt', 'uv.lock', 'Dockerfile*', 'docker-compose.yml', '.github/workflows/tests.yml']
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- The branch ruleset on `main` requires the `test` and `ruff` status checks.
- Their workflows (`tests.yml`, `lint.yml`) had `paths:` filters that omitted `uv.lock`.
- Dependabot uv-group PRs only modify `uv.lock`, so the required checks never triggered → those PRs were permanently BLOCKED (e.g. #184 aiohttp bump).

This adds `uv.lock` to the push + pull_request `paths:` filters in both workflows so the required checks run on dependency-lock updates.

## Test plan
- [ ] `test` and `ruff` checks run on this PR
- [ ] After merge, re-trigger #184 and confirm `test`/`ruff` run there