### PR TITLE
fix(media): refresh message on location unavailable

### DIFF
--- a/src/media_errors.py
+++ b/src/media_errors.py
@@ -1,0 +1,42 @@
+"""Classification of refreshable Telegram media-download errors.
+
+Telegram's ``upload.GetFile`` can report a media file's storage location as
+temporarily unavailable or invalid. These are transient/per-file conditions:
+the documented response (mirrored by the official Telegram Desktop client) is to
+re-fetch the message for a fresh reference/location and retry, then leave the
+item for a later attempt rather than failing hard.
+
+Two shapes reach us through Telethon:
+
+* ``LOCATION_NOT_AVAILABLE`` has no generated Telethon exception class, so
+  ``rpc_message_to_error`` falls back by numeric code (400 -> ``BadRequestError``)
+  and preserves the raw server string in ``exc.message`` — match it by text.
+* ``LOCATION_INVALID`` *does* have a generated class (``LocationInvalidError``)
+  whose ``.message`` is the generic ``"BAD_REQUEST"`` — match it by type.
+
+This lives in its own module (not ``message_utils``, which is stdlib-only and is
+shipped inside the standalone viewer image) so the Telethon import never reaches
+the viewer.
+"""
+
+from __future__ import annotations
+
+from telethon.errors import LocationInvalidError, RPCError
+
+# Server message codes (already upper-case) handled by re-fetch + backoff retry.
+MEDIA_LOCATION_ERROR_MESSAGES = frozenset({"LOCATION_NOT_AVAILABLE", "LOCATION_INVALID"})
+
+
+def is_media_location_error(exc: BaseException) -> bool:
+    """Return ``True`` for a refreshable Telegram media-location error.
+
+    Matches precisely (no loose substring): by exact ``exc.message`` for codes
+    Telethon surfaces as a generic ``BadRequestError`` (e.g. ``LOCATION_NOT_AVAILABLE``)
+    and by exception type for codes with a generated class (``LocationInvalidError``).
+    """
+    if not isinstance(exc, RPCError):
+        return False
+    if isinstance(exc, LocationInvalidError):
+        return True
+    message = getattr(exc, "message", None)
+    return isinstance(message, str) and message.upper() in MEDIA_LOCATION_ERROR_MESSAGES

--- a/src/parallel_download.py
+++ b/src/parallel_download.py
@@ -246,6 +246,11 @@ class ParallelDownloader:
                 # The file actually lives on another DC; native download_media
                 # handles migration, so bail out to single-stream for this file.
                 raise ParallelDownloadUnavailable(f"file migrated to DC {exc.new_dc}") from exc
+            # Any other RPCError (incl. LOCATION_NOT_AVAILABLE / LOCATION_INVALID
+            # from upload.GetFile) intentionally propagates unchanged so the
+            # caller's refresh + retry loop can handle it. Do NOT add a broad
+            # `except Exception -> ParallelDownloadUnavailable` here: it would
+            # mask those as a stale single-stream fallback (see is_media_location_error).
             data = result.bytes
             if not data:
                 # Empty response before EOF would leave a gap; coverage check

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -101,6 +101,17 @@ def _media_retry_backoff_seconds(attempt: int) -> float:
     return base + random.uniform(0.5, 1.5)
 
 
+def _is_non_retryable_media_op(exc: BaseException) -> bool:
+    """Errors the media-download loop handles itself, so ``call_with_flood_retry``
+    must re-raise them rather than retry: location errors (the outer loop refreshes
+    and backs off) and a per-operation ``TimeoutError`` (the outer loop decides).
+
+    Keeping these out of ``call_with_flood_retry`` also means the per-operation
+    timeout never wraps — and so never cancels — its FloodWait sleeps.
+    """
+    return is_media_location_error(exc) or isinstance(exc, TimeoutError)
+
+
 def _pre_generate_thumbnail(source_path: str, media_root: str) -> None:
     """Pre-generate 200px WebP thumbnail for gallery grid view."""
     try:
@@ -1745,10 +1756,19 @@ class TelegramBackup:
         blows up the surrounding retry loop. Handles a deleted/unavailable
         message (``[]`` or ``[None]``) by returning ``None``.
         """
-        try:
-            fresh_messages = await asyncio.wait_for(
-                call_with_flood_retry(self.client.get_messages, chat_id, ids=[message.id]),
+
+        async def _get_messages_once():
+            # Time only the single Telegram call, so call_with_flood_retry still
+            # owns (and is never cancelled mid-) any FloodWait sleep.
+            return await asyncio.wait_for(
+                self.client.get_messages(chat_id, ids=[message.id]),
                 timeout=MEDIA_REFRESH_TIMEOUT_SECONDS,
+            )
+
+        try:
+            fresh_messages = await call_with_flood_retry(
+                _get_messages_once,
+                non_retryable=lambda exc: isinstance(exc, TimeoutError),
             )
         except (TimeoutError, RPCError, ConnectionError, OSError) as e:
             logger.debug("Could not refresh media reference (%s)", type(e).__name__)
@@ -1756,6 +1776,20 @@ class TelegramBackup:
         if fresh_messages and fresh_messages[0]:
             return fresh_messages[0]
         return None
+
+    async def _fetch_media_bytes_bounded(self, message: Message, tmp_path: str, file_size: int, timeout_val):
+        """``_fetch_media_bytes`` bounded by a per-operation timeout.
+
+        Timing only the single download operation (rather than the whole
+        ``call_with_flood_retry`` wrapper) ensures a Telegram FloodWait sleep is
+        never cancelled by the download timeout. A timed-out operation raises
+        ``TimeoutError``, which ``_is_non_retryable_media_op`` lets propagate to
+        the outer retry loop.
+        """
+        coro = self._fetch_media_bytes(message, tmp_path, file_size)
+        if timeout_val is None:
+            return await coro
+        return await asyncio.wait_for(coro, timeout=timeout_val)
 
     async def _download_media_to_path(self, message: Message, tmp_path: str, file_size: int, chat_id: int):
         """Download a message's media to ``tmp_path`` with bounded refresh + retry.
@@ -1780,15 +1814,13 @@ class TelegramBackup:
                 if os.path.exists(tmp_path):
                     os.remove(tmp_path)
                 try:
