### PR TITLE
feat(messages): preserve previous message versions

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - 'Dockerfile'
       - 'requirements.txt'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - 'scripts/**'
       - 'src/**'
       - '.github/workflows/docker-publish.yml'
       # Exclude viewer-only changes

--- a/alembic/versions/20260626_015_add_message_versions.py
+++ b/alembic/versions/20260626_015_add_message_versions.py
@@ -1,0 +1,77 @@
+"""Add message versions table.
+
+Revision ID: 015
+Revises: 014
+Create Date: 2026-06-26
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "015"
+down_revision: str | None = "014"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+TABLE_NAME = "message_versions"
+IDX_MESSAGE_DATE = "idx_message_versions_message_date"
+IDX_MESSAGE_CAPTURED = "idx_message_versions_message_captured"
+
+
+def _table_exists(inspector: sa.Inspector) -> bool:
+    return TABLE_NAME in inspector.get_table_names()
+
+
+def _index_exists(inspector: sa.Inspector, name: str) -> bool:
+    return name in {idx["name"] for idx in inspector.get_indexes(TABLE_NAME)}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if not _table_exists(inspector):
+        op.create_table(
+            TABLE_NAME,
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("message_id", sa.BigInteger(), nullable=False),
+            sa.Column("chat_id", sa.BigInteger(), nullable=False),
+            sa.Column("text", sa.Text(), nullable=True),
+            sa.Column("date", sa.DateTime(), nullable=False),
+            sa.Column("change_hash", sa.String(length=64), nullable=False),
+            sa.Column("captured_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+            sa.ForeignKeyConstraint(
+                ["message_id", "chat_id"],
+                ["messages.id", "messages.chat_id"],
+                name="fk_message_versions_message",
+                ondelete="CASCADE",
+            ),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("change_hash", name="uq_message_versions_change_hash"),
+        )
+        inspector = sa.inspect(conn)
+
+    if not _index_exists(inspector, IDX_MESSAGE_DATE):
+        op.create_index(IDX_MESSAGE_DATE, TABLE_NAME, ["chat_id", "message_id", "date"])
+        inspector = sa.inspect(conn)
+    if not _index_exists(inspector, IDX_MESSAGE_CAPTURED):
+        op.create_index(IDX_MESSAGE_CAPTURED, TABLE_NAME, ["chat_id", "message_id", "captured_at"])
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if not _table_exists(inspector):
+        return
+
+    indexes = {idx["name"] for idx in inspector.get_indexes(TABLE_NAME)}
+    if IDX_MESSAGE_CAPTURED in indexes:
+        op.drop_index(IDX_MESSAGE_CAPTURED, table_name=TABLE_NAME)
+    if IDX_MESSAGE_DATE in indexes:
+        op.drop_index(IDX_MESSAGE_DATE, table_name=TABLE_NAME)
+    op.drop_table(TABLE_NAME)

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -112,6 +112,15 @@ if has_tables and not has_alembic:
         \"\"\")
         has_013_paths = cur.fetchone()[0]
 
+    # Check artifact from migration 015: message_versions table
+    cur.execute(\"\"\"
+        SELECT EXISTS (
+            SELECT FROM information_schema.tables
+            WHERE table_name = 'message_versions'
+        );
+    \"\"\")
+    has_015_message_versions = cur.fetchone()[0]
+
     # Check artifact from migration 014: messages soft-delete marker columns
     cur.execute(\"\"\"
         SELECT
@@ -232,7 +241,9 @@ if has_tables and not has_alembic:
     has_push_subs = cur.fetchone()[0]
 
     # Determine which version to stamp based on existing schema
-    if has_014_soft_delete:
+    if has_015_message_versions and has_014_soft_delete:
+        stamp_version = '015'
+    elif has_014_soft_delete:
         stamp_version = '014'
     elif has_013_paths:
         stamp_version = '013'
@@ -333,6 +344,10 @@ if has_tables and not has_alembic:
         cur.execute(\"SELECT EXISTS(SELECT 1 FROM media WHERE chat_id < 0 AND file_path LIKE '%/' || CAST(chat_id AS TEXT) || '/%' LIMIT 1)\")
         has_013_paths = cur.fetchone()[0]
 
+    # Check artifact from migration 015: message_versions table
+    cur.execute(\"SELECT name FROM sqlite_master WHERE type='table' AND name='message_versions'\")
+    has_015_message_versions = cur.fetchone() is not None
+
     # Check artifact from migration 014: messages soft-delete marker columns
     cur.execute(\"PRAGMA table_info(messages)\")
     msg_columns = {row[1] for row in cur.fetchall()}
@@ -386,7 +401,9 @@ if has_tables and not has_alembic:
     has_push_subs = cur.fetchone() is not None
 
     # Determine which version to stamp based on existing schema
-    if has_014_soft_delete:
+    if has_015_message_versions and has_014_soft_delete:
+        stamp_version = '015'
+    elif has_014_soft_delete:
         stamp_version = '014'
     elif has_013_paths:
         stamp_version = '013'

--- a/scripts/migrate-sqlite-to-postgres.py
+++ b/scripts/migrate-sqlite-to-postgres.py
@@ -46,7 +46,7 @@ import sys
 # Add parent directory to path for imports
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from src.db.migrate import migrate_sqlite_to_postgres, verify_migration
+from src.db.migrate import MIGRATION_MODELS, _count_model_records, migrate_sqlite_to_postgres, verify_migration
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
 logger = logging.getLogger(__name__)
@@ -137,21 +137,16 @@ async def run_migration(sqlite_path: str, postgres_url: str, batch_size: int, dr
     if dry_run:
         logger.info("\n[DRY RUN] Would migrate the following tables:")
         # Just show what would be migrated
-        from sqlalchemy import func, select
-
         from src.db.base import DatabaseManager
-        from src.db.models import Chat, Media, Message, Metadata, Reaction, SyncStatus, User
 
         sqlite_url = f"sqlite+aiosqlite:///{sqlite_path}"
         source = DatabaseManager(sqlite_url)
         await source.init()
 
-        models = [User, Chat, Message, Media, Reaction, SyncStatus, Metadata]
         try:
-            for model in models:
+            for model in MIGRATION_MODELS:
                 async with source.get_session() as session:
-                    result = await session.execute(select(func.count()).select_from(model))
-                    count = result.scalar() or 0
+                    count = await _count_model_records(session, model, missing_table_is_zero=True)
                     logger.info(f"  - {model.__tablename__}: {count:,} records")
         finally:
             await source.close()

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -82,6 +82,12 @@ def _message_version_hash(
     text: str | None,
     date: datetime,
 ) -> str:
+    # FROZEN CONTRACT: this exact encoding (key set, sort_keys, separators,
+    # microsecond timespec) IS the dedup identity for message_versions rows via
+    # the unique change_hash column. Changing any detail silently re-admits
+    # duplicates of already-stored versions. Known accepted limit: repeated
+    # no-edit_date edits that oscillate back to the same text reuse the same
+    # fallback date and dedup into one row.
     payload = {
         "chat_id": chat_id,
         "message_id": message_id,
@@ -234,6 +240,14 @@ class DatabaseAdapter:
         text: str | None,
         date: datetime,
     ) -> bool:
+        """Best-effort capture of a superseded text into message_versions.
+
+        Versioning is plain text only — formatting/entity-only edits produce the
+        same text and are intentionally not versioned. Runs inside a SAVEPOINT so
+        an unexpected failure here can never poison the transaction or abort the
+        message upsert/batch it belongs to (the expected duplicate case is already
+        silenced by ON CONFLICT DO NOTHING on change_hash).
+        """
         date = _strip_tz(date)
         if date is None:
             return False
@@ -252,13 +266,32 @@ class DatabaseAdapter:
             "change_hash": change_hash,
             "captured_at": utcnow_naive(),
         }
-        result = await session.execute(self._insert_message_version_stmt(values))
+        try:
+            async with session.begin_nested():
+                result = await session.execute(self._insert_message_version_stmt(values))
+        except Exception as e:
+            logger.warning("Could not record a message version (%s); message update continues", type(e).__name__)
+            return False
         return bool(result.rowcount)
 
     def _message_version_date(self, message: Message) -> datetime:
         return _strip_tz(message.edit_date) or _strip_tz(message.date)
 
     def _should_apply_upsert_text(self, existing: Message, values: dict[str, Any]) -> bool:
+        """Decide whether a re-scanned/imported message may replace archived text.
+
+        Truth table (upsert sources: backup re-scan, gap-fill, import):
+        - same text            -> apply only to bump edit_date, and only when strictly
+                                  newer (``>`` via _newer_edit_date) so identical
+                                  replays are perfect no-ops (reaction-only edits).
+        - empty -> non-empty   -> always fill (late hydration), even without an
+                                  edit_date; caller preserves the existing edit_date.
+        - differing text, no incoming edit_date -> refuse: an upsert source with no
+                                  edit evidence must never clobber archived text.
+        - differing text, incoming edit_date >= archived (or archived None) -> apply.
+          ``>=`` (not ``>``) is deliberate: listener and backup can deliver the same
+          edit with equal timestamps but the text seen later is the fresher fetch.
+        """
         new_text = values.get("text")
         new_edit_date = _strip_tz(values.get("edit_date"))
         old_text = existing.text
@@ -277,6 +310,13 @@ class DatabaseAdapter:
         return False
 
     def _should_apply_edit_text(self, existing: Message, new_text: str, edit_date: datetime | None) -> bool:
+        """Decide whether a live edit event (listener/sync) may replace archived text.
+
+        Differs from the upsert policy on the no-edit_date case: a live event with
+        ``edit_date=None`` is applied only when the archived row was never edited —
+        an already-edited row is never rolled over on date-less evidence (rare
+        bot-API edits may hit this; conservative by design, covered by tests).
+        """
         old_edit_date = _strip_tz(existing.edit_date)
         edit_date = _strip_tz(edit_date)
 
@@ -302,52 +342,90 @@ class DatabaseAdapter:
         result = await session.execute(stmt.execution_options(populate_existing=True))
         return result.scalar_one_or_none()
 
+    async def _load_message_snapshot(self, session, chat_id: int, message_id: int) -> Message | None:
+        """Plain lock-free read, used only for the fast-path no-change check."""
+        stmt = select(Message).where(and_(Message.chat_id == chat_id, Message.id == message_id))
+        result = await session.execute(stmt.execution_options(populate_existing=True))
+        return result.scalar_one_or_none()
+
+    def _pending_update_values(
+        self, existing: Message, message_data: dict[str, Any], values: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Columns an upsert would actually change on ``existing`` (may be empty).
+
+        Applies the text/edit_date gating policy, then drops every key whose value
+        already matches the row, so re-scanning an unchanged message performs no
+        write at all. Deliberate scope note: when text is withheld (older or
+        no-evidence source), the remaining metadata (raw_data, reply_to_*, sender,
+        …) still refreshes from the incoming payload — non-text fields stay
+        last-writer-wins exactly as before versioning existed.
+        """
+        update_values = _message_conflict_update_values(message_data, values)
+        if self._should_apply_upsert_text(existing, values):
+            if values.get("edit_date") is None and existing.edit_date is not None:
+                # Text change arrived without edit evidence (e.g. late hydration):
+                # keep the existing edit_date rather than nulling it.
+                update_values.pop("edit_date", None)
+        else:
+            update_values.pop("text", None)
+            update_values.pop("edit_date", None)
+
+        changed = {}
+        for key, value in update_values.items():
+            if key in ("id", "chat_id"):
+                continue
+            if getattr(existing, key) != value:
+                changed[key] = value
+        return changed
+
     async def _apply_existing_message_update(
         self,
         session,
         message_data: dict[str, Any],
         values: dict[str, Any],
-        source: str,
     ) -> None:
-        existing = await self._load_message_for_update(session, values["chat_id"], values["id"])
-        if existing is None:
+        # Fast path: a lock-free read to detect the common re-scan case of a fully
+        # unchanged message, so full re-backups don't pay the write lock + extra
+        # statements per row. The definitive decision is re-made under the lock
+        # below; skipping here is safe because a concurrent writer that changes the
+        # row after our snapshot has, by definition, applied data at least as new
+        # as ours.
+        snapshot = await self._load_message_snapshot(session, values["chat_id"], values["id"])
+        if snapshot is None:
+            logger.debug("Upsert no-op: message row vanished during conflict resolution")
+            return
+        if not self._pending_update_values(snapshot, message_data, values):
             return
 
-        update_values = _message_conflict_update_values(message_data, values)
-        apply_text = self._should_apply_upsert_text(existing, values)
-        new_edit_date = values.get("edit_date")
-        if apply_text and new_edit_date is None and existing.edit_date is not None:
-            update_values.pop("edit_date", None)
-            new_edit_date = existing.edit_date
+        existing = await self._load_message_for_update(session, values["chat_id"], values["id"])
+        if existing is None:
+            logger.debug("Upsert no-op: message row vanished during conflict resolution")
+            return
 
-        if apply_text:
-            if existing.text != values.get("text"):
-                await self._record_message_version(
-                    session=session,
-                    chat_id=existing.chat_id,
-                    message_id=existing.id,
-                    text=existing.text,
-                    date=self._message_version_date(existing),
-                )
-            else:
-                update_values.pop("text", None)
-        else:
-            update_values.pop("text", None)
-            update_values.pop("edit_date", None)
-
+        update_values = self._pending_update_values(existing, message_data, values)
+        if not update_values:
+            return
+        if "text" in update_values:
+            await self._record_message_version(
+                session=session,
+                chat_id=existing.chat_id,
+                message_id=existing.id,
+                text=existing.text,
+                date=self._message_version_date(existing),
+            )
         await session.execute(
             update(Message)
             .where(and_(Message.chat_id == values["chat_id"], Message.id == values["id"]))
             .values(**update_values)
         )
 
-    async def _insert_or_update_message(self, session, message_data: dict[str, Any], source: str) -> None:
+    async def _insert_or_update_message(self, session, message_data: dict[str, Any]) -> None:
         values = self._message_values(message_data)
         result = await session.execute(self._insert_message_stmt(values))
         if result.rowcount:
             return
 
-        await self._apply_existing_message_update(session, message_data, values, source)
+        await self._apply_existing_message_update(session, message_data, values)
 
     # ========== Metadata Operations ==========
 
@@ -599,17 +677,18 @@ class DatabaseAdapter:
 
     # ========== Message Operations ==========
 
-    async def insert_message(self, message_data: dict[str, Any], source: str = "upsert") -> None:
+    @retry_on_locked()
+    async def insert_message(self, message_data: dict[str, Any]) -> None:
         """Insert a message record.
 
         v6.0.0: media_type, media_id, media_path removed - use insert_media() separately.
         """
         async with self.db_manager.async_session_factory() as session:
-            await self._insert_or_update_message(session, message_data, source)
+            await self._insert_or_update_message(session, message_data)
             await session.commit()
 
     @retry_on_locked()
-    async def insert_messages_batch(self, messages_data: list[dict[str, Any]], source: str = "upsert") -> None:
+    async def insert_messages_batch(self, messages_data: list[dict[str, Any]]) -> None:
         """Insert multiple message records in a single transaction.
 
         v6.0.0: media_type, media_id, media_path removed - use insert_media() separately.
@@ -619,7 +698,7 @@ class DatabaseAdapter:
 
         async with self.db_manager.async_session_factory() as session:
             for m in messages_data:
-                await self._insert_or_update_message(session, m, source)
+                await self._insert_or_update_message(session, m)
 
             await session.commit()
 
@@ -742,20 +821,27 @@ class DatabaseAdapter:
                 logger.warning(f"Message {message_id} found in {len(chat_ids)} chats, skipping ambiguous deletion")
             return None
 
+    @retry_on_locked()
     async def update_message_text(
-        self, chat_id: int, message_id: int, new_text: str, edit_date: datetime | None, source: str = "edit"
-    ) -> None:
-        """Update a message's text and edit_date."""
+        self, chat_id: int, message_id: int, new_text: str, edit_date: datetime | None
+    ) -> str:
+        """Update a message's text and edit_date.
+
+        Returns the outcome so callers can keep honest counters and only
+        broadcast edits that actually changed the archive:
+        ``"applied"`` | ``"noop"`` (already current / older evidence) |
+        ``"not_found"`` (message not archived).
+        """
         edit_date = _strip_tz(edit_date)
         async with self.db_manager.async_session_factory() as session:
             message = await self._load_message_for_update(session, chat_id, message_id)
             if message is None:
                 logger.debug("Edit no-op: message not found in archive")
-                return
+                return "not_found"
 
             if not self._should_apply_edit_text(message, new_text, edit_date):
                 logger.debug("Edit no-op: message already current")
-                return
+                return "noop"
 
             if message.text != new_text:
                 await self._record_message_version(
@@ -772,6 +858,7 @@ class DatabaseAdapter:
             )
             await session.commit()
             logger.debug("Updated archived message text")
+            return "applied"
 
     async def backfill_is_outgoing(self, owner_id: int) -> None:
         """Backfill is_outgoing flag for messages sent by the owner."""
@@ -838,6 +925,34 @@ class DatabaseAdapter:
             result = await session.execute(stmt)
             return [self._message_version_to_dict(row) for row in result.scalars()]
 
+    def _message_versions_query(
+        self,
+        chat_id: int | None = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+    ):
+        # No join to messages: versions already carry (chat_id, message_id), and
+        # referential integrity is owned by the explicit deletes in
+        # delete_message / delete_chat_and_related_data.
+        stmt = select(MessageVersion)
+
+        conditions = []
+        if chat_id is not None:
+            conditions.append(MessageVersion.chat_id == chat_id)
+        if start_date:
+            conditions.append(MessageVersion.date >= start_date)
+        if end_date:
+            conditions.append(MessageVersion.date <= end_date)
+        if conditions:
+            stmt = stmt.where(and_(*conditions))
+
+        return stmt.order_by(
+            MessageVersion.chat_id.asc(),
+            MessageVersion.message_id.asc(),
+            MessageVersion.date.asc(),
+            MessageVersion.id.asc(),
+        )
+
     async def get_message_versions_by_date_range(
         self,
         chat_id: int | None = None,
@@ -846,29 +961,19 @@ class DatabaseAdapter:
     ) -> list[dict[str, Any]]:
         """Get previous message versions by version date/chat filter."""
         async with self.db_manager.async_session_factory() as session:
