### PR TITLE
fix(web): initialize media gallery state before use

### DIFF
--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1646,6 +1646,21 @@
                 const selectedDate = ref(null)
                 let flatpickrInstance = null
                 const showScrollToBottom = ref(false)
+
+                // Media Gallery state (v7.10.0)
+                const showMediaGallery = ref(false)
+                const mediaGalleryTab = ref('photos')
+                const mediaGalleryItems = ref([])
+                const mediaGalleryLoading = ref(false)
+                const mediaGalleryHasMore = ref(true)
+                const mediaGalleryCounts = ref({})
+
+                const mediaTabs = [
+                    { id: 'photos', label: 'Photos & Videos' },
+                    { id: 'voice', label: 'Voice' },
+                    { id: 'files', label: 'Files' },
+                ]
+
                 // Messages that arrived (WS/poll) while the user was scrolled up reading
                 // history — shown as a badge on the jump-to-latest button; cleared when the
                 // user returns near the bottom or switches view.
@@ -2921,20 +2936,6 @@
                     currentUsername.value = ''
                     showAdminPanel.value = false
                 }
-
-                // Media Gallery state (v7.10.0)
-                const showMediaGallery = ref(false)
-                const mediaGalleryTab = ref('photos')
-                const mediaGalleryItems = ref([])
-                const mediaGalleryLoading = ref(false)
-                const mediaGalleryHasMore = ref(true)
-                const mediaGalleryCounts = ref({})
-
-                const mediaTabs = [
-                    { id: 'photos', label: 'Photos & Videos' },
-                    { id: 'voice', label: 'Voice' },
-                    { id: 'files', label: 'Files' },
-                ]
 
                 // Media Gallery methods (v7.10.0)
                 const loadMediaGallery = async (append = false) => {


### PR DESCRIPTION
## Summary

Fix of the client errors:

```
vue.global.prod.js:5 ReferenceError: Cannot access 'showMediaGallery' before initialization

vue.global.prod.js:5 TypeError: Cannot read properties of undefined (reading 'username')
```

- Move the Media Gallery state into the initial Vue `setup()` state block.
- Ensure `showMediaGallery` is initialized before callbacks and watchers reference it, preventing the page from failing during startup.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change

## Database Changes

- [ ] Schema changes (Alembic migration required)
- [ ] Data migration script added in `scripts/`
- [x] No database changes

## Data Consistency Checklist

Not applicable — no database code was changed.

- [ ] All `chat_id` values use marked format (via `_get_marked_id()`)
- [ ] All datetime values pass through `_strip_tz()` before DB operations
- [ ] INSERT and UPDATE operations handle the same fields identically

## Testing

- [ ] Tests pass locally (`python -m pytest tests/ -v`)
- [ ] Linting passes (`ruff check .`)
- [ ] Formatting passes (`ruff format --check .`)
- [x] Manually tested in development environment

## Security Checklist

- [x] No secrets or credentials committed
- [x] User input handling is not affected
- [x] Authentication/authorization behavior is not affected

## Deployment Notes

- Rebuild the viewer Docker image to include the updated `index.html`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized the Shared Media state declarations for improved code structure.
  * No user-visible behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->