### PR TITLE
fix(backup): preserve service action metadata in raw_data

### DIFF
--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -8,6 +8,7 @@ import base64
 import logging
 import os
 import random
+import re
 from datetime import UTC, datetime
 
 from telethon import TelegramClient
@@ -287,6 +288,17 @@ async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
                     MAX_FLOOD_RETRIES,
                 )
             await asyncio.sleep(sleep_duration)
+
+
+def _service_action_type(action: object) -> str:
+    """Normalize a Telethon MessageAction class name to snake_case.
+
+    Examples: MessageActionTopicCreate -> "topic_create",
+    MessageActionTopicEdit -> "topic_edit",
+    MessageActionChatEditTitle -> "chat_edit_title".
+    """
+    name = type(action).__name__.removeprefix("MessageAction")
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
 
 
 class TelegramBackup:
@@ -1411,6 +1423,19 @@ class TelegramBackup:
             "is_outgoing": 1 if message.out else 0,
             "is_pinned": 1 if getattr(message, "pinned", False) else 0,
         }
+
+        # Preserve service-action metadata (e.g. forum topic creations and
+        # renames) so historical backfills keep parity with the listener's
+        # raw_data convention (service_type / action_type, since v6.0.0).
+        # Without this, service events are stored without their payload and
+        # the information is irrecoverable once the history is archived.
+        action = getattr(message, "action", None)
+        if action is not None:
+            message_data["raw_data"]["service_type"] = "service"
+            message_data["raw_data"]["action_type"] = _service_action_type(action)
+            action_title = getattr(action, "title", None)
+            if action_title is not None:
+                message_data["raw_data"]["new_title"] = self._text_with_entities_to_string(action_title)
 
         # Capture grouped_id for album detection (multiple photos/videos sent together)
         if message.grouped_id:

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -12,6 +12,8 @@ from unittest.mock import AsyncMock, MagicMock
 from telethon.tl.types import (
     Channel,
     Chat,
+    MessageActionTopicCreate,
+    MessageActionTopicEdit,
     MessageMediaContact,
     MessageMediaDocument,
     MessageMediaGeo,
@@ -366,6 +368,9 @@ class TestBackupCheckpointing(unittest.TestCase):
         # topic-skip guard in _backup_dialog doesn't accidentally filter
         # every message via MagicMock truthiness.
         msg.reply_to = reply_to
+        # Explicitly None so the service-action capture in _process_message
+        # is not triggered by MagicMock truthiness.
+        msg.action = None
         return msg
 
     def test_checkpoint_after_every_batch(self):
@@ -1164,6 +1169,9 @@ class TestProcessMessage(unittest.TestCase):
         msg.media = None
         msg.reactions = None
         msg.post_author = None
+        # Explicitly None so the service-action capture in _process_message
+        # is not triggered by MagicMock truthiness.
+        msg.action = None
         return msg
 
     def test_basic_text_message(self):
@@ -1214,6 +1222,49 @@ class TestProcessMessage(unittest.TestCase):
         msg.post_author = "Editor Name"
         result = self._run(self.backup._process_message(msg, 100))
         self.assertEqual(result["raw_data"]["post_author"], "Editor Name")
+
+    def test_topic_create_action_stored_in_raw_data(self):
+        """Topic-create service action stores service metadata in raw_data."""
+        msg = self._make_message(8, text=None)
+        msg.action = MessageActionTopicCreate(title="Synthetic Topic", icon_color=0)
+        result = self._run(self.backup._process_message(msg, 100))
+        self.assertEqual(result["raw_data"]["service_type"], "service")
+        self.assertEqual(result["raw_data"]["action_type"], "topic_create")
+        self.assertEqual(result["raw_data"]["new_title"], "Synthetic Topic")
+        # Topic creations are linkable: the topic id equals the service
+        # message id (forum_topics.id == messages.id).
+        self.assertEqual(result["id"], 8)
+
+    def test_topic_edit_action_stores_new_title(self):
+        """Topic rename stores the new title and stays linkable by topic id."""
+        msg = self._make_message(9, text=None)
+        msg.action = MessageActionTopicEdit(title="Renamed Topic")
+        msg.reply_to = MagicMock()
+        msg.reply_to.forum_topic = True
+        msg.reply_to.reply_to_top_id = 8
+        result = self._run(self.backup._process_message(msg, 100))
+        self.assertEqual(result["raw_data"]["service_type"], "service")
+        self.assertEqual(result["raw_data"]["action_type"], "topic_edit")
+        self.assertEqual(result["raw_data"]["new_title"], "Renamed Topic")
+        # Topic edits are linkable through reply_to_top_id.
+        self.assertEqual(result["reply_to_top_id"], 8)
+
+    def test_topic_edit_without_title_has_no_new_title(self):
+        """Topic edits that do not rename (e.g. close) store no new_title."""
+        msg = self._make_message(10, text=None)
+        msg.action = MessageActionTopicEdit(closed=True)
+        result = self._run(self.backup._process_message(msg, 100))
+        self.assertEqual(result["raw_data"]["service_type"], "service")
+        self.assertEqual(result["raw_data"]["action_type"], "topic_edit")
+        self.assertNotIn("new_title", result["raw_data"])
+
+    def test_regular_message_has_no_service_metadata(self):
+        """Regular messages carry no service metadata in raw_data."""
+        msg = self._make_message(11)
+        result = self._run(self.backup._process_message(msg, 100))
+        self.assertNotIn("service_type", result["raw_data"])
+        self.assertNotIn("action_type", result["raw_data"])
+        self.assertNotIn("new_title", result["raw_data"])
 
     def test_none_text_becomes_empty_string(self):
         """Message with None text stores empty string."""

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -62,6 +62,9 @@ def _make_message(msg_id, *, reply_to=None, text="hello", media=None):
     msg.media = media
     msg.reactions = None
     msg.post_author = None
+    # Explicitly None so the service-action capture in _process_message
+    # is not triggered by MagicMock truthiness.
+    msg.action = None
     return msg
 
 


### PR DESCRIPTION
## Summary

- Fixes #190: historical backfills (`_process_message`) now preserve `message.action` metadata in `raw_data`, restoring parity with the live listener's convention (`service_type` / `action_type` / `new_title`, in place since v6.0.0).
- Forum topic history becomes auditable and reconstructible with existing columns: `topic_create` links via `messages.id == forum_topics.id`; `topic_edit` via `reply_to_top_id`. `new_title` goes through the existing `_text_with_entities_to_string` helper.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change

## Database Changes

- [ ] Schema changes (Alembic migration required)
- [ ] Data migration script added in `scripts/`
- [x] No database changes

## Data Consistency Checklist

- [x] All `chat_id` values use marked format (via `_get_marked_id()`) — no chat_id handling changed
- [x] All datetime values pass through `_strip_tz()` before DB operations — no datetime handling changed
- [x] INSERT and UPDATE operations handle the same fields identically — no DB operations changed

## Testing

- [x] Tests pass locally (`python -m pytest tests/ -v`) — 1847 passed on Python 3.14
- [x] Linting passes (`ruff check .`)
- [x] Formatting passes (`ruff format --check .`)
- [x] Manually tested in development environment — fresh backfill of a synthetic test forum recovered all 4 service actions (2x topic_create, 1x topic_edit, 1x channel_migrate_from) with titles, fully linkable, including a topic rename performed before any backup existed

## Security Checklist

- [x] No secrets or credentials committed
- [x] User input properly validated/sanitized — values come from Telethon objects, titles through the existing TextWithEntities helper
- [x] Authentication/authorization properly checked — N/A, no auth paths touched

## Deployment Notes

- No image or config changes needed; existing archives are unaffected. Already-backfilled service rows gain metadata only if their history is re-fetched.
- Naming is easy to adjust if you prefer different keys (e.g. `action_title` instead of `new_title`, or the listener's curated vocabulary for `action_type`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backups now capture and preserve service event metadata for forum topic operations (creations and renames), ensuring these events are tracked with full context in historical records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->