### PR TITLE
feat(folders): back up full folder membership, not just include_peers

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -2288,6 +2288,34 @@ class DatabaseAdapter:
                 )
             return folders
 
+    async def get_chats_for_folder_resolution(self) -> list[dict[str, Any]]:
+        """Return every archived chat with the facts needed to evaluate a folder's
+        category flags: id, type, whether it is a bot, and archived state.
+
+        Bot-ness is only meaningful for private chats and is read from the users
+        table (chats store bots as type ``private``). The join is on ``User.id ==
+        Chat.id`` — a private chat's id is the positive user id, while group and
+        channel ids are negative/marked and can never collide with a user id, so
+        they always resolve to ``is_bot = 0``.
+        """
+        async with self.db_manager.async_session_factory() as session:
+            stmt = select(
+                Chat.id,
+                Chat.type,
+                Chat.is_archived,
+                func.coalesce(User.is_bot, 0).label("is_bot"),
+            ).outerjoin(User, User.id == Chat.id)
+            result = await session.execute(stmt)
+            return [
+                {
+                    "id": row.id,
+                    "type": row.type,
+                    "is_bot": bool(row.is_bot),
+                    "is_archived": bool(row.is_archived),
+                }
+                for row in result
+            ]
+
     @retry_on_locked()
     async def cleanup_stale_folders(self, active_folder_ids: list[int]) -> None:
         """Remove folders that no longer exist in Telegram."""

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -2224,6 +2224,11 @@ class DatabaseAdapter:
             await session.execute(stmt)
             await session.commit()
 
+    # Flag-based folders can now resolve to very large member sets, so the
+    # existence check is chunked to stay well under driver bind-parameter caps
+    # (SQLite ~32766, PostgreSQL 65535).
+    _FOLDER_MEMBER_CHUNK = 500
+
     @retry_on_locked()
     async def sync_folder_members(self, folder_id: int, chat_ids: list[int]) -> None:
         """Sync folder membership: replace all members for a folder."""
@@ -2233,11 +2238,15 @@ class DatabaseAdapter:
 
             # Insert new members (only for chats that exist in our DB)
             if chat_ids:
-                # Verify which chat_ids actually exist
-                existing = await session.execute(select(Chat.id).where(Chat.id.in_(chat_ids)))
-                existing_ids = {row[0] for row in existing}
+                # Dedup while preserving order; verify existence in bounded chunks.
+                unique_ids = list(dict.fromkeys(chat_ids))
+                existing_ids: set[int] = set()
+                for i in range(0, len(unique_ids), self._FOLDER_MEMBER_CHUNK):
+                    chunk = unique_ids[i : i + self._FOLDER_MEMBER_CHUNK]
+                    result = await session.execute(select(Chat.id).where(Chat.id.in_(chunk)))
+                    existing_ids.update(row[0] for row in result)
 
-                for cid in chat_ids:
+                for cid in unique_ids:
                     if cid in existing_ids:
                         session.add(ChatFolderMember(folder_id=folder_id, chat_id=cid))
 

