### PR TITLE
fix(viewer): stop realtime poll clobbering a jump-to-message window (#213)

### DIFF
--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1742,6 +1742,12 @@
                 // monotonically older).
                 let oldestMessageCursor = null
                 let loadFailureStreak = 0
+                // True while the view is a detached jump-to-message window (loadMessagesAroundId)
+                // that does NOT contain the live tail. The realtime poll fetches the latest page
+                // (offset=0) and would upsert it in and snap the view back to newest, so the poll
+                // is suppressed until a tail-inclusive view is re-established (via
+                // resetMessagePagination, which every openChat/openTopic/search entry calls).
+                let viewingPinnedWindow = false
 
                 const messageIdKey = (msg) => msg?.id == null ? null : String(msg.id)
 
@@ -1784,6 +1790,10 @@
                     hasMore.value = true
                     oldestMessageCursor = null
                     loadFailureStreak = 0
+                    // Every openChat/openTopic/search entry loads a tail-inclusive view through
+                    // here, so clear the pinned-window flag (loadMessagesAroundId re-sets it after
+                    // its own reset). This also re-enables the realtime poll.
+                    viewingPinnedWindow = false
                     // View-entry chokepoint: every message-list swap goes through here, so the
                     // unseen-badge from the previous view resets alongside pagination.
                     unseenMessageCount.value = 0
@@ -3072,6 +3082,10 @@
                             if (chatVersion !== myVersion) return
                             messages.value = data.messages || data
                             resetMessagePagination()
+                            // This window is detached from the live tail — pause the realtime
+                            // poll so it can't fetch the latest page and snap us back to newest
+                            // (#213). Cleared when a tail-inclusive view is re-established.
+                            viewingPinnedWindow = true
                             await nextTick()
                             if (chatVersion !== myVersion) return
                             setupMessagesScrollObserver()
@@ -3350,7 +3364,7 @@
                 // Check for new messages and deletions
                 let isRefreshing = false
                 const checkForNewMessages = async () => {
-                    if (!selectedChat.value || isRefreshing || messageSearchQuery.value) return
+                    if (!selectedChat.value || isRefreshing || messageSearchQuery.value || viewingPinnedWindow) return
 
                     isRefreshing = true
                     const myVersion = chatVersion

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -3619,10 +3619,24 @@
                     }
                 }
 