-            stmt = select(MessageVersion).join(
-                Message,
-                and_(MessageVersion.message_id == Message.id, MessageVersion.chat_id == Message.chat_id),
-            )
-
-            conditions = []
-            if chat_id:
-                conditions.append(MessageVersion.chat_id == chat_id)
-            if start_date:
-                conditions.append(MessageVersion.date >= start_date)
-            if end_date:
-                conditions.append(MessageVersion.date <= end_date)
-            if conditions:
-                stmt = stmt.where(and_(*conditions))
-
-            stmt = stmt.order_by(
-                MessageVersion.chat_id.asc(),
-                MessageVersion.message_id.asc(),
-                MessageVersion.date.asc(),
-                MessageVersion.id.asc(),
-            )
-            result = await session.execute(stmt)
+            result = await session.execute(self._message_versions_query(chat_id, start_date, end_date))
             return [self._message_version_to_dict(row) for row in result.scalars()]
+
+    async def iter_message_versions_for_export(self, chat_id: int):
+        """Stream a chat's message versions one by one (async generator).
+
+        Mirrors get_messages_for_export so the export endpoint never
+        materializes an entire edit history in memory.
+        """
+        async with self.db_manager.async_session_factory() as session:
+            result = await session.stream(self._message_versions_query(chat_id))
+            async for row in result.scalars():
+                yield self._message_version_to_dict(row)
 
     async def get_chat_stats(self, chat_id: int) -> dict[str, Any]:
         """Get statistics for a specific chat (message count, media count, total size).

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -31,6 +31,7 @@ from .models import (
     ForumTopic,
     Media,
     Message,
+    MessageVersion,
     Metadata,
     Reaction,
     SyncStatus,
@@ -62,8 +63,43 @@ def _message_conflict_update_values(message_data: dict[str, Any], values: dict[s
         update_values.pop("deleted_at", None)
     elif "deleted_at" not in message_data:
         update_values.pop("deleted_at", None)
+    if "is_pinned" not in message_data:
+        update_values.pop("is_pinned", None)
 
     return update_values
+
+
+def _datetime_hash_value(dt: datetime | None) -> str | None:
+    dt = _strip_tz(dt)
+    if dt is None:
+        return None
+    return dt.isoformat(timespec="microseconds")
+
+
+def _message_version_hash(
+    chat_id: int,
+    message_id: int,
+    text: str | None,
+    date: datetime,
+) -> str:
+    payload = {
+        "chat_id": chat_id,
+        "message_id": message_id,
+        "text": text,
+        "date": _datetime_hash_value(date),
+    }
+    encoded = json.dumps(payload, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _newer_edit_date(current: datetime | None, incoming: datetime | None) -> bool:
+    current = _strip_tz(current)
+    incoming = _strip_tz(incoming)
+    if incoming is None:
+        return False
+    if current is None:
+        return True
+    return incoming > current
 
 
 def retry_on_locked(
@@ -160,6 +196,158 @@ class DatabaseAdapter:
             except Exception as e2:
                 logger.error(f"Failed to serialize raw_data even after conversion: {e2}")
                 return "{}"
+
+    def _message_values(self, message_data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "id": message_data["id"],
+            "chat_id": message_data["chat_id"],
+            "sender_id": message_data.get("sender_id"),
+            "date": _strip_tz(message_data["date"]),
+            "text": message_data.get("text"),
+            "reply_to_msg_id": message_data.get("reply_to_msg_id"),
+            "reply_to_top_id": message_data.get("reply_to_top_id"),
+            "reply_to_text": message_data.get("reply_to_text"),
+            "forward_from_id": message_data.get("forward_from_id"),
+            "edit_date": _strip_tz(message_data.get("edit_date")),
+            "raw_data": self._serialize_raw_data(message_data.get("raw_data", {})),
+            "is_outgoing": message_data.get("is_outgoing", 0),
+            "is_pinned": message_data.get("is_pinned", 0),
+            "is_deleted": message_data.get("is_deleted", 0),
+            "deleted_at": _strip_tz(message_data.get("deleted_at")),
+        }
+
+    def _insert_message_stmt(self, values: dict[str, Any]):
+        if self._is_sqlite:
+            return sqlite_insert(Message).values(**values).on_conflict_do_nothing(index_elements=["id", "chat_id"])
+        return pg_insert(Message).values(**values).on_conflict_do_nothing(index_elements=["id", "chat_id"])
+
+    def _insert_message_version_stmt(self, values: dict[str, Any]):
+        if self._is_sqlite:
+            return sqlite_insert(MessageVersion).values(**values).on_conflict_do_nothing(index_elements=["change_hash"])
+        return pg_insert(MessageVersion).values(**values).on_conflict_do_nothing(index_elements=["change_hash"])
+
+    async def _record_message_version(
+        self,
+        session,
+        chat_id: int,
+        message_id: int,
+        text: str | None,
+        date: datetime,
+    ) -> bool:
+        date = _strip_tz(date)
+        if date is None:
+            return False
+
+        change_hash = _message_version_hash(
+            chat_id=chat_id,
+            message_id=message_id,
+            text=text,
+            date=date,
+        )
+        values = {
+            "chat_id": chat_id,
+            "message_id": message_id,
+            "text": text,
+            "date": date,
+            "change_hash": change_hash,
+            "captured_at": utcnow_naive(),
+        }
+        result = await session.execute(self._insert_message_version_stmt(values))
+        return bool(result.rowcount)
+
+    def _message_version_date(self, message: Message) -> datetime:
+        return _strip_tz(message.edit_date) or _strip_tz(message.date)
+
+    def _should_apply_upsert_text(self, existing: Message, values: dict[str, Any]) -> bool:
+        new_text = values.get("text")
+        new_edit_date = _strip_tz(values.get("edit_date"))
+        old_text = existing.text
+        old_edit_date = _strip_tz(existing.edit_date)
+
+        if old_text == new_text:
+            return _newer_edit_date(old_edit_date, new_edit_date)
+        if (old_text is None or old_text == "") and new_text not in (None, ""):
+            return True
+        if new_edit_date is None:
+            return False
+        if old_edit_date is None:
+            return True
+        if new_edit_date >= old_edit_date:
+            return True
+        return False
+
+    def _should_apply_edit_text(self, existing: Message, new_text: str, edit_date: datetime | None) -> bool:
+        old_edit_date = _strip_tz(existing.edit_date)
+        edit_date = _strip_tz(edit_date)
+
+        if existing.text == new_text and old_edit_date == edit_date:
+            return False
+        if edit_date is None:
+            return old_edit_date is None
+        if old_edit_date is None:
+            return True
+        return edit_date >= old_edit_date
+
+    async def _load_message_for_update(self, session, chat_id: int, message_id: int) -> Message | None:
+        if self._is_sqlite:
+            # SQLite has no row-level SELECT FOR UPDATE. A no-op write acquires the
+            # transaction's write lock before we re-read and decide whether to update.
+            await session.execute(
+                update(Message).where(and_(Message.chat_id == chat_id, Message.id == message_id)).values(id=Message.id)
+            )
+            stmt = select(Message).where(and_(Message.chat_id == chat_id, Message.id == message_id))
+        else:
+            stmt = select(Message).where(and_(Message.chat_id == chat_id, Message.id == message_id)).with_for_update()
+
+        result = await session.execute(stmt.execution_options(populate_existing=True))
+        return result.scalar_one_or_none()
+
+    async def _apply_existing_message_update(
+        self,
+        session,
+        message_data: dict[str, Any],
+        values: dict[str, Any],
+        source: str,
+    ) -> None:
+        existing = await self._load_message_for_update(session, values["chat_id"], values["id"])
+        if existing is None:
+            return
+
+        update_values = _message_conflict_update_values(message_data, values)
+        apply_text = self._should_apply_upsert_text(existing, values)
+        new_edit_date = values.get("edit_date")
+        if apply_text and new_edit_date is None and existing.edit_date is not None:
+            update_values.pop("edit_date", None)
+            new_edit_date = existing.edit_date
+
+        if apply_text:
+            if existing.text != values.get("text"):
+                await self._record_message_version(
+                    session=session,
+                    chat_id=existing.chat_id,
+                    message_id=existing.id,
+                    text=existing.text,
+                    date=self._message_version_date(existing),
+                )
+            else:
+                update_values.pop("text", None)
+        else:
+            update_values.pop("text", None)
+            update_values.pop("edit_date", None)
+
+        await session.execute(
+            update(Message)
+            .where(and_(Message.chat_id == values["chat_id"], Message.id == values["id"]))
+            .values(**update_values)
+        )
+
+    async def _insert_or_update_message(self, session, message_data: dict[str, Any], source: str) -> None:
+        values = self._message_values(message_data)
+        result = await session.execute(self._insert_message_stmt(values))
+        if result.rowcount:
+            return
+
+        await self._apply_existing_message_update(session, message_data, values, source)
 
     # ========== Metadata Operations ==========
 
@@ -411,42 +599,17 @@ class DatabaseAdapter:
 
     # ========== Message Operations ==========
 
-    async def insert_message(self, message_data: dict[str, Any]) -> None:
+    async def insert_message(self, message_data: dict[str, Any], source: str = "upsert") -> None:
         """Insert a message record.
 
         v6.0.0: media_type, media_id, media_path removed - use insert_media() separately.
         """
         async with self.db_manager.async_session_factory() as session:
-            values = {
-                "id": message_data["id"],
-                "chat_id": message_data["chat_id"],
-                "sender_id": message_data.get("sender_id"),
-                "date": _strip_tz(message_data["date"]),
-                "text": message_data.get("text"),
-                "reply_to_msg_id": message_data.get("reply_to_msg_id"),
-                "reply_to_top_id": message_data.get("reply_to_top_id"),
-                "reply_to_text": message_data.get("reply_to_text"),
-                "forward_from_id": message_data.get("forward_from_id"),
-                "edit_date": _strip_tz(message_data.get("edit_date")),
-                "raw_data": self._serialize_raw_data(message_data.get("raw_data", {})),
-                "is_outgoing": message_data.get("is_outgoing", 0),
-                "is_deleted": message_data.get("is_deleted", 0),
-                "deleted_at": _strip_tz(message_data.get("deleted_at")),
-            }
-            update_values = _message_conflict_update_values(message_data, values)
-
-            if self._is_sqlite:
-                stmt = sqlite_insert(Message).values(**values)
-                stmt = stmt.on_conflict_do_update(index_elements=["id", "chat_id"], set_=update_values)
-            else:
-                stmt = pg_insert(Message).values(**values)
-                stmt = stmt.on_conflict_do_update(index_elements=["id", "chat_id"], set_=update_values)
-
-            await session.execute(stmt)
+            await self._insert_or_update_message(session, message_data, source)
             await session.commit()
 
     @retry_on_locked()
-    async def insert_messages_batch(self, messages_data: list[dict[str, Any]]) -> None:
+    async def insert_messages_batch(self, messages_data: list[dict[str, Any]], source: str = "upsert") -> None:
         """Insert multiple message records in a single transaction.
 
         v6.0.0: media_type, media_id, media_path removed - use insert_media() separately.
@@ -456,33 +619,7 @@ class DatabaseAdapter:
 
         async with self.db_manager.async_session_factory() as session:
             for m in messages_data:
-                values = {
-                    "id": m["id"],
-                    "chat_id": m["chat_id"],
-                    "sender_id": m.get("sender_id"),
-                    "date": _strip_tz(m["date"]),
-                    "text": m.get("text"),
-                    "reply_to_msg_id": m.get("reply_to_msg_id"),
-                    "reply_to_top_id": m.get("reply_to_top_id"),
-                    "reply_to_text": m.get("reply_to_text"),
-                    "forward_from_id": m.get("forward_from_id"),
-                    "edit_date": _strip_tz(m.get("edit_date")),
-                    "raw_data": self._serialize_raw_data(m.get("raw_data", {})),
-                    "is_outgoing": m.get("is_outgoing", 0),
-                    "is_pinned": m.get("is_pinned", 0),
-                    "is_deleted": m.get("is_deleted", 0),
-                    "deleted_at": _strip_tz(m.get("deleted_at")),
-                }
-                update_values = _message_conflict_update_values(m, values)
-
-                if self._is_sqlite:
-                    stmt = sqlite_insert(Message).values(**values)
-                    stmt = stmt.on_conflict_do_update(index_elements=["id", "chat_id"], set_=update_values)
-                else:
-                    stmt = pg_insert(Message).values(**values)
-                    stmt = stmt.on_conflict_do_update(index_elements=["id", "chat_id"], set_=update_values)
-
-                await session.execute(stmt)
+                await self._insert_or_update_message(session, m, source)
 
             await session.commit()
 
@@ -551,6 +688,12 @@ class DatabaseAdapter:
     async def delete_message(self, chat_id: int, message_id: int) -> None:
         """Delete a specific message and its media."""
         async with self.db_manager.async_session_factory() as session:
+            # Delete previous versions
+            await session.execute(
+                delete(MessageVersion).where(
+                    and_(MessageVersion.chat_id == chat_id, MessageVersion.message_id == message_id)
+                )
+            )
             # Delete associated media
             await session.execute(delete(Media).where(and_(Media.chat_id == chat_id, Media.message_id == message_id)))
             # Delete reactions
@@ -600,17 +743,35 @@ class DatabaseAdapter:
             return None
 
     async def update_message_text(
-        self, chat_id: int, message_id: int, new_text: str, edit_date: datetime | None
+        self, chat_id: int, message_id: int, new_text: str, edit_date: datetime | None, source: str = "edit"
     ) -> None:
         """Update a message's text and edit_date."""
+        edit_date = _strip_tz(edit_date)
         async with self.db_manager.async_session_factory() as session:
+            message = await self._load_message_for_update(session, chat_id, message_id)
+            if message is None:
+                logger.debug("Edit no-op: message not found in archive")
+                return
+
+            if not self._should_apply_edit_text(message, new_text, edit_date):
+                logger.debug("Edit no-op: message already current")
+                return
+
+            if message.text != new_text:
+                await self._record_message_version(
+                    session=session,
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    text=message.text,
+                    date=self._message_version_date(message),
+                )
             await session.execute(
                 update(Message)
                 .where(and_(Message.chat_id == chat_id, Message.id == message_id))
-                .values(text=new_text, edit_date=_strip_tz(edit_date))
+                .values(text=new_text, edit_date=edit_date)
             )
             await session.commit()
-            logger.debug(f"Updated message {message_id} in chat {chat_id}")
+            logger.debug("Updated archived message text")
 
     async def backfill_is_outgoing(self, owner_id: int) -> None:
         """Backfill is_outgoing flag for messages sent by the owner."""
@@ -656,6 +817,58 @@ class DatabaseAdapter:
             "is_deleted": int(is_deleted),
             "deleted_at": deleted_at,
         }