--- a/src/folder_utils.py
+++ b/src/folder_utils.py
@@ -1,0 +1,126 @@
+"""Pure helpers for resolving Telegram chat-folder (dialog filter) membership.
+
+Telegram folders (``dialogFilter`` / TDLib ``chatFolder``) define their contents
+three ways at once: explicit peer lists (``pinned_peers``, ``include_peers``,
+``exclude_peers``) and category flags (``contacts``, ``non_contacts``, ``groups``,
+``broadcasts``, ``bots`` plus the ``exclude_*`` state flags). The backup only ever
+persists membership for chats we actually archived, so this module answers a
+bounded question: *of the chats in the archive, which belong to folder F?*
+
+Kept dependency-free and pure (no Telethon, no DB) so the set-algebra is
+unit-testable in isolation. Peer lists are expected already resolved to marked
+chat ids; category evaluation uses the ``chats.type`` taxonomy that
+``_extract_chat_data`` writes — only ``private`` / ``group`` / ``channel``
+(megagroups are stored as ``group``; bots are ``private`` with ``is_bot`` coming
+from the users table).
+
+Membership precedence (matches the TDLib / Telegram Desktop reference
+``need_dialog`` / ``ChatFilter::contains`` algorithms):
+
+    1. chat ∈ (pinned ∪ include)  → member          (explicit peers dominate)
+    2. chat ∈ exclude_peers       → not a member     (absolute over type/state)
+    3. chat's category ∉ flags    → not a member
+    4. exclude_* state flags      → drop type matches only
+
+* Explicit ``pinned``/``include`` peers are **absolute** — always members
+  regardless of ``exclude_peers`` or the ``exclude_*`` state flags. (pinned and
+  include are disjoint by construction; deduped here via a union.)
+* The ``exclude_*`` state flags refine only the flag/type matches, never the
+  explicit peers. ``exclude_muted`` and ``exclude_read`` depend on live
+  notification/unread state that the archive does not store, so they are **not
+  applied** (a best-effort that errs toward showing a folder's chats rather than
+  hiding the folder entirely). ``exclude_archived`` *is* applied — we store
+  ``is_archived``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+# chats.type values that represent a "group" for the ``groups`` flag. Megagroups
+# are persisted as "group"; "supergroup" is tolerated defensively in case another
+# code path ever writes it.
+_GROUP_TYPES = frozenset({"group", "supergroup"})
+
+
+@dataclass(frozen=True)
+class FolderChat:
+    """The minimal archived-chat facts needed to evaluate a folder's flags."""
+
+    id: int
+    type: str  # "private" | "group" | "channel"
+    is_bot: bool = False
+    is_archived: bool = False
+
+
+@dataclass(frozen=True)
+class FolderRules:
+    """A dialog filter's rules, with peer lists already resolved to marked ids."""
+
+    pinned_ids: frozenset[int] = field(default_factory=frozenset)
+    include_ids: frozenset[int] = field(default_factory=frozenset)
+    exclude_ids: frozenset[int] = field(default_factory=frozenset)
+    contacts: bool = False
+    non_contacts: bool = False
+    groups: bool = False
+    broadcasts: bool = False
+    bots: bool = False
+    exclude_muted: bool = False  # not reconstructable from the archive; not applied
+    exclude_read: bool = False  # not reconstructable from the archive; not applied
+    exclude_archived: bool = False
+
+    @property
+    def has_type_flags(self) -> bool:
+        return any((self.contacts, self.non_contacts, self.groups, self.broadcasts, self.bots))
+
+
+def _matches_type_flags(chat: FolderChat, rules: FolderRules, contact_ids: frozenset[int]) -> bool:
+    """Whether a chat matches any of the folder's category flags.
+
+    A bot matches ``bots`` only — Telegram treats bots as their own category, so
+    a bot never falls through to ``contacts``/``non_contacts``.
+    """
+    if chat.type in _GROUP_TYPES:
+        return rules.groups
+    if chat.type == "channel":
+        return rules.broadcasts
+    if chat.type == "private":
+        if chat.is_bot:
+            return rules.bots
+        if chat.id in contact_ids:
+            return rules.contacts
+        return rules.non_contacts
+    return False
+
+
+def resolve_folder_member_ids(
+    rules: FolderRules,
+    chats: Iterable[FolderChat],
+    contact_ids: Iterable[int] = (),
+) -> set[int]:
+    """Return the member chat ids of a folder.
+
+    Explicit ``pinned``/``include`` peers are returned as-is (their existence in
+    the archive is filtered downstream by ``sync_folder_members``, which only
+    persists members that exist in the ``chats`` table). Flag/type matches are
+    drawn from ``chats`` — the flags can only be evaluated against chats we've
+    archived. ``contact_ids`` is the account's contact user ids (positive user
+    ids, matching a private chat's id).
+    """
+    contacts = frozenset(contact_ids)
+    explicit = rules.pinned_ids | rules.include_ids
+    # Explicit peers dominate: always members, regardless of exclude_peers or the
+    # exclude_* state flags (TDLib checks the explicit lists first).
+    members: set[int] = set(explicit)
+    if rules.has_type_flags:
+        for chat in chats:
+            cid = chat.id
+            if cid in explicit or cid in rules.exclude_ids:
+                continue
+            if not _matches_type_flags(chat, rules, contacts):
+                continue
+            if rules.exclude_archived and chat.is_archived:
+                continue
+            members.add(cid)
+    return members

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -23,6 +23,7 @@ from telethon.errors import (
 from telethon.tl.types import (
     Channel,
     Chat,
+    InputPeerSelf,
     Message,
     MessageMediaContact,
     MessageMediaDocument,
@@ -2466,10 +2467,17 @@ class TelegramBackup:
             logger.warning(f"  → Failed to infer forum topics: {e}")
             return 0
 
-    def _resolve_peer_ids(self, peers) -> set[int]:
-        """Resolve a DialogFilter peer list (InputPeer objects) to marked chat ids."""
+    def _resolve_peer_ids(self, peers, own_id: int | None = None) -> set[int]:
+        """Resolve a DialogFilter peer list (InputPeer objects) to marked chat ids.
+
+        ``own_id`` maps ``InputPeerSelf`` (how a pinned Saved Messages chat is
+        stored) to the account's own user id, which get_peer_id cannot resolve.
+        """
         ids: set[int] = set()
         for peer in peers or []:
+            if own_id is not None and isinstance(peer, InputPeerSelf):
+                ids.add(own_id)
+                continue
             try:
                 ids.add(self._get_marked_id(peer))
             except Exception:
@@ -2483,16 +2491,16 @@ class TelegramBackup:
                     ids.add(-1000000000000 - peer.channel_id)
         return ids
 
-    def _folder_rules_from_filter(self, f) -> FolderRules:
+    def _folder_rules_from_filter(self, f, own_id: int | None = None) -> FolderRules:
         """Build resolver rules from a DialogFilter / DialogFilterChatlist.
 
         Chatlist (shareable) folders carry no flags or exclude_peers; getattr
         defaults keep them as a pure pinned+include allowlist.
         """
         return FolderRules(
-            pinned_ids=frozenset(self._resolve_peer_ids(getattr(f, "pinned_peers", []))),
-            include_ids=frozenset(self._resolve_peer_ids(getattr(f, "include_peers", []))),
-            exclude_ids=frozenset(self._resolve_peer_ids(getattr(f, "exclude_peers", []))),
+            pinned_ids=frozenset(self._resolve_peer_ids(getattr(f, "pinned_peers", []), own_id)),
+            include_ids=frozenset(self._resolve_peer_ids(getattr(f, "include_peers", []), own_id)),
+            exclude_ids=frozenset(self._resolve_peer_ids(getattr(f, "exclude_peers", []), own_id)),
             contacts=bool(getattr(f, "contacts", False)),
             non_contacts=bool(getattr(f, "non_contacts", False)),
             groups=bool(getattr(f, "groups", False)),
@@ -2518,6 +2526,15 @@ class TelegramBackup:
             logger.warning(f"Could not fetch contacts for folder resolution: {e}")
             return set()
 
+    async def _get_own_id(self) -> int | None:
+        """Return the account's own user id (for resolving self/Saved Messages)."""
+        try:
+            me = await call_with_flood_retry(self.client.get_me)
+            return me.id if me is not None else None
+        except Exception as e:
+            logger.warning(f"Could not resolve own id for folder resolution: {e}")
+            return None
+
     async def _backup_folders(self) -> int:
         """
         Fetch and store user's Telegram chat folders (dialog filters).
@@ -2538,14 +2555,12 @@ class TelegramBackup:
             # result might be a list directly or have a .filters attribute
             filters = result.filters if hasattr(result, "filters") else result
 
-            # Resolve every folder against the same archived-chat snapshot, fetched
-            # once. Contacts are fetched lazily and only if a folder needs them.
-            resolution_rows = await self.db.get_chats_for_folder_resolution()
-            resolution_chats = [
-                FolderChat(id=r["id"], type=r["type"], is_bot=r["is_bot"], is_archived=r["is_archived"])
-                for r in resolution_rows
-            ]
+            # The archived-chat snapshot and contacts are fetched at most once per
+            # run, lazily, and reused across folders — an account with only the
+            # default "All" filter pays for neither.
+            resolution_chats: list[FolderChat] | None = None
             contact_ids: set[int] | None = None
+            own_id = await self._get_own_id()
 
             folder_count = 0
             active_folder_ids = []
@@ -2572,9 +2587,18 @@ class TelegramBackup:
                 }
                 await self.db.upsert_chat_folder(folder_data)
 
-                rules = self._folder_rules_from_filter(f)
+                if resolution_chats is None:
+                    resolution_chats = [
+                        FolderChat(id=r["id"], type=r["type"], is_bot=r["is_bot"], is_archived=r["is_archived"])
+                        for r in await self.db.get_chats_for_folder_resolution()
+                    ]
+
+                rules = self._folder_rules_from_filter(f, own_id)
                 if (rules.contacts or rules.non_contacts) and contact_ids is None:
                     contact_ids = await self._get_contact_ids()
+                    # Saved Messages (self) counts as a contact, matching Telegram.
+                    if own_id is not None:
+                        contact_ids.add(own_id)
 
                 member_ids = resolve_folder_member_ids(rules, resolution_chats, contact_ids or set())
                 # Always sync (even to an empty set) so a folder that lost all its

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -37,6 +37,7 @@ from telethon.utils import get_peer_id
 from .avatar_utils import get_avatar_paths
 from .config import Config
 from .db import DatabaseAdapter, create_adapter
+from .folder_utils import FolderChat, FolderRules, resolve_folder_member_ids
 from .media_errors import is_media_location_error
 from .message_utils import (
     compute_file_hash,
@@ -2465,9 +2466,66 @@ class TelegramBackup:
             logger.warning(f"  → Failed to infer forum topics: {e}")
             return 0
 
+    def _resolve_peer_ids(self, peers) -> set[int]:
+        """Resolve a DialogFilter peer list (InputPeer objects) to marked chat ids."""
+        ids: set[int] = set()
+        for peer in peers or []:
+            try:
+                ids.add(self._get_marked_id(peer))
+            except Exception:
+                # Some peers might not be resolvable via get_peer_id; fall back to
+                # the raw id fields with the standard marked-id conventions.
+                if hasattr(peer, "user_id"):
+                    ids.add(peer.user_id)
+                elif hasattr(peer, "chat_id"):
+                    ids.add(-peer.chat_id)
+                elif hasattr(peer, "channel_id"):
+                    ids.add(-1000000000000 - peer.channel_id)
+        return ids
+
+    def _folder_rules_from_filter(self, f) -> FolderRules:
+        """Build resolver rules from a DialogFilter / DialogFilterChatlist.
+
+        Chatlist (shareable) folders carry no flags or exclude_peers; getattr
+        defaults keep them as a pure pinned+include allowlist.
+        """
+        return FolderRules(
+            pinned_ids=frozenset(self._resolve_peer_ids(getattr(f, "pinned_peers", []))),
+            include_ids=frozenset(self._resolve_peer_ids(getattr(f, "include_peers", []))),
+            exclude_ids=frozenset(self._resolve_peer_ids(getattr(f, "exclude_peers", []))),
+            contacts=bool(getattr(f, "contacts", False)),
+            non_contacts=bool(getattr(f, "non_contacts", False)),
+            groups=bool(getattr(f, "groups", False)),
+            broadcasts=bool(getattr(f, "broadcasts", False)),
+            bots=bool(getattr(f, "bots", False)),
+            exclude_muted=bool(getattr(f, "exclude_muted", False)),
+            exclude_read=bool(getattr(f, "exclude_read", False)),
+            exclude_archived=bool(getattr(f, "exclude_archived", False)),
+        )
+
+    async def _get_contact_ids(self) -> set[int]:
+        """Fetch the account's contact user ids (for contacts/non_contacts flags).
+
+        Returns an empty set on failure — folders relying on those flags simply
+        fall back to their explicit peers rather than aborting the backup.
+        """
+        try:
+            from telethon.tl.functions.contacts import GetContactsRequest
+
+            result = await call_with_flood_retry(self.client, GetContactsRequest(hash=0))
+            return {u.id for u in getattr(result, "users", [])}
+        except Exception as e:
+            logger.warning(f"Could not fetch contacts for folder resolution: {e}")
+            return set()
+
     async def _backup_folders(self) -> int:
         """
         Fetch and store user's Telegram chat folders (dialog filters).
+
+        Resolves each folder's FULL effective membership against the chats we've
+        archived — explicit pinned/include peers minus exclude peers, plus the
+        category flags (contacts/non_contacts/groups/broadcasts/bots), not only
+        include_peers — so folders defined by pins or flags aren't left empty.
 
         Returns:
             Number of folders backed up
@@ -2479,6 +2537,15 @@ class TelegramBackup:
 
             # result might be a list directly or have a .filters attribute
             filters = result.filters if hasattr(result, "filters") else result
+
+            # Resolve every folder against the same archived-chat snapshot, fetched
+            # once. Contacts are fetched lazily and only if a folder needs them.
+            resolution_rows = await self.db.get_chats_for_folder_resolution()
+            resolution_chats = [
+                FolderChat(id=r["id"], type=r["type"], is_bot=r["is_bot"], is_archived=r["is_archived"])
+                for r in resolution_rows
+            ]
+            contact_ids: set[int] | None = None
 
             folder_count = 0
             active_folder_ids = []
@@ -2505,27 +2572,17 @@ class TelegramBackup:
                 }
                 await self.db.upsert_chat_folder(folder_data)
 
-                # Resolve include_peers to chat IDs
-                chat_ids = []
-                include_peers = getattr(f, "include_peers", []) or []
-                for peer in include_peers:
-                    try:
-                        chat_id = self._get_marked_id(peer)
-                        chat_ids.append(chat_id)
-                    except Exception:
-                        # Some peers might not be resolvable
-                        if hasattr(peer, "user_id"):
-                            chat_ids.append(peer.user_id)
-                        elif hasattr(peer, "chat_id"):
-                            chat_ids.append(-peer.chat_id)
-                        elif hasattr(peer, "channel_id"):
-                            chat_ids.append(-1000000000000 - peer.channel_id)
+                rules = self._folder_rules_from_filter(f)
+                if (rules.contacts or rules.non_contacts) and contact_ids is None:
+                    contact_ids = await self._get_contact_ids()
 
-                if chat_ids:
-                    await self.db.sync_folder_members(folder_id, chat_ids)
+                member_ids = resolve_folder_member_ids(rules, resolution_chats, contact_ids or set())
+                # Always sync (even to an empty set) so a folder that lost all its
+                # archived chats is emptied rather than keeping stale members.
+                await self.db.sync_folder_members(folder_id, list(member_ids))
 
                 folder_count += 1
-                logger.debug(f"  → Folder '{title}' (ID: {folder_id}): {len(chat_ids)} chats")
+                logger.debug(f"  → Folder '{title}' (ID: {folder_id}): {len(member_ids)} chats")
 
             # Remove folders that no longer exist
             await self.db.cleanup_stale_folders(active_folder_ids)

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -2602,6 +2602,35 @@ class TestGetAllFolders:
         assert result == []
 
 
+class TestGetChatsForFolderResolution:
+    """Test get_chats_for_folder_resolution (folder flag evaluation source)."""
+
+    @pytest.mark.asyncio
+    async def test_maps_rows_to_resolution_dicts(self):
+        """Rows are mapped to id/type/is_bot/is_archived with bools coerced."""
+        db_manager, mock_session = _make_mock_db_manager()
+        adapter = DatabaseAdapter(db_manager)
+
+        def _row(cid, ctype, is_archived, is_bot):
+            row = MagicMock()
+            row.id = cid
+            row.type = ctype
+            row.is_archived = is_archived
+            row.is_bot = is_bot
+            return row
+
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter([_row(500, "private", 0, 1), _row(-100, "group", 1, 0)]))
+        mock_session.execute.return_value = mock_result
+
+        result = await adapter.get_chats_for_folder_resolution()
+
+        assert result == [
+            {"id": 500, "type": "private", "is_bot": True, "is_archived": False},
+            {"id": -100, "type": "group", "is_bot": False, "is_archived": True},
+        ]
+
+
 # ============================================================
 # Viewer account: get, get_by_username, get_all, update — lines 1735-1765
 # ============================================================

--- a/tests/test_folder_resolution_integration.py
+++ b/tests/test_folder_resolution_integration.py
@@ -1,0 +1,120 @@
+"""Integration tests for folder-membership resolution against real SQLite.
+
+Exercises the actual SQL in get_chats_for_folder_resolution (the users outer
+join) and the chunked existence check in sync_folder_members — paths that the
+mock-based unit tests only reason about.
+"""
+
+import os
+import sys
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Base, Chat, ChatFolder, ChatFolderMember, User
+
+
+@pytest_asyncio.fixture
+async def adapter():
+    """In-memory SQLite adapter with the folder tables created."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db_manager = DatabaseManager.__new__(DatabaseManager)
+    db_manager.engine = engine
+    db_manager.database_url = "sqlite+aiosqlite://"
+    db_manager._is_sqlite = True
+    db_manager.async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    yield DatabaseAdapter(db_manager)
+    await engine.dispose()
+
+
+class TestGetChatsForFolderResolutionSQL:
+    @pytest.mark.asyncio
+    async def test_join_resolves_is_bot_and_never_collides(self, adapter):
+        """The users join sets is_bot for bot privates only; group ids never collide."""
+        async with adapter.db_manager.async_session_factory() as session:
+            session.add(Chat(id=500, type="private", title=None))  # bot private
+            session.add(Chat(id=600, type="private", title=None))  # human private
+            session.add(Chat(id=700, type="private", title=None))  # no user row at all
+            session.add(Chat(id=-100, type="group", title="G"))  # negative id
+            session.add(User(id=500, is_bot=1))
+            session.add(User(id=600, is_bot=0))
+            await session.commit()
+
+        rows = await adapter.get_chats_for_folder_resolution()
+        by_id = {r["id"]: r for r in rows}
+
+        assert by_id[500]["is_bot"] is True
+        assert by_id[600]["is_bot"] is False
+        assert by_id[700]["is_bot"] is False  # coalesced from a missing user row
+        assert by_id[-100]["is_bot"] is False  # negative group id can't match a user id
+        assert by_id[-100]["type"] == "group"
+
+
+class TestSyncFolderMembersChunking:
+    @pytest.mark.asyncio
+    async def test_large_member_set_is_chunked_and_existence_filtered(self, adapter):
+        """More members than the chunk size persist correctly; non-existent ids drop."""
+        n = adapter._FOLDER_MEMBER_CHUNK * 2 + 37  # forces 3 chunks
+        async with adapter.db_manager.async_session_factory() as session:
+            session.add(ChatFolder(id=1, title="Big", emoticon=None, sort_order=0))
+            for cid in range(1, n + 1):
+                session.add(Chat(id=cid, type="group", title=f"c{cid}"))
+            await session.commit()
+
+        # Real ids + a duplicate + an id with no chat row.
+        member_ids = list(range(1, n + 1)) + [1, 1, 99999999]
+        await adapter.sync_folder_members(1, member_ids)
+
+        async with adapter.db_manager.async_session_factory() as session:
+            from sqlalchemy import func, select
+
+            total = (
+                await session.execute(
+                    select(func.count(ChatFolderMember.chat_id)).where(ChatFolderMember.folder_id == 1)
+                )
+            ).scalar()
+            has_bogus = (
+                await session.execute(
+                    select(ChatFolderMember.chat_id).where(
+                        ChatFolderMember.folder_id == 1, ChatFolderMember.chat_id == 99999999
+                    )
+                )
+            ).first()
+
+        assert total == n  # every real id once (deduped), none doubled
+        assert has_bogus is None  # non-existent chat filtered out
+
+    @pytest.mark.asyncio
+    async def test_empty_member_set_clears_existing(self, adapter):
+        """Syncing an empty set removes all of a folder's members."""
+        async with adapter.db_manager.async_session_factory() as session:
+            session.add(ChatFolder(id=2, title="F", emoticon=None, sort_order=0))
+            session.add(Chat(id=10, type="group", title="c"))
+            session.add(ChatFolderMember(folder_id=2, chat_id=10))
+            await session.commit()
+
+        await adapter.sync_folder_members(2, [])
+
+        async with adapter.db_manager.async_session_factory() as session:
+            from sqlalchemy import func, select
+
+            total = (
+                await session.execute(
+                    select(func.count(ChatFolderMember.chat_id)).where(ChatFolderMember.folder_id == 2)
+                )
+            ).scalar()
+        assert total == 0

--- a/tests/test_folder_utils.py
+++ b/tests/test_folder_utils.py
@@ -1,0 +1,143 @@
+"""Unit tests for pure folder-membership resolution (src/folder_utils.py)."""
+
+from src.folder_utils import FolderChat, FolderRules, resolve_folder_member_ids
+
+
+def _chats():
+    """A small archive spanning every category the resolver distinguishes."""
+    return [
+        FolderChat(id=1001, type="private", is_bot=False),  # a contact
+        FolderChat(id=1002, type="private", is_bot=False),  # a non-contact
+        FolderChat(id=1003, type="private", is_bot=True),  # a bot
+        FolderChat(id=-2001, type="group"),  # basic group / megagroup
+        FolderChat(id=-2002, type="supergroup"),  # tolerated group alias
+        FolderChat(id=-1002003, type="channel"),  # broadcast channel
+    ]
+
+
+CONTACTS = frozenset({1001})
+
+
+# --- explicit peers ---------------------------------------------------------
+
+
+def test_include_peer_is_member():
+    rules = FolderRules(include_ids=frozenset({1001}))
+    assert resolve_folder_member_ids(rules, _chats(), CONTACTS) == {1001}
+
+
+def test_pinned_peer_is_member():
+    rules = FolderRules(pinned_ids=frozenset({-1002003}))
+    assert resolve_folder_member_ids(rules, _chats(), CONTACTS) == {-1002003}
+
+
+def test_pinned_and_include_overlap_dedup():
+    rules = FolderRules(pinned_ids=frozenset({1001}), include_ids=frozenset({1001, 1002}))
+    assert resolve_folder_member_ids(rules, _chats(), CONTACTS) == {1001, 1002}
+
+
+def test_no_rules_yields_no_members():
+    assert resolve_folder_member_ids(FolderRules(), _chats(), CONTACTS) == set()
+
+
+def test_explicit_peer_passes_through_for_existence_filtering():
+    # Explicit peers are returned as-is even if absent from the resolution
+    # snapshot; sync_folder_members drops any that aren't archived.
+    rules = FolderRules(include_ids=frozenset({999999}))
+    assert resolve_folder_member_ids(rules, _chats(), CONTACTS) == {999999}
+
+
+def test_flag_matches_are_bounded_by_provided_chats():
+    # Type/flag membership can only come from the archived chats passed in.
+    rules = FolderRules(groups=True)
+    assert resolve_folder_member_ids(rules, [], CONTACTS) == set()
+
+
+# --- exclude_peers is absolute ---------------------------------------------
+
+
+def test_exclude_peer_removes_flag_match():
+    rules = FolderRules(groups=True, exclude_ids=frozenset({-2001}))
+    assert resolve_folder_member_ids(rules, _chats(), CONTACTS) == {-2002}
+
+
+def test_explicit_include_beats_exclude_peer():
+    # Disjoint by construction, but if a malformed filter lists a chat in both,
+    # explicit include wins (matches the TDLib reference precedence).
+    rules = FolderRules(include_ids=frozenset({1001}), exclude_ids=frozenset({1001}))
+    assert resolve_folder_member_ids(rules, _chats(), CONTACTS) == {1001}
+
+
+# --- category flags ---------------------------------------------------------
+
+
+def test_groups_flag_matches_group_and_supergroup_only():
+    rules = FolderRules(groups=True)
+    assert resolve_folder_member_ids(rules, _chats(), CONTACTS) == {-2001, -2002}
+
+
+def test_broadcasts_flag_matches_channels_only():
+    rules = FolderRules(broadcasts=True)
+    assert resolve_folder_member_ids(rules, _chats(), CONTACTS) == {-1002003}
+
+
+def test_bots_flag_matches_bot_only():
+    rules = FolderRules(bots=True)
+    assert resolve_folder_member_ids(rules, _chats(), CONTACTS) == {1003}
+
+
+def test_bot_never_matches_contacts_or_non_contacts():
+    # 1003 is a bot; even with contacts+non_contacts it stays out (matches bots only).
+    rules = FolderRules(contacts=True, non_contacts=True)
+    result = resolve_folder_member_ids(rules, _chats(), CONTACTS)
+    assert 1003 not in result
+    assert result == {1001, 1002}
+
+
+def test_contacts_flag_matches_contact_private_only():
+    rules = FolderRules(contacts=True)
+    assert resolve_folder_member_ids(rules, _chats(), CONTACTS) == {1001}
+
+
+def test_non_contacts_flag_matches_non_contact_private_only():
+    rules = FolderRules(non_contacts=True)
+    assert resolve_folder_member_ids(rules, _chats(), CONTACTS) == {1002}
+
+
+def test_combined_flags_union():
+    rules = FolderRules(groups=True, broadcasts=True, bots=True)
+    assert resolve_folder_member_ids(rules, _chats(), CONTACTS) == {-2001, -2002, -1002003, 1003}
+
+
+# --- exclude_* state flags --------------------------------------------------
+
+
+def test_exclude_archived_drops_archived_flag_match():
+    chats = [
+        FolderChat(id=-3001, type="group", is_archived=False),
+        FolderChat(id=-3002, type="group", is_archived=True),
+    ]
+    rules = FolderRules(groups=True, exclude_archived=True)
+    assert resolve_folder_member_ids(rules, chats, frozenset()) == {-3001}
+
+
+def test_exclude_archived_does_not_drop_explicit_include():
+    # Explicit includes are absolute — an archived pinned/included chat stays.
+    chats = [FolderChat(id=-3002, type="group", is_archived=True)]
+    rules = FolderRules(include_ids=frozenset({-3002}), groups=True, exclude_archived=True)
+    assert resolve_folder_member_ids(rules, chats, frozenset()) == {-3002}
+
+
+def test_exclude_muted_and_read_are_not_applied():
+    # We can't reconstruct mute/unread state, so these flags don't hide anything.
+    rules = FolderRules(groups=True, exclude_muted=True, exclude_read=True)
+    assert resolve_folder_member_ids(rules, _chats(), CONTACTS) == {-2001, -2002}
+
+
+# --- chatlist (shareable, include-only) -------------------------------------
+
+
+def test_chatlist_style_include_only():
+    # DialogFilterChatlist has no flags/excludes; only pinned+include resolve.
+    rules = FolderRules(pinned_ids=frozenset({1001}), include_ids=frozenset({-1002003}))
+    assert resolve_folder_member_ids(rules, _chats(), CONTACTS) == {1001, -1002003}

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -19,6 +19,7 @@ from telethon.errors import (
 )
 from telethon.tl.types import (
     Channel,
+    InputPeerSelf,
     MessageMediaDocument,
     MessageMediaPhoto,
     User,
@@ -1254,6 +1255,8 @@ class TestBackupFolders(unittest.TestCase):
     def setUp(self):
         self.backup = _make_backup()
         self.backup._get_marked_id = MagicMock(return_value=100)
+        # Default: no self/Saved-Messages resolution unless a test opts in.
+        self.backup._get_own_id = AsyncMock(return_value=None)
 
     def test_backs_up_folders_with_peers(self):
         """Folders with include_peers are synced."""
@@ -1416,6 +1419,78 @@ class TestBackupFolders(unittest.TestCase):
         _run(self.backup._backup_folders())
 
         self.backup.db.upsert_chat_folder.assert_awaited()
+
+    def test_input_peer_self_resolves_to_own_id(self):
+        """A folder pinning Saved Messages (InputPeerSelf) resolves to own id."""
+        folder = _make_filter(id=20, title="Saved", pinned_peers=[InputPeerSelf()])
+        self.backup._get_own_id = AsyncMock(return_value=555)
+        self.backup.client = AsyncMock(return_value=[folder])
+
+        _run(self.backup._backup_folders())
+
+        synced = self.backup.db.sync_folder_members.call_args[0][1]
+        self.assertIn(555, synced)
+
+    def test_snapshot_and_contacts_fetched_once_across_folders(self):
+        """The chat snapshot and contact list are fetched once per run, not per folder."""
+        folders = [
+            _make_filter(id=21, title="A", contacts=True),
+            _make_filter(id=22, title="B", contacts=True),
+            _make_filter(id=23, title="C", groups=True),
+        ]
+        self.backup.db.get_chats_for_folder_resolution = AsyncMock(return_value=[])
+        self.backup._get_contact_ids = AsyncMock(return_value=set())
+        self.backup.client = AsyncMock(return_value=folders)
+
+        _run(self.backup._backup_folders())
+
+        self.backup.db.get_chats_for_folder_resolution.assert_awaited_once()
+        self.backup._get_contact_ids.assert_awaited_once()
+
+
+class TestFolderResolutionHelpers(unittest.TestCase):
+    """Test _get_contact_ids / _get_own_id / _folder_rules_from_filter helpers."""
+
+    def setUp(self):
+        self.backup = _make_backup()
+
+    def test_get_contact_ids_returns_user_ids(self):
+        result = MagicMock()
+        result.users = [MagicMock(id=1), MagicMock(id=2)]
+        self.backup.client = AsyncMock(return_value=result)
+
+        ids = _run(self.backup._get_contact_ids())
+
+        self.assertEqual(ids, {1, 2})
+
+    def test_get_contact_ids_handles_failure(self):
+        self.backup.client = AsyncMock(side_effect=Exception("flood"))
+        self.assertEqual(_run(self.backup._get_contact_ids()), set())
+
+    def test_get_own_id_returns_id(self):
+        me = MagicMock()
+        me.id = 4242
+        self.backup.client.get_me = AsyncMock(return_value=me)
+        self.assertEqual(_run(self.backup._get_own_id()), 4242)
+
+    def test_get_own_id_handles_failure(self):
+        self.backup.client.get_me = AsyncMock(side_effect=Exception("nope"))
+        self.assertIsNone(_run(self.backup._get_own_id()))
+
+    def test_folder_rules_from_chatlist_uses_safe_defaults(self):
+        """A chatlist-shaped filter (no flags / exclude attrs) is a pure allowlist."""
+        from types import SimpleNamespace
+
+        self.backup._get_marked_id = MagicMock(side_effect=lambda p: p)
+        chatlist = SimpleNamespace(pinned_peers=[11], include_peers=[22])
+
+        rules = self.backup._folder_rules_from_filter(chatlist)
+
+        self.assertEqual(rules.pinned_ids, frozenset({11}))
+        self.assertEqual(rules.include_ids, frozenset({22}))
+        self.assertEqual(rules.exclude_ids, frozenset())
+        self.assertFalse(rules.has_type_flags)
+        self.assertFalse(rules.exclude_archived)
 
 
 # ===========================================================================

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -49,6 +49,9 @@ def _make_backup(**overrides):
     backup.config.should_skip_topic = MagicMock(return_value=False)
     backup.config.deletion_mode = "hard"
     backup.db = overrides.get("db", AsyncMock())
+    # Folder resolution reads the archived-chat snapshot; default to empty so
+    # tests that exercise _backup_folders get an iterable, not a bare AsyncMock.
+    backup.db.get_chats_for_folder_resolution = AsyncMock(return_value=[])
     backup.client = overrides.get("client", AsyncMock())
     backup._owns_client = overrides.get("_owns_client", True)
     backup._cleaned_media_chats = set()
@@ -1218,6 +1221,33 @@ class TestBackupForumTopicsFallback(unittest.TestCase):
 # ===========================================================================
 
 
+_FOLDER_FLAGS = (
+    "contacts",
+    "non_contacts",
+    "groups",
+    "broadcasts",
+    "bots",
+    "exclude_muted",
+    "exclude_read",
+    "exclude_archived",
+)
+
+
+def _make_filter(**over):
+    """Build a DialogFilter-like mock with safe defaults for every field the
+    resolver reads (peer lists empty, all flags off), overridable per test."""
+    f = MagicMock()
+    f.id = over.get("id", 1)
+    f.title = over.get("title", "Folder")
+    f.emoticon = over.get("emoticon")
+    f.pinned_peers = over.get("pinned_peers", [])
+    f.include_peers = over.get("include_peers", [])
+    f.exclude_peers = over.get("exclude_peers", [])
+    for flag in _FOLDER_FLAGS:
+        setattr(f, flag, over.get(flag, False))
+    return f
+
+
 class TestBackupFolders(unittest.TestCase):
     """Test _backup_folders chat folder sync."""
 
@@ -1227,12 +1257,7 @@ class TestBackupFolders(unittest.TestCase):
 
     def test_backs_up_folders_with_peers(self):
         """Folders with include_peers are synced."""
-        folder = MagicMock()
-        folder.id = 1
-        folder.title = "Work"
-        folder.emoticon = None
-        peer = MagicMock()
-        folder.include_peers = [peer]
+        folder = _make_filter(id=1, title="Work", include_peers=[MagicMock()])
 
         self.backup.client = AsyncMock(return_value=[folder])
 
@@ -1244,13 +1269,9 @@ class TestBackupFolders(unittest.TestCase):
 
     def test_folder_with_text_with_entities_title(self):
         """Folder title that has .text attribute is extracted."""
-        folder = MagicMock()
-        folder.id = 2
         title_obj = MagicMock()
         title_obj.text = "Personal"
-        folder.title = title_obj
-        folder.emoticon = "star"
-        folder.include_peers = []
+        folder = _make_filter(id=2, title=title_obj, emoticon="star")
 
         self.backup.client = AsyncMock(return_value=[folder])
 
@@ -1262,11 +1283,7 @@ class TestBackupFolders(unittest.TestCase):
     def test_skips_filters_without_id_or_title(self):
         """Filters without id/title attributes (default All) are skipped."""
         default_filter = MagicMock(spec=[])  # no id or title
-        real_folder = MagicMock()
-        real_folder.id = 3
-        real_folder.title = "Archived"
-        real_folder.emoticon = None
-        real_folder.include_peers = []
+        real_folder = _make_filter(id=3, title="Archived")
 
         self.backup.client = AsyncMock(return_value=[default_filter, real_folder])
 
@@ -1282,16 +1299,69 @@ class TestBackupFolders(unittest.TestCase):
 
         self.assertEqual(result, 0)
 
+    def test_pinned_peers_are_included(self):
+        """pinned_peers resolve into folder membership, not just include_peers."""
+        folder = _make_filter(id=10, title="Pinned", pinned_peers=[MagicMock()])
+        self.backup._get_marked_id = MagicMock(return_value=777)
+        self.backup.client = AsyncMock(return_value=[folder])
+
+        _run(self.backup._backup_folders())
+
+        call_args = self.backup.db.sync_folder_members.call_args[0]
+        self.assertIn(777, call_args[1])
+
+    def test_exclude_peers_removes_flag_match(self):
+        """A groups folder resolves group chats minus its exclude_peers."""
+        folder = _make_filter(id=11, title="Groups", groups=True, exclude_peers=[MagicMock()])
+        # exclude peer resolves to -2002; groups in the archive are -2001 and -2002.
+        self.backup._get_marked_id = MagicMock(return_value=-2002)
+        self.backup.db.get_chats_for_folder_resolution = AsyncMock(
+            return_value=[
+                {"id": -2001, "type": "group", "is_bot": False, "is_archived": False},
+                {"id": -2002, "type": "group", "is_bot": False, "is_archived": False},
+            ]
+        )
+        self.backup.client = AsyncMock(return_value=[folder])
+
+        _run(self.backup._backup_folders())
+
+        synced = self.backup.db.sync_folder_members.call_args[0][1]
+        self.assertIn(-2001, synced)
+        self.assertNotIn(-2002, synced)
+
+    def test_contacts_flag_fetches_contacts_and_resolves(self):
+        """A contacts folder pulls the contact list and matches contact privates."""
+        folder = _make_filter(id=12, title="People", contacts=True)
+        self.backup.db.get_chats_for_folder_resolution = AsyncMock(
+            return_value=[
+                {"id": 501, "type": "private", "is_bot": False, "is_archived": False},
+                {"id": 502, "type": "private", "is_bot": False, "is_archived": False},
+            ]
+        )
+        self.backup._get_contact_ids = AsyncMock(return_value={501})
+        self.backup.client = AsyncMock(return_value=[folder])
+
+        _run(self.backup._backup_folders())
+
+        self.backup._get_contact_ids.assert_awaited_once()
+        synced = self.backup.db.sync_folder_members.call_args[0][1]
+        self.assertEqual(set(synced), {501})
+
+    def test_no_contact_fetch_without_contact_flags(self):
+        """Contacts are not fetched for folders that don't use contact flags."""
+        folder = _make_filter(id=13, title="Groups", groups=True)
+        self.backup._get_contact_ids = AsyncMock(return_value=set())
+        self.backup.client = AsyncMock(return_value=[folder])
+
+        _run(self.backup._backup_folders())
+
+        self.backup._get_contact_ids.assert_not_awaited()
+
     def test_peer_resolution_fallback_user_id(self):
         """Peer with user_id fallback when get_marked_id raises."""
-        folder = MagicMock()
-        folder.id = 4
-        folder.title = "Friends"
-        folder.emoticon = None
-
         peer = MagicMock()
         peer.user_id = 42
-        folder.include_peers = [peer]
+        folder = _make_filter(id=4, title="Friends", include_peers=[peer])
 
         def fail_on_peer(p):
             if p is peer:
@@ -1308,15 +1378,9 @@ class TestBackupFolders(unittest.TestCase):
 
     def test_peer_resolution_fallback_chat_id(self):
         """Peer with chat_id fallback when get_marked_id raises."""
-        folder = MagicMock()
-        folder.id = 5
-        folder.title = "Groups"
-        folder.emoticon = None
-
         peer = MagicMock(spec=["chat_id"])
         peer.chat_id = 999
-        del peer.user_id  # Ensure user_id path not taken
-        folder.include_peers = [peer]
+        folder = _make_filter(id=5, title="Groups", include_peers=[peer])
 
         self.backup._get_marked_id = MagicMock(side_effect=Exception("fail"))
         self.backup.client = AsyncMock(return_value=[folder])
@@ -1328,14 +1392,9 @@ class TestBackupFolders(unittest.TestCase):
 
     def test_peer_resolution_fallback_channel_id(self):
         """Peer with channel_id fallback when get_marked_id raises."""
-        folder = MagicMock()
-        folder.id = 6
-        folder.title = "Channels"
-        folder.emoticon = None
-
         peer = MagicMock(spec=["channel_id"])
         peer.channel_id = 555
-        folder.include_peers = [peer]
+        folder = _make_filter(id=6, title="Channels", include_peers=[peer])
 
         self.backup._get_marked_id = MagicMock(side_effect=Exception("fail"))
         self.backup.client = AsyncMock(return_value=[folder])
@@ -1347,11 +1406,7 @@ class TestBackupFolders(unittest.TestCase):
 
     def test_result_has_filters_attribute(self):
         """Handles result object with .filters attribute."""
-        folder = MagicMock()
-        folder.id = 7
-        folder.title = "Test"
-        folder.emoticon = None
-        folder.include_peers = []
+        folder = _make_filter(id=7, title="Test")
 
         result_obj = MagicMock()
         result_obj.filters = [folder]

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -1362,7 +1362,7 @@ class TestBackupFolders(unittest.TestCase):
 
     def test_peer_resolution_fallback_user_id(self):
         """Peer with user_id fallback when get_marked_id raises."""
-        peer = MagicMock()
+        peer = MagicMock(spec=["user_id"])
         peer.user_id = 42
         folder = _make_filter(id=4, title="Friends", include_peers=[peer])
 


### PR DESCRIPTION
## Summary

Follow-up to the #208 empty-folder fix (#209). Telegram chat folders (`dialogFilter`) define membership three ways at once: explicit peer lists (`pinned_peers`, `include_peers`, `exclude_peers`) and category flags (`contacts`, `non_contacts`, `groups`, `broadcasts`, `bots` + the `exclude_*` flags). `_backup_folders` only resolved `include_peers`, so a folder built from pinned chats or category flags got **no** `chat_folder_members` rows — and after #209 (which hides folders with zero archived members) those folders disappear from the viewer entirely.

This resolves each folder's **effective** membership against the chats we've actually archived and persists it.

## What changed

- **New `src/folder_utils.py`** — a pure, dependency-free resolver (`resolve_folder_member_ids` + `FolderChat`/`FolderRules`). The precedence matches the canonical **TDLib** (`need_dialog`) and **Telegram Desktop** (`ChatFilter::contains`) implementations: explicit `pinned`/`include` dominate → `exclude_peers` absolute → category gate → `exclude_*` state flags refine only the type matches. `groups` = basic groups + supergroups, `broadcasts` = channels, `bots` = bots (a bot matches `bots` only), `contacts`/`non_contacts` = private chats split by contact status.
- **`adapter.get_chats_for_folder_resolution()`** — returns archived chats with `is_bot` via a `users` join (bots are stored as type `private`). **No schema change / no migration.**
- **`_backup_folders`** — fetches the archived-chat snapshot once, fetches the contact list lazily (only when a folder uses `contacts`/`non_contacts`), resolves pinned/include/exclude + flags per folder, and always calls `sync_folder_members` (so a folder that lost all its archived chats is emptied rather than keeping stale rows). Peer resolution and rule-building factored into helpers.

## Caveat (intentional)

`exclude_muted` and `exclude_read` depend on live notification/unread state that the archive doesn't store, so they're **best-effort not applied** — a folder like "Unread channels" shows its channels rather than being hidden. This errs toward showing a folder's chats. `exclude_archived` **is** applied (we store `is_archived`).

## Testing

- 19 pure resolver unit tests covering every flag, precedence, dedup, and the chatlist allowlist case.
- New adapter test for `get_chats_for_folder_resolution`; rewritten `TestBackupFolders` + new pinned/exclude/contacts/no-contact-fetch integration cases.
- Full suite **2015 passed / 0 failed**; `ruff check` + `ruff format --check` clean.

Semantics verified against primary sources: [dialogFilter](https://core.telegram.org/constructor/dialogFilter), [dialogFilterChatlist](https://core.telegram.org/constructor/dialogFilterChatlist), TDLib `DialogFilter.cpp`, tdesktop `data_chat_filters.cpp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized dialog-filter folder membership resolution for backups, including pinned, include, exclude, and type/contacts/bot matching.
  * Folder membership now uses an archived-chat snapshot to derive results and keeps backups aligned with computed membership.
  * Improved handling for large folder member sets via deduplication and bounded existence checks.

* **Bug Fixes**
  * Folder contents now reliably sync to computed results, including empty folders.
  * Archived-chat filtering and explicit includes now behave consistently; mute/read exclusions are not applied.

* **Tests**
  * Expanded unit and SQL integration coverage for folder resolution and membership sync.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->