### PR TITLE
security: block fork PRs from running on the self-hosted runner

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,6 +13,10 @@ jobs:
   analyze:
     name: Analyze
     runs-on: [self-hosted, Linux, X64]
+    # Do not run untrusted fork PR code on the self-hosted runner.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,10 @@ on:
 jobs:
   ruff:
     runs-on: [self-hosted, Linux, X64]
+    # Do not run untrusted fork PR code on the self-hosted runner.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -16,6 +16,10 @@ jobs:
   shellcheck:
     name: Check shell scripts
     runs-on: [self-hosted, Linux, X64]
+    # Do not run untrusted fork PR code on the self-hosted runner.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
 
     steps:
       - name: Checkout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,10 @@ on:
 jobs:
   test:
     runs-on: [self-hosted, Linux, X64]
+    # Do not run untrusted fork PR code on the self-hosted runner.
+    if: >-
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Adds a fork-guard `if:` so `pull_request`-triggered CI jobs run on the self-hosted runner **only for same-repo events**, never for PRs from forks.

## Why
On a public repo, a job that triggers on `pull_request` and runs on a self-hosted runner lets anyone's fork PR execute attacker-controlled code on the runner host. The guard keeps runs self-hosted for trusted events (push, schedule, workflow_dispatch, same-repo branch PRs) while skipping fork PRs. Same pattern already used in `tailscale-rs`.

```yaml
if: >-
  github.event_name != 'pull_request' ||
  github.event.pull_request.head.repo.full_name == github.repository
```

Files: codeql.yml, lint.yml, shellcheck.yml, tests.yml