+
+    def _message_version_to_dict(self, row: MessageVersion) -> dict[str, Any]:
+        return {
+            "chat_id": row.chat_id,
+            "message_id": row.message_id,
+            "text": row.text,
+            "date": row.date,
+        }
+
+    async def get_message_versions(self, chat_id: int, message_id: int, limit: int = 100) -> list[dict[str, Any]]:
+        """Get preserved previous text versions for a message."""
+        async with self.db_manager.async_session_factory() as session:
+            stmt = (
+                select(MessageVersion)
+                .where(and_(MessageVersion.chat_id == chat_id, MessageVersion.message_id == message_id))
+                .order_by(MessageVersion.date.desc(), MessageVersion.id.desc())
+                .limit(limit)
+            )
+            result = await session.execute(stmt)
+            return [self._message_version_to_dict(row) for row in result.scalars()]
+
+    async def get_message_versions_by_date_range(
+        self,
+        chat_id: int | None = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+    ) -> list[dict[str, Any]]:
+        """Get previous message versions by version date/chat filter."""
+        async with self.db_manager.async_session_factory() as session:
+            stmt = select(MessageVersion).join(
+                Message,
+                and_(MessageVersion.message_id == Message.id, MessageVersion.chat_id == Message.chat_id),
+            )
+
+            conditions = []
+            if chat_id:
+                conditions.append(MessageVersion.chat_id == chat_id)
+            if start_date:
+                conditions.append(MessageVersion.date >= start_date)
+            if end_date:
+                conditions.append(MessageVersion.date <= end_date)
+            if conditions:
+                stmt = stmt.where(and_(*conditions))
+
+            stmt = stmt.order_by(
+                MessageVersion.chat_id.asc(),
+                MessageVersion.message_id.asc(),
+                MessageVersion.date.asc(),
+                MessageVersion.id.asc(),
+            )
+            result = await session.execute(stmt)
+            return [self._message_version_to_dict(row) for row in result.scalars()]
 
     async def get_chat_stats(self, chat_id: int) -> dict[str, Any]:
         """Get statistics for a specific chat (message count, media count, total size).
@@ -1257,6 +1470,8 @@ class DatabaseAdapter:
     async def delete_chat_and_related_data(self, chat_id: int, media_base_path: str = None) -> None:
         """Delete a chat and all related data."""
         async with self.db_manager.async_session_factory() as session:
+            # Delete previous versions
+            await session.execute(delete(MessageVersion).where(MessageVersion.chat_id == chat_id))
             # Delete media records
             await session.execute(delete(Media).where(Media.chat_id == chat_id))
             # Delete reactions
@@ -1411,8 +1626,26 @@ class DatabaseAdapter:
 
                 messages.append(msg)
 
+            version_counts = {msg["id"]: 0 for msg in messages}
+            version_count_message_ids = [msg["id"] for msg in messages]
+            if version_count_message_ids:
+                count_stmt = (
+                    select(MessageVersion.message_id, func.count(MessageVersion.id).label("version_count"))
+                    .where(
+                        and_(
+                            MessageVersion.chat_id == chat_id,
+                            MessageVersion.message_id.in_(version_count_message_ids),
+                        )
+                    )
+                    .group_by(MessageVersion.message_id)
+                )
+                count_result = await session.execute(count_stmt)
+                version_counts.update({row.message_id: int(row.version_count or 0) for row in count_result})
+
             # Get reply texts and reactions for each message
             for msg in messages:
+                msg["version_count"] = version_counts.get(msg["id"], 0)
+
                 if msg.get("reply_to_msg_id") and not msg.get("reply_to_text"):
                     reply_result = await session.execute(
                         select(Message.text).where(

--- a/src/db/migrate.py
+++ b/src/db/migrate.py
@@ -58,13 +58,18 @@ MIGRATION_MODELS = [
 
 
 def _is_missing_table_error(exc: Exception, table_name: str) -> bool:
-    """Return True for dialect-specific missing-table errors."""
+    """Return True only for the anchored dialect messages for a missing table.
+
+    Deliberately strict: loose containment (any "does not exist" plus the table
+    name appearing anywhere, including in the echoed SQL statement) could
+    classify real errors — schema drift, dropped connections — as "table
+    missing" and silently report 0 records during migration verification.
+    """
     message = str(exc).lower()
     table = table_name.lower()
     return (
-        ("no such table" in message and table in message)
-        or ("undefinedtable" in message and table in message)
-        or ("does not exist" in message and table in message)
+        f"no such table: {table}" in message  # SQLite / aiosqlite
+        or f'relation "{table}" does not exist' in message  # PostgreSQL / asyncpg
     )
 
 

--- a/src/db/migrate.py
+++ b/src/db/migrate.py
@@ -9,6 +9,8 @@ import os
 from urllib.parse import quote_plus
 
 from sqlalchemy import func, select
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from .base import DatabaseManager
 from .models import (
@@ -20,6 +22,7 @@ from .models import (
     ForumTopic,
     Media,
     Message,
+    MessageVersion,
     Metadata,
     PushSubscription,
     Reaction,
@@ -37,6 +40,7 @@ MIGRATION_MODELS = [
     User,
     Chat,
     Message,
+    MessageVersion,
     Media,
     Reaction,
     SyncStatus,
@@ -51,6 +55,31 @@ MIGRATION_MODELS = [
     ViewerToken,
     AppSettings,
 ]
+
+
+def _is_missing_table_error(exc: Exception, table_name: str) -> bool:
+    """Return True for dialect-specific missing-table errors."""
+    message = str(exc).lower()
+    table = table_name.lower()
+    return (
+        ("no such table" in message and table in message)
+        or ("undefinedtable" in message and table in message)
+        or ("does not exist" in message and table in message)
+    )
+
+
+async def _count_model_records(session: AsyncSession, model: type[Base], missing_table_is_zero: bool = False) -> int:
+    """Count records for a model, optionally treating missing legacy tables as empty."""
+    table_name = model.__tablename__
+    try:
+        result = await session.execute(select(func.count()).select_from(model))
+    except SQLAlchemyError as exc:
+        if missing_table_is_zero and _is_missing_table_error(exc, table_name):
+            await session.rollback()
+            logger.info(f"  {table_name}: source table missing; treating as 0 records")
+            return 0
+        raise
+    return result.scalar() or 0
 
 
 async def migrate_sqlite_to_postgres(
@@ -140,8 +169,7 @@ async def _migrate_table(source: DatabaseManager, target: DatabaseManager, model
 
     async with source.get_session() as src_session:
         # Get total count
-        count_result = await src_session.execute(select(func.count()).select_from(model))
-        total_records = count_result.scalar() or 0
+        total_records = await _count_model_records(src_session, model, missing_table_is_zero=True)
 
         if total_records == 0:
             logger.info(f"  {table_name}: 0 records (empty)")
@@ -222,12 +250,10 @@ async def verify_migration(sqlite_path: str = None, postgres_url: str = None) ->
             table_name = model.__tablename__
 
             async with source.get_session() as session:
-                result = await session.execute(select(func.count()).select_from(model))
-                sqlite_count = result.scalar() or 0
+                sqlite_count = await _count_model_records(session, model, missing_table_is_zero=True)
 
             async with target.get_session() as session:
-                result = await session.execute(select(func.count()).select_from(model))
-                postgres_count = result.scalar() or 0
+                postgres_count = await _count_model_records(session, model)
 
             results[table_name] = {
                 "sqlite": sqlite_count,

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -22,6 +22,8 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
+from ..message_utils import utcnow_naive
+
 
 class Base(DeclarativeBase):
     """Base class for all models."""
@@ -126,7 +128,7 @@ class MessageVersion(Base):
     text: Mapped[str | None] = mapped_column(Text)
     date: Mapped[datetime] = mapped_column(DateTime, nullable=False)
     change_hash: Mapped[str] = mapped_column(String(64), nullable=False)
-    captured_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
+    captured_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
 
     message: Mapped[Message] = relationship(
         "Message",
@@ -136,6 +138,10 @@ class MessageVersion(Base):
     )
 
     __table_args__ = (
+        # NOTE: the CASCADE is inert on SQLite (PRAGMA foreign_keys is off by
+        # default) — the explicit MessageVersion deletes in delete_message and
+        # delete_chat_and_related_data are the load-bearing cleanup. Keep them
+        # in sync with any future message-deletion path.
         ForeignKeyConstraint(
             ["message_id", "chat_id"],
             ["messages.id", "messages.chat_id"],

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -98,6 +98,7 @@ class Message(Base):
     )
     reactions: Mapped[list[Reaction]] = relationship("Reaction", back_populates="message", lazy="dynamic")
     media_items: Mapped[list[Media]] = relationship("Media", back_populates="message", lazy="selectin")
+    versions: Mapped[list[MessageVersion]] = relationship("MessageVersion", back_populates="message", lazy="dynamic")
 
     __table_args__ = (
         Index("idx_messages_chat_id", "chat_id"),
@@ -111,6 +112,39 @@ class Message(Base):
         Index("idx_messages_reply_to", "chat_id", "reply_to_msg_id"),
         # v6.2.0: Index for topic message lookups in forum chats
         Index("idx_messages_topic", "chat_id", "reply_to_top_id"),
+    )
+
+
+class MessageVersion(Base):
+    """Historical text versions for edited messages."""
+
+    __tablename__ = "message_versions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    message_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    chat_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    text: Mapped[str | None] = mapped_column(Text)
+    date: Mapped[datetime] = mapped_column(DateTime, nullable=False)
+    change_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    captured_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
+
+    message: Mapped[Message] = relationship(
+        "Message",
+        back_populates="versions",
+        primaryjoin="and_(MessageVersion.message_id==Message.id, MessageVersion.chat_id==Message.chat_id)",
+        foreign_keys="[MessageVersion.message_id, MessageVersion.chat_id]",
+    )
+
+    __table_args__ = (
+        ForeignKeyConstraint(
+            ["message_id", "chat_id"],
+            ["messages.id", "messages.chat_id"],
+            name="fk_message_versions_message",
+            ondelete="CASCADE",
+        ),
+        UniqueConstraint("change_hash", name="uq_message_versions_change_hash"),
+        Index("idx_message_versions_message_date", "chat_id", "message_id", "date"),
+        Index("idx_message_versions_message_captured", "chat_id", "message_id", "captured_at"),
     )
 
 

--- a/src/export_backup.py
+++ b/src/export_backup.py
@@ -67,6 +67,7 @@ class BackupExporter:
 
         # Get messages
         messages = await self.db.get_messages_by_date_range(chat_id, start_dt, end_dt)
+        message_versions = await self.db.get_message_versions_by_date_range(chat_id, start_dt, end_dt)
 
         # Get chats
         chats = await self.db.get_all_chats()
@@ -76,9 +77,14 @@ class BackupExporter:
         export_data = {
             "export_date": datetime.now().isoformat(),
             "filters": {"chat_id": chat_id, "start_date": start_date, "end_date": end_date},
-            "statistics": {"total_messages": len(messages), "total_chats": len(chats_dict)},
+            "statistics": {
+                "total_messages": len(messages),
+                "total_chats": len(chats_dict),
+                "total_message_versions": len(message_versions),
+            },
             "chats": chats,
             "messages": messages,
+            "message_versions": message_versions,
         }
 
         # Write to file

--- a/src/listener.py
+++ b/src/listener.py
@@ -268,6 +268,7 @@ class TelegramListener:
         self.stats = {
             "edits_received": 0,
             "edits_applied": 0,
+            "edits_skipped": 0,  # No-op edits (already current / not archived)
             "deletions_received": 0,
             "deletions_applied": 0,
             "deletions_skipped": 0,  # Skipped due to LISTEN_DELETIONS=false
@@ -735,16 +736,22 @@ class TelegramListener:
                     self.stats["operations_discarded"] += 1
                     return
 
-                # Apply the edit immediately
-                await self.db.update_message_text(
+                # Apply the edit immediately; count and broadcast only when the
+                # archive actually changed, so stats stay honest and the viewer
+                # never displays text the archive rejected as stale.
+                outcome = await self.db.update_message_text(
                     chat_id=chat_id,
                     message_id=message.id,
                     new_text=new_text,
                     edit_date=edit_date,
-                    source="listener_edit",
                 )
+                if outcome != "applied":
+                    self.stats["edits_skipped"] += 1
+                    logger.debug("📝 Edit skipped (%s)", outcome)
+                    return
+
                 self.stats["edits_applied"] += 1
-                logger.debug(f"📝 Edit applied: chat={chat_id} msg={message.id}")
+                logger.debug("📝 Edit applied")
 
                 # Notify viewer of the update
                 await self._notify_update(
@@ -922,7 +929,7 @@ class TelegramListener:
                     media_type = self._get_media_type(message.media)
 
                 # Insert the message FIRST (required for FK constraint on media table)
-                await self.db.insert_message(message_data, source="listener_new")
+                await self.db.insert_message(message_data)
                 self.stats["new_messages_saved"] += 1
 
                 # v6.0.0: Handle media - create Media record AFTER message exists
@@ -1081,8 +1088,8 @@ class TelegramListener:
                                 },
                                 "is_outgoing": 0,
                             }
-                            await self.db.insert_message(message_data, source="listener_service")
-                            logger.info(f"📌 Service message saved: {service_text}")
+                            await self.db.insert_message(message_data)
+                            logger.info("📌 Service message saved")
                     except Exception as e:
                         logger.warning(f"Failed to save service message: {e}")
 
@@ -1262,6 +1269,7 @@ class TelegramListener:
             logger.info("   📝 Edits:")
             logger.info(f"      Received: {self.stats['edits_received']}")
             logger.info(f"      Applied:  {self.stats['edits_applied']}")
+            logger.info(f"      Skipped:  {self.stats['edits_skipped']}")
             logger.info("")
             logger.info("   🗑️ Deletions:")
             logger.info(f"      Received: {self.stats['deletions_received']}")

--- a/src/listener.py
+++ b/src/listener.py
@@ -737,7 +737,11 @@ class TelegramListener:
 
                 # Apply the edit immediately
                 await self.db.update_message_text(
-                    chat_id=chat_id, message_id=message.id, new_text=new_text, edit_date=edit_date
+                    chat_id=chat_id,
+                    message_id=message.id,
+                    new_text=new_text,
+                    edit_date=edit_date,
+                    source="listener_edit",
                 )
                 self.stats["edits_applied"] += 1
                 logger.debug(f"📝 Edit applied: chat={chat_id} msg={message.id}")
@@ -918,7 +922,7 @@ class TelegramListener:
                     media_type = self._get_media_type(message.media)
 
                 # Insert the message FIRST (required for FK constraint on media table)
-                await self.db.insert_message(message_data)
+                await self.db.insert_message(message_data, source="listener_new")
                 self.stats["new_messages_saved"] += 1
 
                 # v6.0.0: Handle media - create Media record AFTER message exists
@@ -1077,7 +1081,7 @@ class TelegramListener:
                                 },
                                 "is_outgoing": 0,
                             }
-                            await self.db.insert_message(message_data)
+                            await self.db.insert_message(message_data, source="listener_service")
                             logger.info(f"📌 Service message saved: {service_text}")
                     except Exception as e:
                         logger.warning(f"Failed to save service message: {e}")

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -1137,9 +1137,9 @@ class TelegramBackup:
 
         return grand_total
 
-    async def _commit_batch(self, batch_data: list[dict], chat_id: int) -> None:
+    async def _commit_batch(self, batch_data: list[dict], chat_id: int, source: str = "backup_upsert") -> None:
         """Persist a batch of processed messages, their media and reactions to the DB."""
-        await self.db.insert_messages_batch(batch_data)
+        await self.db.insert_messages_batch(batch_data, source=source)
 
         for msg in batch_data:
             if msg.get("_media_data"):
@@ -1190,13 +1190,13 @@ class TelegramBackup:
             batch_data.append(msg_data)
 
             if len(batch_data) >= batch_size:
-                await self._commit_batch(batch_data, chat_id)
+                await self._commit_batch(batch_data, chat_id, source="gap_fill")
                 recovered += len(batch_data)
                 batch_data = []
 
         # Flush remaining messages
         if batch_data:
-            await self._commit_batch(batch_data, chat_id)
+            await self._commit_batch(batch_data, chat_id, source="gap_fill")
             recovered += len(batch_data)
 
         return recovered
@@ -1360,7 +1360,9 @@ class TelegramBackup:
 
                     if should_update:
                         # Update text and edit_date
-                        await self.db.update_message_text(chat_id, msg_id, remote_msg.message, remote_msg.edit_date)
+                        await self.db.update_message_text(
+                            chat_id, msg_id, remote_msg.message, remote_msg.edit_date, source="sync_edit"
+                        )
                         total_updated += 1
 
             except Exception as e:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -1137,9 +1137,9 @@ class TelegramBackup:
 
         return grand_total
 
-    async def _commit_batch(self, batch_data: list[dict], chat_id: int, source: str = "backup_upsert") -> None:
+    async def _commit_batch(self, batch_data: list[dict], chat_id: int) -> None:
         """Persist a batch of processed messages, their media and reactions to the DB."""
-        await self.db.insert_messages_batch(batch_data, source=source)
+        await self.db.insert_messages_batch(batch_data)
 
         for msg in batch_data:
             if msg.get("_media_data"):
@@ -1190,13 +1190,13 @@ class TelegramBackup:
             batch_data.append(msg_data)
 
             if len(batch_data) >= batch_size:
-                await self._commit_batch(batch_data, chat_id, source="gap_fill")
+                await self._commit_batch(batch_data, chat_id)
                 recovered += len(batch_data)
                 batch_data = []
 
         # Flush remaining messages
         if batch_data:
-            await self._commit_batch(batch_data, chat_id, source="gap_fill")
+            await self._commit_batch(batch_data, chat_id)
             recovered += len(batch_data)
 
         return recovered
@@ -1345,25 +1345,24 @@ class TelegramBackup:
                         total_deleted += 1
                         continue
 
-                    # Check for edits
-                    # We compare string representations of edit_date
+                    # Check for edits. Telethon delivers tz-aware UTC datetimes
+                    # while the archive stores naive UTC — normalize before
+                    # comparing, otherwise every previously-edited message looks
+                    # changed on every sync pass and pays a pointless locked
+                    # update round-trip.
                     remote_edit_date = remote_msg.edit_date
-                    local_edit_date_str = local_messages[msg_id]
+                    if remote_edit_date is not None and remote_edit_date.tzinfo is not None:
+                        remote_edit_date = remote_edit_date.replace(tzinfo=None)
+                    local_edit_date = local_messages[msg_id]
 
-                    should_update = False
-
-                    if remote_edit_date:
-                        # If remote has edit_date, check if it differs from local
-                        # This handles cases where local is None or different
-                        if str(remote_edit_date) != str(local_edit_date_str):
-                            should_update = True
-
-                    if should_update:
-                        # Update text and edit_date
-                        await self.db.update_message_text(
-                            chat_id, msg_id, remote_msg.message, remote_msg.edit_date, source="sync_edit"
+                    if remote_edit_date and remote_edit_date != local_edit_date:
+                        # Update text and edit_date; count only edits the archive
+                        # actually accepted (the adapter re-checks under lock).
+                        outcome = await self.db.update_message_text(
+                            chat_id, msg_id, remote_msg.message, remote_msg.edit_date
                         )
-                        total_updated += 1
+                        if outcome == "applied":
+                            total_updated += 1
 
             except Exception as e:
                 logger.error(f"Error syncing batch for chat {chat_id}: {e}")

--- a/src/telegram_import.py
+++ b/src/telegram_import.py
@@ -753,7 +753,7 @@ class TelegramImporter:
         media: list[dict[str, Any]],
     ) -> None:
         """Flush a batch of messages and media to the database."""
-        await self.db.insert_messages_batch(messages, source="import")
+        await self.db.insert_messages_batch(messages)
 
         for m in media:
             source = m.pop("_source")

--- a/src/telegram_import.py
+++ b/src/telegram_import.py
@@ -753,7 +753,7 @@ class TelegramImporter:
         media: list[dict[str, Any]],
     ) -> None:
         """Flush a batch of messages and media to the database."""
-        await self.db.insert_messages_batch(messages)
+        await self.db.insert_messages_batch(messages, source="import")
 
         for m in media:
             source = m.pop("_source")

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -867,6 +867,11 @@ def _strip_original_media_paths(messages: list[dict]) -> None:
                     item["no_download"] = True
 
 
+def _export_chat_metadata(chat: dict) -> dict:
+    """Return the minimal chat metadata needed by JSON exports."""
+    return {key: chat.get(key) for key in ("id", "type", "title", "username")}
+
+
 # Setup paths
 templates_dir = Path(__file__).parent / "templates"
 static_dir = Path(__file__).parent / "static"
@@ -1467,6 +1472,27 @@ async def get_messages(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+@app.get("/api/chats/{chat_id}/messages/{message_id}/versions")
+async def get_message_versions(
+    chat_id: int,
+    message_id: int,
+    user: UserContext = Depends(require_auth),
+    limit: int = Query(100, ge=1, le=500),
+):
+    """Get preserved previous versions for a message."""
+    user_chat_ids = get_user_chat_ids(user)
+    if user_chat_ids is not None and chat_id not in user_chat_ids:
+        raise HTTPException(status_code=403, detail="Access denied")
+
+    try:
+        return await db.get_message_versions(chat_id=chat_id, message_id=message_id, limit=limit)
+    except Exception as e:
+        logger.error(f"Error fetching message versions: {e}", exc_info=True)
+        if _is_db_connection_error(e):
+            raise HTTPException(status_code=503, detail="Database temporarily unavailable")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
 @app.get("/api/chats/{chat_id}/pinned")
 async def get_pinned_messages(chat_id: int, user: UserContext = Depends(require_auth)):
     """Get all pinned messages for a chat, ordered by date descending (newest first)."""
@@ -1953,15 +1979,20 @@ async def export_chat(chat_id: int, user: UserContext = Depends(require_auth)):
         filename = f"{safe_name}_export.json"
 
         async def iter_json():
-            yield "[\n"
+            yield "{\n"
+            yield f'  "chat": {json.dumps(_export_chat_metadata(chat), ensure_ascii=False, default=str)},\n'
+            yield '  "messages": [\n'
             first = True
             async for msg in db.get_messages_for_export(chat_id):
                 if not first:
                     yield ",\n"
                 first = False
                 # Ensure UTF-8 encoding for non-Latin characters
-                yield json.dumps(msg, ensure_ascii=False)
-            yield "\n]"
+                yield "    " + json.dumps(msg, ensure_ascii=False, default=str)
+            yield "\n  ],\n"
+            message_versions = await db.get_message_versions_by_date_range(chat_id=chat_id)
+            yield ('  "message_versions": ' + json.dumps(message_versions, ensure_ascii=False, default=str) + "\n")
+            yield "}"
 
         # RFC 5987 encoding for non-ASCII filenames
         encoded_filename = quote(filename)

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1990,8 +1990,16 @@ async def export_chat(chat_id: int, user: UserContext = Depends(require_auth)):
                 # Ensure UTF-8 encoding for non-Latin characters
                 yield "    " + json.dumps(msg, ensure_ascii=False, default=str)
             yield "\n  ],\n"
-            message_versions = await db.get_message_versions_by_date_range(chat_id=chat_id)
-            yield ('  "message_versions": ' + json.dumps(message_versions, ensure_ascii=False, default=str) + "\n")
+            # Stream versions like messages: a chat's edit history can be large,
+            # so it must never be materialized into a single list/dumps here.
+            yield '  "message_versions": [\n'
+            first_version = True
+            async for version in db.iter_message_versions_for_export(chat_id):
+                if not first_version:
+                    yield ",\n"
+                first_version = False
+                yield "    " + json.dumps(version, ensure_ascii=False, default=str)
+            yield "\n  ]\n"
             yield "}"
 
         # RFC 5987 encoding for non-ASCII filenames

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1197,9 +1197,20 @@
                                     <!-- Metadata -->
                                     <div
                                         class="text-[10px] opacity-60 text-right mt-1 flex justify-end items-center gap-1">
-                                        <span v-if="msg.edit_date">edited</span>
-                                        <span v-if="msg.is_deleted">deleted</span>
-                                        {{ formatTime(msg.date) }}
+                                        <span v-if="msg.is_deleted" class="order-1" :title="formatMetadataTimestampTitle('Deleted', msg.deleted_at)">deleted</span>
+                                        <button v-if="Number(msg.version_count) > 0"
+                                            type="button"
+                                            @click.stop="toggleMessageVersions(msg)"
+                                            class="order-2 hover:text-blue-300 transition-colors"
+                                            :class="{ 'text-blue-300': isVersionsPanelOpenFor(msg) }"
+                                            :aria-expanded="isVersionsPanelOpenFor(msg)"
+                                            :title="formatMetadataTimestampTitle('Edited', msg.edit_date)">
+                                            edited({{ msg.version_count }})
+                                        </button>
+                                        <span v-else-if="msg.edit_date"
+                                            class="order-2"
+                                            :title="formatMetadataTimestampTitle('Edited', msg.edit_date)">edited</span>
+                                        <span class="order-3">{{ formatTime(msg.date) }}</span>
                                     </div>
                                 </div>
                             </div>
@@ -1270,6 +1281,70 @@
                     </button>
                 </div>
             </div>
+        </div>
+
+        <!-- Message Versions Drawer -->
+        <div v-if="versionsMessage"
+            class="fixed inset-0 z-50 bg-black/70 flex justify-end"
+            @click.self="closeVersionsPanel">
+            <aside class="h-full w-full sm:max-w-lg bg-tg-sidebar border-l border-gray-700 shadow-2xl flex flex-col">
+                <header class="shrink-0 border-b border-gray-700 px-4 py-3">
+                    <div class="flex items-start justify-between gap-3">
+                        <div class="min-w-0">
+                            <h3 class="text-base font-semibold text-white">Versions</h3>
+                            <div class="mt-1 text-xs text-tg-muted truncate">
+                                {{ formatDateFull(versionsMessage.date) }} {{ formatTime(versionsMessage.date) }}
+                            </div>
+                        </div>
+                        <button @click="closeVersionsPanel"
+                            class="text-gray-400 hover:text-white transition p-1"
+                            title="Close">
+                            <i class="fa-solid fa-xmark text-lg"></i>
+                        </button>
+                    </div>
+                </header>
+
+                <div class="flex-1 overflow-y-auto p-4 space-y-4">
+                    <div v-if="isMessageVersionsLoading(versionsMessage)" class="flex items-center gap-2 text-sm text-tg-muted">
+                        <div class="loading-spinner"></div>
+                        <span>Loading versions...</span>
+                    </div>
+
+                    <div v-else-if="getMessageVersionsError(versionsMessage)"
+                        class="rounded-md border border-red-500/30 bg-red-500/10 p-3 text-sm text-red-200">
+                        <div class="mb-3">{{ getMessageVersionsError(versionsMessage) }}</div>
+                        <button @click="reloadMessageVersions(versionsMessage)"
+                            class="inline-flex items-center gap-2 rounded bg-red-500/20 px-3 py-1.5 text-xs text-red-100 hover:bg-red-500/30">
+                            <i class="fa-solid fa-rotate-right"></i>
+                            <span>Retry</span>
+                        </button>
+                    </div>
+
+                    <div v-else-if="getMessageVersions(versionsMessage).length === 0"
+                        class="rounded-md border border-white/10 bg-black/20 p-4 text-sm text-tg-muted">
+                        No previous versions retained
+                    </div>
+
+                    <div v-else class="space-y-3">
+                        <div class="flex items-center justify-between gap-3 text-xs text-tg-muted">
+                            <span>{{ getMessageVersions(versionsMessage).length }} previous versions</span>
+                            <span v-if="getMessageVersions(versionsMessage).length >= 100">Showing latest loaded set</span>
+                        </div>
+
+                        <article v-for="(entry, idx) in getMessageVersions(versionsMessage)"
+                            :key="`${entry.message_id || versionsMessage.id}:${entry.date || idx}:${idx}`"
+                            class="rounded-md border border-white/10 bg-black/20 p-3">
+                            <div class="mb-3 text-xs text-tg-muted">
+                                {{ formatMessageVersionDate(entry.date) }}
+                            </div>
+
+                            <div class="max-h-64 overflow-y-auto whitespace-pre-wrap break-words rounded bg-gray-950/60 p-2 text-sm text-gray-100">
+                                {{ entry.text || '' }}
+                            </div>
+                        </article>
+                    </div>
+                </div>
+            </aside>
         </div>
 
         <!-- Lightbox Modal for Images -->
@@ -1527,6 +1602,11 @@
             setup() {
                 const chats = ref([])
                 const messages = ref([])
+                const messageVersionsByMessage = ref({})
+                const versionsMessage = ref(null)
+                const messageVersionsLoading = ref({})
+                const messageVersionsErrors = ref({})
+                const messageVersionsRequestSeq = ref({})
                 const selectedChat = ref(null)
                 const searchQuery = ref('')
                 const messageSearchQuery = ref('')
@@ -2260,8 +2340,16 @@
                                 m.id === data.message_id && (data.chat_id == null || m.chat_id === data.chat_id)
                             )
                             if (editMsg) {
+                                const previousText = editMsg.text
                                 editMsg.text = data.new_text
                                 editMsg.edit_date = data.edit_date
+                                if (previousText !== data.new_text) {
+                                    editMsg.version_count = (Number(editMsg.version_count) || 0) + 1
+                                }
+                                clearMessageVersionsCache(editMsg)
+                                if (isVersionsPanelOpenFor(editMsg)) {
+                                    loadMessageVersions(editMsg)
+                                }
                             }
                             break
 
@@ -3438,6 +3526,110 @@
                     return moment.utc(dateStr).tz(viewerTimezone.value).format('HH:mm')
                 }
 
+                const formatMetadataTimestampTitle = (label, dateStr) => {
+                    if (!dateStr) return label
+                    return `${label} ${formatDateFull(dateStr)} ${formatTime(dateStr)}`
+                }
+
+                const formatMessageVersionDate = (dateStr) => {
+                    if (!dateStr) return ''
+                    return moment.utc(dateStr).tz(viewerTimezone.value).format('MMM D, HH:mm')
+                }
+
+                const messageVersionsKey = (msg) => {
+                    const chatId = msg.chat_id ?? selectedChat.value?.id
+                    return `${chatId}:${msg.id}`
+                }
+
+                const setMessageVersionsRecord = (recordRef, key, value) => {
+                    recordRef.value = { ...recordRef.value, [key]: value }
+                }
+
+                const clearMessageVersionsRecord = (recordRef, key) => {
+                    const next = { ...recordRef.value }
+                    delete next[key]
+                    recordRef.value = next
+                }
+
+                const messageVersionSortTime = (entry) => {
+                    if (!entry?.date) return 0
+                    const value = moment.utc(entry.date).valueOf()
+                    return Number.isFinite(value) ? value : 0
+                }
+
+                const getMessageVersions = (msg) => {
+                    const versions = messageVersionsByMessage.value[messageVersionsKey(msg)] || []
+                    return [...versions].sort((a, b) => {
+                        const dateDiff = messageVersionSortTime(b) - messageVersionSortTime(a)
+                        if (dateDiff !== 0) return dateDiff
+                        return 0
+                    })
+                }
+                const isMessageVersionsLoading = (msg) => !!messageVersionsLoading.value[messageVersionsKey(msg)]
+                const getMessageVersionsError = (msg) => messageVersionsErrors.value[messageVersionsKey(msg)] || ''
+                const isVersionsPanelOpenFor = (msg) => {
+                    return !!versionsMessage.value && messageVersionsKey(versionsMessage.value) === messageVersionsKey(msg)
+                }
+
+                const clearMessageVersionsCache = (msg) => {
+                    const key = messageVersionsKey(msg)
+                    clearMessageVersionsRecord(messageVersionsByMessage, key)
+                    clearMessageVersionsRecord(messageVersionsErrors, key)
+                }
+
+                const loadMessageVersions = async (msg) => {
+                    const chatId = msg.chat_id ?? selectedChat.value?.id
+                    if (!chatId || msg.id == null) return
+
+                    const key = messageVersionsKey(msg)
+                    const requestSeq = (messageVersionsRequestSeq.value[key] || 0) + 1
+                    setMessageVersionsRecord(messageVersionsRequestSeq, key, requestSeq)
+                    setMessageVersionsRecord(messageVersionsLoading, key, true)
+                    clearMessageVersionsRecord(messageVersionsErrors, key)
+
+                    try {
+                        const res = await fetch(`/api/chats/${chatId}/messages/${msg.id}/versions?limit=100`, {
+                            credentials: 'include'
+                        })
+                        if (!res.ok) throw new Error('Failed to load message versions')
+                        const versions = await res.json()
+                        if (messageVersionsRequestSeq.value[key] !== requestSeq) return
+                        setMessageVersionsRecord(messageVersionsByMessage, key, versions)
+                    } catch (e) {
+                        if (messageVersionsRequestSeq.value[key] !== requestSeq) return
+                        console.error('Failed to load message versions:', e)
+                        setMessageVersionsRecord(messageVersionsErrors, key, 'Failed to load message versions')
+                    } finally {
+                        if (messageVersionsRequestSeq.value[key] === requestSeq) {
+                            setMessageVersionsRecord(messageVersionsLoading, key, false)
+                        }
+                    }
+                }
+
+                const toggleMessageVersions = async (msg) => {
+                    const key = messageVersionsKey(msg)
+                    if (versionsMessage.value && messageVersionsKey(versionsMessage.value) === key) {
+                        versionsMessage.value = null
+                        return
+                    }
+
+                    versionsMessage.value = msg
+                    if (!messageVersionsByMessage.value[key] && !messageVersionsLoading.value[key]) {
+                        await loadMessageVersions(msg)
+                    }
+                }
+
+                const closeVersionsPanel = () => {
+                    versionsMessage.value = null
+                }
+
+                const reloadMessageVersions = async (msg) => {
+                    const key = messageVersionsKey(msg)
+                    clearMessageVersionsRecord(messageVersionsByMessage, key)
+                    clearMessageVersionsRecord(messageVersionsErrors, key)
+                    await loadMessageVersions(msg)
+                }
+
                 const formatReactionEmoji = (emoji) => {
                     // Handle custom emojis (stored as custom_documentId)
                     if (emoji && emoji.startsWith('custom_')) {
@@ -4016,6 +4208,7 @@
                     filteredChats,
                     selectedChat,
                     messages,
+                    versionsMessage,
                     sortedMessages,
                     searchQuery,
                     messageSearchQuery,
@@ -4066,6 +4259,15 @@
                     formatDate,
                     formatDateFull,
                     formatTime,
+                    formatMetadataTimestampTitle,
+                    getMessageVersions,
+                    isMessageVersionsLoading,
+                    getMessageVersionsError,
+                    isVersionsPanelOpenFor,
+                    toggleMessageVersions,
+                    closeVersionsPanel,
+                    reloadMessageVersions,
+                    formatMessageVersionDate,
                     formatLastBackupTime,
                     formatReactionEmoji,
                     getMediaUrl,

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -3587,6 +3587,7 @@
                                 return
                             }
                             if (res.status === 503) {
+                                if (messageVersionsRequestSeq.value[key] !== requestSeq) return
                                 setMessageVersionsRecord(messageVersionsErrors, key, 'Database temporarily unavailable')
                                 return
                             }

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1287,7 +1287,7 @@
         <div v-if="versionsMessage"
             class="fixed inset-0 z-50 bg-black/70 flex justify-end"
             @click.self="closeVersionsPanel">
-            <aside class="h-full w-full sm:max-w-lg bg-tg-sidebar border-l border-gray-700 shadow-2xl flex flex-col">
+            <aside role="dialog" aria-modal="true" aria-label="Message versions" class="h-full w-full sm:max-w-lg bg-tg-sidebar border-l border-gray-700 shadow-2xl flex flex-col">
                 <header class="shrink-0 border-b border-gray-700 px-4 py-3">
                     <div class="flex items-start justify-between gap-3">
                         <div class="min-w-0">
@@ -1296,7 +1296,7 @@
                                 {{ formatDateFull(versionsMessage.date) }} {{ formatTime(versionsMessage.date) }}
                             </div>
                         </div>
-                        <button @click="closeVersionsPanel"
+                        <button ref="versionsCloseBtn" @click="closeVersionsPanel"
                             class="text-gray-400 hover:text-white transition p-1"
                             title="Close">
                             <i class="fa-solid fa-xmark text-lg"></i>
@@ -1305,7 +1305,7 @@
                 </header>
 
                 <div class="flex-1 overflow-y-auto p-4 space-y-4">
-                    <div v-if="isMessageVersionsLoading(versionsMessage)" class="flex items-center gap-2 text-sm text-tg-muted">
+                    <div v-if="isMessageVersionsLoading(versionsMessage)" role="status" aria-live="polite" class="flex items-center gap-2 text-sm text-tg-muted">
                         <div class="loading-spinner"></div>
                         <span>Loading versions...</span>
                     </div>
@@ -1328,14 +1328,14 @@
                     <div v-else class="space-y-3">
                         <div class="flex items-center justify-between gap-3 text-xs text-tg-muted">
                             <span>{{ getMessageVersions(versionsMessage).length }} previous versions</span>
-                            <span v-if="getMessageVersions(versionsMessage).length >= 100">Showing latest loaded set</span>
+                            <span v-if="getMessageVersions(versionsMessage).length === 100">Showing the latest 100</span>
                         </div>
 
                         <article v-for="(entry, idx) in getMessageVersions(versionsMessage)"
                             :key="`${entry.message_id || versionsMessage.id}:${entry.date || idx}:${idx}`"
                             class="rounded-md border border-white/10 bg-black/20 p-3">
                             <div class="mb-3 text-xs text-tg-muted">
-                                {{ formatMessageVersionDate(entry.date) }}
+                                as of {{ formatMessageVersionDate(entry.date) }}
                             </div>
 
                             <div class="max-h-64 overflow-y-auto whitespace-pre-wrap break-words rounded bg-gray-950/60 p-2 text-sm text-gray-100">
@@ -1607,6 +1607,7 @@
                 const messageVersionsLoading = ref({})
                 const messageVersionsErrors = ref({})
                 const messageVersionsRequestSeq = ref({})
+                const versionsCloseBtn = ref(null)
                 const selectedChat = ref(null)
                 const searchQuery = ref('')
                 const messageSearchQuery = ref('')
@@ -3551,19 +3552,8 @@
                     recordRef.value = next
                 }
 
-                const messageVersionSortTime = (entry) => {
-                    if (!entry?.date) return 0
-                    const value = moment.utc(entry.date).valueOf()
-                    return Number.isFinite(value) ? value : 0
-                }
-
                 const getMessageVersions = (msg) => {
-                    const versions = messageVersionsByMessage.value[messageVersionsKey(msg)] || []
-                    return [...versions].sort((a, b) => {
-                        const dateDiff = messageVersionSortTime(b) - messageVersionSortTime(a)
-                        if (dateDiff !== 0) return dateDiff
-                        return 0
-                    })
+                    return messageVersionsByMessage.value[messageVersionsKey(msg)] || []
                 }
                 const isMessageVersionsLoading = (msg) => !!messageVersionsLoading.value[messageVersionsKey(msg)]
                 const getMessageVersionsError = (msg) => messageVersionsErrors.value[messageVersionsKey(msg)] || ''
@@ -3591,7 +3581,17 @@
                         const res = await fetch(`/api/chats/${chatId}/messages/${msg.id}/versions?limit=100`, {
                             credentials: 'include'
                         })
-                        if (!res.ok) throw new Error('Failed to load message versions')
+                        if (!res.ok) {
+                            if (res.status === 401) {
+                                isAuthenticated.value = false
+                                return
+                            }
+                            if (res.status === 503) {
+                                setMessageVersionsRecord(messageVersionsErrors, key, 'Database temporarily unavailable')
+                                return
+                            }
+                            throw new Error('Failed to load message versions')
+                        }
                         const versions = await res.json()
                         if (messageVersionsRequestSeq.value[key] !== requestSeq) return
                         setMessageVersionsRecord(messageVersionsByMessage, key, versions)
@@ -3609,11 +3609,13 @@
                 const toggleMessageVersions = async (msg) => {
                     const key = messageVersionsKey(msg)
                     if (versionsMessage.value && messageVersionsKey(versionsMessage.value) === key) {
-                        versionsMessage.value = null
+                        closeVersionsPanel()
                         return
                     }
 
                     versionsMessage.value = msg
+                    document.addEventListener('keydown', handleVersionsKeydown)
+                    nextTick(() => versionsCloseBtn.value?.focus())
                     if (!messageVersionsByMessage.value[key] && !messageVersionsLoading.value[key]) {
                         await loadMessageVersions(msg)
                     }
@@ -3621,6 +3623,7 @@
 
                 const closeVersionsPanel = () => {
                     versionsMessage.value = null
+                    document.removeEventListener('keydown', handleVersionsKeydown)
                 }
 
                 const reloadMessageVersions = async (msg) => {
@@ -3628,6 +3631,11 @@
                     clearMessageVersionsRecord(messageVersionsByMessage, key)
                     clearMessageVersionsRecord(messageVersionsErrors, key)
                     await loadMessageVersions(msg)
+                }
+
+                const handleVersionsKeydown = (e) => {
+                    if (!versionsMessage.value) return
+                    if (e.key === 'Escape') closeVersionsPanel()
                 }
 
                 const formatReactionEmoji = (emoji) => {
@@ -4209,6 +4217,7 @@
                     selectedChat,
                     messages,
                     versionsMessage,
+                    versionsCloseBtn,
                     sortedMessages,
                     searchQuery,
                     messageSearchQuery,

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -791,7 +791,6 @@ class TestMessageOperations:
         """insert_message on SQLite executes an upsert and commits."""
         db_manager, mock_session = _make_mock_db_manager(is_sqlite=True)
         adapter = DatabaseAdapter(db_manager)
-        mock_session.get.return_value = None
 
         msg_data = {
             "id": 1,
@@ -809,7 +808,6 @@ class TestMessageOperations:
         """insert_message on PostgreSQL executes an upsert and commits."""
         db_manager, mock_session = _make_mock_db_manager(is_sqlite=False)
         adapter = DatabaseAdapter(db_manager)
-        mock_session.get.return_value = None
 
         msg_data = {
             "id": 2,
@@ -838,7 +836,6 @@ class TestMessageOperations:
         """insert_messages_batch processes each message and commits once."""
         db_manager, mock_session = _make_mock_db_manager(is_sqlite=True)
         adapter = DatabaseAdapter(db_manager)
-        mock_session.get.return_value = None
 
         messages = [
             {"id": 1, "chat_id": 100, "date": datetime(2025, 1, 1), "text": "msg1"},
@@ -967,9 +964,12 @@ class TestMessageOperations:
         select_result = MagicMock()
         select_result.scalar_one_or_none.return_value = existing
         mock_session.execute.side_effect = [MagicMock(), select_result, MagicMock(), MagicMock()]
+        # _record_message_version runs inside a SAVEPOINT (session.begin_nested)
+        mock_session.begin_nested = MagicMock(return_value=AsyncMock())
 
-        await adapter.update_message_text(100, 42, "edited text", datetime(2025, 6, 1))
+        outcome = await adapter.update_message_text(100, 42, "edited text", datetime(2025, 6, 1))
 
+        assert outcome == "applied"
         assert mock_session.execute.await_count == 4
         mock_session.commit.assert_awaited_once()
 

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -791,6 +791,7 @@ class TestMessageOperations:
         """insert_message on SQLite executes an upsert and commits."""
         db_manager, mock_session = _make_mock_db_manager(is_sqlite=True)
         adapter = DatabaseAdapter(db_manager)
+        mock_session.get.return_value = None
 
         msg_data = {
             "id": 1,
@@ -808,6 +809,7 @@ class TestMessageOperations:
         """insert_message on PostgreSQL executes an upsert and commits."""
         db_manager, mock_session = _make_mock_db_manager(is_sqlite=False)
         adapter = DatabaseAdapter(db_manager)
+        mock_session.get.return_value = None
 
         msg_data = {
             "id": 2,
@@ -836,6 +838,7 @@ class TestMessageOperations:
         """insert_messages_batch processes each message and commits once."""
         db_manager, mock_session = _make_mock_db_manager(is_sqlite=True)
         adapter = DatabaseAdapter(db_manager)
+        mock_session.get.return_value = None
 
         messages = [
             {"id": 1, "chat_id": 100, "date": datetime(2025, 1, 1), "text": "msg1"},
@@ -874,14 +877,14 @@ class TestMessageOperations:
 
     @pytest.mark.asyncio
     async def test_delete_message_deletes_media_reactions_and_message(self):
-        """delete_message issues three deletes and one commit."""
+        """delete_message issues deletes for versions, media, reactions, message and commits."""
         db_manager, mock_session = _make_mock_db_manager()
         adapter = DatabaseAdapter(db_manager)
 
         await adapter.delete_message(chat_id=100, message_id=42)
 
-        # 3 deletes: media, reactions, message
-        assert mock_session.execute.await_count == 3
+        # 4 deletes: versions, media, reactions, message
+        assert mock_session.execute.await_count == 4
         mock_session.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -955,10 +958,19 @@ class TestMessageOperations:
         """update_message_text issues an update and commits."""
         db_manager, mock_session = _make_mock_db_manager()
         adapter = DatabaseAdapter(db_manager)
+        existing = MagicMock()
+        existing.id = 42
+        existing.chat_id = 100
+        existing.date = datetime(2025, 5, 1)
+        existing.text = "original"
+        existing.edit_date = None
+        select_result = MagicMock()
+        select_result.scalar_one_or_none.return_value = existing
+        mock_session.execute.side_effect = [MagicMock(), select_result, MagicMock(), MagicMock()]
 
         await adapter.update_message_text(100, 42, "edited text", datetime(2025, 6, 1))
 
-        mock_session.execute.assert_awaited_once()
+        assert mock_session.execute.await_count == 4
         mock_session.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -1156,15 +1168,15 @@ class TestDeleteChatOperations:
     """Test delete_chat_and_related_data and related cleanup operations."""
 
     @pytest.mark.asyncio
-    async def test_delete_chat_issues_five_deletes(self):
-        """delete_chat_and_related_data deletes media, reactions, messages, sync, and chat."""
+    async def test_delete_chat_issues_six_deletes(self):
+        """delete_chat_and_related_data deletes versions, media, reactions, messages, sync, and chat."""
         db_manager, mock_session = _make_mock_db_manager()
         adapter = DatabaseAdapter(db_manager)
 
         await adapter.delete_chat_and_related_data(100)
 
-        # 5 deletes: media, reactions, messages, sync_status, chat
-        assert mock_session.execute.await_count == 5
+        # 6 deletes: versions, media, reactions, messages, sync_status, chat
+        assert mock_session.execute.await_count == 6
         mock_session.commit.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -2172,11 +2184,14 @@ class TestGetMessagesPaginated:
         mock_result = MagicMock()
         mock_result.__iter__ = MagicMock(return_value=iter([row]))
 
-        # Second execute call returns the reply text
+        version_count_result = MagicMock()
+        version_count_result.__iter__ = MagicMock(return_value=iter([]))
+
+        # Third execute call returns the reply text
         reply_result = MagicMock()
         reply_result.scalar_one_or_none.return_value = "Original message text"
 
-        mock_session.execute.side_effect = [mock_result, reply_result]
+        mock_session.execute.side_effect = [mock_result, version_count_result, reply_result]
         adapter.get_reactions = AsyncMock(return_value=[])
 
         result = await adapter.get_messages_paginated(chat_id=100)

--- a/tests/test_db_adapter_soft_delete_upsert.py
+++ b/tests/test_db_adapter_soft_delete_upsert.py
@@ -1,10 +1,12 @@
-from datetime import datetime
+import asyncio
+from datetime import UTC, datetime
 
 import pytest
+from sqlalchemy import select
 
 from src.db.adapter import DatabaseAdapter
 from src.db.base import DatabaseManager
-from src.db.models import Message
+from src.db.models import Message, MessageVersion
 
 
 @pytest.fixture
@@ -22,6 +24,16 @@ async def _get_message(adapter: DatabaseAdapter, message_id: int, chat_id: int) 
         message = await session.get(Message, (message_id, chat_id))
         assert message is not None
         return message
+
+
+async def _get_versions(adapter: DatabaseAdapter, message_id: int, chat_id: int) -> list[MessageVersion]:
+    async with adapter.db_manager.async_session_factory() as session:
+        result = await session.execute(
+            select(MessageVersion)
+            .where(MessageVersion.message_id == message_id, MessageVersion.chat_id == chat_id)
+            .order_by(MessageVersion.id.asc())
+        )
+        return list(result.scalars())
 
 
 @pytest.mark.asyncio
@@ -48,7 +60,7 @@ async def test_insert_message_upsert_preserves_soft_delete_marker(sqlite_adapter
     )
 
     message = await _get_message(sqlite_adapter, 1, 100)
-    assert message.text == "reprocessed"
+    assert message.text == "original"
     assert message.is_deleted == 1
     assert message.deleted_at == deleted_at
 
@@ -81,7 +93,7 @@ async def test_insert_messages_batch_upsert_preserves_soft_delete_marker(sqlite_
     )
 
     message = await _get_message(sqlite_adapter, 2, 100)
-    assert message.text == "reprocessed"
+    assert message.text == "original"
     assert message.is_deleted == 1
     assert message.deleted_at == deleted_at
 
@@ -189,3 +201,393 @@ async def test_get_messages_sync_data_excludes_soft_deleted(sqlite_adapter):
 
     sync_data = await sqlite_adapter.get_messages_sync_data(200)
     assert set(sync_data.keys()) == {10}
+
+
+@pytest.mark.asyncio
+async def test_update_message_text_records_previous_version(sqlite_adapter):
+    await sqlite_adapter.insert_message(
+        {"id": 20, "chat_id": 300, "date": datetime(2026, 6, 26, 9, 0), "text": "original"}
+    )
+
+    edit_date = datetime(2026, 6, 26, 9, 5)
+    await sqlite_adapter.update_message_text(300, 20, "edited", edit_date, source="listener_edit")
+
+    message = await _get_message(sqlite_adapter, 20, 300)
+    versions = await _get_versions(sqlite_adapter, 20, 300)
+    assert message.text == "edited"
+    assert message.edit_date == edit_date
+    assert len(versions) == 1
+    assert versions[0].text == "original"
+    assert versions[0].date == datetime(2026, 6, 26, 9, 0)
+
+
+@pytest.mark.asyncio
+async def test_update_message_text_is_idempotent(sqlite_adapter):
+    edit_date = datetime(2026, 6, 26, 10, 5)
+    await sqlite_adapter.insert_message(
+        {"id": 21, "chat_id": 300, "date": datetime(2026, 6, 26, 10, 0), "text": "original"}
+    )
+
+    await sqlite_adapter.update_message_text(300, 21, "edited", edit_date, source="listener_edit")
+    await sqlite_adapter.update_message_text(300, 21, "edited", edit_date, source="sync_edit")
+
+    versions = await _get_versions(sqlite_adapter, 21, 300)
+    assert len(versions) == 1
+    assert versions[0].text == "original"
+
+
+@pytest.mark.asyncio
+async def test_update_message_text_same_text_updates_edit_date_without_version(sqlite_adapter):
+    await sqlite_adapter.insert_message(
+        {"id": 28, "chat_id": 300, "date": datetime(2026, 6, 26, 10, 0), "text": "original"}
+    )
+
+    reaction_edit_date = datetime(2026, 6, 26, 10, 15)
+    await sqlite_adapter.update_message_text(300, 28, "original", reaction_edit_date, source="sync_edit")
+
+    message = await _get_message(sqlite_adapter, 28, 300)
+    versions = await _get_versions(sqlite_adapter, 28, 300)
+    assert message.text == "original"
+    assert message.edit_date == reaction_edit_date
+    assert versions == []
+
+
+@pytest.mark.asyncio
+async def test_update_message_text_older_edit_date_does_not_roll_back(sqlite_adapter):
+    current_edit_date = datetime(2026, 6, 26, 10, 30)
+    old_edit_date = datetime(2026, 6, 26, 10, 10)
+    await sqlite_adapter.insert_message(
+        {
+            "id": 27,
+            "chat_id": 300,
+            "date": datetime(2026, 6, 26, 10, 0),
+            "text": "current",
+            "edit_date": current_edit_date,
+        }
+    )
+
+    await sqlite_adapter.update_message_text(300, 27, "older", old_edit_date, source="listener_edit")
+
+    message = await _get_message(sqlite_adapter, 27, 300)
+    versions = await _get_versions(sqlite_adapter, 27, 300)
+    assert message.text == "current"
+    assert message.edit_date == current_edit_date
+    assert versions == []
+
+
+@pytest.mark.asyncio
+async def test_text_only_edit_records_previous_version(sqlite_adapter):
+    await sqlite_adapter.insert_message(
+        {"id": 22, "chat_id": 300, "date": datetime(2026, 6, 26, 11, 0), "text": "caption"}
+    )
+
+    await sqlite_adapter.update_message_text(300, 22, "caption edited", None, source="listener_edit")
+
+    message = await _get_message(sqlite_adapter, 22, 300)
+    versions = await _get_versions(sqlite_adapter, 22, 300)
+    assert message.text == "caption edited"
+    assert message.edit_date is None
+    assert len(versions) == 1
+    assert versions[0].text == "caption"
+    assert versions[0].date == datetime(2026, 6, 26, 11, 0)
+
+
+@pytest.mark.asyncio
+async def test_upsert_with_newer_edit_date_records_previous_version(sqlite_adapter):
+    await sqlite_adapter.insert_message(
+        {"id": 23, "chat_id": 300, "date": datetime(2026, 6, 26, 12, 0), "text": "original"}
+    )
+    edit_date = datetime(2026, 6, 26, 12, 30)
+
+    await sqlite_adapter.insert_message(
+        {
+            "id": 23,
+            "chat_id": 300,
+            "date": datetime(2026, 6, 26, 12, 0),
+            "text": "edited via backup",
+            "edit_date": edit_date,
+        },
+        source="backup_upsert",
+    )
+
+    message = await _get_message(sqlite_adapter, 23, 300)
+    versions = await _get_versions(sqlite_adapter, 23, 300)
+    assert message.text == "edited via backup"
+    assert message.edit_date == edit_date
+    assert len(versions) == 1
+    assert versions[0].text == "original"
+    assert versions[0].date == datetime(2026, 6, 26, 12, 0)
+
+
+@pytest.mark.asyncio
+async def test_upsert_with_same_edit_date_records_previous_version(sqlite_adapter):
+    edit_date = datetime(2026, 6, 26, 12, 30)
+    await sqlite_adapter.insert_message(
+        {
+            "id": 33,
+            "chat_id": 300,
+            "date": datetime(2026, 6, 26, 12, 0),
+            "text": "original",
+            "edit_date": edit_date,
+        }
+    )
+
+    await sqlite_adapter.insert_message(
+        {
+            "id": 33,
+            "chat_id": 300,
+            "date": datetime(2026, 6, 26, 12, 0),
+            "text": "edited via backup",
+            "edit_date": edit_date,
+        },
+        source="backup_upsert",
+    )
+
+    message = await _get_message(sqlite_adapter, 33, 300)
+    versions = await _get_versions(sqlite_adapter, 33, 300)
+    assert message.text == "edited via backup"
+    assert message.edit_date == edit_date
+    assert len(versions) == 1
+    assert versions[0].text == "original"
+    assert versions[0].date == edit_date
+
+
+@pytest.mark.asyncio
+async def test_upsert_with_same_aware_edit_date_records_previous_version(sqlite_adapter):
+    edit_date = datetime(2026, 6, 26, 12, 30)
+    aware_edit_date = datetime(2026, 6, 26, 12, 30, tzinfo=UTC)
+    await sqlite_adapter.insert_message(
+        {
+            "id": 34,
+            "chat_id": 300,
+            "date": datetime(2026, 6, 26, 12, 0),
+            "text": "original",
+            "edit_date": edit_date,
+        }
+    )
+
+    await sqlite_adapter.insert_message(
+        {
+            "id": 34,
+            "chat_id": 300,
+            "date": datetime(2026, 6, 26, 12, 0),
+            "text": "edited via backup",
+            "edit_date": aware_edit_date,
+        },
+        source="backup_upsert",
+    )
+
+    message = await _get_message(sqlite_adapter, 34, 300)
+    versions = await _get_versions(sqlite_adapter, 34, 300)
+    assert message.text == "edited via backup"
+    assert message.edit_date == edit_date
+    assert len(versions) == 1
+    assert versions[0].text == "original"
+    assert versions[0].date == edit_date
+
+
+@pytest.mark.asyncio
+async def test_repeated_upsert_with_same_edit_date_is_idempotent(sqlite_adapter):
+    edit_date = datetime(2026, 6, 26, 12, 30)
+    edited_message = {
+        "id": 35,
+        "chat_id": 300,
+        "date": datetime(2026, 6, 26, 12, 0),
+        "text": "edited via backup",
+        "edit_date": edit_date,
+    }
+    await sqlite_adapter.insert_message(
+        {
+            "id": 35,
+            "chat_id": 300,
+            "date": datetime(2026, 6, 26, 12, 0),
+            "text": "original",
+            "edit_date": edit_date,
+        }
+    )
+
+    await sqlite_adapter.insert_message(edited_message, source="backup_upsert")
+    await sqlite_adapter.insert_message(edited_message, source="backup_upsert")
+
+    message = await _get_message(sqlite_adapter, 35, 300)
+    versions = await _get_versions(sqlite_adapter, 35, 300)
+    assert message.text == "edited via backup"
+    assert message.edit_date == edit_date
+    assert len(versions) == 1
+    assert versions[0].text == "original"
+    assert versions[0].date == edit_date
+
+
+@pytest.mark.asyncio
+async def test_upsert_same_text_updates_edit_date_without_version(sqlite_adapter):
+    await sqlite_adapter.insert_message(
+        {"id": 29, "chat_id": 300, "date": datetime(2026, 6, 26, 12, 0), "text": "original"}
+    )
+    reaction_edit_date = datetime(2026, 6, 26, 12, 30)
+
+    await sqlite_adapter.insert_message(
+        {
+            "id": 29,
+            "chat_id": 300,
+            "date": datetime(2026, 6, 26, 12, 0),
+            "text": "original",
+            "edit_date": reaction_edit_date,
+        },
+        source="backup_upsert",
+    )
+
+    message = await _get_message(sqlite_adapter, 29, 300)
+    versions = await _get_versions(sqlite_adapter, 29, 300)
+    assert message.text == "original"
+    assert message.edit_date == reaction_edit_date
+    assert versions == []
+
+
+@pytest.mark.asyncio
+async def test_upsert_with_older_edit_date_does_not_roll_back(sqlite_adapter):
+    current_edit_date = datetime(2026, 6, 26, 13, 30)
+    old_edit_date = datetime(2026, 6, 26, 13, 5)
+    await sqlite_adapter.insert_message(
+        {
+            "id": 24,
+            "chat_id": 300,
+            "date": datetime(2026, 6, 26, 13, 0),
+            "text": "current text",
+            "edit_date": current_edit_date,
+        }
+    )
+
+    await sqlite_adapter.insert_message(
+        {
+            "id": 24,
+            "chat_id": 300,
+            "date": datetime(2026, 6, 26, 13, 0),
+            "text": "old import text",
+            "edit_date": old_edit_date,
+        },
+        source="import",
+    )
+
+    message = await _get_message(sqlite_adapter, 24, 300)
+    versions = await _get_versions(sqlite_adapter, 24, 300)
+    assert message.text == "current text"
+    assert message.edit_date == current_edit_date
+    assert versions == []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_upserts_keep_newest_edit_date(sqlite_adapter):
+    await sqlite_adapter.insert_message(
+        {"id": 32, "chat_id": 300, "date": datetime(2026, 6, 26, 15, 0), "text": "original"}
+    )
+
+    async def upsert(text: str, edit_date: datetime) -> None:
+        await sqlite_adapter.insert_message(
+            {
+                "id": 32,
+                "chat_id": 300,
+                "date": datetime(2026, 6, 26, 15, 0),
+                "text": text,
+                "edit_date": edit_date,
+            },
+            source="backup_upsert",
+        )
+
+    newer = datetime(2026, 6, 26, 15, 30)
+    older = datetime(2026, 6, 26, 15, 10)
+    await asyncio.gather(upsert("newer", newer), upsert("older", older))
+
+    message = await _get_message(sqlite_adapter, 32, 300)
+    assert message.text == "newer"
+    assert message.edit_date == newer
+
+
+@pytest.mark.asyncio
+async def test_upsert_filling_empty_text_preserves_existing_edit_date(sqlite_adapter):
+    current_edit_date = datetime(2026, 6, 26, 13, 45)
+    await sqlite_adapter.insert_message(
+        {
+            "id": 26,
+            "chat_id": 300,
+            "date": datetime(2026, 6, 26, 13, 40),
+            "text": "",
+            "edit_date": current_edit_date,
+        }
+    )
+
+    await sqlite_adapter.insert_message(
+        {
+            "id": 26,
+            "chat_id": 300,
+            "date": datetime(2026, 6, 26, 13, 40),
+            "text": "filled text",
+        },
+        source="backup_upsert",
+    )
+
+    message = await _get_message(sqlite_adapter, 26, 300)
+    versions = await _get_versions(sqlite_adapter, 26, 300)
+    assert message.text == "filled text"
+    assert message.edit_date == current_edit_date
+    assert len(versions) == 1
+    assert versions[0].text == ""
+    assert versions[0].date == current_edit_date
+
+
+@pytest.mark.asyncio
+async def test_get_message_versions_returns_dicts(sqlite_adapter):
+    await sqlite_adapter.insert_message({"id": 25, "chat_id": 300, "date": datetime(2026, 6, 26, 14, 0), "text": "v1"})
+    await sqlite_adapter.update_message_text(300, 25, "v2", datetime(2026, 6, 26, 14, 5), source="sync_edit")
+    await sqlite_adapter.update_message_text(300, 25, "v3", datetime(2026, 6, 26, 14, 10), source="sync_edit")
+
+    versions = await sqlite_adapter.get_message_versions(300, 25)
+    assert len(versions) == 2
+    assert versions[0]["message_id"] == 25
+    assert versions[0]["chat_id"] == 300
+    assert "id" not in versions[0]
+    assert "change_hash" not in versions[0]
+    assert "captured_at" not in versions[0]
+    assert [version["text"] for version in versions] == ["v2", "v1"]
+    assert [version["date"] for version in versions] == [
+        datetime(2026, 6, 26, 14, 5),
+        datetime(2026, 6, 26, 14, 0),
+    ]
+
+    limited_versions = await sqlite_adapter.get_message_versions(300, 25, limit=1)
+    assert [version["text"] for version in limited_versions] == ["v2"]
+
+
+@pytest.mark.asyncio
+async def test_get_messages_paginated_includes_version_counts(sqlite_adapter):
+    await sqlite_adapter.insert_message({"id": 40, "chat_id": 300, "date": datetime(2026, 6, 26, 15, 0), "text": "v1"})
+    await sqlite_adapter.insert_message(
+        {"id": 41, "chat_id": 300, "date": datetime(2026, 6, 26, 15, 1), "text": "unchanged"}
+    )
+    await sqlite_adapter.insert_message(
+        {"id": 42, "chat_id": 300, "date": datetime(2026, 6, 26, 15, 2), "text": "text-only"}
+    )
+    await sqlite_adapter.update_message_text(300, 40, "v2", datetime(2026, 6, 26, 15, 5), source="sync_edit")
+    await sqlite_adapter.update_message_text(300, 40, "v3", datetime(2026, 6, 26, 15, 10), source="sync_edit")
+    await sqlite_adapter.update_message_text(300, 42, "text-only edited", None, source="listener_edit")
+
+    messages = await sqlite_adapter.get_messages_paginated(300, limit=10)
+    counts = {message["id"]: message["version_count"] for message in messages}
+    assert counts[40] == 2
+    assert counts[41] == 0
+    assert counts[42] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_message_versions_by_date_range_filters_version_dates(sqlite_adapter):
+    await sqlite_adapter.insert_message({"id": 30, "chat_id": 300, "date": datetime(2026, 6, 25, 14, 0), "text": "old"})
+    await sqlite_adapter.insert_message({"id": 31, "chat_id": 300, "date": datetime(2026, 6, 26, 14, 0), "text": "new"})
+    await sqlite_adapter.update_message_text(300, 30, "old edited", datetime(2026, 6, 25, 14, 5))
+    await sqlite_adapter.update_message_text(300, 31, "new edited", datetime(2026, 6, 26, 14, 5))
+
+    versions = await sqlite_adapter.get_message_versions_by_date_range(
+        chat_id=300,
+        start_date=datetime(2026, 6, 26),
+        end_date=datetime(2026, 6, 27),
+    )
+
+    assert [row["message_id"] for row in versions] == [31]

--- a/tests/test_db_adapter_soft_delete_upsert.py
+++ b/tests/test_db_adapter_soft_delete_upsert.py
@@ -60,6 +60,8 @@ async def test_insert_message_upsert_preserves_soft_delete_marker(sqlite_adapter
     )
 
     message = await _get_message(sqlite_adapter, 1, 100)
+    # Re-processing without edit evidence (no edit_date) must NOT overwrite
+    # archived text — upserts only replace text with a newer/equal edit_date.
     assert message.text == "original"
     assert message.is_deleted == 1
     assert message.deleted_at == deleted_at
@@ -93,6 +95,7 @@ async def test_insert_messages_batch_upsert_preserves_soft_delete_marker(sqlite_
     )
 
     message = await _get_message(sqlite_adapter, 2, 100)
+    # Same invariant as above for the batch path: no edit evidence, no overwrite.
     assert message.text == "original"
     assert message.is_deleted == 1
     assert message.deleted_at == deleted_at
@@ -210,7 +213,7 @@ async def test_update_message_text_records_previous_version(sqlite_adapter):
     )
 
     edit_date = datetime(2026, 6, 26, 9, 5)
-    await sqlite_adapter.update_message_text(300, 20, "edited", edit_date, source="listener_edit")
+    await sqlite_adapter.update_message_text(300, 20, "edited", edit_date)
 
     message = await _get_message(sqlite_adapter, 20, 300)
     versions = await _get_versions(sqlite_adapter, 20, 300)
@@ -228,8 +231,8 @@ async def test_update_message_text_is_idempotent(sqlite_adapter):
         {"id": 21, "chat_id": 300, "date": datetime(2026, 6, 26, 10, 0), "text": "original"}
     )
 
-    await sqlite_adapter.update_message_text(300, 21, "edited", edit_date, source="listener_edit")
-    await sqlite_adapter.update_message_text(300, 21, "edited", edit_date, source="sync_edit")
+    await sqlite_adapter.update_message_text(300, 21, "edited", edit_date)
+    await sqlite_adapter.update_message_text(300, 21, "edited", edit_date)
 
     versions = await _get_versions(sqlite_adapter, 21, 300)
     assert len(versions) == 1
@@ -243,7 +246,7 @@ async def test_update_message_text_same_text_updates_edit_date_without_version(s
     )
 
     reaction_edit_date = datetime(2026, 6, 26, 10, 15)
-    await sqlite_adapter.update_message_text(300, 28, "original", reaction_edit_date, source="sync_edit")
+    await sqlite_adapter.update_message_text(300, 28, "original", reaction_edit_date)
 
     message = await _get_message(sqlite_adapter, 28, 300)
     versions = await _get_versions(sqlite_adapter, 28, 300)
@@ -266,7 +269,7 @@ async def test_update_message_text_older_edit_date_does_not_roll_back(sqlite_ada
         }
     )
 
-    await sqlite_adapter.update_message_text(300, 27, "older", old_edit_date, source="listener_edit")
+    await sqlite_adapter.update_message_text(300, 27, "older", old_edit_date)
 
     message = await _get_message(sqlite_adapter, 27, 300)
     versions = await _get_versions(sqlite_adapter, 27, 300)
@@ -281,7 +284,7 @@ async def test_text_only_edit_records_previous_version(sqlite_adapter):
         {"id": 22, "chat_id": 300, "date": datetime(2026, 6, 26, 11, 0), "text": "caption"}
     )
 
-    await sqlite_adapter.update_message_text(300, 22, "caption edited", None, source="listener_edit")
+    await sqlite_adapter.update_message_text(300, 22, "caption edited", None)
 
     message = await _get_message(sqlite_adapter, 22, 300)
     versions = await _get_versions(sqlite_adapter, 22, 300)
@@ -307,7 +310,6 @@ async def test_upsert_with_newer_edit_date_records_previous_version(sqlite_adapt
             "text": "edited via backup",
             "edit_date": edit_date,
         },
-        source="backup_upsert",
     )
 
     message = await _get_message(sqlite_adapter, 23, 300)
@@ -340,7 +342,6 @@ async def test_upsert_with_same_edit_date_records_previous_version(sqlite_adapte
             "text": "edited via backup",
             "edit_date": edit_date,
         },
-        source="backup_upsert",
     )
 
     message = await _get_message(sqlite_adapter, 33, 300)
@@ -374,7 +375,6 @@ async def test_upsert_with_same_aware_edit_date_records_previous_version(sqlite_
             "text": "edited via backup",
             "edit_date": aware_edit_date,
         },
-        source="backup_upsert",
     )
 
     message = await _get_message(sqlite_adapter, 34, 300)
@@ -406,8 +406,8 @@ async def test_repeated_upsert_with_same_edit_date_is_idempotent(sqlite_adapter)
         }
     )
 
-    await sqlite_adapter.insert_message(edited_message, source="backup_upsert")
-    await sqlite_adapter.insert_message(edited_message, source="backup_upsert")
+    await sqlite_adapter.insert_message(edited_message)
+    await sqlite_adapter.insert_message(edited_message)
 
     message = await _get_message(sqlite_adapter, 35, 300)
     versions = await _get_versions(sqlite_adapter, 35, 300)
@@ -433,7 +433,6 @@ async def test_upsert_same_text_updates_edit_date_without_version(sqlite_adapter
             "text": "original",
             "edit_date": reaction_edit_date,
         },
-        source="backup_upsert",
     )
 
     message = await _get_message(sqlite_adapter, 29, 300)
@@ -465,7 +464,6 @@ async def test_upsert_with_older_edit_date_does_not_roll_back(sqlite_adapter):
             "text": "old import text",
             "edit_date": old_edit_date,
         },
-        source="import",
     )
 
     message = await _get_message(sqlite_adapter, 24, 300)
@@ -490,7 +488,6 @@ async def test_concurrent_upserts_keep_newest_edit_date(sqlite_adapter):
                 "text": text,
                 "edit_date": edit_date,
             },
-            source="backup_upsert",
         )
 
     newer = datetime(2026, 6, 26, 15, 30)
@@ -522,7 +519,6 @@ async def test_upsert_filling_empty_text_preserves_existing_edit_date(sqlite_ada
             "date": datetime(2026, 6, 26, 13, 40),
             "text": "filled text",
         },
-        source="backup_upsert",
     )
 
     message = await _get_message(sqlite_adapter, 26, 300)
@@ -537,8 +533,8 @@ async def test_upsert_filling_empty_text_preserves_existing_edit_date(sqlite_ada
 @pytest.mark.asyncio
 async def test_get_message_versions_returns_dicts(sqlite_adapter):
     await sqlite_adapter.insert_message({"id": 25, "chat_id": 300, "date": datetime(2026, 6, 26, 14, 0), "text": "v1"})
-    await sqlite_adapter.update_message_text(300, 25, "v2", datetime(2026, 6, 26, 14, 5), source="sync_edit")
-    await sqlite_adapter.update_message_text(300, 25, "v3", datetime(2026, 6, 26, 14, 10), source="sync_edit")
+    await sqlite_adapter.update_message_text(300, 25, "v2", datetime(2026, 6, 26, 14, 5))
+    await sqlite_adapter.update_message_text(300, 25, "v3", datetime(2026, 6, 26, 14, 10))
 
     versions = await sqlite_adapter.get_message_versions(300, 25)
     assert len(versions) == 2
@@ -566,9 +562,9 @@ async def test_get_messages_paginated_includes_version_counts(sqlite_adapter):
     await sqlite_adapter.insert_message(
         {"id": 42, "chat_id": 300, "date": datetime(2026, 6, 26, 15, 2), "text": "text-only"}
     )
-    await sqlite_adapter.update_message_text(300, 40, "v2", datetime(2026, 6, 26, 15, 5), source="sync_edit")
-    await sqlite_adapter.update_message_text(300, 40, "v3", datetime(2026, 6, 26, 15, 10), source="sync_edit")
-    await sqlite_adapter.update_message_text(300, 42, "text-only edited", None, source="listener_edit")
+    await sqlite_adapter.update_message_text(300, 40, "v2", datetime(2026, 6, 26, 15, 5))
+    await sqlite_adapter.update_message_text(300, 40, "v3", datetime(2026, 6, 26, 15, 10))
+    await sqlite_adapter.update_message_text(300, 42, "text-only edited", None)
 
     messages = await sqlite_adapter.get_messages_paginated(300, limit=10)
     counts = {message["id"]: message["version_count"] for message in messages}
@@ -591,3 +587,100 @@ async def test_get_message_versions_by_date_range_filters_version_dates(sqlite_a
     )
 
     assert [row["message_id"] for row in versions] == [31]
+
+
+@pytest.mark.asyncio
+async def test_update_message_text_reports_outcome(sqlite_adapter):
+    await sqlite_adapter.insert_message(
+        {"id": 50, "chat_id": 300, "date": datetime(2026, 6, 26, 9, 0), "text": "original"}
+    )
+
+    applied = await sqlite_adapter.update_message_text(300, 50, "edited", datetime(2026, 6, 26, 9, 5))
+    noop = await sqlite_adapter.update_message_text(300, 50, "edited", datetime(2026, 6, 26, 9, 5))
+    missing = await sqlite_adapter.update_message_text(300, 999, "x", datetime(2026, 6, 26, 9, 5))
+
+    assert applied == "applied"
+    assert noop == "noop"
+    assert missing == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_upsert_preserves_is_pinned_when_absent(sqlite_adapter):
+    """Re-backups without pinning data must not reset the pinned flag.
+
+    Regression guard for the _message_conflict_update_values pop: the old
+    unconditional upsert reset is_pinned to 0 on every re-scan.
+    """
+    await sqlite_adapter.insert_message(
+        {"id": 51, "chat_id": 300, "date": datetime(2026, 6, 26, 10, 0), "text": "pin me", "is_pinned": 1}
+    )
+
+    await sqlite_adapter.insert_message(
+        {"id": 51, "chat_id": 300, "date": datetime(2026, 6, 26, 10, 0), "text": "pin me"}
+    )
+
+    message = await _get_message(sqlite_adapter, 51, 300)
+    assert message.is_pinned == 1
+
+
+@pytest.mark.asyncio
+async def test_upsert_different_text_without_any_edit_date_is_refused(sqlite_adapter):
+    """Documented conservative case: differing text with NO edit evidence on either
+    side is not applied and records no version (an upsert source must prove
+    freshness via edit_date before replacing archived text)."""
+    await sqlite_adapter.insert_message(
+        {"id": 52, "chat_id": 300, "date": datetime(2026, 6, 26, 11, 0), "text": "archived"}
+    )
+
+    await sqlite_adapter.insert_message(
+        {"id": 52, "chat_id": 300, "date": datetime(2026, 6, 26, 11, 0), "text": "import text"}
+    )
+
+    message = await _get_message(sqlite_adapter, 52, 300)
+    versions = await _get_versions(sqlite_adapter, 52, 300)
+    assert message.text == "archived"
+    assert versions == []
+
+
+@pytest.mark.asyncio
+async def test_version_record_failure_does_not_abort_message_update(sqlite_adapter, monkeypatch):
+    """A poisoned version insert is contained by its SAVEPOINT: the text update
+    still lands, the failure only costs the history entry."""
+    await sqlite_adapter.insert_message(
+        {"id": 53, "chat_id": 300, "date": datetime(2026, 6, 26, 12, 0), "text": "original"}
+    )
+
+    def _broken_stmt(values):
+        raise RuntimeError("simulated version-insert failure")
+
+    monkeypatch.setattr(sqlite_adapter, "_insert_message_version_stmt", _broken_stmt)
+
+    outcome = await sqlite_adapter.update_message_text(300, 53, "edited", datetime(2026, 6, 26, 12, 5))
+
+    message = await _get_message(sqlite_adapter, 53, 300)
+    versions = await _get_versions(sqlite_adapter, 53, 300)
+    assert outcome == "applied"
+    assert message.text == "edited"
+    assert versions == []
+
+
+@pytest.mark.asyncio
+async def test_unchanged_reupsert_is_a_semantic_noop(sqlite_adapter):
+    """Re-scanning an identical message changes nothing and records nothing
+    (the fast path returns before taking the write lock)."""
+    data = {
+        "id": 54,
+        "chat_id": 300,
+        "date": datetime(2026, 6, 26, 13, 0),
+        "text": "stable",
+        "edit_date": datetime(2026, 6, 26, 13, 5),
+    }
+    await sqlite_adapter.insert_message(data)
+
+    await sqlite_adapter.insert_message(dict(data))
+
+    message = await _get_message(sqlite_adapter, 54, 300)
+    versions = await _get_versions(sqlite_adapter, 54, 300)
+    assert message.text == "stable"
+    assert message.edit_date == datetime(2026, 6, 26, 13, 5)
+    assert versions == []

--- a/tests/test_db_migrate.py
+++ b/tests/test_db_migrate.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy.exc import OperationalError
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -283,7 +284,24 @@ class TestMigrateTable:
         # Records should be expunged from source and merged into target
         assert mock_src_session.expunge.call_count == 2
         assert mock_tgt_session.merge.await_count == 2
-        mock_tgt_session.commit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_zero_when_source_table_missing(self):
+        """Missing legacy source tables are treated as empty."""
+        from src.db.models import MessageVersion
+
+        mock_source, mock_session = _make_mock_manager()
+        mock_target, _ = _make_mock_manager()
+        mock_session.execute.side_effect = OperationalError(
+            "SELECT count(*) FROM message_versions",
+            {},
+            Exception("no such table: message_versions"),
+        )
+
+        result = await _migrate_table(mock_source, mock_target, MessageVersion, batch_size=100)
+
+        assert result == 0
+        mock_session.rollback.assert_awaited_once()
 
 
 # ============================================================
@@ -385,6 +403,39 @@ class TestVerifyMigrationFlow:
             assert counts["sqlite"] == 100
             assert counts["postgres"] == 50
             assert counts["match"] is False
+
+    @pytest.mark.asyncio
+    async def test_source_missing_table_counts_as_zero(self):
+        """verify_migration treats a missing legacy source table as 0 records."""
+        from src.db.models import MessageVersion
+
+        mock_src_session = AsyncMock()
+        mock_src_session.execute.side_effect = OperationalError(
+            "SELECT count(*) FROM message_versions",
+            {},
+            Exception("no such table: message_versions"),
+        )
+
+        mock_tgt_session = AsyncMock()
+        mock_tgt_result = MagicMock()
+        mock_tgt_result.scalar.return_value = 0
+        mock_tgt_session.execute.return_value = mock_tgt_result
+
+        mock_source, _ = _make_mock_manager(session_mock=mock_src_session)
+        mock_target, _ = _make_mock_manager(session_mock=mock_tgt_session)
+
+        with (
+            patch("src.db.migrate.MIGRATION_MODELS", [MessageVersion]),
+            patch("src.db.migrate.DatabaseManager") as MockDM,
+        ):
+            MockDM.side_effect = [mock_source, mock_target]
+            result = await verify_migration(
+                sqlite_path="/fake/path.db",
+                postgres_url="postgresql+asyncpg://u:p@h/d",
+            )
+
+        assert result["message_versions"] == {"sqlite": 0, "postgres": 0, "match": True}
+        mock_src_session.rollback.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_closes_connections_after_verification(self):

--- a/tests/test_entrypoint_schema_detection.py
+++ b/tests/test_entrypoint_schema_detection.py
@@ -1,0 +1,16 @@
+"""Regression tests for container entrypoint schema stamping guards."""
+
+from pathlib import Path
+
+ENTRYPOINT = Path(__file__).resolve().parents[1] / "scripts" / "entrypoint.sh"
+
+
+def test_entrypoint_detects_message_versions_for_revision_015():
+    """Pre-Alembic stamp detection should use the revision-015 table name."""
+    script = ENTRYPOINT.read_text(encoding="utf-8")
+    old_table_name = "message_" + "edit_history"
+
+    assert old_table_name not in script
+    assert "message_versions" in script
+    assert "has_015_message_versions" in script
+    assert "if has_015_message_versions and has_014_soft_delete:" in script

--- a/tests/test_export_backup.py
+++ b/tests/test_export_backup.py
@@ -52,6 +52,11 @@ async def test_export_to_json_writes_correct_structure():
                 {"id": 2, "text": "world", "date": "2024-01-02"},
             ]
         )
+        mock_db.get_message_versions_by_date_range = AsyncMock(
+            return_value=[
+                {"id": 1, "chat_id": -100123, "message_id": 1, "text": "helo", "date": "2024-01-01"},
+            ]
+        )
         mock_db.get_all_chats = AsyncMock(
             return_value=[
                 {"id": -100123, "type": "group", "title": "Test Group"},
@@ -70,7 +75,9 @@ async def test_export_to_json_writes_correct_structure():
         assert "export_date" in data
         assert data["statistics"]["total_messages"] == 2
         assert data["statistics"]["total_chats"] == 1
+        assert data["statistics"]["total_message_versions"] == 1
         assert len(data["messages"]) == 2
+        assert len(data["message_versions"]) == 1
         assert len(data["chats"]) == 1
         assert data["filters"]["chat_id"] is None
         assert data["filters"]["start_date"] is None
@@ -86,6 +93,7 @@ async def test_export_to_json_with_date_filters():
     try:
         mock_db = AsyncMock()
         mock_db.get_messages_by_date_range = AsyncMock(return_value=[])
+        mock_db.get_message_versions_by_date_range = AsyncMock(return_value=[])
         mock_db.get_all_chats = AsyncMock(return_value=[])
 
         exporter = BackupExporter(mock_db)
@@ -98,6 +106,9 @@ async def test_export_to_json_with_date_filters():
         assert call_args[0][0] == 123
         assert call_args[0][1] == datetime(2024, 1, 1)
         assert call_args[0][2] == datetime(2024, 6, 30)
+        mock_db.get_message_versions_by_date_range.assert_awaited_once_with(
+            123, datetime(2024, 1, 1), datetime(2024, 6, 30)
+        )
 
         with open(output_file, encoding="utf-8") as f:
             data = json.load(f)
@@ -115,6 +126,7 @@ async def test_export_to_json_creates_parent_directories():
     try:
         mock_db = AsyncMock()
         mock_db.get_messages_by_date_range = AsyncMock(return_value=[])
+        mock_db.get_message_versions_by_date_range = AsyncMock(return_value=[])
         mock_db.get_all_chats = AsyncMock(return_value=[])
 
         exporter = BackupExporter(mock_db)

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -98,7 +98,6 @@ def test_message_status_badges_show_timestamps_on_hover():
     assert edited_title in html
     assert deleted_title in html
     assert html.index(deleted_title) < html.index(edited_title)
-    assert 'class="order-2 hover:text-blue-300 transition-colors"' in html
     assert '<span v-if="msg.is_deleted" class="order-1"' in html
     assert '<span class="order-3">{{ formatTime(msg.date) }}</span>' in html
     assert "const formatMetadataTimestampTitle = (label, dateStr) =>" in html
@@ -112,26 +111,58 @@ def test_message_versions_use_drawer_not_inline_panel():
     drawer_index = html.index("<!-- Message Versions Drawer -->")
     lightbox_index = html.index("<!-- Lightbox Modal for Images -->")
     metadata_index = html.index("<!-- Metadata -->")
-    drawer_html = html[drawer_index:lightbox_index]
 
     assert metadata_index < drawer_index < lightbox_index
-    assert 'class="fixed inset-0 z-50 bg-black/70 flex justify-end"' in drawer_html
-    assert "Version {{ idx + 1 }}" not in drawer_html
-    assert "Current message" not in drawer_html
-    assert "Change {{ idx + 1 }}" not in drawer_html
-    assert "Before" not in drawer_html
-    assert "After" not in drawer_html
 
 
-def test_message_versions_are_sorted_descending_in_viewer():
-    """Previous versions should display newest first in the viewer drawer."""
+def test_message_versions_no_client_resort():
+    """The drawer must not re-sort versions client-side; the server returns them ordered."""
     html = INDEX_HTML.read_text(encoding="utf-8")
 
-    sort_start = html.index("const messageVersionSortTime = (entry) =>")
-    versions_start = html.index("const getMessageVersions = (msg) =>")
-    sort_body = html[sort_start : html.index("const isMessageVersionsLoading", versions_start)]
+    assert "messageVersionSortTime" not in html
+    assert "const getMessageVersions = (msg) =>" in html
 
-    assert sort_start < versions_start
-    assert "messageVersionSortTime(b) - messageVersionSortTime(a)" in sort_body
-    assert "return (b.id || 0) - (a.id || 0)" not in sort_body
+    get_start = html.index("const getMessageVersions = (msg) =>")
+    next_fn = html.index("const isMessageVersionsLoading", get_start)
+    get_body = html[get_start:next_fn]
+    assert ".sort(" not in get_body
     assert "entry.change_hash" not in html
+
+
+def test_versions_escape_closes_panel():
+    """The Escape key must be wired to closeVersionsPanel via a keydown handler."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert "const handleVersionsKeydown = (e) =>" in html
+    assert "document.addEventListener('keydown', handleVersionsKeydown)" in html
+    assert "document.removeEventListener('keydown', handleVersionsKeydown)" in html
+
+    handler_start = html.index("const handleVersionsKeydown = (e) =>")
+    next_fn = html.index("const formatReactionEmoji", handler_start)
+    handler_body = html[handler_start:next_fn]
+    assert "Escape" in handler_body
+    assert "closeVersionsPanel()" in handler_body
+
+
+def test_versions_drawer_dialog_semantics():
+    """The versions drawer aside must carry ARIA dialog attributes."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    drawer_index = html.index("<!-- Message Versions Drawer -->")
+    lightbox_index = html.index("<!-- Lightbox Modal for Images -->")
+    drawer_html = html[drawer_index:lightbox_index]
+
+    assert 'role="dialog"' in drawer_html
+    assert 'aria-modal="true"' in drawer_html
+
+
+def test_versions_401_sets_unauthenticated():
+    """A 401 from the versions endpoint must flip isAuthenticated to false."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    load_start = html.index("const loadMessageVersions = async (msg) =>")
+    toggle_start = html.index("const toggleMessageVersions = async (msg) =>")
+    load_body = html[load_start:toggle_start]
+
+    assert "res.status === 401" in load_body
+    assert "isAuthenticated.value = false" in load_body

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -13,3 +13,125 @@ def test_media_gallery_refs_are_initialized_before_watcher():
     watcher_index = html.index("watch(showMediaGallery")
 
     assert state_index < watcher_index
