### PR TITLE
fix(viewer): hide chat folders with no backed-up chats (#208)

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -2246,6 +2246,14 @@ class DatabaseAdapter:
     async def get_all_folders(self, allowed_chat_ids: set[int] | None = None) -> list[dict[str, Any]]:
         """Get all chat folders with their chat counts.
 
+        Only folders that contain at least one backed-up (and, for restricted
+        viewers, accessible) chat are returned. The viewer reflects the archive,
+        not the full Telegram account: a folder whose chats were all excluded
+        from backup — or that is empty on Telegram — would otherwise show as an
+        empty filter tab that returns nothing when clicked (#208). Folder
+        membership is already limited to chats present in our DB by
+        sync_folder_members, so a zero count means "nothing archived here".
+
         Args:
             allowed_chat_ids: If set, only count chats the user can access.
         """
@@ -2266,8 +2274,8 @@ class DatabaseAdapter:
             for row in result:
                 folder = row.ChatFolder
                 count = row.chat_count or 0
-                # Skip folders with no visible chats for restricted users
-                if allowed_chat_ids is not None and count == 0:
+                # Hide folders with no backed-up chats (empty tabs help no one)
+                if count == 0:
                     continue
                 folders.append(
                     {

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -2557,6 +2557,38 @@ class TestGetAllFolders:
         assert result == []
 
     @pytest.mark.asyncio
+    async def test_filters_empty_folders_for_default_viewer(self):
+        """Folders with no backed-up chats are hidden even without an ACL (#208).
+
+        A folder whose Telegram chats were all excluded from backup (count 0), or
+        that has no membership rows at all (None), must not appear as an empty
+        tab for the default/admin viewer — only folders with archived chats show.
+        """
+        db_manager, mock_session = _make_mock_db_manager()
+        adapter = DatabaseAdapter(db_manager)
+
+        def _row(folder_id, title, chat_count):
+            folder = MagicMock()
+            folder.id = folder_id
+            folder.title = title
+            folder.emoticon = None
+            folder.sort_order = folder_id
+            row = MagicMock()
+            row.ChatFolder = folder
+            row.chat_count = chat_count
+            return row
+
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(
+            return_value=iter([_row(1, "Work", 3), _row(2, "Empty", 0), _row(3, "Family", None)])
+        )
+        mock_session.execute.return_value = mock_result
+
+        result = await adapter.get_all_folders()
+        assert [f["id"] for f in result] == [1]
+        assert result[0]["chat_count"] == 3
+
+    @pytest.mark.asyncio
     async def test_returns_empty_when_no_folders(self):
         """get_all_folders returns empty list when no folders exist."""
         db_manager, mock_session = _make_mock_db_manager()


### PR DESCRIPTION
## Summary

Fixes #208. When a user backs up only a subset of their chats (whitelist), the viewer's folder filter bar still listed **every** Telegram folder — including folders none of whose chats were archived. Clicking such a tab showed nothing.

## Root cause

`DatabaseAdapter.get_all_folders` counts folder membership and already skips zero-count folders — but only when `allowed_chat_ids` is set (i.e. for restricted viewer accounts). The default/admin viewer (`allowed_chat_ids is None`) fell through and returned every folder, empty or not.

Folder membership is already limited to chats that exist in our DB by `sync_folder_members` (it inserts a `chat_folder_members` row only for chats present in the `chats` table). So a zero membership count already means "nothing archived under this folder".

## Fix

Skip `count == 0` folders for **all** viewers, not just restricted ones. The viewer now reflects what was actually crawled rather than the full Telegram account. One-line semantic change in `get_all_folders`, plus a regression test for the default-viewer path (the restricted-viewer path was already covered).

No feature flag: an empty folder tab that returns nothing helps no one, and this matches the reporter's clarified intent — folders should appear only for the chats/channels/groups being archived.

## Testing

- New `test_filters_empty_folders_for_default_viewer` in `TestGetAllFolders` (count 0 and `None`-count folders both hidden without an ACL; non-empty folder retained).
- Existing restricted-viewer and non-empty coverage unchanged.
- Full suite green locally (1990 passed); `ruff check` + `ruff format --check` clean.

Thanks @sube32 for the report and the clear worked example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Empty folders are now hidden from folder lists, so only folders with backed-up chats appear.
  * Folder counts are preserved for visible folders, and folders with no accessible chats are excluded consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->