-                const scrollToLatest = () => {
-                    scrollToBottom(true)
+                const scrollToLatest = async () => {
                     showScrollToBottom.value = false
                     unseenMessageCount.value = 0
+                    // From a detached jump-to-message window, scrolling alone only reaches the
+                    // top of that stale window and leaves the realtime poll paused (#213/#214) —
+                    // the button would look like "back to live" while nothing updates. Reload the
+                    // live tail so this control genuinely returns the user to the newest messages.
+                    if (viewingPinnedWindow) {
+                        const myVersion = ++chatVersion  // invalidate in-flight pinned-window loads
+                        loading.value = false
+                        messages.value = []
+                        resetMessagePagination()  // clears viewingPinnedWindow → poll resumes
+                        await loadMessages()
+                        if (chatVersion !== myVersion) return
+                        await nextTick()
+                        if (chatVersion !== myVersion) return
+                    }
+                    scrollToBottom(true)
                 }
 
                 const isOwnMessage = (msg) => {

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -257,6 +257,14 @@ def test_jump_window_suppresses_realtime_poll():
     # ...and every tail-inclusive view entry clears it via resetMessagePagination.
     assert "viewingPinnedWindow = false" in reset_body
 
+    # The "scroll to latest" button must genuinely return to live from a pinned
+    # window (reload the tail), not just scroll the stale window (#214 review).
+    latest_start = html.index("const scrollToLatest = async () =>")
+    latest_body = html[latest_start : html.index("const isOwnMessage = (msg) =>", latest_start)]
+    assert "if (viewingPinnedWindow)" in latest_body
+    assert "resetMessagePagination()" in latest_body
+    assert "await loadMessages()" in latest_body
+
 
 def test_realtime_polling_skips_search_results():
     """Latest-message polling should not mix unfiltered rows into search results."""
@@ -390,7 +398,7 @@ def test_unseen_message_badge_tracks_background_arrivals():
     reset_start = html.index("const resetMessagePagination = () =>")
     reset_body = html[reset_start : html.index("// Mirrors backend coalesce", reset_start)]
     assert "unseenMessageCount.value = 0" in reset_body
-    latest_start = html.index("const scrollToLatest = () =>")
+    latest_start = html.index("const scrollToLatest = async () =>")
     latest_body = html[latest_start : html.index("const isOwnMessage = (msg) =>", latest_start)]
     assert "unseenMessageCount.value = 0" in latest_body
     # Button shows for the badge even before the distance threshold, with an aria-label.

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -237,6 +237,27 @@ def test_jump_to_message_resets_history_pagination():
     assert jump_body.index("resetMessagePagination()") < jump_body.index("setupMessagesScrollObserver()")
 
 
+def test_jump_window_suppresses_realtime_poll():
+    """A jump-to-message window pauses the offset=0 poll so it can't snap to newest (#213)."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    jump_start = html.index("const loadMessagesAroundId = async (messageId) =>")
+    jump_body = html[jump_start : html.index("watch(showMediaGallery", jump_start)]
+    refresh_start = html.index("const checkForNewMessages = async () =>")
+    refresh_body = html[refresh_start : html.index("const loadMessages = async () =>", refresh_start)]
+    reset_start = html.index("const resetMessagePagination = () =>")
+    reset_body = html[reset_start : html.index("// Mirrors backend coalesce", reset_start)]
+
+    assert "let viewingPinnedWindow = false" in html
+    # The poll bails while a detached window is shown...
+    assert "|| viewingPinnedWindow) return" in refresh_body
+    # ...the jump sets the flag AFTER its own resetMessagePagination()...
+    assert "viewingPinnedWindow = true" in jump_body
+    assert jump_body.index("resetMessagePagination()") < jump_body.index("viewingPinnedWindow = true")
+    # ...and every tail-inclusive view entry clears it via resetMessagePagination.
+    assert "viewingPinnedWindow = false" in reset_body
+
+
 def test_realtime_polling_skips_search_results():
     """Latest-message polling should not mix unfiltered rows into search results."""
     html = INDEX_HTML.read_text(encoding="utf-8")
@@ -246,7 +267,7 @@ def test_realtime_polling_skips_search_results():
     search_start = html.index("const searchMessages = async () =>")
     search_body = html[search_start : html.index("const handleScroll = (e) =>", search_start)]
 
-    assert "if (!selectedChat.value || isRefreshing || messageSearchQuery.value) return" in refresh_body
+    assert "isRefreshing || messageSearchQuery.value" in refresh_body
     assert "chatVersion++" in search_body
     # The version bump makes an invalidated in-flight load skip its own loading=false
     # (finally sees a version mismatch), so search must reset the gate itself or a


### PR DESCRIPTION
## Summary

Fixes #213. On v7.20.0, clicking a media item in the per-chat gallery to jump to its message loads the correct `before_id` history window (200), then an `offset=0` fetch immediately clobbers it and the view snaps back to the newest messages — the target is never shown.

## Root cause

`loadMessagesAroundId` **replaces** the message list with a detached window around the target (`messages.value = data`) that does **not** contain the live tail. The 3s realtime poll (`checkForNewMessages`, `?limit=50&offset=0`) then fetches the latest page and `upsertMessages` adds it; because the jumps smooth-scroll is still animating from the bottom, `shouldStickToBottom` reads true and the poll calls `scrollToBottom()` → snap to newest.

Calendar **jump-to-date** was unaffected (as #213 notes) because `jumpToDate` *keeps* the existing tail in the list (`messages.value.push(message)` + background gap-fill), so the polls upsert of the latest page is a no-op.

## Fix

A `viewingPinnedWindow` flag: `loadMessagesAroundId` sets it (after its `resetMessagePagination`), `checkForNewMessages` bails while it is set, and `resetMessagePagination` clears it — so the poll resumes automatically the moment any `openChat`/`openTopic`/`search` re-establishes a tail-inclusive view. In-flight polls started before the jump are already invalidated by the existing `++chatVersion` guard, so both the racing and the future poll are covered. Realtime updates pause only while you are reading a detached jump window, which is the correct behavior.

## Testing

- New `test_jump_window_suppresses_realtime_poll` pins the flag, the poll guard, the set-after-reset ordering, and the clear in `resetMessagePagination`.
- Full suite **2026 passed / 0 failed**; `ruff` clean; viewer JS `node --check` clean.

No release cut per request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented realtime message refresh from disrupting “jump-to-message” browsing in a detached message window.
  * Restored live, tail-inclusive realtime updates when returning to the standard latest view.
* **Tests**
  * Added regression coverage to ensure realtime polling is suppressed during pinned/jump windows and re-enabled when exiting.
  * Updated realtime-search skip and unseen-message related tests to match recent UI/template behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->