+
+
+def test_message_versions_are_loaded_only_from_click_handler():
+    """Viewer message versions should be fetched lazily from the edited button."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert '@click.stop="toggleMessageVersions(msg)"' in html
+    assert 'v-if="versionsMessage"' in html
+    assert '@click.self="closeVersionsPanel"' in html
+    assert "const loadMessageVersions = async (msg) =>" in html
+    assert "const toggleMessageVersions = async (msg) =>" in html
+    assert "const versionsMessage = ref(null)" in html
+
+    load_start = html.index("const loadMessageVersions = async (msg) =>")
+    toggle_start = html.index("const toggleMessageVersions = async (msg) =>")
+    versions_fetch = html.index("/versions?limit=100")
+
+    assert load_start < versions_fetch < toggle_start
+    assert html.count("/versions?limit=100") == 1
+    assert "/edits?limit=100" not in html
+
+
+def test_message_versions_trigger_is_plain_text():
+    """The edited trigger should stay visually quiet in message metadata."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert "fa-solid fa-pen" not in html
+    assert "decoration-dotted" not in html
+    assert "underline-offset-2" not in html
+    assert "edited({{ msg.version_count }})" in html
+
+
+def test_edited_without_versions_is_not_clickable():
+    """Edited messages should open versions only when retained versions exist."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    clickable = 'v-if="Number(msg.version_count) > 0"'
+    fallback = 'v-else-if="msg.edit_date"'
+    click_handler = '@click.stop="toggleMessageVersions(msg)"'
+
+    assert clickable in html
+    assert fallback in html
+    assert html.index(clickable) < html.index(click_handler) < html.index(fallback)
+    assert '<span v-else-if="msg.edit_date"' in html
+    assert ">edited</span>" in html
+
+
+def test_versions_can_open_without_edit_date_when_count_exists():
+    """Retained versions should be clickable even when the current edit marker is absent."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert 'v-if="Number(msg.version_count) > 0"' in html
+    assert 'v-if="msg.edit_date && Number(msg.version_count) > 0"' not in html
+    assert ":title=\"formatMetadataTimestampTitle('Edited', msg.edit_date)\"" in html
+
+
+def test_message_versions_ignore_stale_load_responses():
+    """Concurrent versions loads should not let older responses overwrite newer state."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert "const messageVersionsRequestSeq = ref({})" in html
+    assert "const requestSeq = (messageVersionsRequestSeq.value[key] || 0) + 1" in html
+    assert "setMessageVersionsRecord(messageVersionsRequestSeq, key, requestSeq)" in html
+    assert html.count("messageVersionsRequestSeq.value[key] !== requestSeq") == 2
+    assert "if (messageVersionsRequestSeq.value[key] === requestSeq)" in html
+
+
+def test_realtime_edits_increment_visible_version_count():
+    """Realtime text edits should keep the edited count in sync without loading versions."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert "const previousText = editMsg.text" in html
+    assert "if (previousText !== data.new_text)" in html
+    assert "editMsg.version_count = (Number(editMsg.version_count) || 0) + 1" in html
+
+
+def test_message_status_badges_show_timestamps_on_hover():
+    """Edited/deleted status badges should expose their event timestamps on hover."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    edited_title = ":title=\"formatMetadataTimestampTitle('Edited', msg.edit_date)\""
+    deleted_title = ":title=\"formatMetadataTimestampTitle('Deleted', msg.deleted_at)\""
+    assert edited_title in html
+    assert deleted_title in html
+    assert html.index(deleted_title) < html.index(edited_title)
+    assert 'class="order-2 hover:text-blue-300 transition-colors"' in html
+    assert '<span v-if="msg.is_deleted" class="order-1"' in html
+    assert '<span class="order-3">{{ formatTime(msg.date) }}</span>' in html
+    assert "const formatMetadataTimestampTitle = (label, dateStr) =>" in html
+    assert "`${label} ${formatDateFull(dateStr)} ${formatTime(dateStr)}`" in html
+
+
+def test_message_versions_use_drawer_not_inline_panel():
+    """Previous versions should render in the drawer so chat flow stays compact."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    drawer_index = html.index("<!-- Message Versions Drawer -->")
+    lightbox_index = html.index("<!-- Lightbox Modal for Images -->")
+    metadata_index = html.index("<!-- Metadata -->")
+    drawer_html = html[drawer_index:lightbox_index]
+
+    assert metadata_index < drawer_index < lightbox_index
+    assert 'class="fixed inset-0 z-50 bg-black/70 flex justify-end"' in drawer_html
+    assert "Version {{ idx + 1 }}" not in drawer_html
+    assert "Current message" not in drawer_html
+    assert "Change {{ idx + 1 }}" not in drawer_html
+    assert "Before" not in drawer_html
+    assert "After" not in drawer_html
+
+
+def test_message_versions_are_sorted_descending_in_viewer():
+    """Previous versions should display newest first in the viewer drawer."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    sort_start = html.index("const messageVersionSortTime = (entry) =>")
+    versions_start = html.index("const getMessageVersions = (msg) =>")
+    sort_body = html[sort_start : html.index("const isMessageVersionsLoading", versions_start)]
+
+    assert sort_start < versions_start
+    assert "messageVersionSortTime(b) - messageVersionSortTime(a)" in sort_body
+    assert "return (b.id || 0) - (a.id || 0)" not in sort_body
+    assert "entry.change_hash" not in html

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -76,7 +76,8 @@ def test_message_versions_ignore_stale_load_responses():
     assert "const messageVersionsRequestSeq = ref({})" in html
     assert "const requestSeq = (messageVersionsRequestSeq.value[key] || 0) + 1" in html
     assert "setMessageVersionsRecord(messageVersionsRequestSeq, key, requestSeq)" in html
-    assert html.count("messageVersionsRequestSeq.value[key] !== requestSeq") == 2
+    # success, catch, AND the 503 branch must all discard stale responses
+    assert html.count("messageVersionsRequestSeq.value[key] !== requestSeq") == 3
     assert "if (messageVersionsRequestSeq.value[key] === requestSeq)" in html
 
 

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -529,6 +529,7 @@ class TestEventHandlers:
             message_id=42,
             new_text="Updated text",
             edit_date=msg.edit_date,
+            source="listener_edit",
         )
 
     def test_on_message_edited_handles_none_text(self, listener_with_handlers):

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -44,7 +44,7 @@ class TestTelegramListener:
         """Create a mock database adapter."""
         db = AsyncMock()
         db.get_all_chats = AsyncMock(return_value=[{"id": -1001234567890}, {"id": 123456789}, {"id": -987654321}])
-        db.update_message_text = AsyncMock()
+        db.update_message_text = AsyncMock(return_value="applied")
         db.delete_message = AsyncMock()
         db.resolve_message_chat_id = AsyncMock(return_value=-1001234567890)
         db.close = AsyncMock()
@@ -265,7 +265,7 @@ class TestEventHandlers:
     def mock_db(self):
         db = AsyncMock()
         db.get_all_chats = AsyncMock(return_value=[])
-        db.update_message_text = AsyncMock()
+        db.update_message_text = AsyncMock(return_value="applied")
         db.delete_message = AsyncMock()
         db.mark_message_deleted = AsyncMock()
         db.resolve_message_chat_id = AsyncMock(return_value=None)
@@ -529,7 +529,6 @@ class TestEventHandlers:
             message_id=42,
             new_text="Updated text",
             edit_date=msg.edit_date,
-            source="listener_edit",
         )
 
     def test_on_message_edited_handles_none_text(self, listener_with_handlers):
@@ -753,7 +752,7 @@ class TestStatsTracking:
     def mock_db(self):
         db = AsyncMock()
         db.get_all_chats = AsyncMock(return_value=[])
-        db.update_message_text = AsyncMock()
+        db.update_message_text = AsyncMock(return_value="applied")
         db.delete_message = AsyncMock()
         db.resolve_message_chat_id = AsyncMock(return_value=None)
         db.upsert_chat = AsyncMock()
@@ -986,7 +985,7 @@ class TestListenerEventHandling:
     def mock_db(self):
         db = AsyncMock()
         db.get_all_chats = AsyncMock(return_value=[])
-        db.update_message_text = AsyncMock()
+        db.update_message_text = AsyncMock(return_value="applied")
         db.delete_message = AsyncMock()
         db.close = AsyncMock()
         return db

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -75,7 +75,7 @@ def _make_db():
     """Build a fully-populated mock DatabaseAdapter."""
     db = AsyncMock()
     db.get_all_chats = AsyncMock(return_value=[])
-    db.update_message_text = AsyncMock()
+    db.update_message_text = AsyncMock(return_value="applied")
     db.delete_message = AsyncMock()
     db.mark_message_deleted = AsyncMock()
     db.resolve_message_chat_id = AsyncMock(return_value=None)

--- a/tests/test_migration_015.py
+++ b/tests/test_migration_015.py
@@ -112,4 +112,12 @@ def test_upgrade_noop_when_table_already_exists():
         )
 
         _run(conn, migration.upgrade)
-        assert "message_versions" in sa.inspect(conn).get_table_names()
+        inspector = sa.inspect(conn)
+        assert "message_versions" in inspector.get_table_names()
+
+        # The partial state (table pre-created WITHOUT the named indexes, e.g. a
+        # half-applied migration) is the riskiest real-world case: upgrade() must
+        # add the missing indexes instead of just tolerating the table.
+        indexes = {idx["name"] for idx in inspector.get_indexes("message_versions")}
+        assert "idx_message_versions_message_date" in indexes
+        assert "idx_message_versions_message_captured" in indexes

--- a/tests/test_migration_015.py
+++ b/tests/test_migration_015.py
@@ -1,0 +1,115 @@
+"""Tests for Alembic migration 015 (message versions table)."""
+
+import importlib.util
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parent.parent / "alembic" / "versions" / "20260626_015_add_message_versions.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("migration_015", _MIGRATION_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(conn, func):
+    ctx = MigrationContext.configure(conn)
+    with Operations.context(ctx):
+        func()
+
+
+def _create_messages_table(conn):
+    conn.execute(
+        sa.text(
+            "CREATE TABLE messages ("
+            "id BIGINT NOT NULL, "
+            "chat_id BIGINT NOT NULL, "
+            "text TEXT, "
+            "edit_date DATETIME, "
+            "PRIMARY KEY (id, chat_id)"
+            ")"
+        )
+    )
+
+
+def test_revision_chain():
+    migration = _load_migration()
+    assert migration.revision == "015"
+    assert migration.down_revision == "014"
+
+
+def test_upgrade_creates_table_indexes_and_constraints_and_is_idempotent():
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_messages_table(conn)
+
+        _run(conn, migration.upgrade)
+        inspector = sa.inspect(conn)
+        assert "message_versions" in inspector.get_table_names()
+
+        columns = {c["name"] for c in inspector.get_columns("message_versions")}
+        assert {
+            "id",
+            "message_id",
+            "chat_id",
+            "text",
+            "date",
+            "change_hash",
+            "captured_at",
+        } <= columns
+
+        indexes = {idx["name"] for idx in inspector.get_indexes("message_versions")}
+        assert "idx_message_versions_message_captured" in indexes
+        assert "idx_message_versions_message_date" in indexes
+
+        uniques = {uc["name"] for uc in inspector.get_unique_constraints("message_versions")}
+        assert "uq_message_versions_change_hash" in uniques
+
+        # Re-run must be a no-op.
+        _run(conn, migration.upgrade)
+        assert "message_versions" in sa.inspect(conn).get_table_names()
+
+
+def test_downgrade_drops_table_and_is_idempotent():
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_messages_table(conn)
+        _run(conn, migration.upgrade)
+
+        _run(conn, migration.downgrade)
+        assert "message_versions" not in sa.inspect(conn).get_table_names()
+
+        _run(conn, migration.downgrade)
+        assert "message_versions" not in sa.inspect(conn).get_table_names()
+
+
+def test_upgrade_noop_when_table_already_exists():
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_messages_table(conn)
+        conn.execute(
+            sa.text(
+                "CREATE TABLE message_versions ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "message_id BIGINT NOT NULL, "
+                "chat_id BIGINT NOT NULL, "
+                "text TEXT, "
+                "date DATETIME NOT NULL, "
+                "change_hash VARCHAR(64) NOT NULL UNIQUE, "
+                "captured_at DATETIME NOT NULL"
+                ")"
+            )
+        )
+
+        _run(conn, migration.upgrade)
+        assert "message_versions" in sa.inspect(conn).get_table_names()

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -485,7 +485,7 @@ class TestBackupCheckpointing(unittest.TestCase):
         finally:
             loop.close()
 
-        backup.db.insert_messages_batch.assert_awaited_once_with(batch, source="backup_upsert")
+        backup.db.insert_messages_batch.assert_awaited_once_with(batch)
         backup.db.insert_media.assert_awaited_once_with({"file_path": "/a.jpg"})
         backup.db.insert_reactions.assert_awaited_once()
 

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -485,7 +485,7 @@ class TestBackupCheckpointing(unittest.TestCase):
         finally:
             loop.close()
 
-        backup.db.insert_messages_batch.assert_awaited_once_with(batch)
+        backup.db.insert_messages_batch.assert_awaited_once_with(batch, source="backup_upsert")
         backup.db.insert_media.assert_awaited_once_with({"file_path": "/a.jpg"})
         backup.db.insert_reactions.assert_awaited_once()
 

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -5,7 +5,7 @@ import os
 import shutil
 import tempfile
 import unittest
-from datetime import datetime
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from telethon.errors import (
@@ -822,7 +822,7 @@ class TestSyncDeletionsAndEdits(unittest.TestCase):
 
     def test_edited_message_updated_in_db(self):
         """Remote message with different edit_date triggers update."""
-        self.backup.db.get_messages_sync_data = AsyncMock(return_value={1: "2024-01-01 00:00:00"})
+        self.backup.db.get_messages_sync_data = AsyncMock(return_value={1: datetime(2024, 1, 1)})
         remote_msg = MagicMock()
         remote_msg.edit_date = datetime(2024, 6, 15)
         remote_msg.message = "updated text"
@@ -832,7 +832,23 @@ class TestSyncDeletionsAndEdits(unittest.TestCase):
         _run(self.backup._sync_deletions_and_edits(100, entity))
 
         self.backup.db.update_message_text.assert_awaited_once()
-        assert self.backup.db.update_message_text.call_args.kwargs["source"] == "sync_edit"
+
+    def test_same_edit_date_aware_vs_naive_not_updated(self):
+        """A tz-aware remote edit_date equal to the archived naive one is a no-op.
+
+        Regression: the old string comparison ("...+00:00" vs naive) treated every
+        previously-edited message as changed on every sync pass.
+        """
+        self.backup.db.get_messages_sync_data = AsyncMock(return_value={1: datetime(2024, 6, 15, 12, 0)})
+        remote_msg = MagicMock()
+        remote_msg.edit_date = datetime(2024, 6, 15, 12, 0, tzinfo=UTC)
+        remote_msg.message = "same text"
+        self.backup.client.get_messages = AsyncMock(return_value=[remote_msg])
+        entity = MagicMock()
+
+        _run(self.backup._sync_deletions_and_edits(100, entity))
+
+        self.backup.db.update_message_text.assert_not_awaited()
 
     def test_unedited_message_not_updated(self):
         """Message with no edit_date does not trigger update."""

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -832,6 +832,7 @@ class TestSyncDeletionsAndEdits(unittest.TestCase):
         _run(self.backup._sync_deletions_and_edits(100, entity))
 
         self.backup.db.update_message_text.assert_awaited_once()
+        assert self.backup.db.update_message_text.call_args.kwargs["source"] == "sync_edit"
 
     def test_unedited_message_not_updated(self):
         """Message with no edit_date does not trigger update."""

--- a/tests/test_web_coverage.py
+++ b/tests/test_web_coverage.py
@@ -64,6 +64,7 @@ def _mock_db():
     db.get_metadata = AsyncMock(return_value=None)
     db.get_chat_stats = AsyncMock(return_value={})
     db.find_message_by_date_with_joins = AsyncMock(return_value=None)
+    db.get_message_versions_by_date_range = AsyncMock(return_value=[])
     db.get_all_viewer_accounts = AsyncMock(return_value=[])
     db.get_viewer_by_username = AsyncMock(return_value=None)
     db.get_viewer_account = AsyncMock(return_value=None)
@@ -860,7 +861,26 @@ class TestExportEndpoint(_WebTestBase):
 
     async def test_export_streams_json_successfully(self):
         """export_chat streams JSON for a valid chat."""
-        self.mock_db.get_chat_by_id = AsyncMock(return_value={"title": "Test Chat", "username": None})
+        self.mock_db.get_chat_by_id = AsyncMock(
+            return_value={
+                "id": 42,
+                "type": "private",
+                "title": "Test Chat",
+                "username": "testchat",
+                "phone": "+15551234567",
+                "description": "private description",
+            }
+        )
+        self.mock_db.get_message_versions_by_date_range = AsyncMock(
+            return_value=[
+                {
+                    "message_id": 2,
+                    "chat_id": 42,
+                    "text": "old",
+                    "date": "2025-01-01",
+                }
+            ]
+        )
 
         async def fake_export(chat_id):
             yield {"id": 1, "text": "hello", "date": "2025-01-01"}
@@ -872,8 +892,16 @@ class TestExportEndpoint(_WebTestBase):
             resp = await client.get("/api/chats/42/export")
         self.assertEqual(resp.status_code, 200)
         data = json.loads(resp.text)
-        self.assertEqual(len(data), 2)
-        self.assertEqual(data[0]["text"], "hello")
+        self.assertEqual(
+            data["chat"],
+            {"id": 42, "type": "private", "title": "Test Chat", "username": "testchat"},
+        )
+        self.assertNotIn("phone", data["chat"])
+        self.assertNotIn("description", data["chat"])
+        self.assertEqual(len(data["messages"]), 2)
+        self.assertEqual(data["messages"][0]["text"], "hello")
+        self.assertEqual(len(data["message_versions"]), 1)
+        self.mock_db.get_message_versions_by_date_range.assert_awaited_once_with(chat_id=42)
 
     async def test_export_handles_db_error(self):
         """export_chat returns 500 on db error."""

--- a/tests/test_web_coverage.py
+++ b/tests/test_web_coverage.py
@@ -65,6 +65,12 @@ def _mock_db():
     db.get_chat_stats = AsyncMock(return_value={})
     db.find_message_by_date_with_joins = AsyncMock(return_value=None)
     db.get_message_versions_by_date_range = AsyncMock(return_value=[])
+
+    async def _no_versions(*args, **kwargs):
+        return
+        yield  # pragma: no cover — makes this an async generator
+
+    db.iter_message_versions_for_export = _no_versions
     db.get_all_viewer_accounts = AsyncMock(return_value=[])
     db.get_viewer_by_username = AsyncMock(return_value=None)
     db.get_viewer_account = AsyncMock(return_value=None)
@@ -871,16 +877,11 @@ class TestExportEndpoint(_WebTestBase):
                 "description": "private description",
             }
         )
-        self.mock_db.get_message_versions_by_date_range = AsyncMock(
-            return_value=[
-                {
-                    "message_id": 2,
-                    "chat_id": 42,
-                    "text": "old",
-                    "date": "2025-01-01",
-                }
-            ]
-        )
+
+        async def fake_versions(chat_id):
+            yield {"message_id": 2, "chat_id": 42, "text": "old", "date": "2025-01-01"}
+
+        self.mock_db.iter_message_versions_for_export = fake_versions
 
         async def fake_export(chat_id):
             yield {"id": 1, "text": "hello", "date": "2025-01-01"}
@@ -901,7 +902,7 @@ class TestExportEndpoint(_WebTestBase):
         self.assertEqual(len(data["messages"]), 2)
         self.assertEqual(data["messages"][0]["text"], "hello")
         self.assertEqual(len(data["message_versions"]), 1)
-        self.mock_db.get_message_versions_by_date_range.assert_awaited_once_with(chat_id=42)
+        self.assertEqual(data["message_versions"][0]["text"], "old")
 
     async def test_export_handles_db_error(self):
         """export_chat returns 500 on db error."""

--- a/tests/test_web_messages_api.py
+++ b/tests/test_web_messages_api.py
@@ -107,6 +107,18 @@ class TestDatabaseAdapterWebMethods(unittest.TestCase):
 
         self.assertTrue(hasattr(DatabaseAdapter, "get_messages_for_export"))
 
+    def test_get_message_versions_method_exists(self):
+        """Verify get_message_versions method exists."""
+        from src.db.adapter import DatabaseAdapter
+
+        self.assertTrue(hasattr(DatabaseAdapter, "get_message_versions"))
+
+    def test_get_message_versions_by_date_range_method_exists(self):
+        """Verify export message-versions method exists."""
+        from src.db.adapter import DatabaseAdapter
+
+        self.assertTrue(hasattr(DatabaseAdapter, "get_message_versions_by_date_range"))
+
 
 class TestWebAppStructure(unittest.TestCase):
     """Test web app structure."""

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -42,6 +42,12 @@ def _mock_db():
     db.get_messages_paginated = AsyncMock(return_value=[])
     db.get_message_versions = AsyncMock(return_value=[])
     db.get_message_versions_by_date_range = AsyncMock(return_value=[])
+
+    async def _no_versions(*args, **kwargs):
+        return
+        yield  # pragma: no cover — makes this an async generator
+
+    db.iter_message_versions_for_export = _no_versions
     db.get_pinned_messages = AsyncMock(return_value=[])
     db.get_all_folders = AsyncMock(return_value=[])
     db.get_forum_topics = AsyncMock(return_value=[])
@@ -400,6 +406,15 @@ class TestMessageVersionsEndpoint(_WebTestBase):
             resp = await client.get("/api/chats/123/messages/42/versions")
 
         self.assertEqual(resp.status_code, 503)
+
+    async def test_generic_error_returns_500(self):
+        """get_message_versions returns 500 on non-connection errors."""
+        self.mock_db.get_message_versions = AsyncMock(side_effect=ValueError("boom"))
+
+        async with self._client() as client:
+            resp = await client.get("/api/chats/123/messages/42/versions")
+
+        self.assertEqual(resp.status_code, 500)
 
 
 # ============================================================================

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -40,6 +40,8 @@ def _mock_db():
     db.get_chat_count = AsyncMock(return_value=0)
     db.get_chat_by_id = AsyncMock(return_value=None)
     db.get_messages_paginated = AsyncMock(return_value=[])
+    db.get_message_versions = AsyncMock(return_value=[])
+    db.get_message_versions_by_date_range = AsyncMock(return_value=[])
     db.get_pinned_messages = AsyncMock(return_value=[])
     db.get_all_folders = AsyncMock(return_value=[])
     db.get_forum_topics = AsyncMock(return_value=[])
@@ -340,6 +342,63 @@ class TestMessagesEndpoint(_WebTestBase):
         self.mock_db.get_messages_paginated = AsyncMock(side_effect=OSError("conn refused"))
         async with self._client() as client:
             resp = await client.get("/api/chats/1/messages")
+        self.assertEqual(resp.status_code, 503)
+
+
+@_skip_unless_web
+class TestMessageVersionsEndpoint(_WebTestBase):
+    """Test /api/chats/{chat_id}/messages/{message_id}/versions endpoint."""
+
+    async def test_returns_message_versions(self):
+        """get_message_versions returns previous versions for an accessible chat."""
+        self.mock_db.get_message_versions = AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "chat_id": 123,
+                    "message_id": 42,
+                    "text": "old",
+                    "date": "2026-06-26T10:00:00",
+                }
+            ]
+        )
+
+        async with self._client() as client:
+            resp = await client.get("/api/chats/123/messages/42/versions?limit=25")
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp.json()[0]["text"], "old")
+        self.mock_db.get_message_versions.assert_awaited_once_with(chat_id=123, message_id=42, limit=25)
+
+    async def test_denies_access_to_restricted_chat(self):
+        """get_message_versions returns 403 when user cannot access the chat."""
+        web_main.AUTH_ENABLED = True
+        token = "restricted-message-versions"
+        web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={100})
+
+        async with self._client() as client:
+            resp = await client.get("/api/chats/999/messages/42/versions", cookies={"viewer_auth": token})
+
+        self.assertEqual(resp.status_code, 403)
+        self.mock_db.get_message_versions.assert_not_awaited()
+
+    async def test_requires_auth_when_auth_enabled(self):
+        """get_message_versions returns 401 for unauthenticated requests."""
+        web_main.AUTH_ENABLED = True
+        web_main.ALLOW_ANONYMOUS_VIEWER = False
+
+        async with self._client() as client:
+            resp = await client.get("/api/chats/123/messages/42/versions")
+
+        self.assertEqual(resp.status_code, 401)
+
+    async def test_db_connection_error_returns_503(self):
+        """get_message_versions returns 503 on DB connection errors."""
+        self.mock_db.get_message_versions = AsyncMock(side_effect=OSError("conn refused"))
+
+        async with self._client() as client:
+            resp = await client.get("/api/chats/123/messages/42/versions")
+
         self.assertEqual(resp.status_code, 503)
 
 


### PR DESCRIPTION
## Summary

- Preserve previous text versions for edited messages in a dedicated `message_versions` table.
- Add authenticated versions API/export support and a lazy-loaded viewer drawer with version counts.
- Keep reaction-only edit markers visible as `edited`, but only make `edited(n)` clickable when retained versions exist.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change

## Database Changes

- [x] Schema changes (Alembic migration required)
- [ ] Data migration script added in `scripts/`
- [ ] No database changes

## Data Consistency Checklist

- [x] All `chat_id` values use marked format (via `_get_marked_id()`)
- [x] All datetime values pass through `_strip_tz()` before DB operations
- [x] INSERT and UPDATE operations handle the same fields identically

## Testing

- [ ] Tests pass locally (`python -m pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Formatting passes (`ruff format --check .`)
- [x] Manually tested in development environment

Targeted local validation:

- `uv run --extra dev pytest tests/test_db_adapter_soft_delete_upsert.py tests/test_web_routes.py tests/test_web_coverage.py tests/test_frontend_bootstrap.py -q`
- `uv run --extra dev pytest tests/test_db_adapter.py::TestDeleteChatOperations::test_delete_chat_issues_six_deletes -q`
- `uv run --extra dev ruff check src/db/adapter.py src/web/main.py src/db/migrate.py tests/test_db_adapter_soft_delete_upsert.py tests/test_frontend_bootstrap.py tests/test_web_routes.py tests/test_web_coverage.py`
- `uv run --extra dev ruff check tests/test_db_adapter.py`
- `git diff --check`

CI/fork validation before the latest review-cleanup amend:

- Full upstream PR CI passed for commit `2878206`.
- Fork GHCR test images built successfully: https://github.com/charys117/Telegram-Archive/actions/runs/28488550242

## Security Checklist

- [x] No secrets or credentials committed
- [x] User input properly validated/sanitized
- [x] Authentication/authorization properly checked

## Deployment Notes

- Alembic migration `015` creates the `message_versions` table.
- Pre-Alembic schema stamping detects `message_versions` for both PostgreSQL and SQLite.
- Docker image rebuild required for deployment.
- This feature branch was deployed and observed running stably before opening the PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added preserved message edit version history across exports and the web viewer, including a new versions endpoint and a “Message Versions” drawer with live update support.
* **Bug Fixes**
  * Improved edit processing to be edit-date–aware and idempotent (no-ops won’t create extra versions), with correct timezone handling.
  * Ensured deletions remove version history safely and that the UI shows accurate per-message version counts.
* **Chores**
  * Enhanced schema detection/stamping and migration verification for missing legacy tables, plus more consistent migration dry-run counting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->