-                    return await asyncio.wait_for(
-                        call_with_flood_retry(
-                            self._fetch_media_bytes,
-                            message,
-                            tmp_path,
-                            file_size,
-                            non_retryable=is_media_location_error,
-                        ),
-                        timeout=timeout_val,
+                    return await call_with_flood_retry(
+                        self._fetch_media_bytes_bounded,
+                        message,
+                        tmp_path,
+                        file_size,
+                        timeout_val,
+                        non_retryable=_is_non_retryable_media_op,
                     )
                 except (FileReferenceExpiredError, RPCError) as e:
                     is_expired_ref = isinstance(e, FileReferenceExpiredError)
@@ -1804,11 +1836,17 @@ class TelegramBackup:
                     refreshed = await self._refresh_message_for_media(chat_id, message)
                     if refreshed is not None:
                         message = refreshed
-                    logger.info(
-                        "Refreshed media reference after a transient error (attempt %d/%d); retrying",
-                        attempt + 1,
-                        MEDIA_REFRESH_MAX_ATTEMPTS,
-                    )
+                        logger.info(
+                            "Refreshed media reference after a transient error (attempt %d/%d); retrying",
+                            attempt + 1,
+                            MEDIA_REFRESH_MAX_ATTEMPTS,
+                        )
+                    else:
+                        logger.info(
+                            "Could not refresh media reference (attempt %d/%d); retrying anyway",
+                            attempt + 1,
+                            MEDIA_REFRESH_MAX_ATTEMPTS,
+                        )
                     if not is_expired_ref:
                         await asyncio.sleep(_media_retry_backoff_seconds(attempt))
                 except TimeoutError:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -81,6 +81,25 @@ MAX_FLOOD_WAIT_SECONDS = _get_int_env("MAX_FLOOD_WAIT_SECONDS", 3600)
 BACKOFF_MIN_SECONDS = _get_float_env("BACKOFF_MIN_SECONDS", 2.0)
 BACKOFF_MAX_SECONDS = _get_float_env("BACKOFF_MAX_SECONDS", 300.0)
 FLOOD_WAIT_LOG_THRESHOLD = _get_int_env("FLOOD_WAIT_LOG_THRESHOLD", 10)
+LOCATION_NOT_AVAILABLE = "LOCATION_NOT_AVAILABLE"
+MEDIA_REFRESH_RPC_MESSAGES = frozenset({LOCATION_NOT_AVAILABLE})
+
+
+def _rpc_error_matches(exc: Exception, messages: frozenset[str] | set[str]) -> bool:
+    if not isinstance(exc, RPCError):
+        return False
+
+    normalized = {message.upper() for message in messages}
+    rpc_message = getattr(exc, "message", None)
+    if isinstance(rpc_message, str) and rpc_message.upper() in normalized:
+        return True
+
+    error_text = str(exc).upper()
+    return any(message in error_text for message in normalized)
+
+
+def _is_location_not_available_error(exc: Exception) -> bool:
+    return _rpc_error_matches(exc, MEDIA_REFRESH_RPC_MESSAGES)
 
 
 def _pre_generate_thumbnail(source_path: str, media_root: str) -> None:
@@ -128,7 +147,13 @@ def _pre_generate_thumbnail(source_path: str, media_root: str) -> None:
         pass
 
 
-async def call_with_flood_retry(coro_fn, *args, max_retries=MAX_FLOOD_RETRIES, **kwargs):
+async def call_with_flood_retry(
+    coro_fn,
+    *args,
+    max_retries=MAX_FLOOD_RETRIES,
+    non_retryable_rpc_messages: frozenset[str] | set[str] | None = None,
+    **kwargs,
+):
     """Retry a single async call on FloodWaitError with bounded sleep and
     general transient errors with configurable exponential backoff and jitter.
 
@@ -189,6 +214,8 @@ async def call_with_flood_retry(coro_fn, *args, max_retries=MAX_FLOOD_RETRIES, *
                     UserBannedInChannelError,
                 ),
             ):
+                raise exc
+            if non_retryable_rpc_messages and _rpc_error_matches(exc, non_retryable_rpc_messages):
                 raise exc
 
             retries += 1
@@ -1704,6 +1731,12 @@ class TelegramBackup:
         except Exception as e:
             logger.error(f"Error cleaning up existing media for chat {chat_id}: {e}", exc_info=True)
 
+    async def _refresh_message_for_media(self, chat_id: int, message: Message) -> Message | None:
+        fresh_messages = await call_with_flood_retry(self.client.get_messages, chat_id, ids=[message.id])
+        if fresh_messages and fresh_messages[0]:
+            return fresh_messages[0]
+        return None
+
     async def _process_media(self, message: Message, chat_id: int) -> dict | None:
         """
         Process and download media from a message.
@@ -1787,16 +1820,37 @@ class TelegramBackup:
                     for attempt in range(3):
                         try:
                             return await asyncio.wait_for(
-                                call_with_flood_retry(self._fetch_media_bytes, message, tmp_path, file_size),
+                                call_with_flood_retry(
+                                    self._fetch_media_bytes,
+                                    message,
+                                    tmp_path,
+                                    file_size,
+                                    non_retryable_rpc_messages=MEDIA_REFRESH_RPC_MESSAGES,
+                                ),
                                 timeout=timeout_val,
                             )
                         except FileReferenceExpiredError:
                             logger.info(f"File reference expired for message {message.id}, refreshing...")
-                            fresh_messages = await call_with_flood_retry(
-                                self.client.get_messages, chat_id, ids=[message.id]
+                            fresh_message = await self._refresh_message_for_media(chat_id, message)
+                            if fresh_message:
+                                message = fresh_message
+                                continue
+                            raise
+                        except RPCError as e:
+                            if not _is_location_not_available_error(e):
+                                raise
+                            logger.info(
+                                "Media location unavailable for chat %s message %s; refreshing before retry "
+                                "(attempt %d/3)",
+                                chat_id,
+                                message.id,
+                                attempt + 1,
                             )
-                            if fresh_messages and fresh_messages[0]:
-                                message = fresh_messages[0]
+                            if attempt == 2:
+                                raise
+                            fresh_message = await self._refresh_message_for_media(chat_id, message)
+                            if fresh_message:
+                                message = fresh_message
                                 continue
                             raise
                         except TimeoutError:
@@ -1842,17 +1896,38 @@ class TelegramBackup:
                             os.remove(tmp_file_path)
                         try:
                             actual_path = await asyncio.wait_for(
-                                call_with_flood_retry(self._fetch_media_bytes, message, tmp_file_path, file_size),
+                                call_with_flood_retry(
+                                    self._fetch_media_bytes,
+                                    message,
+                                    tmp_file_path,
+                                    file_size,
+                                    non_retryable_rpc_messages=MEDIA_REFRESH_RPC_MESSAGES,
+                                ),
                                 timeout=timeout_val,
                             )
                             break
                         except FileReferenceExpiredError:
                             logger.info(f"File reference expired for message {message.id}, refreshing...")
-                            fresh_messages = await call_with_flood_retry(
-                                self.client.get_messages, chat_id, ids=[message.id]
+                            fresh_message = await self._refresh_message_for_media(chat_id, message)
+                            if fresh_message:
+                                message = fresh_message
+                                continue
+                            raise
+                        except RPCError as e:
+                            if not _is_location_not_available_error(e):
+                                raise
+                            logger.info(
+                                "Media location unavailable for chat %s message %s; refreshing before retry "
+                                "(attempt %d/3)",
+                                chat_id,
+                                message.id,
+                                attempt + 1,
                             )
-                            if fresh_messages and fresh_messages[0]:
-                                message = fresh_messages[0]
+                            if attempt == 2:
+                                raise
+                            fresh_message = await self._refresh_message_for_media(chat_id, message)
+                            if fresh_message:
+                                message = fresh_message
                                 continue
                             raise
                         except TimeoutError:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -8,6 +8,7 @@ import base64
 import logging
 import os
 import random
+from collections.abc import Callable
 from datetime import UTC, datetime
 
 from telethon import TelegramClient
@@ -36,6 +37,7 @@ from telethon.utils import get_peer_id
 from .avatar_utils import get_avatar_paths
 from .config import Config
 from .db import DatabaseAdapter, create_adapter
+from .media_errors import is_media_location_error
 from .message_utils import (
     compute_file_hash,
     download_and_shard_media,
@@ -81,27 +83,22 @@ MAX_FLOOD_WAIT_SECONDS = _get_int_env("MAX_FLOOD_WAIT_SECONDS", 3600)
 BACKOFF_MIN_SECONDS = _get_float_env("BACKOFF_MIN_SECONDS", 2.0)
 BACKOFF_MAX_SECONDS = _get_float_env("BACKOFF_MAX_SECONDS", 300.0)
 FLOOD_WAIT_LOG_THRESHOLD = _get_int_env("FLOOD_WAIT_LOG_THRESHOLD", 10)
-LOCATION_NOT_AVAILABLE = "LOCATION_NOT_AVAILABLE"
-MEDIA_REFRESH_RPC_MESSAGES = frozenset({LOCATION_NOT_AVAILABLE})
+# Bounded re-fetch+retry for transient media errors (expired reference / location
+# unavailable). After this many download attempts the item is left for the next
+# scheduled backup run instead of being retried indefinitely.
+MEDIA_REFRESH_MAX_ATTEMPTS = _get_int_env("MEDIA_REFRESH_MAX_ATTEMPTS", 3)
+# Upper bound on a single message-refresh round-trip so it can never hang.
+MEDIA_REFRESH_TIMEOUT_SECONDS = _get_int_env("MEDIA_REFRESH_TIMEOUT_SECONDS", 120)
 
 
-def _rpc_error_matches(exc: Exception, messages: frozenset[str] | set[str]) -> bool:
-    """Return whether a Telethon RPCError carries one of the given message codes."""
-    if not isinstance(exc, RPCError):
-        return False
+def _media_retry_backoff_seconds(attempt: int) -> float:
+    """Bounded exponential backoff (+jitter) between media-refresh retries.
 
-    normalized = {message.upper() for message in messages}
-    rpc_message = getattr(exc, "message", None)
-    if isinstance(rpc_message, str) and rpc_message.upper() in normalized:
-        return True
-
-    error_text = str(exc).upper()
-    return any(message in error_text for message in normalized)
-
-
-def _is_location_not_available_error(exc: Exception) -> bool:
-    """Return whether Telegram reported an unavailable media file location."""
-    return _rpc_error_matches(exc, MEDIA_REFRESH_RPC_MESSAGES)
+    Location errors are transient server-side conditions, so we pause before
+    retrying rather than hammering ``upload.GetFile`` (which risks a FloodWait).
+    """
+    base = min(BACKOFF_MAX_SECONDS, BACKOFF_MIN_SECONDS * (2.0**attempt))
+    return base + random.uniform(0.5, 1.5)
 
 
 def _pre_generate_thumbnail(source_path: str, media_root: str) -> None:
@@ -153,7 +150,7 @@ async def call_with_flood_retry(
     coro_fn,
     *args,
     max_retries=MAX_FLOOD_RETRIES,
-    non_retryable_rpc_messages: frozenset[str] | set[str] | None = None,
+    non_retryable: Callable[[BaseException], bool] | None = None,
     **kwargs,
 ):
     """Retry a single async call on FloodWaitError with bounded sleep and
@@ -162,6 +159,11 @@ async def call_with_flood_retry(
     Use this for one-shot Telegram API calls (``get_dialogs``, ``get_me``, etc.)
     that are not async iterators.  For ``iter_messages`` use
     ``iter_messages_with_flood_retry`` instead.
+
+    ``non_retryable`` is an optional predicate; when it returns ``True`` for a
+    raised exception, that exception is re-raised immediately instead of being
+    retried here, letting the caller handle it (e.g. refresh a stale media
+    reference and retry with its own backoff).
     """
     retries = 0
     while True:
@@ -217,7 +219,9 @@ async def call_with_flood_retry(
                 ),
             ):
                 raise exc
-            if non_retryable_rpc_messages and _rpc_error_matches(exc, non_retryable_rpc_messages):
+            if non_retryable is not None and non_retryable(exc):
+                # Caller handles this error itself (e.g. refresh the message and
+                # retry), so don't burn this retry budget on it here.
                 raise exc
 
             retries += 1
@@ -1734,11 +1738,104 @@ class TelegramBackup:
             logger.error(f"Error cleaning up existing media for chat {chat_id}: {e}", exc_info=True)
 
     async def _refresh_message_for_media(self, chat_id: int, message: Message) -> Message | None:
-        """Fetch a fresh message so Telegram can issue updated media file references."""
-        fresh_messages = await call_with_flood_retry(self.client.get_messages, chat_id, ids=[message.id])
+        """Best-effort re-fetch so Telegram issues an updated media reference/location.
+
+        Bounded by ``MEDIA_REFRESH_TIMEOUT_SECONDS`` so it can never hang, and
+        swallows transient errors (returning ``None``) so a failed refresh never
+        blows up the surrounding retry loop. Handles a deleted/unavailable
+        message (``[]`` or ``[None]``) by returning ``None``.
+        """
+        try:
+            fresh_messages = await asyncio.wait_for(
+                call_with_flood_retry(self.client.get_messages, chat_id, ids=[message.id]),
+                timeout=MEDIA_REFRESH_TIMEOUT_SECONDS,
+            )
+        except (TimeoutError, RPCError, ConnectionError, OSError) as e:
+            logger.debug("Could not refresh media reference (%s)", type(e).__name__)
+            return None
         if fresh_messages and fresh_messages[0]:
             return fresh_messages[0]
         return None
+
+    async def _download_media_to_path(self, message: Message, tmp_path: str, file_size: int, chat_id: int):
+        """Download a message's media to ``tmp_path`` with bounded refresh + retry.
+
+        Transient Telegram errors that a fresh message can fix — an expired file
+        reference, or an unavailable/invalid media *location* — trigger a
+        re-fetch of the message (for a new reference/location). A location error
+        is a transient server-side condition, so we also pause with exponential
+        backoff before retrying; an expired reference is fixed by the refresh
+        itself and is retried immediately. After ``MEDIA_REFRESH_MAX_ATTEMPTS``
+        the last real error is raised so the caller records the item as
+        not-downloaded; the next scheduled backup run re-attempts it.
+
+        Returns the downloaded path on success.
+        """
+        timeout = getattr(self.config, "download_timeout_seconds", 3600)
+        timeout_val = timeout if isinstance(timeout, int) and timeout > 0 else None
+        last = MEDIA_REFRESH_MAX_ATTEMPTS - 1
+        try:
+            for attempt in range(MEDIA_REFRESH_MAX_ATTEMPTS):
+                # Start each attempt clean so a prior partial never corrupts it.
+                if os.path.exists(tmp_path):
+                    os.remove(tmp_path)
+                try:
+                    return await asyncio.wait_for(
+                        call_with_flood_retry(
+                            self._fetch_media_bytes,
+                            message,
+                            tmp_path,
+                            file_size,
+                            non_retryable=is_media_location_error,
+                        ),
+                        timeout=timeout_val,
+                    )
+                except (FileReferenceExpiredError, RPCError) as e:
+                    is_expired_ref = isinstance(e, FileReferenceExpiredError)
+                    if not is_expired_ref and not is_media_location_error(e):
+                        raise  # not refreshable — let the outer handler record it
+                    if attempt >= last:
+                        logger.warning(
+                            "Media still unavailable after %d attempt(s) (%s); leaving it for a future backup run",
+                            attempt + 1,
+                            type(e).__name__,
+                        )
+                        raise
+                    refreshed = await self._refresh_message_for_media(chat_id, message)
+                    if refreshed is not None:
+                        message = refreshed
+                    logger.info(
+                        "Refreshed media reference after a transient error (attempt %d/%d); retrying",
+                        attempt + 1,
+                        MEDIA_REFRESH_MAX_ATTEMPTS,
+                    )
+                    if not is_expired_ref:
+                        await asyncio.sleep(_media_retry_backoff_seconds(attempt))
+                except TimeoutError:
+                    if attempt >= last:
+                        logger.error(
+                            "Media download timed out after %ss on attempt %d/%d; giving up for this run",
+                            timeout,
+                            attempt + 1,
+                            MEDIA_REFRESH_MAX_ATTEMPTS,
+                        )
+                        raise
+                    logger.warning(
+                        "Media download timed out after %ss (attempt %d/%d); retrying",
+                        timeout,
+                        attempt + 1,
+                        MEDIA_REFRESH_MAX_ATTEMPTS,
+                    )
+            # Defensive: the loop returns on success or raises on the final attempt.
+            raise FileReferenceExpiredError(request=None)
+        except BaseException:
+            # Never leave a partial .part behind on failure or cancellation.
+            if os.path.exists(tmp_path):
+                try:
+                    os.remove(tmp_path)
+                except OSError:
+                    pass
+            raise
 
     async def _process_media(self, message: Message, chat_id: int) -> dict | None:
         """
@@ -1817,49 +1914,7 @@ class TelegramBackup:
                 os.makedirs(shared_dir, exist_ok=True)
 
                 async def _download_fn(tmp_path):
-                    nonlocal message
-                    timeout = getattr(self.config, "download_timeout_seconds", 3600)
-                    timeout_val = timeout if isinstance(timeout, int) and timeout > 0 else None
-                    for attempt in range(3):
-                        try:
-                            return await asyncio.wait_for(
-                                call_with_flood_retry(
-                                    self._fetch_media_bytes,
-                                    message,
-                                    tmp_path,
-                                    file_size,
-                                    non_retryable_rpc_messages=MEDIA_REFRESH_RPC_MESSAGES,
-                                ),
-                                timeout=timeout_val,
-                            )
-                        except FileReferenceExpiredError:
-                            logger.info(f"File reference expired for message {message.id}, refreshing...")
-                            fresh_message = await self._refresh_message_for_media(chat_id, message)
-                            if fresh_message:
-                                message = fresh_message
-                                continue
-                            raise
-                        except RPCError as e:
-                            if not _is_location_not_available_error(e):
-                                raise
-                            logger.info(
-                                "Media location unavailable; refreshing before retry (attempt %d/3)",
-                                attempt + 1,
-                            )
-                            if attempt == 2:
-                                raise
-                            fresh_message = await self._refresh_message_for_media(chat_id, message)
-                            if fresh_message:
-                                message = fresh_message
-                                continue
-                            raise
-                        except TimeoutError:
-                            logger.error(
-                                f"Download timed out after {timeout} seconds for message {message.id} (attempt {attempt + 1}/3)"
-                            )
-                            if attempt == 2:
-                                raise
-                    raise FileReferenceExpiredError(request=None)
+                    return await self._download_media_to_path(message, tmp_path, file_size, chat_id)
 
                 shared_file_path, content_hash = await download_and_shard_media(
                     db=self.db,
@@ -1888,53 +1943,7 @@ class TelegramBackup:
                 if not os.path.lexists(file_path):
                     task_id = id(asyncio.current_task()) if asyncio.current_task() else 0
                     tmp_file_path = f"{file_path}.{os.getpid()}.{task_id}.part"
-                    timeout = getattr(self.config, "download_timeout_seconds", 3600)
-                    timeout_val = timeout if isinstance(timeout, int) and timeout > 0 else None
-                    for attempt in range(3):
-                        # Clear any partial file from a prior attempt so each retry starts clean.
-                        if os.path.exists(tmp_file_path):
-                            os.remove(tmp_file_path)
-                        try:
-                            actual_path = await asyncio.wait_for(
-                                call_with_flood_retry(
-                                    self._fetch_media_bytes,
-                                    message,
-                                    tmp_file_path,
-                                    file_size,
-                                    non_retryable_rpc_messages=MEDIA_REFRESH_RPC_MESSAGES,
-                                ),
-                                timeout=timeout_val,
-                            )
-                            break
-                        except FileReferenceExpiredError:
-                            logger.info(f"File reference expired for message {message.id}, refreshing...")
-                            fresh_message = await self._refresh_message_for_media(chat_id, message)
-                            if fresh_message:
-                                message = fresh_message
-                                continue
-                            raise
-                        except RPCError as e:
-                            if not _is_location_not_available_error(e):
-                                raise
-                            logger.info(
-                                "Media location unavailable; refreshing before retry (attempt %d/3)",
-                                attempt + 1,
-                            )
-                            if attempt == 2:
-                                raise
-                            fresh_message = await self._refresh_message_for_media(chat_id, message)
-                            if fresh_message:
-                                message = fresh_message
-                                continue
-                            raise
-                        except TimeoutError:
-                            logger.error(
-                                f"Download timed out after {timeout} seconds for message {message.id} (attempt {attempt + 1}/3)"
-                            )
-                            if attempt == 2:
-                                raise
-                    else:
-                        raise FileReferenceExpiredError(request=None)
+                    actual_path = await self._download_media_to_path(message, tmp_file_path, file_size, chat_id)
                     file_path = finalize_atomic_download(
                         actual_path if isinstance(actual_path, str) else None,
                         tmp_file_path,

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -86,6 +86,7 @@ MEDIA_REFRESH_RPC_MESSAGES = frozenset({LOCATION_NOT_AVAILABLE})
 
 
 def _rpc_error_matches(exc: Exception, messages: frozenset[str] | set[str]) -> bool:
+    """Return whether a Telethon RPCError carries one of the given message codes."""
     if not isinstance(exc, RPCError):
         return False
 
@@ -99,6 +100,7 @@ def _rpc_error_matches(exc: Exception, messages: frozenset[str] | set[str]) -> b
 
 
 def _is_location_not_available_error(exc: Exception) -> bool:
+    """Return whether Telegram reported an unavailable media file location."""
     return _rpc_error_matches(exc, MEDIA_REFRESH_RPC_MESSAGES)
 
 
@@ -1732,6 +1734,7 @@ class TelegramBackup:
             logger.error(f"Error cleaning up existing media for chat {chat_id}: {e}", exc_info=True)
 
     async def _refresh_message_for_media(self, chat_id: int, message: Message) -> Message | None:
+        """Fetch a fresh message so Telegram can issue updated media file references."""
         fresh_messages = await call_with_flood_retry(self.client.get_messages, chat_id, ids=[message.id])
         if fresh_messages and fresh_messages[0]:
             return fresh_messages[0]
@@ -1840,10 +1843,7 @@ class TelegramBackup:
                             if not _is_location_not_available_error(e):
                                 raise
                             logger.info(
-                                "Media location unavailable for chat %s message %s; refreshing before retry "
-                                "(attempt %d/3)",
-                                chat_id,
-                                message.id,
+                                "Media location unavailable; refreshing before retry (attempt %d/3)",
                                 attempt + 1,
                             )
                             if attempt == 2:
@@ -1917,10 +1917,7 @@ class TelegramBackup:
                             if not _is_location_not_available_error(e):
                                 raise
                             logger.info(
-                                "Media location unavailable for chat %s message %s; refreshing before retry "
-                                "(attempt %d/3)",
-                                chat_id,
-                                message.id,
+                                "Media location unavailable; refreshing before retry (attempt %d/3)",
                                 attempt + 1,
                             )
                             if attempt == 2:

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -1648,6 +1648,34 @@ class TestMediaRefreshErrorHelpers(unittest.TestCase):
             # Best-effort refresh: must return None rather than raising.
             self.assertIsNone(_run(backup._refresh_message_for_media(100, _make_message(11))))
 
+    def test_media_retry_backoff_seconds_grows_and_is_bounded(self):
+        """Backoff grows with the attempt and stays under the configured ceiling (+jitter)."""
+        self.assertGreater(
+            telegram_backup._media_retry_backoff_seconds(1),
+            telegram_backup._media_retry_backoff_seconds(0),
+        )
+        big = telegram_backup._media_retry_backoff_seconds(100)
+        self.assertLessEqual(big, telegram_backup.BACKOFF_MAX_SECONDS + 1.5)
+
+    def test_is_non_retryable_media_op(self):
+        """Location errors and per-operation timeouts bypass call_with_flood_retry's retries."""
+        self.assertTrue(
+            telegram_backup._is_non_retryable_media_op(BadRequestError(MagicMock(), "LOCATION_NOT_AVAILABLE", 400))
+        )
+        self.assertTrue(telegram_backup._is_non_retryable_media_op(TimeoutError()))
+        self.assertFalse(telegram_backup._is_non_retryable_media_op(BadRequestError(MagicMock(), "MEDIA_EMPTY", 400)))
+
+    def test_fetch_media_bytes_bounded_times_out_only_the_operation(self):
+        """The per-operation timeout bounds a slow download and raises TimeoutError."""
+        backup = _make_backup()
+
+        async def slow_fetch(message, path, size):
+            await asyncio.sleep(1)
+
+        backup._fetch_media_bytes = AsyncMock(side_effect=slow_fetch)
+        with self.assertRaises(TimeoutError):
+            _run(backup._fetch_media_bytes_bounded(_make_message(1), "/tmp/unused", 100, 0.01))
+
 
 # ===========================================================================
 # _process_media (lines 1420-1427, 1433-1435)
@@ -2108,6 +2136,56 @@ class TestProcessMedia(unittest.TestCase):
 
         self.assertEqual(result, tmp_path)
         self.assertEqual(fetched, [msg, fresh_msg])
+
+    def test_download_media_to_path_retries_then_succeeds_after_timeout(self):
+        """A per-operation timeout is retried by the outer loop, then succeeds."""
+        msg = self._make_photo_message(25)
+        calls = []
+
+        async def fake_fetch(message, path, size):
+            calls.append(message)
+            if len(calls) == 1:
+                raise TimeoutError()
+            with open(path, "wb") as f:
+                f.write(b"x")
+            return path
+
+        self.backup._fetch_media_bytes = AsyncMock(side_effect=fake_fetch)
+        tmp_path = os.path.join(self.temp_dir, "timeout_ok.part")
+
+        result = _run(self.backup._download_media_to_path(msg, tmp_path, 100, 100))
+
+        self.assertEqual(result, tmp_path)
+        self.assertEqual(len(calls), 2)
+
+    def test_download_media_to_path_gives_up_after_persistent_timeout(self):
+        """Persistent per-operation timeouts exhaust attempts and raise TimeoutError."""
+        msg = self._make_photo_message(26)
+        self.backup._fetch_media_bytes = AsyncMock(side_effect=TimeoutError())
+        tmp_path = os.path.join(self.temp_dir, "timeout_fail.part")
+
+        with self.assertRaises(TimeoutError):
+            _run(self.backup._download_media_to_path(msg, tmp_path, 100, 100))
+
+        self.assertEqual(self.backup._fetch_media_bytes.await_count, 3)
+
+    def test_download_media_to_path_cleans_partial_on_failure(self):
+        """A partial .part written before a failure is removed (no orphan left behind)."""
+        msg = self._make_photo_message(27)
+        self.backup.client.get_messages = AsyncMock(return_value=[None])
+
+        async def fake_fetch(message, path, size):
+            with open(path, "wb") as f:
+                f.write(b"partial")
+            raise BadRequestError(MagicMock(), "LOCATION_NOT_AVAILABLE", 400)
+
+        self.backup._fetch_media_bytes = AsyncMock(side_effect=fake_fetch)
+        tmp_path = os.path.join(self.temp_dir, "cleanup.part")
+
+        with self.assertRaises(BadRequestError):
+            _run(self.backup._download_media_to_path(msg, tmp_path, 100, 100))
+
+        self.assertFalse(os.path.exists(tmp_path))
 
 
 # ===========================================================================

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -8,7 +8,7 @@ import unittest
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from telethon.errors import BadRequestError, ChannelPrivateError, ChatForbiddenError
+from telethon.errors import BadRequestError, ChannelPrivateError, ChatForbiddenError, FileReferenceExpiredError
 from telethon.tl.types import (
     Channel,
     MessageMediaDocument,
@@ -16,6 +16,7 @@ from telethon.tl.types import (
     User,
 )
 
+from src import telegram_backup
 from src.telegram_backup import TelegramBackup, run_backup, run_fill_gaps
 
 # ---------------------------------------------------------------------------
@@ -1524,6 +1525,68 @@ class TestGetMediaSize(unittest.TestCase):
 
 
 # ===========================================================================
+# Media refresh error helpers
+# ===========================================================================
+
+
+class TestMediaRefreshErrorHelpers(unittest.TestCase):
+    """Test helper behavior used to route refreshable media download errors."""
+
+    def test_rpc_error_matches_ignores_non_rpc_errors(self):
+        """Non-RPC exceptions do not match Telegram RPC message names."""
+        self.assertFalse(
+            telegram_backup._rpc_error_matches(
+                ValueError("LOCATION_NOT_AVAILABLE"),
+                telegram_backup.MEDIA_REFRESH_RPC_MESSAGES,
+            )
+        )
+
+    def test_rpc_error_matches_rpc_message(self):
+        """Known RPC messages match by the Telethon .message field."""
+        exc = BadRequestError(MagicMock(), "location_not_available", 400)
+
+        self.assertTrue(telegram_backup._is_location_not_available_error(exc))
+
+    def test_rpc_error_matches_string_fallback(self):
+        """Unknown Telethon subclasses still match when the text contains the code."""
+        exc = BadRequestError(MagicMock(), "LOCATION_NOT_AVAILABLE", 400)
+        exc.message = None
+
+        self.assertTrue(telegram_backup._is_location_not_available_error(exc))
+
+    def test_call_with_flood_retry_can_bypass_non_retryable_rpc_messages(self):
+        """Media callers can prevent stale-reference RPC errors from retrying internally."""
+        attempts = 0
+
+        async def fail_with_location_not_available():
+            nonlocal attempts
+            attempts += 1
+            raise BadRequestError(MagicMock(), "LOCATION_NOT_AVAILABLE", 400)
+
+        with self.assertRaises(BadRequestError):
+            _run(
+                telegram_backup.call_with_flood_retry(
+                    fail_with_location_not_available,
+                    max_retries=5,
+                    non_retryable_rpc_messages=telegram_backup.MEDIA_REFRESH_RPC_MESSAGES,
+                )
+            )
+
+        self.assertEqual(attempts, 1)
+
+    def test_refresh_message_for_media_returns_none_when_missing(self):
+        """A deleted or unavailable message yields no refreshed media reference."""
+        backup = _make_backup()
+        message = _make_message(11)
+        backup.client.get_messages = AsyncMock(return_value=[None])
+
+        result = _run(backup._refresh_message_for_media(100, message))
+
+        self.assertIsNone(result)
+        backup.client.get_messages.assert_awaited_once_with(100, ids=[11])
+
+
+# ===========================================================================
 # _process_media (lines 1420-1427, 1433-1435)
 # ===========================================================================
 
@@ -1686,6 +1749,174 @@ class TestProcessMedia(unittest.TestCase):
         self.assertTrue(result["downloaded"])
         self.backup.client.get_messages.assert_awaited_once_with(100, ids=[6])
         self.assertEqual(download_messages, [stale_msg, fresh_msg])
+
+    def test_file_reference_expired_refreshes_message_before_direct_retry(self):
+        """FileReferenceExpiredError keeps the existing refresh behavior for direct downloads."""
+        stale_msg = self._make_photo_message(7)
+        fresh_msg = self._make_photo_message(7)
+        self._setup_photo_download()
+        self.backup.client.get_messages = AsyncMock(return_value=[fresh_msg])
+
+        download_messages = []
+
+        async def fake_download(message, path):
+            download_messages.append(message)
+            if len(download_messages) == 1:
+                raise FileReferenceExpiredError(request=MagicMock())
+            with open(path, "wb") as f:
+                f.write(b"photo")
+            return path
+
+        self.backup.client.download_media = AsyncMock(side_effect=fake_download)
+
+        result = _run(self.backup._process_media(stale_msg, 100))
+
+        self.assertTrue(result["downloaded"])
+        self.backup.client.get_messages.assert_awaited_once_with(100, ids=[7])
+        self.assertEqual(download_messages, [stale_msg, fresh_msg])
+
+    def test_file_reference_expired_refreshes_message_before_dedup_retry(self):
+        """FileReferenceExpiredError keeps the existing refresh behavior for dedup downloads."""
+        self.backup.config.deduplicate_media = True
+        self.backup.db.find_media_by_content_hash = AsyncMock(return_value=None)
+        stale_msg = self._make_photo_message(8)
+        fresh_msg = self._make_photo_message(8)
+        self._setup_photo_download()
+        self.backup.client.get_messages = AsyncMock(return_value=[fresh_msg])
+
+        download_messages = []
+
+        async def fake_download(message, path):
+            download_messages.append(message)
+            if len(download_messages) == 1:
+                raise FileReferenceExpiredError(request=MagicMock())
+            with open(path, "wb") as f:
+                f.write(b"photo")
+            return path
+
+        self.backup.client.download_media = AsyncMock(side_effect=fake_download)
+
+        result = _run(self.backup._process_media(stale_msg, 100))
+
+        self.assertTrue(result["downloaded"])
+        self.backup.client.get_messages.assert_awaited_once_with(100, ids=[8])
+        self.assertEqual(download_messages, [stale_msg, fresh_msg])
+
+    def test_non_location_rpc_error_does_not_refresh_message(self):
+        """Non-refreshable RPC errors still fail without fetching a fresh message."""
+        msg = self._make_photo_message(9)
+        self._setup_photo_download()
+        self.backup.client.get_messages = AsyncMock()
+
+        with patch(
+            "src.telegram_backup.call_with_flood_retry",
+            AsyncMock(side_effect=BadRequestError(MagicMock(), "MEDIA_EMPTY", 400)),
+        ):
+            result = _run(self.backup._process_media(msg, 100))
+
+        self.assertFalse(result["downloaded"])
+        self.backup.client.get_messages.assert_not_awaited()
+
+    def test_non_location_rpc_error_dedup_does_not_refresh_message(self):
+        """Non-refreshable RPC errors fail without refresh in the dedup path too."""
+        self.backup.config.deduplicate_media = True
+        msg = self._make_photo_message(14)
+        self._setup_photo_download()
+        self.backup.client.get_messages = AsyncMock()
+
+        with patch(
+            "src.telegram_backup.call_with_flood_retry",
+            AsyncMock(side_effect=BadRequestError(MagicMock(), "MEDIA_EMPTY", 400)),
+        ):
+            result = _run(self.backup._process_media(msg, 100))
+
+        self.assertFalse(result["downloaded"])
+        self.backup.client.get_messages.assert_not_awaited()
+
+    def test_location_not_available_fails_when_refresh_returns_no_message(self):
+        """A refreshable location error fails open when the message cannot be refreshed."""
+        msg = self._make_photo_message(10)
+        self._setup_photo_download()
+        self.backup.client.get_messages = AsyncMock(return_value=[None])
+        self.backup.client.download_media = AsyncMock(
+            side_effect=BadRequestError(MagicMock(), "LOCATION_NOT_AVAILABLE", 400)
+        )
+
+        result = _run(self.backup._process_media(msg, 100))
+
+        self.assertFalse(result["downloaded"])
+        self.backup.client.get_messages.assert_awaited_once_with(100, ids=[10])
+
+    def test_file_reference_expired_direct_fails_when_refresh_returns_no_message(self):
+        """A direct FileReferenceExpiredError fails open when refresh cannot find the message."""
+        msg = self._make_photo_message(15)
+        self._setup_photo_download()
+        self.backup.client.get_messages = AsyncMock(return_value=[None])
+        self.backup.client.download_media = AsyncMock(side_effect=FileReferenceExpiredError(request=MagicMock()))
+
+        result = _run(self.backup._process_media(msg, 100))
+
+        self.assertFalse(result["downloaded"])
+        self.backup.client.get_messages.assert_awaited_once_with(100, ids=[15])
+
+    def test_file_reference_expired_dedup_fails_when_refresh_returns_no_message(self):
+        """A dedup FileReferenceExpiredError fails open when refresh cannot find the message."""
+        self.backup.config.deduplicate_media = True
+        msg = self._make_photo_message(16)
+        self._setup_photo_download()
+        self.backup.client.get_messages = AsyncMock(return_value=[None])
+        self.backup.client.download_media = AsyncMock(side_effect=FileReferenceExpiredError(request=MagicMock()))
+
+        result = _run(self.backup._process_media(msg, 100))
+
+        self.assertFalse(result["downloaded"])
+        self.backup.client.get_messages.assert_awaited_once_with(100, ids=[16])
+
+    def test_location_not_available_final_direct_attempt_fails_without_refresh(self):
+        """The final LOCATION_NOT_AVAILABLE attempt raises without a third refresh."""
+        stale_msg = self._make_photo_message(12)
+        fresh_msg_1 = self._make_photo_message(12)
+        fresh_msg_2 = self._make_photo_message(12)
+        self._setup_photo_download()
+        self.backup.client.get_messages = AsyncMock(side_effect=[[fresh_msg_1], [fresh_msg_2]])
+
+        download_messages = []
+
+        async def fake_download(message, _path):
+            download_messages.append(message)
+            raise BadRequestError(MagicMock(), "LOCATION_NOT_AVAILABLE", 400)
+
+        self.backup.client.download_media = AsyncMock(side_effect=fake_download)
+
+        result = _run(self.backup._process_media(stale_msg, 100))
+
+        self.assertFalse(result["downloaded"])
+        self.assertEqual(self.backup.client.get_messages.await_count, 2)
+        self.assertEqual(download_messages, [stale_msg, fresh_msg_1, fresh_msg_2])
+
+    def test_location_not_available_final_dedup_attempt_fails_without_refresh(self):
+        """The dedup path also stops refreshing after the final retry."""
+        self.backup.config.deduplicate_media = True
+        self.backup.db.find_media_by_content_hash = AsyncMock(return_value=None)
+        stale_msg = self._make_photo_message(13)
+        fresh_msg_1 = self._make_photo_message(13)
+        fresh_msg_2 = self._make_photo_message(13)
+        self._setup_photo_download()
+        self.backup.client.get_messages = AsyncMock(side_effect=[[fresh_msg_1], [fresh_msg_2]])
+
+        download_messages = []
+
+        async def fake_download(message, _path):
+            download_messages.append(message)
+            raise BadRequestError(MagicMock(), "LOCATION_NOT_AVAILABLE", 400)
+
+        self.backup.client.download_media = AsyncMock(side_effect=fake_download)
+
+        result = _run(self.backup._process_media(stale_msg, 100))
+
+        self.assertFalse(result["downloaded"])
+        self.assertEqual(self.backup.client.get_messages.await_count, 2)
+        self.assertEqual(download_messages, [stale_msg, fresh_msg_1, fresh_msg_2])
 
 
 # ===========================================================================

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -8,7 +8,7 @@ import unittest
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from telethon.errors import ChannelPrivateError, ChatForbiddenError
+from telethon.errors import BadRequestError, ChannelPrivateError, ChatForbiddenError
 from telethon.tl.types import (
     Channel,
     MessageMediaDocument,
@@ -1541,6 +1541,20 @@ class TestProcessMedia(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree(self.temp_dir, ignore_errors=True)
 
+    def _make_photo_message(self, msg_id):
+        msg = _make_message(msg_id)
+        media = MagicMock(spec=MessageMediaPhoto)
+        media.photo = MagicMock()
+        media.photo.id = 999
+        media.mime_type = "image/jpeg"
+        msg.media = media
+        return msg
+
+    def _setup_photo_download(self):
+        self.backup._get_media_type = MagicMock(return_value="photo")
+        self.backup._get_media_size = MagicMock(return_value=100)
+        self.backup._get_media_filename = MagicMock(return_value="test.jpg")
+
     def test_document_with_dimensions_and_duration(self):
         """Document with width, height, and duration stores metadata."""
         msg = _make_message(1)
@@ -1620,6 +1634,58 @@ class TestProcessMedia(unittest.TestCase):
         result = _run(self.backup._process_media(msg, 100))
 
         self.assertFalse(result["downloaded"])
+
+    def test_location_not_available_refreshes_message_before_direct_retry(self):
+        """LOCATION_NOT_AVAILABLE refreshes the message before direct-download retry."""
+        stale_msg = self._make_photo_message(5)
+        fresh_msg = self._make_photo_message(5)
+        self._setup_photo_download()
+        self.backup.client.get_messages = AsyncMock(return_value=[fresh_msg])
+
+        download_messages = []
+
+        async def fake_download(message, path):
+            download_messages.append(message)
+            if len(download_messages) == 1:
+                raise BadRequestError(MagicMock(), "LOCATION_NOT_AVAILABLE", 400)
+            with open(path, "wb") as f:
+                f.write(b"photo")
+            return path
+
+        self.backup.client.download_media = AsyncMock(side_effect=fake_download)
+
+        result = _run(self.backup._process_media(stale_msg, 100))
+
+        self.assertTrue(result["downloaded"])
+        self.backup.client.get_messages.assert_awaited_once_with(100, ids=[5])
+        self.assertEqual(download_messages, [stale_msg, fresh_msg])
+
+    def test_location_not_available_refreshes_message_before_dedup_retry(self):
+        """LOCATION_NOT_AVAILABLE refreshes the message before shared-store retry."""
+        self.backup.config.deduplicate_media = True
+        self.backup.db.find_media_by_content_hash = AsyncMock(return_value=None)
+        stale_msg = self._make_photo_message(6)
+        fresh_msg = self._make_photo_message(6)
+        self._setup_photo_download()
+        self.backup.client.get_messages = AsyncMock(return_value=[fresh_msg])
+
+        download_messages = []
+
+        async def fake_download(message, path):
+            download_messages.append(message)
+            if len(download_messages) == 1:
+                raise BadRequestError(MagicMock(), "LOCATION_NOT_AVAILABLE", 400)
+            with open(path, "wb") as f:
+                f.write(b"photo")
+            return path
+
+        self.backup.client.download_media = AsyncMock(side_effect=fake_download)
+
+        result = _run(self.backup._process_media(stale_msg, 100))
+
+        self.assertTrue(result["downloaded"])
+        self.backup.client.get_messages.assert_awaited_once_with(100, ids=[6])
+        self.assertEqual(download_messages, [stale_msg, fresh_msg])
 
 
 # ===========================================================================

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -8,7 +8,15 @@ import unittest
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from telethon.errors import BadRequestError, ChannelPrivateError, ChatForbiddenError, FileReferenceExpiredError
+from telethon.errors import (
+    BadRequestError,
+    ChannelPrivateError,
+    ChatForbiddenError,
+    FileReferenceExpiredError,
+    FloodWaitError,
+    LocationInvalidError,
+    rpc_message_to_error,
+)
 from telethon.tl.types import (
     Channel,
     MessageMediaDocument,
@@ -17,6 +25,7 @@ from telethon.tl.types import (
 )
 
 from src import telegram_backup
+from src.media_errors import is_media_location_error
 from src.telegram_backup import TelegramBackup, run_backup, run_fill_gaps
 
 # ---------------------------------------------------------------------------
@@ -1530,32 +1539,46 @@ class TestGetMediaSize(unittest.TestCase):
 
 
 class TestMediaRefreshErrorHelpers(unittest.TestCase):
-    """Test helper behavior used to route refreshable media download errors."""
+    """Classification + refresh helpers used to recover transient media errors."""
 
-    def test_rpc_error_matches_ignores_non_rpc_errors(self):
-        """Non-RPC exceptions do not match Telegram RPC message names."""
-        self.assertFalse(
-            telegram_backup._rpc_error_matches(
-                ValueError("LOCATION_NOT_AVAILABLE"),
-                telegram_backup.MEDIA_REFRESH_RPC_MESSAGES,
-            )
-        )
+    def test_is_media_location_error_ignores_non_rpc_errors(self):
+        """Non-RPC exceptions are never treated as media-location errors."""
+        self.assertFalse(is_media_location_error(ValueError("LOCATION_NOT_AVAILABLE")))
 
-    def test_rpc_error_matches_rpc_message(self):
-        """Known RPC messages match by the Telethon .message field."""
-        exc = BadRequestError(MagicMock(), "location_not_available", 400)
+    def test_is_media_location_error_matches_message_case_insensitively(self):
+        """LOCATION_NOT_AVAILABLE is matched via the generic BadRequestError .message (any case)."""
+        self.assertTrue(is_media_location_error(BadRequestError(MagicMock(), "LOCATION_NOT_AVAILABLE", 400)))
+        self.assertTrue(is_media_location_error(BadRequestError(MagicMock(), "location_not_available", 400)))
 
-        self.assertTrue(telegram_backup._is_location_not_available_error(exc))
+    def test_is_media_location_error_matches_location_invalid_by_type(self):
+        """LOCATION_INVALID has a generated class whose .message is 'BAD_REQUEST', so match by type."""
+        exc = LocationInvalidError(request=None)
+        self.assertEqual(getattr(exc, "message", None), "BAD_REQUEST")  # documents why type-matching is needed
+        self.assertTrue(is_media_location_error(exc))
 
-    def test_rpc_error_matches_string_fallback(self):
-        """Unknown Telethon subclasses still match when the text contains the code."""
-        exc = BadRequestError(MagicMock(), "LOCATION_NOT_AVAILABLE", 400)
-        exc.message = None
+    def test_is_media_location_error_rejects_other_rpc_errors(self):
+        """Unrelated RPC errors (e.g. MEDIA_EMPTY) are not refreshable."""
+        self.assertFalse(is_media_location_error(BadRequestError(MagicMock(), "MEDIA_EMPTY", 400)))
 
-        self.assertTrue(telegram_backup._is_location_not_available_error(exc))
+    def test_is_media_location_error_matches_real_wire_conversion(self):
+        """A LOCATION_NOT_AVAILABLE built the way Telethon really builds it off the wire is matched.
 
-    def test_call_with_flood_retry_can_bypass_non_retryable_rpc_messages(self):
-        """Media callers can prevent stale-reference RPC errors from retrying internally."""
+        Exercises the actual rpc_message_to_error fallback (unknown 400 code ->
+        generic BadRequestError with .message preserved) instead of a hand-built mock,
+        so the test can't pass while production behaves differently.
+        """
+
+        class _WireError:
+            error_message = "LOCATION_NOT_AVAILABLE"
+            error_code = 400
+
+        exc = rpc_message_to_error(_WireError(), "GetFileRequest")
+        self.assertIsInstance(exc, BadRequestError)
+        self.assertEqual(exc.message, "LOCATION_NOT_AVAILABLE")
+        self.assertTrue(is_media_location_error(exc))
+
+    def test_call_with_flood_retry_non_retryable_predicate_reraises_immediately(self):
+        """A non_retryable predicate makes call_with_flood_retry re-raise on the first hit."""
         attempts = 0
 
         async def fail_with_location_not_available():
@@ -1568,14 +1591,37 @@ class TestMediaRefreshErrorHelpers(unittest.TestCase):
                 telegram_backup.call_with_flood_retry(
                     fail_with_location_not_available,
                     max_retries=5,
-                    non_retryable_rpc_messages=telegram_backup.MEDIA_REFRESH_RPC_MESSAGES,
+                    non_retryable=is_media_location_error,
                 )
             )
 
         self.assertEqual(attempts, 1)
 
+    def test_call_with_flood_retry_still_retries_errors_outside_predicate(self):
+        """Errors the predicate rejects keep using the normal transient backoff path."""
+        attempts = 0
+
+        async def fail_then_succeed():
+            nonlocal attempts
+            attempts += 1
+            if attempts < 3:
+                raise BadRequestError(MagicMock(), "MEDIA_EMPTY", 400)
+            return "ok"
+
+        with patch("src.telegram_backup.asyncio.sleep", new=AsyncMock()):
+            result = _run(
+                telegram_backup.call_with_flood_retry(
+                    fail_then_succeed,
+                    max_retries=5,
+                    non_retryable=is_media_location_error,
+                )
+            )
+
+        self.assertEqual(result, "ok")
+        self.assertEqual(attempts, 3)
+
     def test_refresh_message_for_media_returns_none_when_missing(self):
-        """A deleted or unavailable message yields no refreshed media reference."""
+        """A deleted/unavailable message ([None]) yields no refreshed reference."""
         backup = _make_backup()
         message = _make_message(11)
         backup.client.get_messages = AsyncMock(return_value=[None])
@@ -1584,6 +1630,23 @@ class TestMediaRefreshErrorHelpers(unittest.TestCase):
 
         self.assertIsNone(result)
         backup.client.get_messages.assert_awaited_once_with(100, ids=[11])
+
+    def test_refresh_message_for_media_returns_none_on_empty_list(self):
+        """An empty get_messages result is handled without IndexError."""
+        backup = _make_backup()
+        backup.client.get_messages = AsyncMock(return_value=[])
+
+        self.assertIsNone(_run(backup._refresh_message_for_media(100, _make_message(11))))
+
+    def test_refresh_message_for_media_swallows_floodwait(self):
+        """A FloodWait (or any error) during refresh is swallowed (-> None), never propagated."""
+        backup = _make_backup()
+        with patch(
+            "src.telegram_backup.call_with_flood_retry",
+            AsyncMock(side_effect=FloodWaitError(request=MagicMock())),
+        ):
+            # Best-effort refresh: must return None rather than raising.
+            self.assertIsNone(_run(backup._refresh_message_for_media(100, _make_message(11))))
 
 
 # ===========================================================================
@@ -1600,6 +1663,11 @@ class TestProcessMedia(unittest.TestCase):
         self.backup.config.media_path = os.path.join(self.temp_dir, "media")
         self.backup.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
         self.backup.config.deduplicate_media = False
+        # Neutralize the real backoff sleep so multi-attempt retry tests stay fast;
+        # `mock_backoff` lets tests assert backoff was (or wasn't) applied.
+        self._backoff_patcher = patch("src.telegram_backup._media_retry_backoff_seconds", return_value=0)
+        self.mock_backoff = self._backoff_patcher.start()
+        self.addCleanup(self._backoff_patcher.stop)
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir, ignore_errors=True)
@@ -1834,7 +1902,12 @@ class TestProcessMedia(unittest.TestCase):
         self.backup.client.get_messages.assert_not_awaited()
 
     def test_location_not_available_fails_when_refresh_returns_no_message(self):
-        """A refreshable location error fails open when the message cannot be refreshed."""
+        """A persistent location error fails clean; refresh is still attempted each non-final try.
+
+        Unlike the original code (which gave up after a single attempt when refresh
+        returned nothing), a location error is transient, so we keep retrying with
+        backoff — the item is simply left for the next backup run.
+        """
         msg = self._make_photo_message(10)
         self._setup_photo_download()
         self.backup.client.get_messages = AsyncMock(return_value=[None])
@@ -1845,10 +1918,12 @@ class TestProcessMedia(unittest.TestCase):
         result = _run(self.backup._process_media(msg, 100))
 
         self.assertFalse(result["downloaded"])
-        self.backup.client.get_messages.assert_awaited_once_with(100, ids=[10])
+        # Refresh attempted on attempts 0 and 1 (not the final attempt).
+        self.assertEqual(self.backup.client.get_messages.await_count, 2)
+        self.backup.client.get_messages.assert_awaited_with(100, ids=[10])
 
     def test_file_reference_expired_direct_fails_when_refresh_returns_no_message(self):
-        """A direct FileReferenceExpiredError fails open when refresh cannot find the message."""
+        """A direct FileReferenceExpiredError fails clean when refresh can't find the message."""
         msg = self._make_photo_message(15)
         self._setup_photo_download()
         self.backup.client.get_messages = AsyncMock(return_value=[None])
@@ -1857,10 +1932,11 @@ class TestProcessMedia(unittest.TestCase):
         result = _run(self.backup._process_media(msg, 100))
 
         self.assertFalse(result["downloaded"])
-        self.backup.client.get_messages.assert_awaited_once_with(100, ids=[15])
+        self.assertEqual(self.backup.client.get_messages.await_count, 2)
+        self.backup.client.get_messages.assert_awaited_with(100, ids=[15])
 
     def test_file_reference_expired_dedup_fails_when_refresh_returns_no_message(self):
-        """A dedup FileReferenceExpiredError fails open when refresh cannot find the message."""
+        """A dedup FileReferenceExpiredError fails clean when refresh can't find the message."""
         self.backup.config.deduplicate_media = True
         msg = self._make_photo_message(16)
         self._setup_photo_download()
@@ -1870,7 +1946,8 @@ class TestProcessMedia(unittest.TestCase):
         result = _run(self.backup._process_media(msg, 100))
 
         self.assertFalse(result["downloaded"])
-        self.backup.client.get_messages.assert_awaited_once_with(100, ids=[16])
+        self.assertEqual(self.backup.client.get_messages.await_count, 2)
+        self.backup.client.get_messages.assert_awaited_with(100, ids=[16])
 
     def test_location_not_available_final_direct_attempt_fails_without_refresh(self):
         """The final LOCATION_NOT_AVAILABLE attempt raises without a third refresh."""
@@ -1917,6 +1994,120 @@ class TestProcessMedia(unittest.TestCase):
         self.assertFalse(result["downloaded"])
         self.assertEqual(self.backup.client.get_messages.await_count, 2)
         self.assertEqual(download_messages, [stale_msg, fresh_msg_1, fresh_msg_2])
+
+    def test_location_not_available_applies_backoff_between_retries(self):
+        """A transient location error backs off before retrying (not a sleepless hammer)."""
+        stale_msg = self._make_photo_message(20)
+        fresh_msg = self._make_photo_message(20)
+        self._setup_photo_download()
+        self.backup.client.get_messages = AsyncMock(return_value=[fresh_msg])
+
+        downloads = []
+
+        async def fake_download(message, path):
+            downloads.append(message)
+            if len(downloads) == 1:
+                raise BadRequestError(MagicMock(), "LOCATION_NOT_AVAILABLE", 400)
+            with open(path, "wb") as f:
+                f.write(b"photo")
+            return path
+
+        self.backup.client.download_media = AsyncMock(side_effect=fake_download)
+
+        result = _run(self.backup._process_media(stale_msg, 100))
+
+        self.assertTrue(result["downloaded"])
+        self.mock_backoff.assert_called()  # backoff applied before the retry
+
+    def test_file_reference_expired_retry_skips_backoff(self):
+        """An expired reference is fixed by the refresh itself, so it retries without backoff."""
+        stale_msg = self._make_photo_message(21)
+        fresh_msg = self._make_photo_message(21)
+        self._setup_photo_download()
+        self.backup.client.get_messages = AsyncMock(return_value=[fresh_msg])
+
+        downloads = []
+
+        async def fake_download(message, path):
+            downloads.append(message)
+            if len(downloads) == 1:
+                raise FileReferenceExpiredError(request=MagicMock())
+            with open(path, "wb") as f:
+                f.write(b"photo")
+            return path
+
+        self.backup.client.download_media = AsyncMock(side_effect=fake_download)
+
+        result = _run(self.backup._process_media(stale_msg, 100))
+
+        self.assertTrue(result["downloaded"])
+        self.mock_backoff.assert_not_called()
+
+    def test_location_not_available_succeeds_on_third_attempt_uses_latest_message(self):
+        """Two failures then success: the retry must use the most recently refreshed message."""
+        stale_msg = self._make_photo_message(22)
+        fresh_msg_1 = self._make_photo_message(22)
+        fresh_msg_2 = self._make_photo_message(22)
+        self._setup_photo_download()
+        self.backup.client.get_messages = AsyncMock(side_effect=[[fresh_msg_1], [fresh_msg_2]])
+
+        downloads = []
+
+        async def fake_download(message, path):
+            downloads.append(message)
+            if len(downloads) < 3:
+                raise BadRequestError(MagicMock(), "LOCATION_NOT_AVAILABLE", 400)
+            with open(path, "wb") as f:
+                f.write(b"photo")
+            return path
+
+        self.backup.client.download_media = AsyncMock(side_effect=fake_download)
+
+        result = _run(self.backup._process_media(stale_msg, 100))
+
+        self.assertTrue(result["downloaded"])
+        self.assertEqual(downloads, [stale_msg, fresh_msg_1, fresh_msg_2])
+        self.assertEqual(self.backup.client.get_messages.await_count, 2)
+
+    def test_download_media_to_path_raises_original_error_after_exhaustion(self):
+        """On exhaustion the original error propagates (not a synthetic one) and no .part is left."""
+        msg = self._make_photo_message(23)
+        self.backup._should_parallelize = MagicMock(return_value=False)
+        self.backup.client.get_messages = AsyncMock(return_value=[None])
+        self.backup.client.download_media = AsyncMock(
+            side_effect=BadRequestError(MagicMock(), "LOCATION_NOT_AVAILABLE", 400)
+        )
+        tmp_path = os.path.join(self.temp_dir, "exhaust.part")
+
+        with self.assertRaises(BadRequestError) as ctx:
+            _run(self.backup._download_media_to_path(msg, tmp_path, 100, 100))
+
+        self.assertEqual(ctx.exception.message, "LOCATION_NOT_AVAILABLE")
+        self.assertFalse(os.path.exists(tmp_path))  # partial cleaned up on failure
+
+    def test_download_media_to_path_recovers_regardless_of_transport(self):
+        """Refresh+retry is driven at the _fetch_media_bytes seam, so it covers any transport."""
+        msg = self._make_photo_message(24)
+        fresh_msg = self._make_photo_message(24)
+        self.backup.client.get_messages = AsyncMock(return_value=[fresh_msg])
+
+        fetched = []
+
+        async def fake_fetch(message, path, size):
+            fetched.append(message)
+            if len(fetched) == 1:
+                raise BadRequestError(MagicMock(), "LOCATION_NOT_AVAILABLE", 400)
+            with open(path, "wb") as f:
+                f.write(b"x")
+            return path
+
+        self.backup._fetch_media_bytes = AsyncMock(side_effect=fake_fetch)
+        tmp_path = os.path.join(self.temp_dir, "transport.part")
+
+        result = _run(self.backup._download_media_to_path(msg, tmp_path, 100, 100))
+
+        self.assertEqual(result, tmp_path)
+        self.assertEqual(fetched, [msg, fresh_msg])
 
 
 # ===========================================================================

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -1650,12 +1650,14 @@ class TestMediaRefreshErrorHelpers(unittest.TestCase):
 
     def test_media_retry_backoff_seconds_grows_and_is_bounded(self):
         """Backoff grows with the attempt and stays under the configured ceiling (+jitter)."""
-        self.assertGreater(
-            telegram_backup._media_retry_backoff_seconds(1),
-            telegram_backup._media_retry_backoff_seconds(0),
-        )
-        big = telegram_backup._media_retry_backoff_seconds(100)
-        self.assertLessEqual(big, telegram_backup.BACKOFF_MAX_SECONDS + 1.5)
+        # Pin the jitter so the comparison is deterministic (never flakes).
+        with patch("src.telegram_backup.random.uniform", return_value=0.5):
+            self.assertGreater(
+                telegram_backup._media_retry_backoff_seconds(1),
+                telegram_backup._media_retry_backoff_seconds(0),
+            )
+            big = telegram_backup._media_retry_backoff_seconds(100)
+            self.assertLessEqual(big, telegram_backup.BACKOFF_MAX_SECONDS + 1.5)
 
     def test_is_non_retryable_media_op(self):
         """Location errors and per-operation timeouts bypass call_with_flood_retry's retries."""


### PR DESCRIPTION
## Summary

- Treat Telegram `LOCATION_NOT_AVAILABLE` media download errors as refreshable in the backup media path.
- Bypass generic stale-reference RPC retries for that error so the outer media retry loop can fetch a fresh message before retrying.
- Cover direct, deduplicated, stale-reference, non-refreshable RPC, missing-refresh, and final-retry failure paths with regression tests.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change

## Database Changes

- [ ] Schema changes (Alembic migration required)
- [ ] Data migration script added in `scripts/`
- [x] No database changes

## Data Consistency Checklist

- [x] All `chat_id` values use marked format (via `_get_marked_id()`)
- [x] All datetime values pass through `_strip_tz()` before DB operations
- [x] INSERT and UPDATE operations handle the same fields identically

Not applicable: this PR does not change database reads or writes.

## Testing

- [x] Tests pass locally (`python -m pytest tests/ -v`)
- [x] Linting passes (`ruff check .`)
- [x] Formatting passes (`ruff format --check .`)
- [ ] Manually tested in development environment

Commands run:

- `python3 -m py_compile src/telegram_backup.py tests/test_telegram_backup_extended.py`
- `/tmp/telegram-archive-test-venv/bin/python -m pytest tests/test_telegram_backup_extended.py -q`
- `/tmp/telegram-archive-test-venv/bin/python -m pytest tests/test_flood_wait_visibility.py -q`
- `/tmp/telegram-archive-test-venv/bin/python -m pytest tests/test_telegram_backup_extended.py tests/test_flood_wait_visibility.py --cov=src.telegram_backup --cov-report=term-missing -q`
- `/tmp/telegram-archive-test-venv/bin/python -m ruff check src/telegram_backup.py tests/test_telegram_backup_extended.py`
- `/tmp/telegram-archive-test-venv/bin/python -m ruff format --check src/telegram_backup.py tests/test_telegram_backup_extended.py`

## Security Checklist

- [x] No secrets or credentials committed
- [x] User input properly validated/sanitized
- [x] Authentication/authorization properly checked

This PR also avoids logging chat IDs or message IDs in the new media-location retry logs.

## Deployment Notes

- Docker image rebuild needed for deployments to pick up the backup retry behavior.
- No configuration, database migration, or manual repair step required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Telegram media reliability by detecting media “location not available/invalid” failures and refreshing the message before retrying the download.
  * Bounded media retry/backoff with jitter and per-operation timeouts to avoid excessive retry pacing; file-reference-expired cases retry immediately without added backoff.
  * More correct error propagation and cleanup: avoids corrupt partial `.part` files and stops refresh/retry for unrelated errors.

* **Tests**
  * Expanded coverage for media error classification, refresh/backoff timing, deduplicated vs non-deduplicated download flows, bounded timeout behavior, and partial-download cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->