### PR TITLE
fix(media): budget filenames for eCryptfs + cap failed-download retries (#212)

### DIFF
--- a/alembic/versions/20260714_016_add_media_download_attempts.py
+++ b/alembic/versions/20260714_016_add_media_download_attempts.py
@@ -1,0 +1,45 @@
+"""Add media.download_attempts (failed-download retry cap).
+
+Revision ID: 016
+Revises: 015
+Create Date: 2026-07-14
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "016"
+down_revision: str | None = "015"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+TABLE_NAME = "media"
+COLUMN_NAME = "download_attempts"
+
+
+def _column_exists(inspector: sa.Inspector) -> bool:
+    return COLUMN_NAME in {c["name"] for c in inspector.get_columns(TABLE_NAME)}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    # Idempotent: create_all()-provisioned databases may already have the column.
+    if TABLE_NAME in inspector.get_table_names() and not _column_exists(inspector):
+        op.add_column(
+            TABLE_NAME,
+            sa.Column("download_attempts", sa.Integer(), nullable=False, server_default="0"),
+        )
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if TABLE_NAME in inspector.get_table_names() and _column_exists(inspector):
+        op.drop_column(TABLE_NAME, COLUMN_NAME)

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -121,6 +121,15 @@ if has_tables and not has_alembic:
     \"\"\")
     has_015_message_versions = cur.fetchone()[0]
 
+    # Check artifact from migration 016: media.download_attempts column
+    cur.execute(\"\"\"
+        SELECT EXISTS (
+            SELECT FROM information_schema.columns
+            WHERE table_name = 'media' AND column_name = 'download_attempts'
+        );
+    \"\"\")
+    has_016_download_attempts = cur.fetchone()[0]
+
     # Check artifact from migration 014: messages soft-delete marker columns
     cur.execute(\"\"\"
         SELECT
@@ -241,7 +250,9 @@ if has_tables and not has_alembic:
     has_push_subs = cur.fetchone()[0]
 
     # Determine which version to stamp based on existing schema
-    if has_015_message_versions and has_014_soft_delete:
+    if has_016_download_attempts and has_015_message_versions and has_014_soft_delete:
+        stamp_version = '016'
+    elif has_015_message_versions and has_014_soft_delete:
         stamp_version = '015'
     elif has_014_soft_delete:
         stamp_version = '014'
@@ -361,6 +372,8 @@ if has_tables and not has_alembic:
     cur.execute(\"PRAGMA table_info(media)\")
     media_columns = {row[1] for row in cur.fetchall()}
     has_011_content_hash = 'content_hash' in media_columns
+    # Check artifact from migration 016: media.download_attempts column
+    has_016_download_attempts = 'download_attempts' in media_columns
 
     # Check all artifacts from migration 010: viewer_tokens, app_settings, viewer_accounts.no_download
     cur.execute(\"SELECT name FROM sqlite_master WHERE type='table' AND name='viewer_tokens'\")
@@ -401,7 +414,9 @@ if has_tables and not has_alembic:
     has_push_subs = cur.fetchone() is not None
 
     # Determine which version to stamp based on existing schema
-    if has_015_message_versions and has_014_soft_delete:
+    if has_016_download_attempts and has_015_message_versions and has_014_soft_delete:
+        stamp_version = '016'
+    elif has_015_message_versions and has_014_soft_delete:
         stamp_version = '015'
     elif has_014_soft_delete:
         stamp_version = '014'

--- a/src/config.py
+++ b/src/config.py
@@ -121,6 +121,18 @@ class Config:
         self.max_media_size_mb = int(os.getenv("MAX_MEDIA_SIZE_MB", "100"))
         # Timeout for media downloads (seconds). 0 disables the timeout.
         self.download_timeout_seconds = int(os.getenv("DOWNLOAD_TIMEOUT_SECONDS", "3600"))
+        # Max usable filename-component length in BYTES for the media store. Default 143
+        # keeps names writable on Synology/eCryptfs encrypted shares (whose filename-
+        # encryption overhead caps components at ~143 bytes, not the usual 255); the temp
+        # ``.part`` suffix is reserved on top of this. Raise to 255 on plain ext4/xfs/btrfs
+        # if you prefer longer decorative names. Only the decorative part is shortened; the
+        # file_id prefix (uniqueness) and the extension are always preserved. (#212)
+        self.max_filename_bytes = int(os.getenv("MEDIA_MAX_FILENAME_BYTES", "143"))
+        # Stop re-fetching a media file that keeps failing to download after this many
+        # attempts, so a permanently-unwritable file (e.g. an over-limit name on an
+        # exotic filesystem, or a revoked file reference) can't tax every backup run
+        # forever. (#212)
+        self.max_media_download_attempts = int(os.getenv("MEDIA_MAX_DOWNLOAD_ATTEMPTS", "5"))
 
         # =====================================================================
         # PARALLEL CHUNKED DOWNLOADS (issue #183)

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1257,13 +1257,17 @@ class DatabaseAdapter:
             if len(rows) < batch_size:
                 return
 
-    async def get_pending_media_downloads(self, max_media_size_bytes: int | None = None) -> list[dict[str, Any]]:
+    async def get_pending_media_downloads(
+        self, max_media_size_bytes: int | None = None, max_attempts: int | None = None
+    ) -> list[dict[str, Any]]:
         """Get media records that failed to download and need retry.
 
         Returns records where downloaded=0 for downloadable media types
         (excludes contact/geo/poll which are metadata-only).
         Files exceeding max_media_size_bytes are excluded to prevent
-        infinite retry of over-limit media.
+        infinite retry of over-limit media. Records whose download_attempts have
+        reached max_attempts are also excluded, so a permanently-failing file
+        (e.g. an unwritable filename) can't be re-fetched every run forever (#212).
         """
         async with self.db_manager.async_session_factory() as session:
             conditions = [
@@ -1272,6 +1276,8 @@ class DatabaseAdapter:
             ]
             if max_media_size_bytes is not None:
                 conditions.append(or_(Media.file_size.is_(None), Media.file_size <= max_media_size_bytes))
+            if max_attempts is not None:
+                conditions.append(Media.download_attempts < max_attempts)
             stmt = select(Media).where(and_(*conditions)).order_by(Media.chat_id, Media.message_id)
             result = await session.execute(stmt)
             return [
@@ -1284,9 +1290,22 @@ class DatabaseAdapter:
                     "file_name": m.file_name,
                     "file_size": m.file_size,
                     "downloaded": m.downloaded,
+                    "download_attempts": m.download_attempts,
                 }
                 for m in result.scalars()
             ]
+
+    @retry_on_locked()
+    async def increment_media_download_attempts(self, media_id: str) -> None:
+        """Bump the failed-download attempt counter for a media record (#212)."""
+        async with self.db_manager.async_session_factory() as session:
+            stmt = (
+                update(Media)
+                .where(Media.id == media_id)
+                .values(download_attempts=func.coalesce(Media.download_attempts, 0) + 1)
+            )
+            await session.execute(stmt)
+            await session.commit()
 
     async def mark_media_for_redownload(self, media_id: str) -> None:
         """Mark a media record as needing re-download."""

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1308,11 +1308,35 @@ class DatabaseAdapter:
             await session.commit()
 
     async def mark_media_for_redownload(self, media_id: str) -> None:
-        """Mark a media record as needing re-download."""
+        """Mark a media record as needing re-download.
+
+        Also resets download_attempts so a row that previously hit the retry
+        cap (#212) becomes eligible for the pending-download retry again.
+        """
         async with self.db_manager.async_session_factory() as session:
-            stmt = update(Media).where(Media.id == media_id).values(downloaded=0, file_path=None, download_date=None)
+            stmt = (
+                update(Media)
+                .where(Media.id == media_id)
+                .values(downloaded=0, file_path=None, download_date=None, download_attempts=0)
+            )
             await session.execute(stmt)
             await session.commit()
+
+    async def count_capped_media_downloads(self, max_attempts: int) -> int:
+        """Count downloadable media permanently skipped after hitting the retry cap (#212).
+
+        Lets the caller surface an aggregate signal instead of silently abandoning
+        files — the very failure mode #212 was about.
+        """
+        async with self.db_manager.async_session_factory() as session:
+            stmt = select(func.count(Media.id)).where(
+                and_(
+                    Media.downloaded == 0,
+                    Media.type.notin_(["contact", "geo", "poll"]),
+                    Media.download_attempts >= max_attempts,
+                )
+            )
+            return (await session.execute(stmt)).scalar() or 0
 
     async def update_media_file_path(self, media_id: str, file_path: str) -> None:
         """Update the stored file_path for a single media record."""

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -205,6 +205,9 @@ class Media(Base):
     duration: Mapped[int | None] = mapped_column(Integer)
     content_hash: Mapped[str | None] = mapped_column(String(64))  # SHA-256 hex digest
     downloaded: Mapped[int] = mapped_column(Integer, default=0)  # 0 or 1
+    # v7.x (#212): failed-download retry counter. The pending-media retry loop skips rows
+    # at/above MEDIA_MAX_DOWNLOAD_ATTEMPTS so a permanently-unwritable file stops re-fetching.
+    download_attempts: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
     download_date: Mapped[datetime | None] = mapped_column(DateTime)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
 

--- a/src/listener.py
+++ b/src/listener.py
@@ -36,6 +36,7 @@ from .avatar_utils import get_avatar_paths
 from .config import Config
 from .db import DatabaseAdapter, create_adapter
 from .message_utils import (
+    build_media_filename,
     compute_file_hash,
     download_and_shard_media,
     extract_topic_id,
@@ -576,9 +577,10 @@ class TelegramListener:
         if hasattr(message.media, "document") and message.media.document:
             for attr in message.media.document.attributes:
                 if hasattr(attr, "file_name") and attr.file_name:
-                    # Use Telegram file ID + original name for deduplication
+                    # Use Telegram file ID + original name for deduplication.
+                    # Length-budget the decorative name for constrained filesystems (#212).
                     if telegram_file_id:
-                        return sanitize_media_filename(f"{telegram_file_id}_{attr.file_name}")
+                        return build_media_filename(telegram_file_id, attr.file_name, self.config.max_filename_bytes)
                     return sanitize_media_filename(attr.file_name)
 
         # Generate filename based on type

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -58,6 +58,56 @@ def sanitize_media_filename(name: str) -> str:
     return name
 
 
+# Reserve for the temp-download suffix ".{pid}.{task_id}.part": pid up to 7 digits,
+# id(asyncio.current_task()) up to ~20 digits on 64-bit, plus 3 dots + "part". A fixed,
+# generous constant keeps the truncated name DETERMINISTIC (independent of live pid/task id).
+_MEDIA_PART_SUFFIX_RESERVE = 40
+
+# Above this, an "extension" is almost certainly not one — treat the whole name as stem.
+_MEDIA_MAX_EXT_BYTES = 16
+
+
+def build_media_filename(file_id: str, original_name: str, name_max_bytes: int) -> str:
+    """Build a length-safe media filename ``<file_id>_<original stem, truncated>.<ext>``.
+
+    ``name_max_bytes`` is the usable per-component byte budget of the target filesystem
+    (e.g. ~143 on Synology eCryptfs, 255 on ext4). The temp-download suffix is reserved
+    internally so the ``.part`` file also fits (see ``download_and_shard_media``). The
+    ``file_id`` prefix (uniqueness) is always preserved; only the decorative original-name
+    stem is shortened. UTF-8 codepoint-safe (never splits a multibyte character) and
+    deterministic (a pure function of its inputs, so retries/dedup recompute the same name).
+    """
+    safe_name = sanitize_media_filename(original_name)
+    stem, ext = os.path.splitext(safe_name)
+    if len(ext.encode("utf-8")) > _MEDIA_MAX_EXT_BYTES:
+        stem, ext = safe_name, ""
+
+    safe_id = str(file_id).replace("/", "_").replace("\\", "_")
+    prefix = f"{safe_id}_"
+
+    budget = name_max_bytes - _MEDIA_PART_SUFFIX_RESERVE - len(prefix.encode("utf-8")) - len(ext.encode("utf-8"))
+    if budget <= 0:
+        # Pathological tiny budget (the reserve already ruled out a truncated stem):
+        # fall back to a short deterministic hash of the original name, keeping
+        # uniqueness (via file_id) and the extension. These tiers check against the
+        # raw name_max_bytes — the reserve was already spent deciding to land here.
+        digest = hashlib.sha1(safe_name.encode("utf-8")).hexdigest()[:8]
+        fallback = f"{safe_id}_{digest}{ext}"
+        if len(fallback.encode("utf-8")) <= name_max_bytes:
+            return fallback
+        with_ext = f"{safe_id}{ext}"
+        if len(with_ext.encode("utf-8")) <= name_max_bytes:
+            return with_ext
+        return safe_id
+
+    # Truncate the stem to the byte budget without splitting a multibyte codepoint.
+    safe_stem = stem.encode("utf-8")[:budget].decode("utf-8", errors="ignore")
+    if not safe_stem:
+        digest = hashlib.sha1(safe_name.encode("utf-8")).hexdigest()[:8]
+        return f"{safe_id}_{digest}{ext}"
+    return f"{safe_id}_{safe_stem}{ext}"
+
+
 def get_shared_file_path(shared_dir: str, file_name: str, content_hash: str | None) -> str:
     """Build the sharded path for a file in the shared store.
 

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -87,10 +87,14 @@ def build_media_filename(file_id: str, original_name: str, name_max_bytes: int) 
 
     budget = name_max_bytes - _MEDIA_PART_SUFFIX_RESERVE - len(prefix.encode("utf-8")) - len(ext.encode("utf-8"))
     if budget <= 0:
-        # Pathological tiny budget (the reserve already ruled out a truncated stem):
-        # fall back to a short deterministic hash of the original name, keeping
-        # uniqueness (via file_id) and the extension. These tiers check against the
-        # raw name_max_bytes — the reserve was already spent deciding to land here.
+        # Pathological tiny budget, only reachable via an absurdly small
+        # MEDIA_MAX_FILENAME_BYTES (never at the 143/255 defaults, where budget is
+        # comfortably positive). Fall back to a short deterministic hash of the
+        # original name, keeping uniqueness (via file_id) and the extension. The
+        # tiers check against the raw name_max_bytes: at a sub-reserve budget the
+        # temp ``.part`` can't be made to fit anyway (a real file_id alone plus the
+        # suffix already overflows), so we return the shortest useful name that fits
+        # the component limit rather than uselessly dropping the extension.
         digest = hashlib.sha1(safe_name.encode("utf-8")).hexdigest()[:8]
         fallback = f"{safe_id}_{digest}{ext}"
         if len(fallback.encode("utf-8")) <= name_max_bytes:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -41,12 +41,12 @@ from .db import DatabaseAdapter, create_adapter
 from .folder_utils import FolderChat, FolderRules, resolve_folder_member_ids
 from .media_errors import is_media_location_error
 from .message_utils import (
+    build_media_filename,
     compute_file_hash,
     download_and_shard_media,
     extract_topic_id,
     finalize_atomic_download,
     resolve_shared_file_path,
-    sanitize_media_filename,
     service_action_type,
 )
 from .parallel_download import (
@@ -958,7 +958,9 @@ class TelegramBackup:
         Respects MAX_MEDIA_SIZE_BYTES — files that still exceed the limit
         are skipped silently.
         """
-        pending = await self.db.get_pending_media_downloads(self.config.get_max_media_size_bytes())
+        pending = await self.db.get_pending_media_downloads(
+            self.config.get_max_media_size_bytes(), self.config.max_media_download_attempts
+        )
         if not pending:
             return
 
@@ -1010,16 +1012,21 @@ class TelegramBackup:
                         skipped += 1
                         continue
 
-                    # Re-attempt _process_media (which handles size checks internally)
+                    # Re-attempt _process_media (which handles size checks internally).
+                    # Count each unsuccessful re-attempt so a permanently-failing file
+                    # (e.g. a filename too long for the target filesystem, #212) stops
+                    # being re-fetched once it hits MEDIA_MAX_DOWNLOAD_ATTEMPTS.
                     try:
                         result = await self._process_media(msg, chat_id)
                         if result and result.get("downloaded"):
                             await self.db.insert_media(result)
                             downloaded += 1
                         else:
+                            await self.db.increment_media_download_attempts(record["id"])
                             skipped += 1
                     except Exception as e:
                         logger.debug(f"Retry failed for pending media: {e}")
+                        await self.db.increment_media_download_attempts(record["id"])
                         failed += 1
 
             except Exception as e:
@@ -2171,10 +2178,12 @@ class TelegramBackup:
                     original_name = attr.file_name
                     break
 
-        # If we have original filename, use it (with file_id prefix for uniqueness)
+        # If we have original filename, use it (with file_id prefix for uniqueness).
+        # Length-budget the decorative name so it stays writable on constrained
+        # filesystems (Synology/eCryptfs ~143 bytes); the file_id prefix + extension
+        # are always preserved. (#212)
         if original_name and telegram_file_id:
-            safe_id = str(telegram_file_id).replace("/", "_").replace("\\", "_")
-            return sanitize_media_filename(f"{safe_id}_{original_name}")
+            return build_media_filename(telegram_file_id, original_name, self.config.max_filename_bytes)
 
         # Determine extension from mime_type, then fall back to media_type
         extension = None

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -961,6 +961,15 @@ class TelegramBackup:
         pending = await self.db.get_pending_media_downloads(
             self.config.get_max_media_size_bytes(), self.config.max_media_download_attempts
         )
+        # Surface (don't silently swallow) files given up after hitting the retry cap —
+        # the silent-loss failure mode #212 was about. Count only (no chat/file names, PII).
+        capped = await self.db.count_capped_media_downloads(self.config.max_media_download_attempts)
+        if capped:
+            logger.warning(
+                f"{capped} media file(s) permanently skipped after "
+                f"{self.config.max_media_download_attempts} failed download attempts "
+                f"(raise MEDIA_MAX_DOWNLOAD_ATTEMPTS to retry them)"
+            )
         if not pending:
             return
 

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -50,6 +50,7 @@ def _make_config(**overrides):
     config.groups_include_ids = set()
     config.channels_include_ids = set()
     config.validate_credentials = MagicMock()
+    config.max_filename_bytes = 255
     config.whitelist_mode = False
     config.chat_ids = set()
     config.listen_edits = True

--- a/tests/test_media_filename.py
+++ b/tests/test_media_filename.py
@@ -1,0 +1,99 @@
+"""Regression tests for build_media_filename (#212 — Synology eCryptfs filename limits)."""
+
+from src.message_utils import _MEDIA_PART_SUFFIX_RESERVE, build_media_filename
+
+SYNOLOGY_BUDGET = 143
+
+
+def test_short_latin_name_unchanged():
+    """A name well within budget should pass through untouched."""
+    assert build_media_filename("12345", "invoice.pdf", SYNOLOGY_BUDGET) == "12345_invoice.pdf"
+
+
+def test_long_latin_stem_truncated_within_budget():
+    """A long Latin stem is truncated so the full name (plus reserve) fits the budget."""
+    name = "a" * 500 + ".pdf"
+    result = build_media_filename("12345", name, SYNOLOGY_BUDGET)
+
+    assert result.endswith(".pdf")
+    assert len(result.encode("utf-8")) + _MEDIA_PART_SUFFIX_RESERVE <= SYNOLOGY_BUDGET
+
+
+def test_long_multibyte_name_is_valid_utf8_and_budgeted():
+    """Cyrillic (multibyte) stems must not split a codepoint and must stay within budget."""
+    name = "документ" * 50 + ".mp4"
+    result = build_media_filename("987654321", name, SYNOLOGY_BUDGET)
+
+    encoded = result.encode("utf-8")
+    assert encoded.decode("utf-8") == result
+    assert len(encoded) + _MEDIA_PART_SUFFIX_RESERVE <= SYNOLOGY_BUDGET
+    assert result.endswith(".mp4")
+
+
+def test_extension_preserved_exactly():
+    """The extension must survive truncation verbatim."""
+    name = "b" * 300 + ".mp4"
+    result = build_media_filename("111", name, SYNOLOGY_BUDGET)
+
+    assert result.endswith(".mp4")
+    assert not result.endswith(".mp4.mp4")
+
+
+def test_deterministic_across_calls():
+    """Same inputs must always produce the identical output (dedup/retry depend on this)."""
+    name = "документ" * 50 + ".mp4"
+    first = build_media_filename("42", name, SYNOLOGY_BUDGET)
+    second = build_media_filename("42", name, SYNOLOGY_BUDGET)
+
+    assert first == second
+
+
+def test_file_id_prefix_always_present():
+    """The file_id prefix (uniqueness) must appear in every produced name."""
+    long_name = "c" * 500 + ".pdf"
+    tiny_budget_name = build_media_filename("999", long_name, 20)
+    normal_name = build_media_filename("999", "short.pdf", SYNOLOGY_BUDGET)
+
+    assert tiny_budget_name.startswith("999")
+    assert normal_name.startswith("999_")
+
+
+def test_pathological_tiny_budget_uses_hash_fallback():
+    """A budget too small for any truncated stem falls back to a deterministic hash."""
+    name = "d" * 500 + ".pdf"
+    result = build_media_filename("777", name, 20)
+
+    assert result.startswith("777")
+    assert result.endswith(".pdf")
+    assert len(result.encode("utf-8")) <= 20
+
+
+def test_name_with_no_extension_handled():
+    """A name without an extension should not gain one and should still be prefixed."""
+    result = build_media_filename("55", "no_extension_here", SYNOLOGY_BUDGET)
+
+    assert result.startswith("55_")
+    assert "." not in result.split("_", 1)[1] or result.split("_", 1)[1].count(".") == 0
+
+
+def test_path_traversal_neutralized():
+    """A traversal-laden original_name must still be neutralized via sanitize_media_filename."""
+    result = build_media_filename("88", "../../etc/passwd", SYNOLOGY_BUDGET)
+
+    assert ".." not in result
+    assert "/" not in result
+    assert result.startswith("88_")
+
+
+def test_reserved_suffix_is_accounted_for():
+    """A name that fits raw 143 bytes but not 143-reserve bytes must still be truncated."""
+    # stem + "_" prefix (len("1_") == 2) sized to fit exactly 143 raw bytes, no extension.
+    stem = "e" * (SYNOLOGY_BUDGET - 2)
+    name = stem  # no extension
+    result = build_media_filename("1", name, SYNOLOGY_BUDGET)
+
+    encoded_result = result.encode("utf-8")
+    assert len(encoded_result) <= SYNOLOGY_BUDGET
+    # Must have actually been truncated (reserve eats into the raw-fits budget).
+    assert len(encoded_result) + _MEDIA_PART_SUFFIX_RESERVE <= SYNOLOGY_BUDGET
+    assert len(result) < len(f"1_{name}")

--- a/tests/test_media_retry_cap.py
+++ b/tests/test_media_retry_cap.py
@@ -93,3 +93,33 @@ class TestRetryCap:
 
         pending = await adapter.get_pending_media_downloads(max_attempts=5)
         assert {p["id"] for p in pending} == {"real"}
+
+    @pytest.mark.asyncio
+    async def test_count_capped_media_downloads(self, adapter):
+        await _add(adapter, "under", attempts=2)
+        await _add(adapter, "at_cap", attempts=5)
+        await _add(adapter, "over_cap", attempts=8)
+        await _add(adapter, "done", downloaded=1, attempts=9)  # downloaded → not counted
+        await _add(adapter, "geo_capped", attempts=9, mtype="geo")  # metadata → not counted
+
+        assert await adapter.count_capped_media_downloads(5) == 2  # at_cap + over_cap
+
+    @pytest.mark.asyncio
+    async def test_mark_for_redownload_resets_attempts(self, adapter):
+        await _add(adapter, "capped", downloaded=1, attempts=9)
+
+        await adapter.mark_media_for_redownload("capped")
+
+        # attempts reset to 0 and downloaded cleared → eligible for retry again
+        async with adapter.db_manager.async_session_factory() as session:
+            from sqlalchemy import select
+
+            row = (
+                await session.execute(
+                    select(Media.download_attempts, Media.downloaded, Media.file_path).where(Media.id == "capped")
+                )
+            ).one()
+        assert row.download_attempts == 0
+        assert row.downloaded == 0
+        assert row.file_path is None
+        assert {p["id"] for p in await adapter.get_pending_media_downloads(max_attempts=5)} == {"capped"}

--- a/tests/test_media_retry_cap.py
+++ b/tests/test_media_retry_cap.py
@@ -1,0 +1,95 @@
+"""Integration tests for the failed-download retry cap (#212), real SQLite.
+
+Covers get_pending_media_downloads(max_attempts=...) filtering and
+increment_media_download_attempts against actual SQL.
+"""
+
+import os
+import sys
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Base, Media
+
+
+@pytest_asyncio.fixture
+async def adapter():
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db_manager = DatabaseManager.__new__(DatabaseManager)
+    db_manager.engine = engine
+    db_manager.database_url = "sqlite+aiosqlite://"
+    db_manager._is_sqlite = True
+    db_manager.async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    yield DatabaseAdapter(db_manager)
+    await engine.dispose()
+
+
+async def _add(adapter, media_id, *, downloaded=0, attempts=0, mtype="video"):
+    async with adapter.db_manager.async_session_factory() as session:
+        session.add(
+            Media(
+                id=media_id, message_id=1, chat_id=-100, type=mtype, downloaded=downloaded, download_attempts=attempts
+            )
+        )
+        await session.commit()
+
+
+class TestRetryCap:
+    @pytest.mark.asyncio
+    async def test_pending_excludes_maxed_out_rows(self, adapter):
+        await _add(adapter, "under", attempts=2)  # below cap
+        await _add(adapter, "at_cap", attempts=5)  # at cap
+        await _add(adapter, "over_cap", attempts=9)  # past cap
+        await _add(adapter, "done", downloaded=1, attempts=0)  # already downloaded
+
+        pending = await adapter.get_pending_media_downloads(max_attempts=5)
+        ids = {p["id"] for p in pending}
+
+        assert ids == {"under"}
+        assert pending[0]["download_attempts"] == 2
+
+    @pytest.mark.asyncio
+    async def test_no_cap_returns_all_pending(self, adapter):
+        await _add(adapter, "a", attempts=99)
+        await _add(adapter, "b", attempts=0)
+
+        pending = await adapter.get_pending_media_downloads()  # max_attempts=None → no cap
+        assert {p["id"] for p in pending} == {"a", "b"}
+
+    @pytest.mark.asyncio
+    async def test_increment_bumps_and_eventually_excludes(self, adapter):
+        await _add(adapter, "m", attempts=4)
+
+        await adapter.increment_media_download_attempts("m")
+
+        async with adapter.db_manager.async_session_factory() as session:
+            from sqlalchemy import select
+
+            val = (await session.execute(select(Media.download_attempts).where(Media.id == "m"))).scalar()
+        assert val == 5
+        # now at the cap → no longer pending
+        assert await adapter.get_pending_media_downloads(max_attempts=5) == []
+
+    @pytest.mark.asyncio
+    async def test_metadata_types_never_pending(self, adapter):
+        await _add(adapter, "geo", mtype="geo")
+        await _add(adapter, "poll", mtype="poll")
+        await _add(adapter, "real", mtype="document")
+
+        pending = await adapter.get_pending_media_downloads(max_attempts=5)
+        assert {p["id"] for p in pending} == {"real"}

--- a/tests/test_migration_016.py
+++ b/tests/test_migration_016.py
@@ -1,0 +1,100 @@
+"""Tests for Alembic migration 016 (media.download_attempts column)."""
+
+import importlib.util
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parent.parent / "alembic" / "versions" / "20260714_016_add_media_download_attempts.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("migration_016", _MIGRATION_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(conn, func):
+    ctx = MigrationContext.configure(conn)
+    with Operations.context(ctx):
+        func()
+
+
+def _create_media_table(conn):
+    conn.execute(
+        sa.text(
+            "CREATE TABLE media ("
+            "id VARCHAR(255) NOT NULL PRIMARY KEY, "
+            "message_id BIGINT, "
+            "chat_id BIGINT, "
+            "downloaded INTEGER DEFAULT 0"
+            ")"
+        )
+    )
+
+
+def _columns(conn):
+    return {c["name"] for c in sa.inspect(conn).get_columns("media")}
+
+
+def test_revision_chain():
+    migration = _load_migration()
+    assert migration.revision == "016"
+    assert migration.down_revision == "015"
+
+
+def test_upgrade_adds_column_and_is_idempotent():
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_media_table(conn)
+
+        _run(conn, migration.upgrade)
+        assert "download_attempts" in _columns(conn)
+
+        # existing rows get the server_default 0
+        conn.execute(sa.text("INSERT INTO media (id) VALUES ('m1')"))
+        val = conn.execute(sa.text("SELECT download_attempts FROM media WHERE id='m1'")).scalar()
+        assert val == 0
+
+        # re-run must be a no-op (column already present)
+        _run(conn, migration.upgrade)
+        assert "download_attempts" in _columns(conn)
+
+
+def test_upgrade_noop_when_column_already_exists():
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_media_table(conn)
+        conn.execute(sa.text("ALTER TABLE media ADD COLUMN download_attempts INTEGER NOT NULL DEFAULT 0"))
+
+        _run(conn, migration.upgrade)  # must not raise
+        assert "download_attempts" in _columns(conn)
+
+
+def test_downgrade_drops_column_and_is_idempotent():
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_media_table(conn)
+        _run(conn, migration.upgrade)
+
+        _run(conn, migration.downgrade)
+        assert "download_attempts" not in _columns(conn)
+
+        _run(conn, migration.downgrade)  # idempotent
+        assert "download_attempts" not in _columns(conn)
+
+
+def test_upgrade_noop_when_media_table_absent():
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _run(conn, migration.upgrade)  # no media table → no-op, no raise
+        assert "media" not in sa.inspect(conn).get_table_names()

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -926,6 +926,9 @@ class TestGetMediaFilename(unittest.TestCase):
 
     def setUp(self):
         self.backup = _make_backup()
+        # Real Config exposes this as an int; the MagicMock config needs it set so the
+        # filename length budget (build_media_filename) is a number, not a MagicMock.
+        self.backup.config.max_filename_bytes = 255
 
     def _make_doc_message(self, *, file_name=None, mime_type=None, msg_id=1, date=None):
         """Create a mock message with document media."""
@@ -3516,6 +3519,50 @@ class TestBackupAllInProgressFlag(unittest.TestCase):
         set_idx = calls.index(("backup_in_progress", "1"))
         clear_idx = calls.index(("backup_in_progress", "0"))
         self.assertLess(set_idx, clear_idx)
+
+
+class TestRetryPendingMediaCap(unittest.TestCase):
+    """_retry_pending_media_downloads increments attempts on unsuccessful re-tries (#212)."""
+
+    def setUp(self):
+        self.backup = _make_backup()
+        self.backup.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
+        self.backup.config.max_media_download_attempts = 5
+        self.backup.config.skip_media_chat_ids = set()
+        self.backup.db.get_pending_media_downloads = AsyncMock(
+            return_value=[{"id": "f1", "message_id": 10, "chat_id": -100, "type": "video"}]
+        )
+        self.backup.db.increment_media_download_attempts = AsyncMock()
+        self.backup.db.insert_media = AsyncMock()
+        msg = MagicMock()
+        msg.id = 10
+        msg.media = MagicMock()
+        self.backup.client = MagicMock()
+        self.backup.client.get_messages = AsyncMock(return_value=[msg])
+
+    def test_passes_attempt_cap_to_query(self):
+        self.backup._process_media = AsyncMock(return_value={"downloaded": True, "id": "f1"})
+        _run(self.backup._retry_pending_media_downloads())
+        self.backup.db.get_pending_media_downloads.assert_awaited_once_with(100 * 1024 * 1024, 5)
+
+    def test_increment_on_failed_download(self):
+        """A download that raises bumps the attempt counter (the #212 name-too-long case)."""
+        self.backup._process_media = AsyncMock(side_effect=OSError(36, "File name too long"))
+        _run(self.backup._retry_pending_media_downloads())
+        self.backup.db.increment_media_download_attempts.assert_awaited_once_with("f1")
+
+    def test_increment_on_no_download_result(self):
+        """A re-attempt that returns no download (e.g. still over a limit) also counts."""
+        self.backup._process_media = AsyncMock(return_value=None)
+        _run(self.backup._retry_pending_media_downloads())
+        self.backup.db.increment_media_download_attempts.assert_awaited_once_with("f1")
+
+    def test_no_increment_on_success(self):
+        """A successful re-download does not bump the counter (row leaves the pending set)."""
+        self.backup._process_media = AsyncMock(return_value={"downloaded": True, "id": "f1"})
+        _run(self.backup._retry_pending_media_downloads())
+        self.backup.db.increment_media_download_attempts.assert_not_awaited()
+        self.backup.db.insert_media.assert_awaited_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -3533,6 +3533,7 @@ class TestRetryPendingMediaCap(unittest.TestCase):
             return_value=[{"id": "f1", "message_id": 10, "chat_id": -100, "type": "video"}]
         )
         self.backup.db.increment_media_download_attempts = AsyncMock()
+        self.backup.db.count_capped_media_downloads = AsyncMock(return_value=0)
         self.backup.db.insert_media = AsyncMock()
         msg = MagicMock()
         msg.id = 10
@@ -3563,6 +3564,15 @@ class TestRetryPendingMediaCap(unittest.TestCase):
         _run(self.backup._retry_pending_media_downloads())
         self.backup.db.increment_media_download_attempts.assert_not_awaited()
         self.backup.db.insert_media.assert_awaited_once()
+
+    def test_capped_files_are_logged_not_silent(self):
+        """Files given up after the cap are surfaced (aggregate count), even with no pending."""
+        self.backup.db.get_pending_media_downloads = AsyncMock(return_value=[])
+        self.backup.db.count_capped_media_downloads = AsyncMock(return_value=3)
+        with self.assertLogs("src.telegram_backup", level="WARNING") as cm:
+            _run(self.backup._retry_pending_media_downloads())
+        self.backup.db.count_capped_media_downloads.assert_awaited_once_with(5)
+        assert any("permanently skipped" in line for line in cm.output)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #212. Media with long filenames was silently lost on Synology **encrypted** (eCryptfs) shares — whose filename-encryption overhead caps a name component at **~143 bytes**, not 255 — and the failed rows were then re-fetched from Telegram on **every** scheduled run forever. Non-Latin (Cyrillic/CJK) filenames hit the limit far sooner. Implements the studied **Option D** from the research (deterministic conservative byte-budget truncation, NOT pathconf-measured or ENAMETOOLONG-probing) plus the retry cap, per the two decisions taken on the issue.

## Why not the naive fix

A 6-agent research panel established that `os.pathconf`/`statvfs` reports **255** over CIFS→Synology (the check runs client-side, on the wrong side of the encryption — confirmed via eCryptfs Launchpad #885744 + the CIFS topology), so "measure the filesystem limit and fit" under-truncates and *is* the bug. Adaptive `ENAMETOOLONG`-probe was also rejected: the pipeline **recomputes** the filename from the message every run and relies on it matching what is on disk, so a probe-length-dependent name breaks dedup/retry. Hence a deterministic fixed budget + hash fallback.

## Filename budgeting

- New pure `build_media_filename()` (`message_utils.py`): byte-aware, extension-preserving, UTF-8 **codepoint-safe**, **deterministic** truncation of the decorative original-name stem, reserving the temp `.part` suffix. The `file_id` prefix (uniqueness) and extension are always kept; a short deterministic `sha1` fallback covers pathological tiny budgets. Called by **both** `_get_media_filename` sites (backup + listener), so the temp file, the sharded store leaf, and the chat symlink all inherit a length-safe name.
- `MEDIA_MAX_FILENAME_BYTES` (default **143**) makes it configurable; only long decorative names are shortened — short names are untouched.

## Retry cap (the "permanent silent tax")

- New `media.download_attempts` column — **Alembic 016** (idempotent; `entrypoint.sh` stamping updated for PG **and** SQLite) plus `MEDIA_MAX_DOWNLOAD_ATTEMPTS` (default **5**). `get_pending_media_downloads` excludes maxed-out rows; `_retry_pending_media_downloads` increments the counter on each unsuccessful re-attempt, so a permanently-unwritable file stops being re-fetched.

## Testing

- Pure unit tests for the truncation helper (byte budget, extension preserved, multibyte-safe, deterministic, hash fallback).
- **Real-SQLite** migration-016 tests (idempotent up/down, server_default) and retry-cap adapter tests (cap filter + increment).
- Retry-loop increment-wiring tests.
- Full suite **2049 passed / 0 failed**; `ruff` clean.

No release cut per request (batching with #213).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for media filename length and download retries.
  * Media filenames now remain safe, deterministic, and within configured byte limits.
  * Failed media downloads are tracked and automatically skipped after reaching the retry limit.
  * Redownload requests reset the retry counter.

* **Bug Fixes**
  * Improved migration handling for databases upgrading to the latest media schema.
  * Added warnings when media downloads are permanently skipped after repeated failures.

* **Tests**
  * Added coverage for filename limits, retry handling, and database migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->