### PR TITLE
feat(forum): show topics during backup + disk-usage storage stat (#200)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [7.17.0] - 2026-06-25
+
+### Added
+- **Forum topics appear immediately** — Topic lists for forum/Topics-mode groups are now fetched up front, at the start of each chat's backup, instead of only at the end of a full run. Large, media-heavy forums no longer show "0 topics" while their media is still downloading; topics show up within seconds and message counts fill in as the backup progresses. ([#200](https://github.com/GeiserX/Telegram-Archive/issues/200))
+- **"Backup in progress" indicator** — The Backup Statistics panel shows a live indicator while a backup run is active, so it's clear when the figures are still being collected rather than final.
+- **"View all messages" for forums without topics** — When a forum group has no topics recorded yet, the viewer now offers a direct link to browse the chat's messages instead of a dead-end "No topics found".
+
+### Changed
+- **Storage statistic reflects actual disk usage** — The "Storage" figure is now measured from on-disk files (`du`-style, counting deduplicated `_shared` blobs once) rather than summing recorded media sizes, so it matches real disk consumption. Sizes are labeled with correct binary units (GiB/MiB/TiB).
+- Forum-topic fetching now paginates beyond 100 topics and retries on FloodWait, so large forums are captured fully.
+
+### Fixed
+- Forum/Topics-mode groups showing "0 topics" in the web viewer during long, media-heavy backups. ([#200](https://github.com/GeiserX/Telegram-Archive/issues/200))
+
+### Credits
+- Thanks to [@1235789gzy1](https://github.com/1235789gzy1) for reporting the forum-topic display and storage-statistic issues in [#200](https://github.com/GeiserX/Telegram-Archive/issues/200).
+
 ## [7.16.0] - 2026-06-25
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.16.0"
+version = "7.17.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.16.0"
+__version__ = "7.17.0"

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1186,9 +1186,13 @@ class DatabaseAdapter:
 
         When ``storage_path`` is given, total media size reflects actual on-disk
         usage (``du`` semantics) via ``compute_directory_size`` so the figure
-        tracks real disk consumption. Otherwise it falls back to the DB snapshot
+        tracks real disk consumption. The filesystem walk is a blocking scan, so
+        it runs off the event loop (``asyncio.to_thread``) and outside the DB
+        session. If the path is missing/unmounted (``du`` is 0 while media rows
+        exist), or no path is given, it falls back to the DB snapshot
         ``SUM(media.file_size WHERE downloaded=1)``.
         """
+        import asyncio
         import json
         from datetime import datetime
 
@@ -1207,14 +1211,11 @@ class DatabaseAdapter:
             media_count = await session.execute(select(func.count(Media.id)).where(Media.downloaded == 1))
             media_count = media_count.scalar() or 0
 
-            # Total media size: actual on-disk usage when a storage path is given,
-            # else the DB snapshot of downloaded media sizes.
-            if storage_path:
-                total_size = compute_directory_size(storage_path)
-            else:
-                total_size = (
-                    await session.execute(select(func.sum(Media.file_size)).where(Media.downloaded == 1))
-                ).scalar() or 0
+            # DB snapshot of downloaded media sizes — the fallback when on-disk
+            # usage is unavailable (e.g. the backup volume is not mounted yet).
+            db_total_size = (
+                await session.execute(select(func.sum(Media.file_size)).where(Media.downloaded == 1))
+            ).scalar() or 0
 
             # Per-chat statistics
             chat_stats_query = select(Message.chat_id, func.count(Message.id).label("message_count")).group_by(
@@ -1223,15 +1224,27 @@ class DatabaseAdapter:
             chat_stats_result = await session.execute(chat_stats_query)
             per_chat_stats = {row.chat_id: row.message_count for row in chat_stats_result}
 
-            stats = {
-                "chats": int(chat_count),
-                "messages": int(msg_count),
-                "media_files": int(media_count),
-                "total_size_mb": float(round(total_size / (1024 * 1024), 2)),
-                "per_chat_message_counts": {int(k): int(v) for k, v in per_chat_stats.items()},
-            }
+        # Total media size: prefer actual on-disk usage. Run the blocking walk off
+        # the event loop and after the session is closed so it never stalls other
+        # requests or pins a DB connection.
+        if storage_path is not None:
+            total_size = await asyncio.to_thread(compute_directory_size, storage_path)
+            if total_size == 0 and media_count > 0:
+                # Path missing/unmounted: don't cache a spurious 0 over the last good value.
+                logger.warning("On-disk storage size is 0 while media exists; using DB snapshot for storage stat")
+                total_size = db_total_size
+        else:
+            total_size = db_total_size
 
-            logger.info(f"Statistics calculated: {chat_count} chats, {msg_count} messages, {media_count} media files")
+        stats = {
+            "chats": int(chat_count),
+            "messages": int(msg_count),
+            "media_files": int(media_count),
+            "total_size_mb": float(round(total_size / (1024 * 1024), 2)),
+            "per_chat_message_counts": {int(k): int(v) for k, v in per_chat_stats.items()},
+        }
+
+        logger.info(f"Statistics calculated: {chat_count} chats, {msg_count} messages, {media_count} media files")
 
         # Store in metadata
         await self.set_metadata("cached_stats", json.dumps(stats))

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -21,7 +21,7 @@ from sqlalchemy import and_, delete, func, or_, select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
-from ..message_utils import utcnow_naive
+from ..message_utils import compute_directory_size, utcnow_naive
 from .base import DatabaseManager
 from .models import (
     AppSettings,
@@ -1181,8 +1181,14 @@ class DatabaseAdapter:
 
         return result
 
-    async def calculate_and_store_statistics(self) -> dict[str, Any]:
-        """Calculate statistics and store in metadata (expensive, run daily)."""
+    async def calculate_and_store_statistics(self, storage_path: str | None = None) -> dict[str, Any]:
+        """Calculate statistics and store in metadata (expensive, run daily).
+
+        When ``storage_path`` is given, total media size reflects actual on-disk
+        usage (``du`` semantics) via ``compute_directory_size`` so the figure
+        tracks real disk consumption. Otherwise it falls back to the DB snapshot
+        ``SUM(media.file_size WHERE downloaded=1)``.
+        """
         import json
         from datetime import datetime
 
@@ -1201,9 +1207,14 @@ class DatabaseAdapter:
             media_count = await session.execute(select(func.count(Media.id)).where(Media.downloaded == 1))
             media_count = media_count.scalar() or 0
 
-            # Total media size
-            total_size = await session.execute(select(func.sum(Media.file_size)).where(Media.downloaded == 1))
-            total_size = total_size.scalar() or 0
+            # Total media size: actual on-disk usage when a storage path is given,
+            # else the DB snapshot of downloaded media sizes.
+            if storage_path:
+                total_size = compute_directory_size(storage_path)
+            else:
+                total_size = (
+                    await session.execute(select(func.sum(Media.file_size)).where(Media.downloaded == 1))
+                ).scalar() or 0
 
             # Per-chat statistics
             chat_stats_query = select(Message.chat_id, func.count(Message.id).label("message_count")).group_by(

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -6,6 +6,7 @@ import hashlib
 import logging
 import os
 import re
+import stat
 from datetime import UTC, datetime
 
 logger = logging.getLogger(__name__)
@@ -14,6 +15,30 @@ logger = logging.getLogger(__name__)
 def utcnow_naive() -> datetime:
     """Return current UTC time without tzinfo, for naive DB datetime columns."""
     return datetime.now(UTC).replace(tzinfo=None)
+
+
+def compute_directory_size(path: str) -> int:
+    """Return total on-disk size (bytes) of regular files under `path`.
+
+    Walks the tree without following symlinks, summing each regular file's
+    lstat size. Symlinks (used by the dedup _shared store) are not followed,
+    so shared blobs are counted exactly once. Missing path or per-entry errors
+    are ignored (best-effort, never raises)."""
+    if not path or not os.path.isdir(path):
+        return 0
+
+    total = 0
+    for root, _dirs, files in os.walk(path, followlinks=False):
+        for name in files:
+            full = os.path.join(root, name)
+            try:
+                st = os.lstat(full)
+            except OSError:
+                continue
+            if stat.S_ISLNK(st.st_mode):
+                continue
+            total += st.st_size
+    return total
 
 
 def sanitize_media_filename(name: str) -> str:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -436,6 +436,11 @@ class TelegramBackup:
             last_backup_time = datetime.utcnow().isoformat() + "Z"
             await self.db.set_metadata("last_backup_time", last_backup_time)
 
+            # Mark a backup as in progress so the viewer can show a "backing up"
+            # indicator and treat partial stats as expected (issue #200). Cleared
+            # in the finally block below, even if the backup raises.
+            await self.db.set_metadata("backup_in_progress", "1")
+
             # Whitelist mode: skip expensive get_dialogs() and fetch only the
             # specified chats directly.  For accounts with many dialogs the full
             # dialog fetch can hang indefinitely (see #95).
@@ -666,7 +671,10 @@ class TelegramBackup:
             else:
                 logger.info("No additional archived dialogs to back up")
 
-            # v6.2.0: Backup forum topics for forum-enabled chats
+            # v6.2.0: Backup forum topics for forum-enabled chats.
+            # Idempotent backstop to the early per-dialog fetch in _backup_dialog
+            # (issue #200): re-runs after messages exist so the message-inference
+            # fallback can fill in any topics the API path missed.
             logger.info("Checking for forum topics...")
             all_backed_up_dialogs = list(filtered_dialogs) + list(archived_to_backup)
             for dialog in all_backed_up_dialogs:
@@ -683,7 +691,7 @@ class TelegramBackup:
 
             # Calculate and cache statistics (also updates metadata for the viewer)
             duration = (datetime.now() - start_time).total_seconds()
-            stats = await self.db.calculate_and_store_statistics()
+            stats = await self.db.calculate_and_store_statistics(storage_path=self.config.backup_path)
 
             # Note: last_backup_time is stored at the START of backup (see beginning of backup_all)
 
@@ -707,6 +715,13 @@ class TelegramBackup:
         except Exception as e:
             logger.error(f"Backup failed: {e}", exc_info=True)
             raise
+        finally:
+            # Always clear the in-progress flag, even on failure, so the viewer
+            # doesn't show a stuck "backing up" indicator after a crash (#200).
+            try:
+                await self.db.set_metadata("backup_in_progress", "0")
+            except Exception as e:
+                logger.warning(f"Failed to clear backup_in_progress flag: {e}")
 
     async def _get_dialogs(self, archived: bool = False) -> list:
         """
@@ -987,6 +1002,14 @@ class TelegramBackup:
         # Save chat information
         chat_data = self._extract_chat_data(entity, is_archived=is_archived)
         await self.db.upsert_chat(chat_data)
+
+        # Fetch forum topics early (cheap, message-independent API call) so the viewer
+        # shows the topic list immediately, before the slow media backfill (issue #200).
+        if getattr(entity, "forum", False):
+            try:
+                await self._backup_forum_topics(chat_id, entity)
+            except Exception as e:
+                logger.warning(f"Early forum-topic fetch failed for chat (will retry at end of run): {e}")
 
         # Clean up existing media if this chat is in the skip list (once per session)
         if (
@@ -2148,49 +2171,98 @@ class TelegramBackup:
                 # offset_date must be a proper date object, not int 0
                 from datetime import datetime as dt
 
-                result = await self.client(
-                    GetForumTopicsRequest(
-                        peer=input_channel, offset_date=dt(1970, 1, 1), offset_id=0, offset_topic=0, limit=100
-                    )
-                )
-
-                # Resolve custom emoji IDs to unicode emojis
-                emoji_map = {}
-                emoji_ids = [t.icon_emoji_id for t in result.topics if getattr(t, "icon_emoji_id", None)]
-                if emoji_ids:
-                    try:
-                        from telethon.tl.functions.messages import GetCustomEmojiDocumentsRequest
-
-                        docs = await self.client(GetCustomEmojiDocumentsRequest(document_id=emoji_ids))
-                        for doc in docs:
-                            for attr in doc.attributes:
-                                if hasattr(attr, "alt") and attr.alt:
-                                    emoji_map[doc.id] = attr.alt
-                                    break
-                        logger.info(f"  → Resolved {len(emoji_map)} topic emojis")
-                    except Exception as e:
-                        logger.warning(f"  → Could not resolve topic emojis: {e}")
-
+                # Paginate through all topics. Each page is wrapped in
+                # call_with_flood_retry so a FloodWait on a large forum doesn't
+                # abort the fetch (issue #200). Telethon invokes a request via
+                # ``self.client(request)``, so pass self.client as the func and
+                # the request object as its sole positional argument.
                 topics_count = 0
-                for topic in result.topics:
-                    emoji_id = getattr(topic, "icon_emoji_id", None)
-                    topic_data = {
-                        "id": topic.id,
-                        "chat_id": chat_id,
-                        "title": topic.title,
-                        "icon_color": getattr(topic, "icon_color", None),
-                        "icon_emoji_id": emoji_id,
-                        "icon_emoji": emoji_map.get(emoji_id) if emoji_id else None,
-                        "is_closed": 1 if getattr(topic, "closed", False) else 0,
-                        "is_pinned": 1 if getattr(topic, "pinned", False) else 0,
-                        "is_hidden": 1 if getattr(topic, "hidden", False) else 0,
-                        "date": getattr(topic, "date", None),
-                    }
-                    if self.config.should_skip_topic(chat_id, topic.id):
-                        logger.debug(f"  → Skipping excluded topic {topic.id}")
-                        continue
-                    await self.db.upsert_forum_topic(topic_data)
-                    topics_count += 1
+                seen_count = 0  # every topic the server returned (pre-skip), for pagination
+                offset_date = dt(1970, 1, 1)
+                offset_id = 0
+                offset_topic = 0
+                total_count = None
+                max_pages = 50  # defensive cap to avoid an unbounded loop
+                for _ in range(max_pages):
+                    result = await call_with_flood_retry(
+                        self.client,
+                        GetForumTopicsRequest(
+                            peer=input_channel,
+                            offset_date=offset_date,
+                            offset_id=offset_id,
+                            offset_topic=offset_topic,
+                            limit=100,
+                        ),
+                    )
+
+                    if total_count is None:
+                        raw_count = getattr(result, "count", 0)
+                        total_count = raw_count if isinstance(raw_count, int) else 0
+
+                    page_topics = result.topics
+                    if not page_topics:
+                        break
+                    seen_count += len(page_topics)
+
+                    # Build a message-id → date map for this page so we can
+                    # advance offset_date from the last topic's top message.
+                    msg_dates = {m.id: m.date for m in getattr(result, "messages", []) if getattr(m, "date", None)}
+
+                    # Resolve custom emoji IDs to unicode emojis for this page
+                    emoji_map = {}
+                    emoji_ids = [t.icon_emoji_id for t in page_topics if getattr(t, "icon_emoji_id", None)]
+                    if emoji_ids:
+                        try:
+                            from telethon.tl.functions.messages import GetCustomEmojiDocumentsRequest
+
+                            docs = await call_with_flood_retry(
+                                self.client, GetCustomEmojiDocumentsRequest(document_id=emoji_ids)
+                            )
+                            for doc in docs:
+                                for attr in doc.attributes:
+                                    if hasattr(attr, "alt") and attr.alt:
+                                        emoji_map[doc.id] = attr.alt
+                                        break
+                            logger.info(f"  → Resolved {len(emoji_map)} topic emojis")
+                        except Exception as e:
+                            logger.warning(f"  → Could not resolve topic emojis: {e}")
+
+                    for topic in page_topics:
+                        # Deleted topics (forumTopicDeleted) only carry an id, no
+                        # title — skip them so we don't store empty placeholders.
+                        topic_title = getattr(topic, "title", None)
+                        if not topic_title:
+                            continue
+                        emoji_id = getattr(topic, "icon_emoji_id", None)
+                        topic_data = {
+                            "id": topic.id,
+                            "chat_id": chat_id,
+                            "title": topic_title,
+                            "icon_color": getattr(topic, "icon_color", None),
+                            "icon_emoji_id": emoji_id,
+                            "icon_emoji": emoji_map.get(emoji_id) if emoji_id else None,
+                            "is_closed": 1 if getattr(topic, "closed", False) else 0,
+                            "is_pinned": 1 if getattr(topic, "pinned", False) else 0,
+                            "is_hidden": 1 if getattr(topic, "hidden", False) else 0,
+                            "date": getattr(topic, "date", None),
+                        }
+                        if self.config.should_skip_topic(chat_id, topic.id):
+                            logger.debug(f"  → Skipping excluded topic {topic.id}")
+                            continue
+                        await self.db.upsert_forum_topic(topic_data)
+                        topics_count += 1
+
+                    # Advance offsets from the LAST topic of this page.
+                    last_topic = page_topics[-1]
+                    offset_topic = last_topic.id
+                    offset_id = getattr(last_topic, "top_message", 0) or 0
+                    offset_date = msg_dates.get(offset_id) or getattr(last_topic, "date", None) or offset_date
+
+                    # Stop once we've seen every topic the server reported.
+                    # seen_count is pre-skip so it matches result.count even when
+                    # some topics are excluded or deleted.
+                    if total_count and seen_count >= total_count:
+                        break
 
                 logger.info(f"  → Backed up {topics_count} forum topics via API")
                 return topics_count
@@ -2369,7 +2441,7 @@ async def run_fill_gaps(config: Config, client: TelegramClient | None = None, ch
         # doesn't show stale totals until the next scheduled recalculation
         if summary["total_recovered"] > 0:
             try:
-                await backup.db.calculate_and_store_statistics()
+                await backup.db.calculate_and_store_statistics(storage_path=config.backup_path)
                 logger.info("Stats recalculated after gap-fill recovery")
             except Exception as e:
                 logger.warning(f"Failed to recalculate stats after gap-fill: {e}")

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -681,9 +681,11 @@ class TelegramBackup:
                 entity = dialog.entity
                 if isinstance(entity, Channel) and getattr(entity, "forum", False):
                     chat_id = self._get_marked_id(entity)
-                    chat_name = self._get_chat_name(entity)
-                    logger.info(f"  → Fetching topics for forum: {chat_name}")
-                    await self._backup_forum_topics(chat_id, entity)
+                    try:
+                        await self._backup_forum_topics(chat_id, entity)
+                    except Exception as e:
+                        # Don't let a topic-fetch failure abort folders/stats below.
+                        logger.warning(f"End-of-run forum-topic fetch failed (will retry next run): {e}")
 
             # v6.2.0: Backup user's chat folders
             logger.info("Backing up chat folders...")
@@ -1005,7 +1007,8 @@ class TelegramBackup:
 
         # Fetch forum topics early (cheap, message-independent API call) so the viewer
         # shows the topic list immediately, before the slow media backfill (issue #200).
-        if getattr(entity, "forum", False):
+        # Same forum-detection guard as the end-of-run backstop loop in backup_all.
+        if isinstance(entity, Channel) and getattr(entity, "forum", False):
             try:
                 await self._backup_forum_topics(chat_id, entity)
             except Exception as e:
@@ -2166,6 +2169,9 @@ class TelegramBackup:
             # Note: In Telethon 1.42+, this is in messages, not channels
             from telethon.tl.functions.messages import GetForumTopicsRequest
 
+            # Defined before the try so a partial result survives a mid-pagination failure.
+            topics_count = 0
+
             try:
                 input_channel = await self.client.get_input_entity(entity)
                 # offset_date must be a proper date object, not int 0
@@ -2176,7 +2182,6 @@ class TelegramBackup:
                 # abort the fetch (issue #200). Telethon invokes a request via
                 # ``self.client(request)``, so pass self.client as the func and
                 # the request object as its sole positional argument.
-                topics_count = 0
                 seen_count = 0  # every topic the server returned (pre-skip), for pagination
                 offset_date = dt(1970, 1, 1)
                 offset_id = 0
@@ -2247,16 +2252,20 @@ class TelegramBackup:
                             "date": getattr(topic, "date", None),
                         }
                         if self.config.should_skip_topic(chat_id, topic.id):
-                            logger.debug(f"  → Skipping excluded topic {topic.id}")
+                            logger.debug("  → Skipping excluded topic")
                             continue
                         await self.db.upsert_forum_topic(topic_data)
                         topics_count += 1
 
-                    # Advance offsets from the LAST topic of this page.
+                    # Advance offsets from the LAST topic of this page. offset_topic is
+                    # the load-bearing cursor (always advances monotonically); anchor the
+                    # message-based offsets on the last topic that actually has a
+                    # top_message, since a trailing forumTopicDeleted carries only an id.
                     last_topic = page_topics[-1]
                     offset_topic = last_topic.id
-                    offset_id = getattr(last_topic, "top_message", 0) or 0
-                    offset_date = msg_dates.get(offset_id) or getattr(last_topic, "date", None) or offset_date
+                    anchor = next((t for t in reversed(page_topics) if getattr(t, "top_message", 0)), last_topic)
+                    offset_id = getattr(anchor, "top_message", 0) or 0
+                    offset_date = msg_dates.get(offset_id) or getattr(anchor, "date", None) or offset_date
 
                     # Stop once we've seen every topic the server reported.
                     # seen_count is pre-skip so it matches result.count even when
@@ -2264,10 +2273,25 @@ class TelegramBackup:
                     if total_count and seen_count >= total_count:
                         break
 
+                if total_count and seen_count < total_count:
+                    logger.warning(
+                        f"  → Forum topic pagination hit the {max_pages}-page cap; "
+                        f"fetched {seen_count} of {total_count} topics"
+                    )
                 logger.info(f"  → Backed up {topics_count} forum topics via API")
                 return topics_count
 
             except Exception as e:
+                # If earlier pages already succeeded, keep them rather than falling
+                # through to per-topic message inference (which issues many more API
+                # calls — bad right after a FloodWait). The end-of-run backstop / next
+                # run continues from here.
+                if topics_count > 0:
+                    logger.warning(
+                        f"GetForumTopicsRequest failed mid-pagination ({e.__class__.__name__}: {e}); "
+                        f"keeping {topics_count} topics fetched so far"
+                    )
+                    return topics_count
                 logger.warning(
                     f"GetForumTopicsRequest failed ({e.__class__.__name__}: {e}), falling back to message inference"
                 )
@@ -2295,7 +2319,7 @@ class TelegramBackup:
             topics_count = 0
             for topic_id in topic_ids:
                 if self.config.should_skip_topic(chat_id, topic_id):
-                    logger.debug(f"  → Skipping excluded topic {topic_id}")
+                    logger.debug("  → Skipping excluded topic")
                     continue
                 # Try to get the topic's first message for metadata
                 try:

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -309,7 +309,7 @@ async def stats_calculation_scheduler():
 
             # Run stats calculation
             logger.info("Running scheduled stats calculation...")
-            await db.calculate_and_store_statistics()
+            await db.calculate_and_store_statistics(storage_path=config.backup_path)
             logger.info("Stats calculation completed")
 
         except asyncio.CancelledError:
@@ -338,7 +338,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     if not stats_calculated_at:
         logger.info("No cached stats found, running initial calculation...")
         try:
-            await db.calculate_and_store_statistics()
+            await db.calculate_and_store_statistics(storage_path=config.backup_path)
         except Exception as e:
             logger.warning(f"Initial stats calculation failed: {e}")
 
@@ -1660,6 +1660,10 @@ async def get_stats(user: UserContext = Depends(require_auth)):
         stats["listener_active"] = bool(listener_active_since)
         stats["listener_active_since"] = listener_active_since if listener_active_since else None
 
+        # Check if a backup is currently in progress (written by backup engine)
+        backup_in_progress = await db.get_metadata("backup_in_progress")
+        stats["backup_in_progress"] = backup_in_progress == "1"
+
         # Notifications config
         stats["push_notifications"] = config.push_notifications  # off, basic, full
         stats["push_enabled"] = push_manager is not None and push_manager.is_enabled
@@ -1679,7 +1683,7 @@ async def get_stats(user: UserContext = Depends(require_auth)):
 async def refresh_stats(user: UserContext = Depends(require_master)):
     """Manually trigger stats recalculation (expensive, use sparingly)."""
     try:
-        stats = await db.calculate_and_store_statistics()
+        stats = await db.calculate_and_store_statistics(storage_path=config.backup_path)
         stats["timezone"] = config.viewer_timezone
         return stats
     except Exception as e:

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -370,8 +370,9 @@
                                         <div class="flex justify-between"><span>📬 Messages:</span><span class="text-white">{{ formatNumber(statsData.messages) }}</span></div>
                                         <div class="flex justify-between"><span>🖼️ Media files:</span><span class="text-white">{{ formatNumber(statsData.media_files) }}</span></div>
                                         <div class="flex justify-between"><span>💾 Storage:</span><span class="text-white">{{ formatSize(statsData.total_size_mb) }}</span></div>
-                                        <div class="pt-2 mt-2 border-t border-gray-700 text-[10px] opacity-70">
-                                            {{ formatStatsTime(statsData.stats_calculated_at) }}
+                                        <div class="pt-2 mt-2 border-t border-gray-700 text-[10px] opacity-70 flex items-center justify-between gap-2">
+                                            <span>{{ formatStatsTime(statsData.stats_calculated_at) }}</span>
+                                            <span v-if="statsData && statsData.backup_in_progress" class="text-blue-400 opacity-100 shrink-0">● Backup in progress…</span>
                                         </div>
                                         <!-- Footer -->
                                         <div class="pt-3 mt-3 border-t border-gray-700 text-center">
@@ -522,8 +523,16 @@
                         </div>
 
                         <!-- Topic list -->
-                        <div v-else-if="topics.length === 0" class="flex flex-col items-center justify-center py-12 text-tg-muted">
-                            <span class="text-sm">No topics found</span>
+                        <div v-else-if="topics.length === 0" class="flex flex-col items-center justify-center py-12 px-4 text-tg-muted text-center gap-3">
+                            <span class="text-sm">No topics backed up yet</span>
+                            <span class="text-xs">
+                                <template v-if="statsData && statsData.backup_in_progress">A backup is currently running — topics appear once it finishes.</template>
+                                <template v-else>If this group uses Topics, they’ll appear after the next full backup completes.</template>
+                            </span>
+                            <button @click="selectTopic(topicsNavEntry.chat || { id: topicsNavEntry.chatId, is_forum: true }, { id: null, title: 'All messages' })"
+                                class="mt-1 px-3 py-1.5 text-xs rounded-full bg-tg-active hover:bg-blue-600 text-white transition">
+                                View all messages
+                            </button>
                         </div>
                         <div v-else v-for="topic in topics" :key="topic.id"
                             @click="selectTopic(topicsNavEntry.chat || { id: topicsNavEntry.chatId, is_forum: true }, topic)"
@@ -1952,7 +1961,8 @@
                     messages: 0,
                     media_files: 0,
                     total_size_mb: 0,
-                    stats_calculated_at: null
+                    stats_calculated_at: null,
+                    backup_in_progress: false
                 })
                 const statsPopupOpen = ref(false)
                 const showStatsUI = ref(true)  // Can be disabled via SHOW_STATS=false
@@ -1972,7 +1982,8 @@
                                 messages: stats.messages || 0,
                                 media_files: stats.media_files || 0,
                                 total_size_mb: stats.total_size_mb || 0,
-                                stats_calculated_at: stats.stats_calculated_at
+                                stats_calculated_at: stats.stats_calculated_at,
+                                backup_in_progress: stats.backup_in_progress || false
                             }
 
                             // Show/hide stats UI based on config
@@ -2032,14 +2043,14 @@
 
                 // Format size in MB to appropriate unit (MB, GB, TB)
                 const formatSize = (sizeMB) => {
-                    if (!sizeMB || sizeMB === 0) return '0 MB'
+                    if (!sizeMB || sizeMB === 0) return '0 MiB'
                     if (sizeMB >= 1024 * 1024) {
-                        return (sizeMB / (1024 * 1024)).toFixed(2) + ' TB'
+                        return (sizeMB / (1024 * 1024)).toFixed(2) + ' TiB'
                     }
                     if (sizeMB >= 1024) {
-                        return (sizeMB / 1024).toFixed(1) + ' GB'
+                        return (sizeMB / 1024).toFixed(1) + ' GiB'
                     }
-                    return sizeMB.toFixed(0) + ' MB'
+                    return sizeMB.toFixed(0) + ' MiB'
                 }
 
                 // Mark initialization complete (called after WS connects and notifications init)

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -529,7 +529,7 @@
                                 <template v-if="statsData && statsData.backup_in_progress">A backup is currently running — topics appear once it finishes.</template>
                                 <template v-else>If this group uses Topics, they’ll appear after the next full backup completes.</template>
                             </span>
-                            <button @click="selectTopic(topicsNavEntry.chat || { id: topicsNavEntry.chatId, is_forum: true }, { id: null, title: 'All messages' })"
+                            <button @click="selectTopic(topicsNavEntry.chat || { id: topicsNavEntry.chatId, is_forum: true }, { id: 'all', title: 'All messages' })"
                                 class="mt-1 px-3 py-1.5 text-xs rounded-full bg-tg-active hover:bg-blue-600 text-white transition">
                                 View all messages
                             </button>
@@ -2784,8 +2784,8 @@
                 const formatFileSize = (bytes) => {
                     if (!bytes) return ''
                     if (bytes < 1024) return bytes + ' B'
-                    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB'
-                    return (bytes / (1024 * 1024)).toFixed(1) + ' MB'
+                    if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KiB'
+                    return (bytes / (1024 * 1024)).toFixed(1) + ' MiB'
                 }
 
                 const loadMessagesAroundId = async (messageId) => {
@@ -3044,7 +3044,8 @@
                         // v6.2.12: Include topic_id filter when viewing a forum topic
                         let refreshUrl = `/api/chats/${selectedChat.value.id}/messages?limit=50&offset=0`
                         const nav = currentNav.value
-                        if (nav.type === 'chat' && nav.topicId) {
+                        // 'all' is the synthetic "view all messages" entry — no topic filter.
+                        if (nav.type === 'chat' && nav.topicId && nav.topicId !== 'all') {
                             refreshUrl += `&topic_id=${nav.topicId}`
                         }
                         const res = await fetch(refreshUrl, {
@@ -3127,7 +3128,7 @@
 
                         // v6.2.0: Add topic_id filter if viewing a topic
                         const nav = currentNav.value
-                        if (nav.type === 'chat' && nav.topicId) {
+                        if (nav.type === 'chat' && nav.topicId && nav.topicId !== 'all') {
                             url += `&topic_id=${nav.topicId}`
                         }
 
@@ -3156,7 +3157,7 @@
                             url = `/api/chats/${selectedChat.value.id}/messages?limit=${limit}&offset=${offset}`
                             url += `&search=${encodeURIComponent(messageSearchQuery.value)}`
                             // Also pass topic_id for search within a topic
-                            if (nav.type === 'chat' && nav.topicId) {
+                            if (nav.type === 'chat' && nav.topicId && nav.topicId !== 'all') {
                                 url += `&topic_id=${nav.topicId}`
                             }
                         }

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -3284,3 +3284,109 @@ class TestIterMediaPathsForRepair:
             assert batches == []
         finally:
             await db_manager.close()
+
+
+# ============================================================
+# compute_directory_size (du-based on-disk usage)
+# ============================================================
+
+
+class TestComputeDirectorySize:
+    """Test the compute_directory_size helper used for du-based storage stats."""
+
+    def test_sums_regular_files_and_ignores_symlinks(self, tmp_path):
+        """Total equals the two real files; a symlink to one is not double-counted."""
+        from src.message_utils import compute_directory_size
+
+        nested = tmp_path / "a" / "b"
+        nested.mkdir(parents=True)
+
+        big = nested / "big.bin"
+        big.write_bytes(b"x" * 1000)
+        small = tmp_path / "small.bin"
+        small.write_bytes(b"y" * 24)
+
+        # A symlink in another subdir pointing at an already-counted file.
+        link_dir = tmp_path / "links"
+        link_dir.mkdir()
+        os.symlink(big, link_dir / "big_link.bin")
+
+        assert compute_directory_size(str(tmp_path)) == 1024
+
+    def test_missing_path_returns_zero(self, tmp_path):
+        """A path that does not exist returns 0."""
+        from src.message_utils import compute_directory_size
+
+        assert compute_directory_size(str(tmp_path / "does_not_exist")) == 0
+
+    def test_empty_and_falsy_path_returns_zero(self, tmp_path):
+        """An empty directory and a falsy path both return 0."""
+        from src.message_utils import compute_directory_size
+
+        assert compute_directory_size(str(tmp_path)) == 0
+        assert compute_directory_size("") == 0
+
+
+# ============================================================
+# calculate_and_store_statistics — du-based storage
+# ============================================================
+
+
+class TestCalculateAndStoreStatisticsStorage:
+    """calculate_and_store_statistics reports on-disk size when given a storage path."""
+
+    @pytest.mark.asyncio
+    async def test_storage_path_uses_disk_size_not_db_file_size(self, tmp_path):
+        """With storage_path, total_size_mb reflects real disk usage, not the DB file_size."""
+        from src.db.base import DatabaseManager
+
+        db_manager = DatabaseManager(f"sqlite:///{tmp_path / 'stats_du.db'}")
+        await db_manager.init()
+        adapter = DatabaseAdapter(db_manager)
+        try:
+            # DB row claims a huge file_size, but disk holds only a tiny file.
+            await adapter.insert_media(
+                {
+                    "id": "media_bogus",
+                    "type": "photo",
+                    "file_size": 5 * 1024 * 1024 * 1024,  # 5 GiB (bogus, DB-only)
+                    "downloaded": True,
+                }
+            )
+
+            storage_dir = tmp_path / "storage"
+            (storage_dir / "chat").mkdir(parents=True)
+            (storage_dir / "chat" / "real.bin").write_bytes(b"z" * (2 * 1024 * 1024))  # 2 MiB on disk
+
+            stats = await adapter.calculate_and_store_statistics(storage_path=str(storage_dir))
+
+            # du-based: 2 MiB, NOT the 5 GiB DB file_size.
+            assert stats["total_size_mb"] == 2.0
+            cached = json.loads(await adapter.get_metadata("cached_stats"))
+            assert cached["total_size_mb"] == 2.0
+        finally:
+            await db_manager.close()
+
+    @pytest.mark.asyncio
+    async def test_without_storage_path_falls_back_to_db_sum(self, tmp_path):
+        """Without storage_path, total_size_mb is derived from the DB SUM(file_size)."""
+        from src.db.base import DatabaseManager
+
+        db_manager = DatabaseManager(f"sqlite:///{tmp_path / 'stats_sum.db'}")
+        await db_manager.init()
+        adapter = DatabaseAdapter(db_manager)
+        try:
+            await adapter.insert_media(
+                {
+                    "id": "media_db",
+                    "type": "photo",
+                    "file_size": 3 * 1024 * 1024,  # 3 MiB
+                    "downloaded": True,
+                }
+            )
+
+            stats = await adapter.calculate_and_store_statistics()
+
+            assert stats["total_size_mb"] == 3.0
+        finally:
+            await db_manager.close()

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -3390,3 +3390,29 @@ class TestCalculateAndStoreStatisticsStorage:
             assert stats["total_size_mb"] == 3.0
         finally:
             await db_manager.close()
+
+    @pytest.mark.asyncio
+    async def test_missing_storage_path_falls_back_to_db_sum_not_zero(self, tmp_path):
+        """An unmounted/missing storage path (du==0) with media present falls back to the DB SUM, not a spurious 0."""
+        from src.db.base import DatabaseManager
+
+        db_manager = DatabaseManager(f"sqlite:///{tmp_path / 'stats_unmounted.db'}")
+        await db_manager.init()
+        adapter = DatabaseAdapter(db_manager)
+        try:
+            await adapter.insert_media(
+                {
+                    "id": "media_x",
+                    "type": "photo",
+                    "file_size": 4 * 1024 * 1024,  # 4 MiB recorded in DB
+                    "downloaded": True,
+                }
+            )
+            missing = tmp_path / "does_not_exist"  # never created → compute_directory_size returns 0
+
+            stats = await adapter.calculate_and_store_statistics(storage_path=str(missing))
+
+            # du is 0 but media exists → use the DB snapshot (4 MiB), not a spurious 0.
+            assert stats["total_size_mb"] == 4.0
+        finally:
+            await db_manager.close()

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -1644,6 +1644,8 @@ class TestBackupForumTopics(unittest.TestCase):
 
         result_obj = MagicMock()
         result_obj.topics = topics
+        result_obj.count = 2  # total topics -> pagination stops after this page
+        result_obj.messages = []
 
         # client(...) is an async callable -- AsyncMock handles this directly
         self.backup.client = AsyncMock()
@@ -1662,6 +1664,8 @@ class TestBackupForumTopics(unittest.TestCase):
 
         result_obj = MagicMock()
         result_obj.topics = topics
+        result_obj.count = 2  # total topics -> pagination stops after this page
+        result_obj.messages = []
 
         self.backup.client = AsyncMock()
         self.backup.client.get_input_entity = AsyncMock(return_value=MagicMock())
@@ -1679,6 +1683,8 @@ class TestBackupForumTopics(unittest.TestCase):
         topic = self._make_topic(7, "Important", closed=True, pinned=True, hidden=False)
         result_obj = MagicMock()
         result_obj.topics = [topic]
+        result_obj.count = 1  # total topics -> pagination stops after this page
+        result_obj.messages = []
 
         self.backup.client = AsyncMock()
         self.backup.client.get_input_entity = AsyncMock(return_value=MagicMock())

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -2495,6 +2495,7 @@ class TestBackupDialogEarlyForumFetch(unittest.TestCase):
     def _make_dialog(self, forum):
         d = MagicMock()
         d.entity = MagicMock()
+        d.entity.__class__ = Channel  # real forum entities are Channels; satisfies isinstance(entity, Channel)
         d.entity.forum = forum
         return d
 
@@ -2611,6 +2612,118 @@ class TestBackupForumTopicsPagination(unittest.TestCase):
         self.assertEqual(count, 2)
         self.assertEqual(backup.db.upsert_forum_topic.await_count, 2)
         self.assertEqual(len(calls), 2)  # page1 then the empty page that stops the loop
+
+    def test_offset_date_advances_from_top_message_date(self):
+        """The next page's offset_date comes from the last topic's top_message date (via messages map)."""
+        backup = _make_backup()
+        backup.client = AsyncMock()
+        backup.client.get_input_entity = AsyncMock(return_value=MagicMock())
+
+        msg_date = datetime(2024, 6, 15, 12, 0)
+        msg = MagicMock()
+        msg.id = 1000  # == _make_topic(100).top_message
+        msg.date = msg_date
+
+        page1 = MagicMock()
+        page1.count = 150
+        page1.topics = [self._make_topic(i) for i in range(1, 101)]  # last is id=100, top_message=1000
+        page1.messages = [msg]
+
+        page2 = MagicMock()
+        page2.count = 150
+        page2.topics = [self._make_topic(i) for i in range(101, 151)]
+        page2.messages = []
+
+        calls = []
+
+        async def fake_call(req):
+            calls.append(req)
+            return page1 if len(calls) == 1 else page2
+
+        backup.client.side_effect = fake_call
+        _run(backup._backup_forum_topics(-100123, MagicMock()))
+
+        self.assertEqual(calls[1].offset_id, 1000)
+        self.assertEqual(calls[1].offset_date, msg_date)  # from the message, not the topic's own date
+
+    def test_terminates_when_all_seen_with_skipped_topics(self):
+        """seen_count is pre-skip, so it meets result.count even when topics are excluded — no extra page."""
+        backup = _make_backup()
+        backup.client = AsyncMock()
+        backup.client.get_input_entity = AsyncMock(return_value=MagicMock())
+        backup.config.should_skip_topic = MagicMock(side_effect=lambda chat_id, tid: tid == 2)
+
+        page1 = MagicMock()
+        page1.count = 3
+        page1.topics = [self._make_topic(1), self._make_topic(2), self._make_topic(3)]
+        page1.messages = []
+
+        calls = []
+
+        async def fake_call(req):
+            calls.append(req)
+            return page1  # a second fetch would loop on the same page — it must not happen
+
+        backup.client.side_effect = fake_call
+        count = _run(backup._backup_forum_topics(-100123, MagicMock()))
+
+        self.assertEqual(len(calls), 1)  # all 3 seen on page 1 → terminate, despite 1 skipped
+        self.assertEqual(count, 2)  # topic id 2 excluded
+        self.assertEqual(backup.db.upsert_forum_topic.await_count, 2)
+
+    def test_count_none_terminates_via_empty_page(self):
+        """A missing/None result.count is coerced safely; the empty-page break still stops the loop."""
+        backup = _make_backup()
+        backup.client = AsyncMock()
+        backup.client.get_input_entity = AsyncMock(return_value=MagicMock())
+
+        page1 = MagicMock()
+        page1.count = None
+        page1.topics = [self._make_topic(1), self._make_topic(2)]
+        page1.messages = []
+
+        empty = MagicMock()
+        empty.count = None
+        empty.topics = []
+        empty.messages = []
+
+        calls = []
+
+        async def fake_call(req):
+            calls.append(req)
+            return page1 if len(calls) == 1 else empty
+
+        backup.client.side_effect = fake_call
+        count = _run(backup._backup_forum_topics(-100123, MagicMock()))
+
+        self.assertEqual(count, 2)
+        self.assertEqual(len(calls), 2)
+
+    def test_partial_result_kept_on_midpagination_failure(self):
+        """If a later page raises after earlier pages stored topics, keep the partial result (no inference)."""
+        backup = _make_backup()
+        backup.client = AsyncMock()
+        backup.client.get_input_entity = AsyncMock(return_value=MagicMock())
+
+        page1 = MagicMock()
+        page1.count = 150
+        page1.topics = [self._make_topic(1), self._make_topic(2)]
+        page1.messages = []
+
+        calls = []
+
+        async def fake_call(req):
+            calls.append(req)
+            if len(calls) == 1:
+                return page1
+            raise RuntimeError("network blip mid-pagination")
+
+        backup.client.side_effect = fake_call
+        count = _run(backup._backup_forum_topics(-100123, MagicMock()))
+
+        self.assertEqual(count, 2)  # page-1 topics kept
+        self.assertEqual(backup.db.upsert_forum_topic.await_count, 2)
+        backup.client.get_messages.assert_not_called()  # inference fallback never ran
 
 
 class TestBackupForumTopicsDeletedGuard(unittest.TestCase):

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -2457,5 +2457,238 @@ class TestMainEntryPointLine1882(unittest.TestCase):
         mock_run.assert_called_once()
 
 
+# ===========================================================================
+# Issue #200: early forum-topic fetch, topic pagination, deleted-topic guard,
+# and the backup_in_progress flag.
+# ===========================================================================
+
+
+class TestBackupDialogEarlyForumFetch(unittest.TestCase):
+    """_backup_dialog should fetch forum topics up front, before the message loop."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.backup = _make_backup()
+        self.backup.config.batch_size = 100
+        self.backup.config.checkpoint_interval = 1
+        self.backup.config.skip_media_chat_ids = set()
+        self.backup.config.skip_media_delete_existing = False
+        self.backup.config.sync_deletions_edits = False
+        self.backup.config.media_path = os.path.join(self.temp_dir, "media")
+        self.backup.db.get_last_message_id = AsyncMock(return_value=0)
+        self.backup._get_marked_id = MagicMock(return_value=-100123)
+        self.backup._extract_chat_data = MagicMock(return_value={"id": -100123})
+        self.backup._ensure_profile_photo = AsyncMock()
+        self.backup._sync_pinned_messages = AsyncMock()
+        self.backup._backup_forum_topics = AsyncMock(return_value=3)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _empty_iter(self):
+        async def fake_iter(*args, **kwargs):
+            return
+            yield  # noqa: RET503
+
+        return fake_iter
+
+    def _make_dialog(self, forum):
+        d = MagicMock()
+        d.entity = MagicMock()
+        d.entity.forum = forum
+        return d
+
+    def test_forum_dialog_fetches_topics_before_message_loop(self):
+        """A forum entity triggers the early _backup_forum_topics call even with 0 messages."""
+        self.backup.client.iter_messages = self._empty_iter()
+        dialog = self._make_dialog(forum=True)
+
+        result = _run(self.backup._backup_dialog(dialog))
+
+        # 0 new messages, but the early forum-topic fetch must still have happened,
+        # called with the marked chat_id and the dialog's entity.
+        self.assertEqual(result, 0)
+        self.backup._backup_forum_topics.assert_awaited_once_with(-100123, dialog.entity)
+
+    def test_non_forum_dialog_does_not_fetch_topics(self):
+        """A non-forum entity must not trigger the early forum-topic fetch."""
+        self.backup.client.iter_messages = self._empty_iter()
+
+        _run(self.backup._backup_dialog(self._make_dialog(forum=False)))
+
+        self.backup._backup_forum_topics.assert_not_awaited()
+
+    def test_early_forum_fetch_failure_does_not_abort_dialog(self):
+        """An exception in the early forum fetch is swallowed so the dialog still completes."""
+        self.backup._backup_forum_topics = AsyncMock(side_effect=Exception("topic fetch boom"))
+        self.backup.client.iter_messages = self._empty_iter()
+
+        result = _run(self.backup._backup_dialog(self._make_dialog(forum=True)))
+
+        self.assertEqual(result, 0)
+        self.backup._backup_forum_topics.assert_awaited_once()
+
+
+class TestBackupForumTopicsPagination(unittest.TestCase):
+    """_backup_forum_topics paginates through every page until result.count is met."""
+
+    def _make_topic(self, topic_id):
+        topic = MagicMock()
+        topic.id = topic_id
+        topic.title = f"Topic {topic_id}"
+        topic.icon_color = 0
+        topic.icon_emoji_id = None
+        topic.closed = False
+        topic.pinned = False
+        topic.hidden = False
+        topic.top_message = topic_id * 10
+        topic.date = datetime(2024, 1, 1)
+        return topic
+
+    def test_paginates_across_two_pages(self):
+        """count=150 split as 100+50 fetches both pages and stores all 150 topics."""
+        backup = _make_backup()
+        backup.client = AsyncMock()
+        backup.client.get_input_entity = AsyncMock(return_value=MagicMock())
+
+        page1 = MagicMock()
+        page1.count = 150
+        page1.topics = [self._make_topic(i) for i in range(1, 101)]
+        page1.messages = []
+
+        page2 = MagicMock()
+        page2.count = 150
+        page2.topics = [self._make_topic(i) for i in range(101, 151)]
+        page2.messages = []
+
+        calls = []
+
+        async def fake_call(req):
+            calls.append(req)
+            return page1 if len(calls) == 1 else page2
+
+        backup.client.side_effect = fake_call
+
+        entity = MagicMock()
+        count = _run(backup._backup_forum_topics(-100123, entity))
+
+        self.assertEqual(count, 150)
+        self.assertEqual(backup.db.upsert_forum_topic.await_count, 150)
+        # Exactly two GetForumTopicsRequest pages were fetched (no emoji calls).
+        self.assertEqual(len(calls), 2)
+        # Offsets must have advanced: the second request differs from the first.
+        self.assertEqual(calls[0].offset_topic, 0)
+        self.assertEqual(calls[1].offset_topic, 100)  # last topic id of page 1
+        self.assertEqual(calls[1].offset_id, 1000)  # page-1 last topic.top_message
+
+    def test_stops_when_page_returns_no_topics(self):
+        """A page with zero topics terminates pagination even if count is larger."""
+        backup = _make_backup()
+        backup.client = AsyncMock()
+        backup.client.get_input_entity = AsyncMock(return_value=MagicMock())
+
+        page1 = MagicMock()
+        page1.count = 999  # claims more than will ever be returned
+        page1.topics = [self._make_topic(1), self._make_topic(2)]
+        page1.messages = []
+
+        empty = MagicMock()
+        empty.count = 999
+        empty.topics = []
+        empty.messages = []
+
+        calls = []
+
+        async def fake_call(req):
+            calls.append(req)
+            return page1 if len(calls) == 1 else empty
+
+        backup.client.side_effect = fake_call
+
+        entity = MagicMock()
+        count = _run(backup._backup_forum_topics(-100123, entity))
+
+        self.assertEqual(count, 2)
+        self.assertEqual(backup.db.upsert_forum_topic.await_count, 2)
+        self.assertEqual(len(calls), 2)  # page1 then the empty page that stops the loop
+
+
+class TestBackupForumTopicsDeletedGuard(unittest.TestCase):
+    """_backup_forum_topics skips forumTopicDeleted objects that lack a title."""
+
+    def test_deleted_topic_without_title_is_skipped(self):
+        backup = _make_backup()
+        backup.client = AsyncMock()
+        backup.client.get_input_entity = AsyncMock(return_value=MagicMock())
+
+        good = MagicMock()
+        good.id = 1
+        good.title = "General"
+        good.icon_color = 0
+        good.icon_emoji_id = None
+        good.closed = False
+        good.pinned = False
+        good.hidden = False
+        good.top_message = 10
+        good.date = datetime(2024, 1, 1)
+
+        # forumTopicDeleted only carries an id -- no title attribute at all.
+        deleted = MagicMock(spec=["id", "top_message"])
+        deleted.id = 2
+        deleted.top_message = 20
+
+        result_obj = MagicMock()
+        result_obj.count = 2
+        result_obj.topics = [good, deleted]
+        result_obj.messages = []
+        backup.client.return_value = result_obj
+
+        entity = MagicMock()
+        count = _run(backup._backup_forum_topics(-100123, entity))
+
+        # Only the titled topic is stored; the deleted one is skipped.
+        self.assertEqual(count, 1)
+        self.assertEqual(backup.db.upsert_forum_topic.await_count, 1)
+        stored = backup.db.upsert_forum_topic.call_args[0][0]
+        self.assertEqual(stored["id"], 1)
+        self.assertEqual(stored["title"], "General")
+
+
+class TestBackupAllInProgressFlag(unittest.TestCase):
+    """backup_all sets backup_in_progress=1 then clears it to 0, even on failure."""
+
+    def _make_backup_for_flag(self):
+        backup = _make_backup()
+        backup.config.phone = "+10000000000"
+        backup.config.whitelist_mode = False
+        backup.config.backup_path = "/data/backups"
+        backup.config.verify_media = False
+        backup.db.set_metadata = AsyncMock()
+        backup.db.backfill_is_outgoing = AsyncMock()
+        backup.client.start = AsyncMock()
+        me = MagicMock()
+        me.id = 12345
+        me.first_name = "Tester"
+        backup.client.get_me = AsyncMock(return_value=me)
+        return backup
+
+    def test_flag_set_and_cleared_on_failure(self):
+        """If a step after the flag is set raises, the finally still clears it to 0."""
+        backup = self._make_backup_for_flag()
+        # Force a failure right after the in-progress flag is set.
+        backup._get_dialogs = AsyncMock(side_effect=RuntimeError("dialog fetch failed"))
+
+        with self.assertRaises(RuntimeError):
+            _run(backup.backup_all())
+
+        calls = [c.args for c in backup.db.set_metadata.call_args_list]
+        self.assertIn(("backup_in_progress", "1"), calls)
+        self.assertIn(("backup_in_progress", "0"), calls)
+        # The clear must come after the set.
+        set_idx = calls.index(("backup_in_progress", "1"))
+        clear_idx = calls.index(("backup_in_progress", "0"))
+        self.assertLess(set_idx, clear_idx)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -481,6 +481,41 @@ class TestStatsEndpoint(_WebTestBase):
         self.assertEqual(data["messages"], 100)
         self.assertNotIn("media_files", data)
 
+    async def test_backup_in_progress_true_when_metadata_is_one(self):
+        """get_stats sets backup_in_progress=True when metadata key is '1'."""
+        self.mock_db.get_cached_statistics = AsyncMock(return_value={})
+        # get_metadata is called multiple times; route key order is:
+        # listener_active_since first, then backup_in_progress
+        self.mock_db.get_metadata = AsyncMock(side_effect=lambda key: "1" if key == "backup_in_progress" else None)
+        async with self._client() as client:
+            resp = await client.get("/api/stats")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("backup_in_progress", data)
+        self.assertTrue(data["backup_in_progress"])
+
+    async def test_backup_in_progress_false_when_metadata_is_zero(self):
+        """get_stats sets backup_in_progress=False when metadata key is '0'."""
+        self.mock_db.get_cached_statistics = AsyncMock(return_value={})
+        self.mock_db.get_metadata = AsyncMock(side_effect=lambda key: "0" if key == "backup_in_progress" else None)
+        async with self._client() as client:
+            resp = await client.get("/api/stats")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("backup_in_progress", data)
+        self.assertFalse(data["backup_in_progress"])
+
+    async def test_backup_in_progress_false_when_metadata_is_none(self):
+        """get_stats sets backup_in_progress=False when metadata key is absent (None)."""
+        self.mock_db.get_cached_statistics = AsyncMock(return_value={})
+        self.mock_db.get_metadata = AsyncMock(return_value=None)
+        async with self._client() as client:
+            resp = await client.get("/api/stats")
+        self.assertEqual(resp.status_code, 200)
+        data = resp.json()
+        self.assertIn("backup_in_progress", data)
+        self.assertFalse(data["backup_in_progress"])
+
 
 # ============================================================================
 # Stats refresh API


### PR DESCRIPTION
## Summary

Fixes #200 — two problems with one root cause: forum/Topics-mode groups showed **"0 topics"** in the viewer during long media-heavy backups, and the **Storage** statistic lagged actual disk usage.

Root cause: `backup_all()` recorded forum topics **and** recomputed stats only at the very end of a full pass, after all messages + media. A ~190 GiB media backlog meant that end-step never ran, so the topic table stayed empty and the cached stats stayed stale.

## Changes

- **Topics up front:** `_backup_dialog` now fetches a forum's topics right after `upsert_chat` (before the media backfill), so the topic list appears within seconds and message counts fill in as the backup progresses. The end-of-run pass is kept as an idempotent backstop.
- **Pagination + FloodWait:** `GetForumTopicsRequest` now paginates beyond 100 topics (via `count`/offsets) and each page is wrapped in `call_with_flood_retry`; deleted (title-less) topics are skipped.
- **Disk-usage storage:** the "Storage" stat is computed from on-disk usage (`compute_directory_size`, du-style, counting the dedup `_shared` store once) instead of `SUM(file_size)`; `calculate_and_store_statistics(storage_path=…)` with a fallback to the old SUM when no path is given. Sizes are labeled in binary units (GiB/MiB/TiB).
- **Backup-in-progress indicator:** a `backup_in_progress` metadata flag (set at the start of `backup_all`, cleared in a `finally`) is exposed via `/api/stats` and shown live in the viewer's Backup Statistics panel.
- **Graceful empty-topics UI:** when a forum has no topics recorded yet, the viewer shows a context-aware hint and a "View all messages" button instead of a dead-end "No topics found".

## Tests

+15 tests covering: early forum fetch, topic pagination (>100), deleted-topic guard, the in-progress flag (cleared in `finally` even on exception), du sizing vs the DB-SUM fallback, and the new `/api/stats` field. Full suite: **1892 passing**; `ruff check .` and `ruff format --check .` clean.

## Notes

- `GetForumTopicsRequest` is correctly imported from `telethon.tl.functions.messages` for the pinned Telethon (1.43.2) — verified that `functions.channels` does not exist there.
- Deferred to a follow-up: parallelizing the media download path so large archives finish faster.

Closes #200


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a live backup status indicator in the web interface.
  * Added a “view all messages” option for forums with no detected topics.
  * Forum topics are now fetched more reliably during backups, including larger topic lists.

* **Bug Fixes**
  * Fixed the “0 topics” display issue in the web viewer during long backups.
  * Improved storage statistics to better match actual disk usage and use correct binary units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->