### PR TITLE
fix(viewer): hotfix missing message_utils in image

### DIFF
--- a/.github/workflows/docker-publish-dev.yml
+++ b/.github/workflows/docker-publish-dev.yml
@@ -29,6 +29,7 @@ jobs:
   build-and-push-dev:
     runs-on: ubuntu-latest
     # Only run for PRs from the same repo (not forks/dependabot) or workflow_dispatch
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-publish-viewer.yml
+++ b/.github/workflows/docker-publish-viewer.yml
@@ -11,6 +11,8 @@ on:
       - 'requirements-viewer.txt'
       - 'src/web/**'
       - 'src/config.py'
+      - 'src/realtime.py'
+      - 'src/message_utils.py'
       - 'src/db/**'
       - '.github/workflows/docker-publish-viewer.yml'
   workflow_dispatch:

--- a/Dockerfile.viewer
+++ b/Dockerfile.viewer
@@ -20,6 +20,7 @@ RUN uv sync --frozen --no-dev --no-install-project
 COPY src/__init__.py ./src/
 COPY src/config.py ./src/
 COPY src/realtime.py ./src/
+COPY src/message_utils.py ./src/
 COPY src/db/ ./src/db/
 COPY src/web/ ./src/web/
 


### PR DESCRIPTION
## Summary

Hotfix for the current viewer image startup failure.

The current viewer container can fail to start because `Dockerfile.viewer` does not copy `src/message_utils.py` into the image, while the viewer startup path now imports it through `src.db.adapter`.

This PR adds the missing file to the viewer image and updates the viewer image publish path filters so future changes to this dependency rebuild the viewer image.

## Changes

- Copy `src/message_utils.py` into the standalone viewer image.
- Add `src/message_utils.py` to the viewer Docker publish workflow path filters.
- Add `src/realtime.py` to the same path filters because it is also copied by `Dockerfile.viewer`.

## Validation

Tested with a fork GHCR build workflow:

- Built the viewer image from this branch.
- Ran smoke test:

```bash
python -c "import src.web.main"
```

- Confirmed the test viewer image can start in deployment.
- Published test image successfully:

```text
ghcr.io/charys117/telegram-archive-viewer:viewer-message-utils-fix
```

Workflow run:

```text
https://github.com/charys117/Telegram-Archive/actions/runs/28196710712
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the viewer container image to include the latest messaging-related updates.
  * Broadened the “Docker Publish Viewer” workflow trigger so it runs when realtime or messaging source files change.
  * Adjusted the “Docker Publish Dev” workflow so the build-and-push job runs only for manual triggers or same-repository pull requests (excluding forks/dependabot).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->