### PR TITLE
ci: use GitHub-hosted ubuntu-latest runners

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -12,11 +12,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: [self-hosted, Linux, X64]
-    # Do not run untrusted fork PR code on the self-hosted runner.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     permissions:
       security-events: write
       contents: read

--- a/.github/workflows/docker-publish-dev.yml
+++ b/.github/workflows/docker-publish-dev.yml
@@ -27,9 +27,8 @@ env:
 
 jobs:
   build-and-push-dev:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     # Only run for PRs from the same repo (not forks/dependabot) or workflow_dispatch
-    if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]')
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-publish-viewer.yml
+++ b/.github/workflows/docker-publish-viewer.yml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   test:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
@@ -45,7 +45,7 @@ jobs:
           python -m pytest tests/ -q -p no:cacheprovider --tb=short
 
   build-and-push:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     needs: test
     permissions:
       contents: read

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   test:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
@@ -48,7 +48,7 @@ jobs:
           python -m pytest tests/ -q -p no:cacheprovider --tb=short
 
   build-and-push:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     needs: test
     permissions:
       contents: read

--- a/.github/workflows/dockerhub-description.yml
+++ b/.github/workflows/dockerhub-description.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   update-description:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         repository:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,11 +10,7 @@ on:
 
 jobs:
   ruff:
-    runs-on: [self-hosted, Linux, X64]
-    # Do not run untrusted fork PR code on the self-hosted runner.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   release:
     name: Create GitHub Release
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -15,11 +15,7 @@ permissions:
 jobs:
   shellcheck:
     name: Check shell scripts
-    runs-on: [self-hosted, Linux, X64]
-    # Do not run untrusted fork PR code on the self-hosted runner.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   stale:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v10
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,11 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: [self-hosted, Linux, X64]
-    # Do not run untrusted fork PR code on the self-hosted runner.
-    if: >-
-      github.event_name != 'pull_request' ||
-      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
     
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
Switches self-hosted Linux CI jobs to GitHub-hosted `ubuntu-latest`.

## Why
GitHub-hosted standard runners are **free and unlimited on public repos**. Moving CI off the home-lab self-hosted runners:
- frees my servers from CI load,
- runs PR code in throwaway isolated VMs (removes the fork-PR attack surface entirely),
- costs $0 on public repos.

The earlier self-hosted fork-guard `if:` is removed (no longer needed on hosted runners). Any macOS/Windows self-hosted jobs (desktop builds) are left unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Transitioned all GitHub Actions workflows to GitHub-hosted runners across build, test, security scanning, linting, and deployment pipelines
  * Simplified workflow configurations by removing conditional execution guards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->