### PR TITLE
feat(messages): add soft deletion mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -173,6 +173,7 @@ ENABLE_LISTENER=false
 # Granular listener controls (only apply when ENABLE_LISTENER=true):
 # LISTEN_EDITS=true
 # LISTEN_DELETIONS=false
+# DELETION_MODE=hard  # hard=legacy delete from archive, soft=mark deleted and keep message
 # LISTEN_NEW_MESSAGES=true
 # LISTEN_NEW_MESSAGES_MEDIA=false
 # LISTEN_CHAT_ACTIONS=true

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ LISTEN_NEW_MESSAGES: "true"    # Save new messages instantly (default: true)
 
 **How it works:** stays connected to Telegram between scheduled backups, captures changes as they happen, and automatically reconnects if disconnected.
 
-**Backup protection:** `LISTEN_DELETIONS=false` is the safe default. Set `LISTEN_DELETIONS=true` only if you want to process deletion events. With the default `DELETION_MODE=hard`, deletions mirror Telegram and remove archived messages. Set `DELETION_MODE=soft` to keep the original archived message and show `deleted` in the message metadata.
+**Backup protection:** `LISTEN_DELETIONS=false` is the safe default. Set `LISTEN_DELETIONS=true` only if you want to process deletion events. With the default `DELETION_MODE=hard`, deletions mirror Telegram and remove archived messages. Set `DELETION_MODE=soft` to keep the original archived message and show `deleted` in the message metadata. Soft-deleted messages are retained in the archive — they remain counted in chat statistics and continue to appear in search and exports, flagged as `deleted`.
 
 **Alternative — batch sync:** set `SYNC_DELETIONS_EDITS=true` to check ALL backed-up messages on each scheduled run. This is expensive and slow, and uses the same `DELETION_MODE` behavior for deleted messages.
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,8 @@ The **Scope** column shows whether each variable applies to the backup scheduler
 | **Real-time Listener** | | | See [Real-time Listener](#real-time-listener) below |
 | `ENABLE_LISTENER` | `false` | B | **Master switch** — enables all `LISTEN_*` features below |
 | `LISTEN_EDITS` | `true` | B | Apply text edits in real-time |
-| `LISTEN_DELETIONS` | `false` | B | Mirror deletions from Telegram. Opt-in only; enabling this can delete archived messages |
+| `LISTEN_DELETIONS` | `false` | B | Process deletion events from Telegram. Opt-in only |
+| `DELETION_MODE` | `hard` | B | When deletions are processed: `hard` removes archived messages (legacy), `soft` keeps messages and marks them deleted |
 | `LISTEN_NEW_MESSAGES` | `true` | B | Save new messages in real-time between scheduled backups |
 | `LISTEN_NEW_MESSAGES_MEDIA` | `false` | B | Also download media immediately (vs. next scheduled backup) |
 | `LISTEN_CHAT_ACTIONS` | `true` | B | Track chat photo, title, and member changes |
@@ -374,15 +375,16 @@ The scheduled backup only captures new messages. To also track edits and deletio
 ```yaml
 ENABLE_LISTENER: "true"        # Master switch — required
 LISTEN_EDITS: "true"           # Track text edits (safe, default: true)
-LISTEN_DELETIONS: "false"      # Keep archive entries when Telegram messages are deleted
+LISTEN_DELETIONS: "false"      # Ignore Telegram deletions entirely
+DELETION_MODE: "hard"          # hard=legacy remove, soft=keep and show "deleted"
 LISTEN_NEW_MESSAGES: "true"    # Save new messages instantly (default: true)
 ```
 
 **How it works:** stays connected to Telegram between scheduled backups, captures changes as they happen, and automatically reconnects if disconnected.
 
-**Backup protection:** `LISTEN_DELETIONS=false` is the safe default. Set `LISTEN_DELETIONS=true` only if you explicitly want mirror behavior where Telegram deletions also remove archived messages.
+**Backup protection:** `LISTEN_DELETIONS=false` is the safe default. Set `LISTEN_DELETIONS=true` only if you want to process deletion events. With the default `DELETION_MODE=hard`, deletions mirror Telegram and remove archived messages. Set `DELETION_MODE=soft` to keep the original archived message and show `deleted` in the message metadata.
 
-**Alternative — batch sync:** set `SYNC_DELETIONS_EDITS=true` to check ALL backed-up messages on each scheduled run. This is expensive and slow — only use for a one-time catch-up, then switch to the real-time listener.
+**Alternative — batch sync:** set `SYNC_DELETIONS_EDITS=true` to check ALL backed-up messages on each scheduled run. This is expensive and slow, and uses the same `DELETION_MODE` behavior for deleted messages.
 
 ### Mass Operation Protection
 
@@ -392,7 +394,7 @@ When the listener is enabled and `LISTEN_DELETIONS=true`, a sliding-window rate 
 2. A sliding window tracks operations per chat over `MASS_OPERATION_WINDOW_SECONDS`
 3. When `MASS_OPERATION_THRESHOLD` is exceeded, remaining operations are blocked for that window
 
-**Example:** someone deletes 50 messages in 10 seconds with default settings (threshold=10, window=30s) — the first 10 are applied, remaining 40 are blocked. For **zero** deletions from your backup, set `LISTEN_DELETIONS=false`.
+**Example:** someone deletes 50 messages in 10 seconds with default settings (threshold=10, window=30s) — the first 10 are applied according to `DELETION_MODE`, remaining 40 are blocked. For **zero** deletion handling, set `LISTEN_DELETIONS=false`.
 
 ### Parallel Downloads
 

--- a/alembic/versions/20260625_014_add_message_soft_delete.py
+++ b/alembic/versions/20260625_014_add_message_soft_delete.py
@@ -1,0 +1,39 @@
+"""Add soft-delete markers to messages.
+
+Revision ID: 014
+Revises: 013
+Create Date: 2026-06-25
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "014"
+down_revision: str | None = "013"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_cols = {c["name"] for c in inspector.get_columns("messages")}
+
+    if "is_deleted" not in existing_cols:
+        op.add_column("messages", sa.Column("is_deleted", sa.Integer(), nullable=False, server_default="0"))
+    if "deleted_at" not in existing_cols:
+        op.add_column("messages", sa.Column("deleted_at", sa.DateTime(), nullable=True))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    existing_cols = {c["name"] for c in inspector.get_columns("messages")}
+
+    if "deleted_at" in existing_cols:
+        op.drop_column("messages", "deleted_at")
+    if "is_deleted" in existing_cols:
+        op.drop_column("messages", "is_deleted")

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,6 +75,7 @@ services:
       # Granular listener controls (only apply when ENABLE_LISTENER=true):
       # LISTEN_EDITS: ${LISTEN_EDITS:-true}
       # LISTEN_DELETIONS: ${LISTEN_DELETIONS:-false}
+      DELETION_MODE: ${DELETION_MODE:-hard}
       # LISTEN_NEW_MESSAGES: ${LISTEN_NEW_MESSAGES:-true}
       # LISTEN_NEW_MESSAGES_MEDIA: ${LISTEN_NEW_MESSAGES_MEDIA:-false}
       # LISTEN_CHAT_ACTIONS: ${LISTEN_CHAT_ACTIONS:-true}

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -112,6 +112,20 @@ if has_tables and not has_alembic:
         \"\"\")
         has_013_paths = cur.fetchone()[0]
 
+    # Check artifact from migration 014: messages soft-delete marker columns
+    cur.execute(\"\"\"
+        SELECT
+            EXISTS (
+                SELECT FROM information_schema.columns
+                WHERE table_name = 'messages' AND column_name = 'is_deleted'
+            )
+            AND EXISTS (
+                SELECT FROM information_schema.columns
+                WHERE table_name = 'messages' AND column_name = 'deleted_at'
+            );
+    \"\"\")
+    has_014_soft_delete = cur.fetchone()[0]
+
     # Check artifact from migration 012: idx_media_chat_type index
     cur.execute(\"\"\"
         SELECT EXISTS (
@@ -218,7 +232,9 @@ if has_tables and not has_alembic:
     has_push_subs = cur.fetchone()[0]
 
     # Determine which version to stamp based on existing schema
-    if has_013_paths:
+    if has_014_soft_delete:
+        stamp_version = '014'
+    elif has_013_paths:
         stamp_version = '013'
     elif has_012_index:
         stamp_version = '012'
@@ -317,6 +333,11 @@ if has_tables and not has_alembic:
         cur.execute(\"SELECT EXISTS(SELECT 1 FROM media WHERE chat_id < 0 AND file_path LIKE '%/' || CAST(chat_id AS TEXT) || '/%' LIMIT 1)\")
         has_013_paths = cur.fetchone()[0]
 
+    # Check artifact from migration 014: messages soft-delete marker columns
+    cur.execute(\"PRAGMA table_info(messages)\")
+    msg_columns = {row[1] for row in cur.fetchall()}
+    has_014_soft_delete = {'is_deleted', 'deleted_at'}.issubset(msg_columns)
+
     # Check artifact from migration 012: idx_media_chat_type index
     cur.execute(\"SELECT name FROM sqlite_master WHERE type='index' AND name='idx_media_chat_type'\")
     has_012_index = cur.fetchone() is not None
@@ -358,8 +379,6 @@ if has_tables and not has_alembic:
     has_005_index = cur.fetchone() is not None
 
     # Check if is_pinned column exists (added in migration 004)
-    cur.execute(\"PRAGMA table_info(messages)\")
-    msg_columns = {row[1] for row in cur.fetchall()}
     has_is_pinned = 'is_pinned' in msg_columns
 
     # Check if push_subscriptions table exists (added in migration 003)
@@ -367,7 +386,9 @@ if has_tables and not has_alembic:
     has_push_subs = cur.fetchone() is not None
 
     # Determine which version to stamp based on existing schema
-    if has_013_paths:
+    if has_014_soft_delete:
+        stamp_version = '014'
+    elif has_013_paths:
         stamp_version = '013'
     elif has_012_index:
         stamp_version = '012'

--- a/src/config.py
+++ b/src/config.py
@@ -284,10 +284,15 @@ class Config:
         # LISTEN_EDITS: Apply text edits to backed up messages (safe, just updates text)
         self.listen_edits = os.getenv("LISTEN_EDITS", "true").lower() == "true"
 
-        # LISTEN_DELETIONS: Delete messages from backup when deleted on Telegram
-        # ⚠️ DEFAULT FALSE - Enabling defeats the purpose of having a backup!
-        # Only enable if you explicitly want to mirror Telegram exactly
+        # LISTEN_DELETIONS: Handle deletion events from Telegram.
+        # DEFAULT FALSE preserves archive data by ignoring deletion events.
         self.listen_deletions = _parse_bool(os.getenv("LISTEN_DELETIONS"), default=False)
+        # DELETION_MODE controls what happens when deletion handling is enabled:
+        # - hard: legacy mirror behavior; remove archived message records
+        # - soft: keep archived messages and mark them deleted
+        self.deletion_mode = os.getenv("DELETION_MODE", "hard").strip().lower()
+        if self.deletion_mode not in {"hard", "soft"}:
+            raise ValueError("DELETION_MODE must be either 'hard' or 'soft'")
 
         # LISTEN_NEW_MESSAGES: Save new messages to backup in real-time
         # When enabled, new messages are saved immediately instead of waiting for scheduled backup
@@ -394,7 +399,10 @@ class Config:
             logger.info("ENABLE_LISTENER enabled - will catch message edits/deletions in real-time")
             logger.info(f"  LISTEN_EDITS: {self.listen_edits}")
             if self.listen_deletions:
-                logger.warning("  ⚠️ LISTEN_DELETIONS: true - Messages will be DELETED from backup!")
+                if self.deletion_mode == "soft":
+                    logger.warning("  LISTEN_DELETIONS: true, DELETION_MODE=soft - Messages will be marked deleted")
+                else:
+                    logger.warning("  ⚠️ LISTEN_DELETIONS: true, DELETION_MODE=hard - Messages will be DELETED from backup!")
             else:
                 logger.info("  LISTEN_DELETIONS: false (backup protected)")
             if self.listen_new_messages:

--- a/src/config.py
+++ b/src/config.py
@@ -402,7 +402,9 @@ class Config:
                 if self.deletion_mode == "soft":
                     logger.warning("  LISTEN_DELETIONS: true, DELETION_MODE=soft - Messages will be marked deleted")
                 else:
-                    logger.warning("  ⚠️ LISTEN_DELETIONS: true, DELETION_MODE=hard - Messages will be DELETED from backup!")
+                    logger.warning(
+                        "  ⚠️ LISTEN_DELETIONS: true, DELETION_MODE=hard - Messages will be DELETED from backup!"
+                    )
             else:
                 logger.info("  LISTEN_DELETIONS: false (backup protected)")
             if self.listen_new_messages:

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -13,7 +13,7 @@ import logging
 import os
 import secrets
 import shutil
-from datetime import UTC, datetime
+from datetime import datetime
 from functools import wraps
 from typing import Any
 
@@ -21,6 +21,7 @@ from sqlalchemy import and_, delete, func, or_, select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
+from ..message_utils import utcnow_naive
 from .base import DatabaseManager
 from .models import (
     AppSettings,
@@ -41,11 +42,6 @@ from .models import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _utcnow_naive() -> datetime:
-    """Return current UTC time without tzinfo for DB columns."""
-    return datetime.now(UTC).replace(tzinfo=None)
 
 
 def _strip_tz(dt: datetime | None) -> datetime | None:
@@ -529,6 +525,8 @@ class DatabaseAdapter:
     async def get_messages_sync_data(self, chat_id: int) -> dict[int, str | None]:
         """Get message IDs and their edit dates for sync checking."""
         async with self.db_manager.async_session_factory() as session:
+            # Exclude soft-deleted rows so sync doesn't re-check them. The is_(None) arm is
+            # defensive (is_deleted is NOT NULL with server_default 0) and mirrors is_archived.
             stmt = select(Message.id, Message.edit_date).where(
                 and_(Message.chat_id == chat_id, or_(Message.is_deleted == 0, Message.is_deleted.is_(None)))
             )
@@ -549,6 +547,7 @@ class DatabaseAdapter:
             row = result.first()
             return row[0] if row else None
 
+    @retry_on_locked()
     async def delete_message(self, chat_id: int, message_id: int) -> None:
         """Delete a specific message and its media."""
         async with self.db_manager.async_session_factory() as session:
@@ -563,13 +562,12 @@ class DatabaseAdapter:
             await session.commit()
             logger.debug(f"Deleted message {message_id} from chat {chat_id}")
 
-    async def mark_message_deleted(
-        self, chat_id: int, message_id: int, deleted_at: datetime | None = None
-    ) -> None:
+    @retry_on_locked()
+    async def mark_message_deleted(self, chat_id: int, message_id: int, deleted_at: datetime | None = None) -> None:
         """Mark a message as deleted on Telegram while keeping archive content."""
-        deleted_at = _strip_tz(deleted_at) or _utcnow_naive()
+        deleted_at = _strip_tz(deleted_at) or utcnow_naive()
         async with self.db_manager.async_session_factory() as session:
-            await session.execute(
+            result = await session.execute(
                 update(Message)
                 .where(and_(Message.chat_id == chat_id, Message.id == message_id))
                 .values(
@@ -578,7 +576,10 @@ class DatabaseAdapter:
                 )
             )
             await session.commit()
-            logger.debug(f"Marked message {message_id} as deleted")
+            if result.rowcount:
+                logger.debug(f"Marked message {message_id} as deleted")
+            else:
+                logger.debug(f"Soft-delete no-op: message {message_id} not in archive")
 
     async def resolve_message_chat_id(self, message_id: int) -> int | None:
         """
@@ -631,7 +632,7 @@ class DatabaseAdapter:
         v6.0.0: media_type, media_id, media_path removed - use media_items relationship.
         """
         is_deleted = getattr(message, "is_deleted", 0)
-        if not isinstance(is_deleted, (bool, int)):
+        if not isinstance(is_deleted, int):
             is_deleted = 0
         deleted_at = getattr(message, "deleted_at", None)
         if not isinstance(deleted_at, datetime):

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -13,7 +13,7 @@ import logging
 import os
 import secrets
 import shutil
-from datetime import datetime
+from datetime import UTC, datetime
 from functools import wraps
 from typing import Any
 
@@ -43,6 +43,11 @@ from .models import (
 logger = logging.getLogger(__name__)
 
 
+def _utcnow_naive() -> datetime:
+    """Return current UTC time without tzinfo for DB columns."""
+    return datetime.now(UTC).replace(tzinfo=None)
+
+
 def _strip_tz(dt: datetime | None) -> datetime | None:
     """Strip timezone info from datetime for PostgreSQL compatibility."""
     if dt is None:
@@ -50,6 +55,19 @@ def _strip_tz(dt: datetime | None) -> datetime | None:
     if hasattr(dt, "tzinfo") and dt.tzinfo is not None:
         return dt.replace(tzinfo=None)
     return dt
+
+
+def _message_conflict_update_values(message_data: dict[str, Any], values: dict[str, Any]) -> dict[str, Any]:
+    """Build update values for message upserts without undoing soft deletes."""
+    update_values = dict(values)
+
+    if not message_data.get("is_deleted"):
+        update_values.pop("is_deleted", None)
+        update_values.pop("deleted_at", None)
+    elif "deleted_at" not in message_data:
+        update_values.pop("deleted_at", None)
+
+    return update_values
 
 
 def retry_on_locked(
@@ -416,14 +434,17 @@ class DatabaseAdapter:
                 "edit_date": _strip_tz(message_data.get("edit_date")),
                 "raw_data": self._serialize_raw_data(message_data.get("raw_data", {})),
                 "is_outgoing": message_data.get("is_outgoing", 0),
+                "is_deleted": message_data.get("is_deleted", 0),
+                "deleted_at": _strip_tz(message_data.get("deleted_at")),
             }
+            update_values = _message_conflict_update_values(message_data, values)
 
             if self._is_sqlite:
                 stmt = sqlite_insert(Message).values(**values)
-                stmt = stmt.on_conflict_do_update(index_elements=["id", "chat_id"], set_=values)
+                stmt = stmt.on_conflict_do_update(index_elements=["id", "chat_id"], set_=update_values)
             else:
                 stmt = pg_insert(Message).values(**values)
-                stmt = stmt.on_conflict_do_update(index_elements=["id", "chat_id"], set_=values)
+                stmt = stmt.on_conflict_do_update(index_elements=["id", "chat_id"], set_=update_values)
 
             await session.execute(stmt)
             await session.commit()
@@ -453,14 +474,17 @@ class DatabaseAdapter:
                     "raw_data": self._serialize_raw_data(m.get("raw_data", {})),
                     "is_outgoing": m.get("is_outgoing", 0),
                     "is_pinned": m.get("is_pinned", 0),
+                    "is_deleted": m.get("is_deleted", 0),
+                    "deleted_at": _strip_tz(m.get("deleted_at")),
                 }
+                update_values = _message_conflict_update_values(m, values)
 
                 if self._is_sqlite:
                     stmt = sqlite_insert(Message).values(**values)
-                    stmt = stmt.on_conflict_do_update(index_elements=["id", "chat_id"], set_=values)
+                    stmt = stmt.on_conflict_do_update(index_elements=["id", "chat_id"], set_=update_values)
                 else:
                     stmt = pg_insert(Message).values(**values)
-                    stmt = stmt.on_conflict_do_update(index_elements=["id", "chat_id"], set_=values)
+                    stmt = stmt.on_conflict_do_update(index_elements=["id", "chat_id"], set_=update_values)
 
                 await session.execute(stmt)
 
@@ -505,7 +529,9 @@ class DatabaseAdapter:
     async def get_messages_sync_data(self, chat_id: int) -> dict[int, str | None]:
         """Get message IDs and their edit dates for sync checking."""
         async with self.db_manager.async_session_factory() as session:
-            stmt = select(Message.id, Message.edit_date).where(Message.chat_id == chat_id)
+            stmt = select(Message.id, Message.edit_date).where(
+                and_(Message.chat_id == chat_id, or_(Message.is_deleted == 0, Message.is_deleted.is_(None)))
+            )
             result = await session.execute(stmt)
             return {row.id: row.edit_date for row in result}
 
@@ -536,6 +562,23 @@ class DatabaseAdapter:
             await session.execute(delete(Message).where(and_(Message.chat_id == chat_id, Message.id == message_id)))
             await session.commit()
             logger.debug(f"Deleted message {message_id} from chat {chat_id}")
+
+    async def mark_message_deleted(
+        self, chat_id: int, message_id: int, deleted_at: datetime | None = None
+    ) -> None:
+        """Mark a message as deleted on Telegram while keeping archive content."""
+        deleted_at = _strip_tz(deleted_at) or _utcnow_naive()
+        async with self.db_manager.async_session_factory() as session:
+            await session.execute(
+                update(Message)
+                .where(and_(Message.chat_id == chat_id, Message.id == message_id))
+                .values(
+                    is_deleted=1,
+                    deleted_at=func.coalesce(Message.deleted_at, deleted_at),
+                )
+            )
+            await session.commit()
+            logger.debug(f"Marked message {message_id} as deleted")
 
     async def resolve_message_chat_id(self, message_id: int) -> int | None:
         """
@@ -587,6 +630,13 @@ class DatabaseAdapter:
 
         v6.0.0: media_type, media_id, media_path removed - use media_items relationship.
         """
+        is_deleted = getattr(message, "is_deleted", 0)
+        if not isinstance(is_deleted, (bool, int)):
+            is_deleted = 0
+        deleted_at = getattr(message, "deleted_at", None)
+        if not isinstance(deleted_at, datetime):
+            deleted_at = None
+
         return {
             "id": message.id,
             "chat_id": message.chat_id,
@@ -602,6 +652,8 @@ class DatabaseAdapter:
             "created_at": message.created_at,
             "is_outgoing": message.is_outgoing,
             "is_pinned": message.is_pinned,
+            "is_deleted": int(is_deleted),
+            "deleted_at": deleted_at,
         }
 
     async def get_chat_stats(self, chat_id: int) -> dict[str, Any]:

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -84,6 +84,8 @@ class Message(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
     is_outgoing: Mapped[int] = mapped_column(Integer, default=0)  # 0 or 1
     is_pinned: Mapped[int] = mapped_column(Integer, default=0)  # 0 or 1 - whether this message is pinned
+    is_deleted: Mapped[int] = mapped_column(Integer, default=0, server_default="0")  # 0 or 1 - deleted on Telegram
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime)
 
     # Relationships
     chat: Mapped[Chat] = relationship("Chat", back_populates="messages")

--- a/src/listener.py
+++ b/src/listener.py
@@ -16,7 +16,7 @@ import asyncio
 import logging
 import os
 from collections import deque
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 from telethon import TelegramClient, events
@@ -41,16 +41,12 @@ from .message_utils import (
     extract_topic_id,
     finalize_atomic_download,
     sanitize_media_filename,
+    utcnow_naive,
 )
 from .realtime import NotificationType, RealtimeNotifier
 from .telegram_backup import call_with_flood_retry
 
 logger = logging.getLogger(__name__)
-
-
-def _utcnow_naive() -> datetime:
-    """Return current UTC time without tzinfo for DB columns."""
-    return datetime.now(UTC).replace(tzinfo=None)
 
 
 class MassOperationProtector:
@@ -439,9 +435,9 @@ class TelegramListener:
         deletion_mode = self._get_deletion_mode()
 
         if deletion_mode == "soft":
-            deleted_at = _utcnow_naive()
+            deleted_at = utcnow_naive()
             await self.db.mark_message_deleted(chat_id, message_id, deleted_at=deleted_at)
-            logger.debug(f"🗑️ Deletion marked: chat={chat_id} msg={message_id}")
+            logger.debug(f"🗑️ Deletion marked: msg={message_id}")
             await self._notify_update(
                 "delete",
                 {
@@ -454,7 +450,7 @@ class TelegramListener:
             return
 
         await self.db.delete_message(chat_id, message_id)
-        logger.debug(f"🗑️ Deletion applied: chat={chat_id} msg={message_id}")
+        logger.debug(f"🗑️ Deletion applied: msg={message_id}")
         await self._notify_update(
             "delete",
             {"chat_id": chat_id, "message_id": message_id, "deletion_mode": "hard"},
@@ -811,7 +807,8 @@ class TelegramListener:
                             await self._apply_message_deletion(resolved, msg_id)
                             self.stats["deletions_applied"] += 1
                         except Exception as e:
-                            logger.debug(f"Could not delete msg {msg_id}: {e}")
+                            self.stats["errors"] += 1
+                            logger.warning(f"Could not apply deletion for msg {msg_id}: {e}")
                         continue
 
                     if not self._should_process_chat(effective_chat_id):

--- a/src/listener.py
+++ b/src/listener.py
@@ -16,7 +16,7 @@ import asyncio
 import logging
 import os
 from collections import deque
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from telethon import TelegramClient, events
@@ -46,6 +46,11 @@ from .realtime import NotificationType, RealtimeNotifier
 from .telegram_backup import call_with_flood_retry
 
 logger = logging.getLogger(__name__)
+
+
+def _utcnow_naive() -> datetime:
+    """Return current UTC time without tzinfo for DB columns."""
+    return datetime.now(UTC).replace(tzinfo=None)
 
 
 class MassOperationProtector:
@@ -285,6 +290,7 @@ class TelegramListener:
         logger.info(f"  LISTEN_EDITS: {config.listen_edits}")
         if config.listen_deletions:
             logger.warning("  ⚠️ LISTEN_DELETIONS: true - Deletions will be processed (with protection)")
+            logger.info(f"  DELETION_MODE: {getattr(config, 'deletion_mode', 'hard')}")
         else:
             logger.info("  LISTEN_DELETIONS: false (backup fully protected)")
         if config.listen_new_messages:
@@ -422,6 +428,37 @@ class TelegramListener:
             await self._notifier.notify(nt, chat_id, data)
         except Exception as e:
             logger.debug(f"Failed to send notification: {e}")
+
+    def _get_deletion_mode(self) -> str:
+        """Return configured deletion mode, defaulting to legacy hard delete."""
+        mode = getattr(self.config, "deletion_mode", "hard")
+        return "soft" if mode == "soft" else "hard"
+
+    async def _apply_message_deletion(self, chat_id: int, message_id: int) -> None:
+        """Apply a Telegram deletion event according to DELETION_MODE."""
+        deletion_mode = self._get_deletion_mode()
+
+        if deletion_mode == "soft":
+            deleted_at = _utcnow_naive()
+            await self.db.mark_message_deleted(chat_id, message_id, deleted_at=deleted_at)
+            logger.debug(f"🗑️ Deletion marked: chat={chat_id} msg={message_id}")
+            await self._notify_update(
+                "delete",
+                {
+                    "chat_id": chat_id,
+                    "message_id": message_id,
+                    "deletion_mode": "soft",
+                    "deleted_at": deleted_at.isoformat(),
+                },
+            )
+            return
+
+        await self.db.delete_message(chat_id, message_id)
+        logger.debug(f"🗑️ Deletion applied: chat={chat_id} msg={message_id}")
+        await self._notify_update(
+            "delete",
+            {"chat_id": chat_id, "message_id": message_id, "deletion_mode": "hard"},
+        )
 
     def _should_process_chat(self, chat_id: int) -> bool:
         """
@@ -771,12 +808,8 @@ class TelegramListener:
                                 self.stats["operations_discarded"] += 1
                                 continue
 
-                            await self.db.delete_message(resolved, msg_id)
+                            await self._apply_message_deletion(resolved, msg_id)
                             self.stats["deletions_applied"] += 1
-                            logger.debug(f"🗑️ Deletion applied (resolved chat): chat={resolved} msg={msg_id}")
-
-                            # Notify viewer
-                            await self._notify_update("delete", {"chat_id": resolved, "message_id": msg_id})
                         except Exception as e:
                             logger.debug(f"Could not delete msg {msg_id}: {e}")
                         continue
@@ -792,12 +825,8 @@ class TelegramListener:
                         continue
 
                     # Apply the deletion immediately
-                    await self.db.delete_message(effective_chat_id, msg_id)
+                    await self._apply_message_deletion(effective_chat_id, msg_id)
                     self.stats["deletions_applied"] += 1
-                    logger.debug(f"🗑️ Deletion applied: chat={effective_chat_id} msg={msg_id}")
-
-                    # Notify viewer of the deletion
-                    await self._notify_update("delete", {"chat_id": effective_chat_id, "message_id": msg_id})
 
             except Exception as e:
                 self.stats["errors"] += 1

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -6,8 +6,14 @@ import hashlib
 import logging
 import os
 import re
+from datetime import UTC, datetime
 
 logger = logging.getLogger(__name__)
+
+
+def utcnow_naive() -> datetime:
+    """Return current UTC time without tzinfo, for naive DB datetime columns."""
+    return datetime.now(UTC).replace(tzinfo=None)
 
 
 def sanitize_media_filename(name: str) -> str:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -1267,9 +1267,9 @@ class TelegramBackup:
                     # Check for deletion
                     if remote_msg is None:
                         if getattr(self.config, "deletion_mode", "hard") == "soft":
-                            await self.db.mark_message_deleted(
-                                chat_id, msg_id, deleted_at=datetime.now(UTC).replace(tzinfo=None)
-                            )
+                            # mark_message_deleted defaults deleted_at to now(UTC); this path
+                            # doesn't broadcast, so no need to pass an explicit timestamp.
+                            await self.db.mark_message_deleted(chat_id, msg_id)
                         else:
                             await self.db.delete_message(chat_id, msg_id)
                         total_deleted += 1

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -1266,7 +1266,12 @@ class TelegramBackup:
                 for msg_id, remote_msg in zip(batch_ids, remote_messages):
                     # Check for deletion
                     if remote_msg is None:
-                        await self.db.delete_message(chat_id, msg_id)
+                        if getattr(self.config, "deletion_mode", "hard") == "soft":
+                            await self.db.mark_message_deleted(
+                                chat_id, msg_id, deleted_at=datetime.now(UTC).replace(tzinfo=None)
+                            )
+                        else:
+                            await self.db.delete_message(chat_id, msg_id)
                         total_deleted += 1
                         continue
 

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -218,10 +218,26 @@ async def handle_realtime_notification(payload: dict):
 
     elif notification_type == "edit":
         await ws_manager.broadcast_to_chat(
-            chat_id, {"type": "edit", "message_id": data.get("message_id"), "new_text": data.get("new_text")}
+            chat_id,
+            {
+                "type": "edit",
+                "chat_id": chat_id,
+                "message_id": data.get("message_id"),
+                "new_text": data.get("new_text"),
+                "edit_date": data.get("edit_date"),
+            },
         )
     elif notification_type == "delete":
-        await ws_manager.broadcast_to_chat(chat_id, {"type": "delete", "message_id": data.get("message_id")})
+        await ws_manager.broadcast_to_chat(
+            chat_id,
+            {
+                "type": "delete",
+                "chat_id": chat_id,
+                "message_id": data.get("message_id"),
+                "deletion_mode": data.get("deletion_mode", "hard"),
+                "deleted_at": data.get("deleted_at"),
+            },
+        )
     elif notification_type == "pin":
         await ws_manager.broadcast_to_chat(
             chat_id,
@@ -2476,6 +2492,17 @@ async def broadcast_message_edit(chat_id: int, message_id: int, new_text: str, e
     )
 
 
-async def broadcast_message_delete(chat_id: int, message_id: int):
+async def broadcast_message_delete(
+    chat_id: int, message_id: int, deletion_mode: str = "hard", deleted_at: str | None = None
+) -> None:
     """Broadcast a message deletion to subscribed clients."""
-    await ws_manager.broadcast_to_chat(chat_id, {"type": "delete", "chat_id": chat_id, "message_id": message_id})
+    await ws_manager.broadcast_to_chat(
+        chat_id,
+        {
+            "type": "delete",
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "deletion_mode": deletion_mode,
+            "deleted_at": deleted_at,
+        },
+    )

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -124,7 +124,13 @@ logging.basicConfig(format="%(asctime)s - %(name)s - %(levelname)s - %(message)s
 logger = logging.getLogger(__name__)
 
 # Initialize config
-config = Config()
+# Wrap construction so an invalid env value (e.g. a bad DELETION_MODE) surfaces a
+# clear message instead of an opaque ASGI import-time traceback / crash-loop.
+try:
+    config = Config()
+except ValueError as e:
+    logger.error(f"Configuration error: {e}")
+    raise
 
 # Global database adapter (initialized on startup)
 db: DatabaseAdapter | None = None

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1171,6 +1171,7 @@
 
                                     <!-- Text with clickable links (for albums, use caption from whichever message has it) -->
                                     <div class="whitespace-pre-wrap break-words message-text"
+                                        :class="{ 'opacity-50': msg.is_deleted }"
                                         v-html="linkifyText(getAlbumCaption(msg) || msg.text)"></div>
 
                                     <!-- Reactions -->
@@ -3042,16 +3043,19 @@
 
                         const latestMessages = await res.json()
                         const latestIds = new Set(latestMessages.map(m => m.id))
-                        // Re-read existing IDs right before mutation to avoid stale snapshots
-                        const existingIds = new Set(messages.value.map(m => m.id))
+                        // Re-read existing messages right before mutation to avoid stale snapshots.
+                        // Index by id once so the new-message filter and soft-delete refresh below
+                        // are O(latest) lookups instead of O(latest × inView) array scans per poll.
+                        const existingById = new Map(messages.value.map(m => [m.id, m]))
+                        const existingIds = new Set(existingById.keys())
 
                         // Find new messages (in server response but not in our view)
                         const newMessages = latestMessages.filter(m => !existingIds.has(m.id))
 
                         // Refresh soft-delete markers for messages already in view
                         latestMessages.forEach(serverMsg => {
-                            const currentMsg = messages.value.find(m => m.id === serverMsg.id && m.chat_id === serverMsg.chat_id)
-                            if (currentMsg) {
+                            const currentMsg = existingById.get(serverMsg.id)
+                            if (currentMsg && currentMsg.chat_id === serverMsg.chat_id) {
                                 currentMsg.is_deleted = serverMsg.is_deleted
                                 currentMsg.deleted_at = serverMsg.deleted_at
                             }

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1188,6 +1188,7 @@
                                     <div
                                         class="text-[10px] opacity-60 text-right mt-1 flex justify-end items-center gap-1">
                                         <span v-if="msg.edit_date">edited</span>
+                                        <span v-if="msg.is_deleted">deleted</span>
                                         {{ formatTime(msg.date) }}
                                     </div>
                                 </div>
@@ -2239,8 +2240,13 @@
                             break
 
                         case 'edit':
+                            if (data.chat_id != null && selectedChat.value?.id !== data.chat_id) {
+                                break
+                            }
                             // Update message text in current view
-                            const editMsg = messages.value.find(m => m.id === data.message_id)
+                            const editMsg = messages.value.find(m =>
+                                m.id === data.message_id && (data.chat_id == null || m.chat_id === data.chat_id)
+                            )
                             if (editMsg) {
                                 editMsg.text = data.new_text
                                 editMsg.edit_date = data.edit_date
@@ -2248,10 +2254,25 @@
                             break
 
                         case 'delete':
-                            // Remove from current view
-                            const deleteIdx = messages.value.findIndex(m => m.id === data.message_id)
-                            if (deleteIdx !== -1) {
-                                messages.value.splice(deleteIdx, 1)
+                            if (data.chat_id != null && selectedChat.value?.id !== data.chat_id) {
+                                break
+                            }
+                            if (data.deletion_mode === 'soft') {
+                                const deleteMsg = messages.value.find(m =>
+                                    m.id === data.message_id && (data.chat_id == null || m.chat_id === data.chat_id)
+                                )
+                                if (deleteMsg) {
+                                    deleteMsg.is_deleted = 1
+                                    deleteMsg.deleted_at = data.deleted_at
+                                }
+                            } else {
+                                // Remove from current view
+                                const deleteIdx = messages.value.findIndex(m =>
+                                    m.id === data.message_id && (data.chat_id == null || m.chat_id === data.chat_id)
+                                )
+                                if (deleteIdx !== -1) {
+                                    messages.value.splice(deleteIdx, 1)
+                                }
                             }
                             break
 
@@ -3026,6 +3047,15 @@
 
                         // Find new messages (in server response but not in our view)
                         const newMessages = latestMessages.filter(m => !existingIds.has(m.id))
+
+                        // Refresh soft-delete markers for messages already in view
+                        latestMessages.forEach(serverMsg => {
+                            const currentMsg = messages.value.find(m => m.id === serverMsg.id && m.chat_id === serverMsg.chat_id)
+                            if (currentMsg) {
+                                currentMsg.is_deleted = serverMsg.is_deleted
+                                currentMsg.deleted_at = serverMsg.deleted_at
+                            }
+                        })
 
                         // Find deleted messages - ONLY check messages that overlap with our fetch
                         // We fetched the latest 50/20 from server. Compare with our newest messages.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1001,6 +1001,17 @@ class TestListenerLogging(unittest.TestCase):
         with patch.dict(os.environ, env_vars, clear=True), self.assertRaises(ValueError):
             Config()
 
+    def test_deletion_mode_normalizes_case_and_whitespace(self):
+        """DELETION_MODE is stripped and lower-cased before validation."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "DELETION_MODE": "  Soft  ",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertEqual(config.deletion_mode, "soft")
+
     def test_listener_enabled_without_deletions(self):
         """ENABLE_LISTENER=true with LISTEN_DELETIONS=false covers protected path."""
         env_vars = {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -962,6 +962,7 @@ class TestListenerLogging(unittest.TestCase):
             config = Config()
             self.assertTrue(config.enable_listener)
             self.assertFalse(config.listen_deletions)
+            self.assertEqual(config.deletion_mode, "hard")
 
     def test_listener_enabled_with_deletions(self):
         """ENABLE_LISTENER=true with LISTEN_DELETIONS=true covers deletion warning path."""
@@ -975,6 +976,30 @@ class TestListenerLogging(unittest.TestCase):
             config = Config()
             self.assertTrue(config.enable_listener)
             self.assertTrue(config.listen_deletions)
+            self.assertEqual(config.deletion_mode, "hard")
+
+    def test_deletion_mode_soft(self):
+        """DELETION_MODE=soft marks deleted messages instead of hard deleting them."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "ENABLE_LISTENER": "true",
+            "LISTEN_DELETIONS": "true",
+            "DELETION_MODE": "soft",
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertEqual(config.deletion_mode, "soft")
+
+    def test_deletion_mode_invalid_raises(self):
+        """DELETION_MODE only accepts soft or hard."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "DELETION_MODE": "archive",
+        }
+        with patch.dict(os.environ, env_vars, clear=True), self.assertRaises(ValueError):
+            Config()
 
     def test_listener_enabled_without_deletions(self):
         """ENABLE_LISTENER=true with LISTEN_DELETIONS=false covers protected path."""

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -344,6 +344,18 @@ class TestMessageToDict:
         assert result["is_deleted"] == 1
         assert result["deleted_at"] == datetime(2025, 6, 2)
 
+    def test_coerces_non_int_is_deleted_and_non_datetime_deleted_at(self):
+        """Defensive guards coerce a non-int is_deleted to 0 and a non-datetime deleted_at to None."""
+        adapter = self._make_adapter()
+        msg = MagicMock()
+        msg.is_deleted = "not-an-int"
+        msg.deleted_at = "not-a-datetime"
+
+        result = adapter._message_to_dict(msg)
+
+        assert result["is_deleted"] == 0
+        assert result["deleted_at"] is None
+
     def test_handles_none_text(self):
         """Message with None text is handled correctly."""
         adapter = self._make_adapter()

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -325,6 +325,8 @@ class TestMessageToDict:
         msg.created_at = datetime(2025, 6, 1)
         msg.is_outgoing = 1
         msg.is_pinned = 0
+        msg.is_deleted = 1
+        msg.deleted_at = datetime(2025, 6, 2)
 
         result = adapter._message_to_dict(msg)
 
@@ -339,6 +341,8 @@ class TestMessageToDict:
         assert result["edit_date"] is None
         assert result["is_outgoing"] == 1
         assert result["is_pinned"] == 0
+        assert result["is_deleted"] == 1
+        assert result["deleted_at"] == datetime(2025, 6, 2)
 
     def test_handles_none_text(self):
         """Message with None text is handled correctly."""
@@ -941,6 +945,17 @@ class TestMessageOperations:
         adapter = DatabaseAdapter(db_manager)
 
         await adapter.update_message_text(100, 42, "edited text", datetime(2025, 6, 1))
+
+        mock_session.execute.assert_awaited_once()
+        mock_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_mark_message_deleted_executes_and_commits(self):
+        """mark_message_deleted stores a soft-delete marker."""
+        db_manager, mock_session = _make_mock_db_manager()
+        adapter = DatabaseAdapter(db_manager)
+
+        await adapter.mark_message_deleted(100, 42, datetime(2025, 6, 1))
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()

--- a/tests/test_db_adapter_soft_delete_upsert.py
+++ b/tests/test_db_adapter_soft_delete_upsert.py
@@ -84,3 +84,108 @@ async def test_insert_messages_batch_upsert_preserves_soft_delete_marker(sqlite_
     assert message.text == "reprocessed"
     assert message.is_deleted == 1
     assert message.deleted_at == deleted_at
+
+
+@pytest.mark.asyncio
+async def test_fresh_insert_not_marked_deleted(sqlite_adapter):
+    """A brand-new message inserts as not-deleted with a null deleted_at."""
+    await sqlite_adapter.insert_message(
+        {"id": 3, "chat_id": 100, "date": datetime(2026, 6, 25, 12, 0), "text": "hello"}
+    )
+
+    message = await _get_message(sqlite_adapter, 3, 100)
+    assert message.is_deleted == 0
+    assert message.deleted_at is None
+
+
+@pytest.mark.asyncio
+async def test_upsert_with_is_deleted_and_timestamp_sets_marker(sqlite_adapter):
+    """An upsert whose payload carries is_deleted + deleted_at sets both on conflict."""
+    deleted_at = datetime(2026, 6, 25, 13, 30)
+
+    await sqlite_adapter.insert_message(
+        {"id": 4, "chat_id": 100, "date": datetime(2026, 6, 25, 13, 0), "text": "original"}
+    )
+    await sqlite_adapter.insert_message(
+        {
+            "id": 4,
+            "chat_id": 100,
+            "date": datetime(2026, 6, 25, 13, 0),
+            "text": "now deleted",
+            "is_deleted": 1,
+            "deleted_at": deleted_at,
+        }
+    )
+
+    message = await _get_message(sqlite_adapter, 4, 100)
+    assert message.is_deleted == 1
+    assert message.deleted_at == deleted_at
+
+
+@pytest.mark.asyncio
+async def test_upsert_with_is_deleted_no_timestamp_preserves_existing(sqlite_adapter):
+    """An upsert with is_deleted=1 but no deleted_at keeps the existing timestamp."""
+    first_deleted_at = datetime(2026, 6, 25, 14, 30)
+
+    await sqlite_adapter.insert_message(
+        {"id": 5, "chat_id": 100, "date": datetime(2026, 6, 25, 14, 0), "text": "original"}
+    )
+    await sqlite_adapter.mark_message_deleted(100, 5, first_deleted_at)
+    await sqlite_adapter.insert_message(
+        {
+            "id": 5,
+            "chat_id": 100,
+            "date": datetime(2026, 6, 25, 14, 0),
+            "text": "reprocessed",
+            "is_deleted": 1,
+        }
+    )
+
+    message = await _get_message(sqlite_adapter, 5, 100)
+    assert message.is_deleted == 1
+    assert message.deleted_at == first_deleted_at
+
+
+@pytest.mark.asyncio
+async def test_mark_message_deleted_twice_keeps_first_timestamp(sqlite_adapter):
+    """Re-marking a soft-deleted message preserves the original deletion time (coalesce)."""
+    first = datetime(2026, 6, 25, 15, 0)
+    second = datetime(2026, 6, 25, 16, 0)
+
+    await sqlite_adapter.insert_message(
+        {"id": 6, "chat_id": 100, "date": datetime(2026, 6, 25, 14, 0), "text": "original"}
+    )
+    await sqlite_adapter.mark_message_deleted(100, 6, first)
+    await sqlite_adapter.mark_message_deleted(100, 6, second)
+
+    message = await _get_message(sqlite_adapter, 6, 100)
+    assert message.is_deleted == 1
+    assert message.deleted_at == first
+
+
+@pytest.mark.asyncio
+async def test_mark_message_deleted_defaults_timestamp_when_none(sqlite_adapter):
+    """Omitting deleted_at falls back to a server-generated timestamp."""
+    await sqlite_adapter.insert_message(
+        {"id": 7, "chat_id": 100, "date": datetime(2026, 6, 25, 14, 0), "text": "original"}
+    )
+    await sqlite_adapter.mark_message_deleted(100, 7)
+
+    message = await _get_message(sqlite_adapter, 7, 100)
+    assert message.is_deleted == 1
+    assert message.deleted_at is not None
+
+
+@pytest.mark.asyncio
+async def test_get_messages_sync_data_excludes_soft_deleted(sqlite_adapter):
+    """Soft-deleted rows are excluded from the sync set so they aren't re-checked."""
+    await sqlite_adapter.insert_message(
+        {"id": 10, "chat_id": 200, "date": datetime(2026, 6, 25, 17, 0), "text": "live"}
+    )
+    await sqlite_adapter.insert_message(
+        {"id": 11, "chat_id": 200, "date": datetime(2026, 6, 25, 17, 1), "text": "to delete"}
+    )
+    await sqlite_adapter.mark_message_deleted(200, 11)
+
+    sync_data = await sqlite_adapter.get_messages_sync_data(200)
+    assert set(sync_data.keys()) == {10}

--- a/tests/test_db_adapter_soft_delete_upsert.py
+++ b/tests/test_db_adapter_soft_delete_upsert.py
@@ -1,0 +1,86 @@
+from datetime import datetime
+
+import pytest
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Message
+
+
+@pytest.fixture
+async def sqlite_adapter(tmp_path):
+    manager = DatabaseManager(f"sqlite:///{tmp_path / 'telegram_archive.db'}")
+    await manager.init()
+    try:
+        yield DatabaseAdapter(manager)
+    finally:
+        await manager.close()
+
+
+async def _get_message(adapter: DatabaseAdapter, message_id: int, chat_id: int) -> Message:
+    async with adapter.db_manager.async_session_factory() as session:
+        message = await session.get(Message, (message_id, chat_id))
+        assert message is not None
+        return message
+
+
+@pytest.mark.asyncio
+async def test_insert_message_upsert_preserves_soft_delete_marker(sqlite_adapter):
+    deleted_at = datetime(2026, 6, 25, 10, 30)
+
+    await sqlite_adapter.insert_message(
+        {
+            "id": 1,
+            "chat_id": 100,
+            "date": datetime(2026, 6, 25, 10, 0),
+            "text": "original",
+        }
+    )
+    await sqlite_adapter.mark_message_deleted(100, 1, deleted_at)
+
+    await sqlite_adapter.insert_message(
+        {
+            "id": 1,
+            "chat_id": 100,
+            "date": datetime(2026, 6, 25, 10, 0),
+            "text": "reprocessed",
+        }
+    )
+
+    message = await _get_message(sqlite_adapter, 1, 100)
+    assert message.text == "reprocessed"
+    assert message.is_deleted == 1
+    assert message.deleted_at == deleted_at
+
+
+@pytest.mark.asyncio
+async def test_insert_messages_batch_upsert_preserves_soft_delete_marker(sqlite_adapter):
+    deleted_at = datetime(2026, 6, 25, 11, 30)
+
+    await sqlite_adapter.insert_messages_batch(
+        [
+            {
+                "id": 2,
+                "chat_id": 100,
+                "date": datetime(2026, 6, 25, 11, 0),
+                "text": "original",
+            }
+        ]
+    )
+    await sqlite_adapter.mark_message_deleted(100, 2, deleted_at)
+
+    await sqlite_adapter.insert_messages_batch(
+        [
+            {
+                "id": 2,
+                "chat_id": 100,
+                "date": datetime(2026, 6, 25, 11, 0),
+                "text": "reprocessed",
+            }
+        ]
+    )
+
+    message = await _get_message(sqlite_adapter, 2, 100)
+    assert message.text == "reprocessed"
+    assert message.is_deleted == 1
+    assert message.deleted_at == deleted_at

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -630,6 +630,45 @@ class TestEventHandlers:
         listener.db.mark_message_deleted.assert_called_once()
         listener.db.delete_message.assert_not_called()
 
+    def test_on_message_deleted_soft_notify_payload(self, listener_with_handlers, full_config):
+        """Soft deletion emits a 'delete' notification carrying deletion_mode=soft and deleted_at."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.MessageDeleted]
+        full_config.deletion_mode = "soft"
+        listener._notify_update = AsyncMock()
+
+        event = MagicMock()
+        event.chat_id = -1001234567890
+        event.deleted_ids = [10]
+
+        asyncio.run(handler(event))
+
+        listener._notify_update.assert_called_once()
+        notif_type, payload = listener._notify_update.call_args.args
+        assert notif_type == "delete"
+        assert payload["deletion_mode"] == "soft"
+        assert payload["message_id"] == 10
+        assert payload["chat_id"] == -1001234567890
+        assert isinstance(payload["deleted_at"], str)  # ISO timestamp for the viewer
+
+    def test_on_message_deleted_hard_notify_payload(self, listener_with_handlers):
+        """Hard deletion emits a 'delete' notification with deletion_mode=hard and no deleted_at."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.MessageDeleted]
+        listener._notify_update = AsyncMock()
+
+        event = MagicMock()
+        event.chat_id = -1001234567890
+        event.deleted_ids = [10]
+
+        asyncio.run(handler(event))
+
+        listener._notify_update.assert_called_once()
+        notif_type, payload = listener._notify_update.call_args.args
+        assert notif_type == "delete"
+        assert payload["deletion_mode"] == "hard"
+        assert "deleted_at" not in payload
+
     def test_on_message_deleted_resolves_chat_when_chat_id_none(self, listener_with_handlers, mock_db):
         """Test delete handler resolves chat_id from DB when event has None chat_id."""
         listener, handlers = listener_with_handlers

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -249,6 +249,7 @@ class TestEventHandlers:
         config.chat_ids = set()
         config.listen_edits = True
         config.listen_deletions = True
+        config.deletion_mode = "hard"
         config.listen_new_messages = True
         config.listen_new_messages_media = False
         config.listen_chat_actions = False
@@ -266,6 +267,7 @@ class TestEventHandlers:
         db.get_all_chats = AsyncMock(return_value=[])
         db.update_message_text = AsyncMock()
         db.delete_message = AsyncMock()
+        db.mark_message_deleted = AsyncMock()
         db.resolve_message_chat_id = AsyncMock(return_value=None)
         db.upsert_chat = AsyncMock()
         db.upsert_user = AsyncMock()
@@ -611,6 +613,22 @@ class TestEventHandlers:
         assert listener.stats["deletions_received"] == 2
         assert listener.stats["deletions_applied"] == 2
         assert listener.db.delete_message.call_count == 2
+        listener.db.mark_message_deleted.assert_not_called()
+
+    def test_on_message_deleted_soft_marks_deletion(self, listener_with_handlers, full_config):
+        """DELETION_MODE=soft marks messages deleted instead of removing them."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.MessageDeleted]
+        full_config.deletion_mode = "soft"
+
+        event = MagicMock()
+        event.chat_id = -1001234567890
+        event.deleted_ids = [10]
+
+        asyncio.run(handler(event))
+
+        listener.db.mark_message_deleted.assert_called_once()
+        listener.db.delete_message.assert_not_called()
 
     def test_on_message_deleted_resolves_chat_when_chat_id_none(self, listener_with_handlers, mock_db):
         """Test delete handler resolves chat_id from DB when event has None chat_id."""

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -54,6 +54,7 @@ def _make_config(**overrides):
     config.chat_ids = set()
     config.listen_edits = True
     config.listen_deletions = True
+    config.deletion_mode = "hard"
     config.listen_new_messages = True
     config.listen_new_messages_media = True
     config.listen_chat_actions = True
@@ -76,6 +77,7 @@ def _make_db():
     db.get_all_chats = AsyncMock(return_value=[])
     db.update_message_text = AsyncMock()
     db.delete_message = AsyncMock()
+    db.mark_message_deleted = AsyncMock()
     db.resolve_message_chat_id = AsyncMock(return_value=None)
     db.upsert_chat = AsyncMock()
     db.upsert_user = AsyncMock()

--- a/tests/test_migration_014.py
+++ b/tests/test_migration_014.py
@@ -1,0 +1,95 @@
+"""Tests for Alembic migration 014 (messages soft-delete columns).
+
+The repo's CLAUDE.md requires every migration to be idempotent and to work on
+the SQLite path. These tests drive the migration's own ``upgrade()`` /
+``downgrade()`` (which use the global ``op`` proxy) against an in-memory SQLite
+database via an Alembic ``Operations`` context.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parent.parent / "alembic" / "versions" / "20260625_014_add_message_soft_delete.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("migration_014", _MIGRATION_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(conn, func):
+    ctx = MigrationContext.configure(conn)
+    with Operations.context(ctx):
+        func()
+
+
+def _columns(conn):
+    return {c["name"] for c in sa.inspect(conn).get_columns("messages")}
+
+
+def test_revision_chain():
+    """014 follows 013 with no branch label."""
+    migration = _load_migration()
+    assert migration.revision == "014"
+    assert migration.down_revision == "013"
+
+
+def test_upgrade_adds_columns_and_is_idempotent():
+    """upgrade() adds both soft-delete columns and is safe to run twice."""
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        conn.execute(sa.text("CREATE TABLE messages (id INTEGER, chat_id INTEGER, text TEXT)"))
+        assert "is_deleted" not in _columns(conn)
+
+        _run(conn, migration.upgrade)
+        cols = _columns(conn)
+        assert "is_deleted" in cols
+        assert "deleted_at" in cols
+
+        # Re-run must be a no-op (idempotent), not raise "duplicate column".
+        _run(conn, migration.upgrade)
+        assert _columns(conn) == cols
+
+
+def test_downgrade_removes_columns_and_is_idempotent():
+    """downgrade() drops both columns and is safe to run twice."""
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        conn.execute(sa.text("CREATE TABLE messages (id INTEGER, chat_id INTEGER, text TEXT)"))
+        _run(conn, migration.upgrade)
+        assert {"is_deleted", "deleted_at"} <= _columns(conn)
+
+        _run(conn, migration.downgrade)
+        cols = _columns(conn)
+        assert "is_deleted" not in cols
+        assert "deleted_at" not in cols
+
+        # Re-run must be a no-op (idempotent).
+        _run(conn, migration.downgrade)
+        assert _columns(conn) == cols
+
+
+def test_upgrade_noop_when_columns_already_exist():
+    """A create_all()-provisioned DB already has the columns; upgrade() is a no-op."""
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE messages "
+                "(id INTEGER, chat_id INTEGER, text TEXT, "
+                "is_deleted INTEGER NOT NULL DEFAULT 0, deleted_at DATETIME)"
+            )
+        )
+        _run(conn, migration.upgrade)
+        assert {"is_deleted", "deleted_at"} <= _columns(conn)

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -37,6 +37,7 @@ def _make_backup(**overrides):
     backup = TelegramBackup.__new__(TelegramBackup)
     backup.config = overrides.get("config", MagicMock())
     backup.config.should_skip_topic = MagicMock(return_value=False)
+    backup.config.deletion_mode = "hard"
     backup.db = overrides.get("db", AsyncMock())
     backup.client = overrides.get("client", AsyncMock())
     backup._owns_client = overrides.get("_owns_client", True)
@@ -796,6 +797,18 @@ class TestSyncDeletionsAndEdits(unittest.TestCase):
         _run(self.backup._sync_deletions_and_edits(100, entity))
 
         self.backup.db.delete_message.assert_awaited_once_with(100, 1)
+
+    def test_deleted_message_soft_marked(self):
+        """DELETION_MODE=soft marks deleted messages instead of hard deleting."""
+        self.backup.config.deletion_mode = "soft"
+        self.backup.db.get_messages_sync_data = AsyncMock(return_value={1: None})
+        self.backup.client.get_messages = AsyncMock(return_value=[None])
+        entity = MagicMock()
+
+        _run(self.backup._sync_deletions_and_edits(100, entity))
+
+        self.backup.db.mark_message_deleted.assert_awaited_once()
+        self.backup.db.delete_message.assert_not_awaited()
 
     def test_edited_message_updated_in_db(self):
         """Remote message with different edit_date triggers update."""


### PR DESCRIPTION
## Summary

Add configurable soft deletion support for archived Telegram messages.

This introduces `DELETION_MODE=soft|hard` for both real-time deletion listener handling and batch deletion/edit sync:

- `hard` keeps the existing behavior and removes archived messages.
- `soft` keeps the original archived message and marks it as deleted.
- The viewer displays deleted messages with a `deleted` metadata label.
- Messages that are both edited and deleted display `edited deleted`.

## Motivation

Previously, enabling deletion handling could mirror Telegram deletions by removing messages from the local archive. That made it hard to preserve archive history while still recording that a message was deleted upstream.

This change allows users to keep the original message content while recording deletion state.

## Changes

- Add `DELETION_MODE` config with default `hard` for backwards compatibility.
- Add `messages.is_deleted` and `messages.deleted_at` columns via Alembic migration `014`.
- Add `mark_message_deleted()` DB adapter method.
- Preserve soft-delete markers during message upserts so retries, gap fill, or reprocessing do not clear deletion state.
- Apply `DELETION_MODE` in the real-time deletion listener and `SYNC_DELETIONS_EDITS=true` batch sync.
- Update WebSocket delete handling so soft deletes update the visible message instead of removing it.
- Update viewer metadata rendering: edited only = `edited`, deleted only = `deleted`, both = `edited deleted`.
- Document `DELETION_MODE` in README and `.env.example`.
- Pass `DELETION_MODE` through `docker-compose.yml`.

## Compatibility

The default remains `DELETION_MODE=hard`, so existing deployments that already enabled deletion handling keep the previous archive behavior.

Users who want to preserve deleted messages should explicitly set:

```env
DELETION_MODE=soft
```

For local direct runs against an existing SQLite DB, run migrations before starting the app:

```bash
uv run alembic upgrade head
```

Docker entrypoint-managed deployments already run Alembic migrations on startup.

## Testing

Ran:

```bash
uv run python -m py_compile src/config.py src/db/adapter.py src/db/models.py src/listener.py src/telegram_backup.py src/web/main.py alembic/versions/20260625_014_add_message_soft_delete.py

uv run --with ruff ruff check src/config.py src/db/adapter.py src/db/models.py src/listener.py src/telegram_backup.py src/web/main.py tests/test_config.py tests/test_listener.py tests/test_listener_extended.py tests/test_telegram_backup_extended.py tests/test_db_adapter_soft_delete_upsert.py alembic/versions/20260625_014_add_message_soft_delete.py

uv run --with pytest --with pytest-asyncio python -m pytest tests/test_config.py::TestListenerLogging tests/test_listener.py::TestEventHandlers tests/test_listener_extended.py::TestOnMessageDeletedRateLimiting tests/test_telegram_backup_extended.py::TestSyncDeletionsAndEdits tests/test_db_adapter_soft_delete_upsert.py -q

uv run --with pytest --with pytest-asyncio python -m pytest tests/test_web_main.py tests/test_web_routes.py -q

uv run --with pytest --with pytest-asyncio python -m pytest tests/test_db_adapter.py tests/test_db_adapter_soft_delete_upsert.py -q
```

Also smoke-tested SQLite Alembic upgrade to head and confirmed migration `014` creates `messages.is_deleted` and `messages.deleted_at`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `DELETION_MODE` (`hard` or `soft`) to control how deleted Telegram messages are processed (default `hard`).
  * WebSocket delete events and the UI now support soft-deletion metadata, including a “deleted” indicator and message dimming.
* **Bug Fixes**
  * Deletion syncing and stored message updates now follow the selected deletion mode, preserving soft-deleted state on upserts.
* **Documentation**
  * Updated environment and README examples to explain `DELETION_MODE`, including the real-time listener behavior.
* **Tests**
  * Expanded test coverage for configuration parsing/validation, listener/backup deletion behavior, and soft-delete upsert & migration 014.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->