### PR TITLE
fix(viewer): fetch the real jump window and anchor scroll by message id

### DIFF
--- a/alembic/versions/20260715_017_add_messages_chat_id_id_index.py
+++ b/alembic/versions/20260715_017_add_messages_chat_id_id_index.py
@@ -1,0 +1,46 @@
+"""Add (chat_id, id) index for jump-window cursors (#213).
+
+The lone before_id / after_id cursor paths bound Message.id within a chat;
+without this index the planner post-filters every row of the chat and sorts
+in a temp B-tree (the composite PK leads with id, so it can't serve the seek).
+
+Revision ID: 017
+Revises: 016
+Create Date: 2026-07-15
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "017"
+down_revision: str | None = "016"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+TABLE_NAME = "messages"
+INDEX_NAME = "idx_messages_chat_id_id"
+
+
+def _index_exists(inspector: sa.Inspector) -> bool:
+    return INDEX_NAME in {ix["name"] for ix in inspector.get_indexes(TABLE_NAME)}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    # Idempotent: create_all()-provisioned databases may already have the index.
+    if TABLE_NAME in inspector.get_table_names() and not _index_exists(inspector):
+        op.create_index(INDEX_NAME, TABLE_NAME, ["chat_id", "id"])
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if TABLE_NAME in inspector.get_table_names() and _index_exists(inspector):
+        op.drop_index(INDEX_NAME, table_name=TABLE_NAME)

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -130,6 +130,15 @@ if has_tables and not has_alembic:
     \"\"\")
     has_016_download_attempts = cur.fetchone()[0]
 
+    # Check artifact from migration 017: idx_messages_chat_id_id index
+    cur.execute(\"\"\"
+        SELECT EXISTS (
+            SELECT FROM pg_indexes
+            WHERE tablename = 'messages' AND indexname = 'idx_messages_chat_id_id'
+        );
+    \"\"\")
+    has_017_chat_id_id_index = cur.fetchone()[0]
+
     # Check artifact from migration 014: messages soft-delete marker columns
     cur.execute(\"\"\"
         SELECT
@@ -250,7 +259,9 @@ if has_tables and not has_alembic:
     has_push_subs = cur.fetchone()[0]
 
     # Determine which version to stamp based on existing schema
-    if has_016_download_attempts and has_015_message_versions and has_014_soft_delete:
+    if has_017_chat_id_id_index and has_016_download_attempts and has_015_message_versions and has_014_soft_delete:
+        stamp_version = '017'
+    elif has_016_download_attempts and has_015_message_versions and has_014_soft_delete:
         stamp_version = '016'
     elif has_015_message_versions and has_014_soft_delete:
         stamp_version = '015'
@@ -375,6 +386,10 @@ if has_tables and not has_alembic:
     # Check artifact from migration 016: media.download_attempts column
     has_016_download_attempts = 'download_attempts' in media_columns
 
+    # Check artifact from migration 017: idx_messages_chat_id_id index
+    cur.execute(\"SELECT name FROM sqlite_master WHERE type='index' AND name='idx_messages_chat_id_id'\")
+    has_017_chat_id_id_index = cur.fetchone() is not None
+
     # Check all artifacts from migration 010: viewer_tokens, app_settings, viewer_accounts.no_download
     cur.execute(\"SELECT name FROM sqlite_master WHERE type='table' AND name='viewer_tokens'\")
     has_010_tokens = cur.fetchone() is not None
@@ -414,7 +429,9 @@ if has_tables and not has_alembic:
     has_push_subs = cur.fetchone() is not None
 
     # Determine which version to stamp based on existing schema
-    if has_016_download_attempts and has_015_message_versions and has_014_soft_delete:
+    if has_017_chat_id_id_index and has_016_download_attempts and has_015_message_versions and has_014_soft_delete:
+        stamp_version = '017'
+    elif has_016_download_attempts and has_015_message_versions and has_014_soft_delete:
         stamp_version = '016'
     elif has_015_message_versions and has_014_soft_delete:
         stamp_version = '015'

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1736,9 +1736,12 @@ class DatabaseAdapter:
             if after_id is not None:
                 # Forward window (#213): the LIMIT must take the rows closest to the
                 # target, so select oldest-first and reverse to newest-first below to
-                # keep the response contract identical to every other mode.
+                # keep the response contract identical to every other mode. Ordering
+                # by id (monotonic per chat) instead of date lets the (chat_id, id)
+                # index satisfy both the bound and the sort — ordering by date here
+                # forced a full per-chat scan plus a temp sort.
                 stmt = stmt.where(Message.id > after_id)
-                stmt = stmt.order_by(Message.date.asc(), Message.id.asc()).limit(limit)
+                stmt = stmt.order_by(Message.id.asc()).limit(limit)
             elif before_date is not None:
                 # Use composite cursor: (date, id) for deterministic ordering
                 # Messages with same date are ordered by id DESC
@@ -1754,9 +1757,10 @@ class DatabaseAdapter:
                 # monotonically over time, so an id-only bound is chronologically
                 # correct within the chat scope. Without this branch a lone before_id
                 # silently fell through to the offset path and returned the latest
-                # page — the jump-to-message window was never fetched.
+                # page — the jump-to-message window was never fetched. Ordering by id
+                # (not date) lets the (chat_id, id) index seek directly to the bound.
                 stmt = stmt.where(Message.id < before_id)
-                stmt = stmt.order_by(Message.date.desc(), Message.id.desc()).limit(limit)
+                stmt = stmt.order_by(Message.id.desc()).limit(limit)
             else:
                 # Offset-based pagination (legacy fallback)
                 stmt = stmt.order_by(Message.date.desc(), Message.id.desc()).limit(limit).offset(offset)

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1669,6 +1669,7 @@ class DatabaseAdapter:
         search: str | None = None,
         before_date: datetime | None = None,
         before_id: int | None = None,
+        after_id: int | None = None,
         topic_id: int | None = None,
     ) -> list[dict[str, Any]]:
         """
@@ -1688,6 +1689,10 @@ class DatabaseAdapter:
             search: Optional text search filter
             before_date: Cursor - get messages before this date (faster than offset)
             before_id: Cursor - message ID to use as tiebreaker for same-date messages
+                (or, without before_date, an id-only bound: rows with id < before_id)
+            after_id: Cursor - get messages newer than this message ID (takes
+                precedence over the other cursors; used for jump-to-message
+                after-context). Response stays newest-first like every other mode.
             topic_id: Optional forum topic ID to filter messages by thread
 
         Returns:
@@ -1728,7 +1733,13 @@ class DatabaseAdapter:
 
             # Cursor-based pagination (preferred - O(1) performance)
             # Mirrored by the viewer (src/web/templates/index.html: compareMessagesDesc/messageCursor) — keep in sync.
-            if before_date is not None:
+            if after_id is not None:
+                # Forward window (#213): the LIMIT must take the rows closest to the
+                # target, so select oldest-first and reverse to newest-first below to
+                # keep the response contract identical to every other mode.
+                stmt = stmt.where(Message.id > after_id)
+                stmt = stmt.order_by(Message.date.asc(), Message.id.asc()).limit(limit)
+            elif before_date is not None:
                 # Use composite cursor: (date, id) for deterministic ordering
                 # Messages with same date are ordered by id DESC
                 if before_id is not None:
@@ -1737,6 +1748,14 @@ class DatabaseAdapter:
                     )
                 else:
                     stmt = stmt.where(Message.date < before_date)
+                stmt = stmt.order_by(Message.date.desc(), Message.id.desc()).limit(limit)
+            elif before_id is not None:
+                # Lone before_id cursor (#213): per-chat Telegram message ids increase
+                # monotonically over time, so an id-only bound is chronologically
+                # correct within the chat scope. Without this branch a lone before_id
+                # silently fell through to the offset path and returned the latest
+                # page — the jump-to-message window was never fetched.
+                stmt = stmt.where(Message.id < before_id)
                 stmt = stmt.order_by(Message.date.desc(), Message.id.desc()).limit(limit)
             else:
                 # Offset-based pagination (legacy fallback)
@@ -1775,6 +1794,10 @@ class DatabaseAdapter:
                         msg["raw_data"] = {}
 
                 messages.append(msg)
+
+            if after_id is not None:
+                # Selected oldest-first for the LIMIT; restore the newest-first contract.
+                messages.reverse()
 
             version_counts = {msg["id"]: 0 for msg in messages}
             version_count_message_ids = [msg["id"] for msg in messages]

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -108,6 +108,9 @@ class Message(Base):
         Index("idx_messages_sender_id", "sender_id"),
         # Composite index for fast pagination: WHERE chat_id = ? ORDER BY date DESC
         Index("idx_messages_chat_date_desc", "chat_id", date.desc()),
+        # v7.22.0: id-bounded jump-window cursors (lone before_id / after_id, #213)
+        # seek on (chat_id, id); the composite PK leads with id so it can't serve them.
+        Index("idx_messages_chat_id_id", "chat_id", "id"),
         # Index for finding pinned messages in a chat
         Index("idx_messages_chat_pinned", "chat_id", "is_pinned"),
         # Index for reply lookups

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1424,6 +1424,7 @@ async def get_messages(
     search: str | None = None,
     before_date: str | None = None,
     before_id: int | None = None,
+    after_id: int | None = None,
     topic_id: int | None = None,
 ):
     """
@@ -1432,6 +1433,8 @@ async def get_messages(
     Supports two pagination modes:
     - Offset-based: ?offset=100 (slower for large offsets)
     - Cursor-based: ?before_date=2026-01-15T12:00:00&before_id=12345 (O(1) performance)
+      A lone ?before_id=N returns rows with id < N (jump-to-message window),
+      and ?after_id=N returns rows with id > N (jump-to-message after-context).
 
     v6.2.0: Added topic_id filter for forum topic messages.
 
@@ -1460,6 +1463,7 @@ async def get_messages(
             search=search,
             before_date=parsed_before_date,
             before_id=before_id,
+            after_id=after_id,
             topic_id=topic_id,
         )
         if user.no_download:

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -968,14 +968,14 @@
                         <template v-for="(msg, index) in sortedMessages" :key="msg.id">
                             <!-- Service Message (chat actions like photo changed, user joined, etc) -->
                             <!-- v6.0.0: Service type moved to raw_data.service_type -->
-                            <div v-if="msg.raw_data?.service_type === 'service'" class="flex justify-center my-2">
+                            <div v-if="msg.raw_data?.service_type === 'service'" :data-msg-id="msg.id" class="flex justify-center my-2">
                                 <div class="service-message px-4 py-1.5 rounded-full text-xs text-center max-w-[80%]"
                                     style="background: rgba(0,0,0,0.3); color: rgba(255,255,255,0.8);">
                                     {{ msg.text }}
                                 </div>
                             </div>
                             <!-- Regular Message (hide duplicate album messages - only show first in group) -->
-                            <div v-else-if="!isHiddenAlbumMessage(msg, index)" class="flex" :class="isOwnMessage(msg) ? 'justify-end' : 'justify-start'">
+                            <div v-else-if="!isHiddenAlbumMessage(msg, index)" :data-msg-id="msg.id" class="flex" :class="isOwnMessage(msg) ? 'justify-end' : 'justify-start'">
                                 <div class="message-bubble p-3 text-sm shadow-sm text-gray-100"
                                     :style="getSenderStyle(msg)">
                                     <!-- Sender Name (if group and first in sequence) -->
@@ -1237,7 +1237,7 @@
                     </div>
 
                     <!-- Scroll to Bottom Button -->
-                    <button v-if="showScrollToBottom || unseenMessageCount > 0"
+                    <button v-if="showScrollToBottom || unseenMessageCount > 0 || viewingPinnedWindow"
                         @click="scrollToLatest"
                         class="scroll-to-bottom-btn relative"
                         :aria-label="unseenMessageCount > 0 ? unseenMessageCount + ' new message(s) — scroll to latest' : 'Scroll to latest messages'"
@@ -1745,9 +1745,12 @@
                 // True while the view is a detached jump-to-message window (loadMessagesAroundId)
                 // that does NOT contain the live tail. The realtime poll fetches the latest page
                 // (offset=0) and would upsert it in and snap the view back to newest, so the poll
-                // is suppressed until a tail-inclusive view is re-established (via
-                // resetMessagePagination, which every openChat/openTopic/search entry calls).
-                let viewingPinnedWindow = false
+                // and the WS new_message handler are suppressed until a tail-inclusive view is
+                // re-established (via resetMessagePagination, which every openChat/openTopic/search
+                // entry calls). Reactive: the scroll-to-latest button renders on it so a pinned
+                // window always has an exit affordance (at scrollTop=0 the scroll-position
+                // heuristic alone would hide the button).
+                const viewingPinnedWindow = ref(false)
 
                 const messageIdKey = (msg) => msg?.id == null ? null : String(msg.id)
 
@@ -1793,7 +1796,7 @@
                     // Every openChat/openTopic/search entry loads a tail-inclusive view through
                     // here, so clear the pinned-window flag (loadMessagesAroundId re-sets it after
                     // its own reset). This also re-enables the realtime poll.
-                    viewingPinnedWindow = false
+                    viewingPinnedWindow.value = false
                     // View-entry chokepoint: every message-list swap goes through here, so the
                     // unseen-badge from the previous view resets alongside pagination.
                     unseenMessageCount.value = 0
@@ -2500,15 +2503,25 @@
                         case 'new_message':
                             // Add to messages if we're viewing that chat/topic (deduplicate by ID)
                             if (selectedChat.value?.id === data.chat_id && data.message?.id != null && messageBelongsToCurrentTopic(data.message)) {
-                                const shouldStickToBottom = isNearMessageBottom(messagesContainer.value)
-                                // insert-only: a bare realtime row (no user/media joins, text truncated
-                                // by the notifier) must never overwrite an already-loaded joined row;
-                                // the next poll tick canonicalizes it via upsertMessages(latestMessages).
-                                if (upsertMessages([data.message], { updateExisting: false }) > 0) {
-                                    if (shouldStickToBottom) {
-                                        nextTick(() => scrollToBottom())
-                                    } else {
-                                        unseenMessageCount.value += 1
+                                if (viewingPinnedWindow.value || messageSearchQuery.value) {
+                                    // Mirror the realtime-poll guard (#213): a detached jump window
+                                    // must not grow live-tail rows (the near-bottom autoscroll below
+                                    // would snap the view back to newest), and a search view must not
+                                    // gain unfiltered rows. Count it for the badge instead — the tail
+                                    // reload on exit fetches it with full joins. (Falls through to the
+                                    // desktop-notification block below.)
+                                    unseenMessageCount.value += 1
+                                } else {
+                                    const shouldStickToBottom = isNearMessageBottom(messagesContainer.value)
+                                    // insert-only: a bare realtime row (no user/media joins, text truncated
+                                    // by the notifier) must never overwrite an already-loaded joined row;
+                                    // the next poll tick canonicalizes it via upsertMessages(latestMessages).
+                                    if (upsertMessages([data.message], { updateExisting: false }) > 0) {
+                                        if (shouldStickToBottom) {
+                                            nextTick(() => scrollToBottom())
+                                        } else {
+                                            unseenMessageCount.value += 1
+                                        }
                                     }
                                 }
                             }
@@ -3073,32 +3086,64 @@
                     const myVersion = ++chatVersion
                     loading.value = true
                     try {
-                        const res = await fetch(`/api/chats/${selectedChat.value.id}/messages?before_id=${messageId + 1}&limit=50`, {
+                        const windowLimit = 50
+                        // Scope both window fetches to the active forum topic like every other
+                        // messages fetch — without it a topic view jumps into cross-topic rows.
+                        let topicParam = ''
+                        const nav = currentNav.value
+                        if (nav.type === 'chat' && nav.topicId && nav.topicId !== 'all') {
+                            topicParam = `&topic_id=${nav.topicId}`
+                        }
+                        // before_id is an exclusive bound, so +1 keeps the target itself as the
+                        // newest row of the history half of the window.
+                        const res = await fetch(`/api/chats/${selectedChat.value.id}/messages?before_id=${messageId + 1}&limit=${windowLimit}${topicParam}`, {
                             credentials: 'include'
                         })
                         if (chatVersion !== myVersion) return
-                        if (res.ok) {
-                            const data = await res.json()
+                        if (!res.ok) return
+                        const data = await res.json()
+                        if (chatVersion !== myVersion) return
+                        const windowRows = data.messages || data
+                        // After-context so the target can sit centered with history on both
+                        // sides (Telegram-style). Best-effort: without it the target still
+                        // renders at the window's bottom edge.
+                        let afterRows = []
+                        let afterFetchComplete = false
+                        try {
+                            const afterRes = await fetch(`/api/chats/${selectedChat.value.id}/messages?after_id=${messageId}&limit=${windowLimit}${topicParam}`, {
+                                credentials: 'include'
+                            })
                             if (chatVersion !== myVersion) return
-                            messages.value = data.messages || data
-                            resetMessagePagination()
-                            // This window is detached from the live tail — pause the realtime
-                            // poll so it can't fetch the latest page and snap us back to newest
-                            // (#213). Cleared when a tail-inclusive view is re-established.
-                            viewingPinnedWindow = true
-                            await nextTick()
-                            if (chatVersion !== myVersion) return
-                            setupMessagesScrollObserver()
-                            const el = document.querySelector(`[data-msg-id="${messageId}"]`)
-                            if (el) {
-                                el.scrollIntoView({ behavior: 'smooth', block: 'center' })
-                                el.classList.add('bg-yellow-500/10')
-                                setTimeout(() => el.classList.remove('bg-yellow-500/10'), 2000)
+                            if (afterRes.ok) {
+                                const afterData = await afterRes.json()
+                                if (chatVersion !== myVersion) return
+                                afterRows = afterData.messages || afterData
+                                afterFetchComplete = true
                             }
+                        } catch (e) {
+                            console.warn('[Jump] after-context fetch failed, showing history-only window', e)
                         }
+                        messages.value = [...afterRows, ...windowRows]
+                        resetMessagePagination()
+                        // A short after-page proves the window already reaches the newest
+                        // message — stay live. Otherwise (full page, or the after-fetch
+                        // failed and we can't know) the view is detached from the live tail:
+                        // pause the realtime poll/WS upserts that would snap it back to
+                        // newest (#213). Cleared when a tail-inclusive view is re-established.
+                        viewingPinnedWindow.value = !(afterFetchComplete && afterRows.length < windowLimit)
+                        await nextTick()
+                        if (chatVersion !== myVersion) return
+                        setupMessagesScrollObserver()
+                        scrollToMessage(messageId)
                     } finally {
                         if (chatVersion === myVersion) {
                             loading.value = false
+                        }
+                        // Re-observe the sentinel after DOM updates (it is v-if'd on !loading,
+                        // so it only mounts after the flip above) — same idiom as loadMessages.
+                        await nextTick()
+                        if (messagesScrollObserver && loadMoreSentinel.value) {
+                            messagesScrollObserver.observe(loadMoreSentinel.value)
                         }
                     }
                 }
@@ -3364,7 +3409,7 @@
                 // Check for new messages and deletions
                 let isRefreshing = false
                 const checkForNewMessages = async () => {
-                    if (!selectedChat.value || isRefreshing || messageSearchQuery.value || viewingPinnedWindow) return
+                    if (!selectedChat.value || isRefreshing || messageSearchQuery.value || viewingPinnedWindow.value) return
 
                     isRefreshing = true
                     const myVersion = chatVersion
@@ -3626,7 +3671,7 @@
                     // top of that stale window and leaves the realtime poll paused (#213/#214) —
                     // the button would look like "back to live" while nothing updates. Reload the
                     // live tail so this control genuinely returns the user to the newest messages.
-                    if (viewingPinnedWindow) {
+                    if (viewingPinnedWindow.value) {
                         const myVersion = ++chatVersion  // invalidate in-flight pinned-window loads
                         loading.value = false
                         messages.value = []
@@ -4141,25 +4186,44 @@
                     })
                 }
 
-                const scrollToMessage = (msgId) => {
-                    // Find message element by ID and scroll to it
-                    const msgIndex = sortedMessages.value.findIndex(m => m.id === msgId)
-                    if (msgIndex !== -1) {
-                        nextTick(() => {
-                            const container = messagesContainer.value
-                            const msgElements = container.querySelectorAll('.message-bubble')
-                            if (msgElements[msgIndex]) {
-                                msgElements[msgIndex].scrollIntoView({ behavior: 'smooth', block: 'center' })
-                                // Highlight briefly
-                                msgElements[msgIndex].style.backgroundColor = '#1e40af'
-                                setTimeout(() => {
-                                    msgElements[msgIndex].style.backgroundColor = ''
-                                }, 1000)
-                            }
-                        })
-                    } else {
-                        console.log('Message not loaded yet')
+                // Resolve the rendered row for a message id via its data-msg-id attribute.
+                // Hidden album members (only the first photo/video of a group renders a row)
+                // resolve to their visible first-in-album sibling so album targets still get
+                // a scroll anchor. Positional lookups (.message-bubble[index]) are unusable
+                // here: service rows and hidden album rows make the DOM list shorter than
+                // sortedMessages, so index-based targeting scrolls to the wrong message.
+                const findMessageElement = (msgId) => {
+                    const container = messagesContainer.value
+                    if (!container) return null
+                    const exact = container.querySelector(`[data-msg-id="${msgId}"]`)
+                    if (exact) return exact
+                    const list = sortedMessages.value
+                    const idx = list.findIndex(m => String(m.id) === String(msgId))
+                    if (idx === -1) return null
+                    const gid = getGroupedId(list[idx])
+                    if (!gid) return null
+                    // sortedMessages is newest-first; the rendered album row is the group
+                    // member with the lowest index (isFirstInAlbum), so walk toward 0.
+                    for (let i = idx - 1; i >= 0; i--) {
+                        if (getGroupedId(list[i]) !== gid) break
+                        const el = container.querySelector(`[data-msg-id="${list[i].id}"]`)
+                        if (el) return el
                     }
+                    return null
+                }
+
+                const scrollToMessage = (msgId) => {
+                    nextTick(() => {
+                        const el = findMessageElement(msgId)
+                        if (!el) {
+                            console.log('Message not loaded yet')
+                            return
+                        }
+                        el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                        // Highlight briefly (same flash the jump path always intended)
+                        el.classList.add('bg-yellow-500/10')
+                        setTimeout(() => el.classList.remove('bg-yellow-500/10'), 2000)
+                    })
                 }
 
                 const openDatePicker = (initialDate) => {
@@ -4226,95 +4290,21 @@
                             return
                         }
 
-                        // Check if message is already loaded
+                        // Fast path: target already rendered — just scroll to it.
                         const existingIndex = sortedMessages.value.findIndex(m => m.id === message.id)
-
                         if (existingIndex !== -1) {
-                            // Message already loaded, just scroll to it
                             await nextTick()
                             scrollToMessage(message.id)
-                        } else {
-                            // Message not loaded, we need to load it
-                            // Since messages are loaded in DESC order (newest first), and we're looking for
-                            // a specific date, we'll add the message to our list and scroll to it
-                            // The message will be properly positioned when we load more messages
-
-                            // Capture oldest loaded message date BEFORE adding the new message
-                            // sortedMessages is newest-first, so last element is oldest
-                            const oldestLoadedDateBeforeJump = sortedMessages.value.length > 0
-                                ? sortedMessages.value[sortedMessages.value.length - 1].date
-                                : null
-
-                            // Add the message to the list (it will be sorted correctly by date)
-                            messages.value.push(message)
-
-                            await nextTick()
-
-                            // Find it in sorted messages and scroll
-                            const sortedIndex = sortedMessages.value.findIndex(m => m.id === message.id)
-                            if (sortedIndex !== -1) {
-                                scrollToMessage(message.id)
-
-                                // Load surrounding messages to fill the gap between jumped message
-                                // and previously loaded messages. loadMessages() uses pagination,
-                                // so we need to keep loading until the gap is filled.
-                                const targetDate = moment(message.date)
-
-                                // Only fill gap if target is older than what we had loaded
-                                if (oldestLoadedDateBeforeJump && targetDate.isBefore(moment(oldestLoadedDateBeforeJump))) {
-                                    // Load messages in background to fill the gap
-                                    const fillGap = async () => {
-                                        // Keep loading until pagination catches up to the target date
-                                        let iterations = 0
-                                        const maxIterations = 20 // Safety limit
-                                        const targetTime = new Date(message.date).getTime()
-
-                                        while (hasMore.value && iterations < maxIterations) {
-                                            // Abort if user switched to a different chat
-                                            if (!selectedChat.value || selectedChat.value.id !== chatIdAtStart) {
-                                                return
-                                            }
-
-                                            // Check if gap is filled by looking at target's position
-                                            // in sorted messages (newest-first, so oldest is last)
-                                            const sorted = sortedMessages.value
-                                            const targetIdx = sorted.findIndex(m => m.id === message.id)
-
-                                            // Gap is filled when target is no longer the oldest loaded
-                                            if (targetIdx !== -1 && targetIdx < sorted.length - 1) {
-                                                break
-                                            }
-
-                                            // Track message IDs before loading to detect new messages
-                                            const idsBefore = new Set(messages.value.map(m => m.id))
-
-                                            await loadMessages()
-                                            iterations++
-
-                                            // Check if any newly loaded message is at or before target date
-                                            // This means pagination has reached the target (gap is filled)
-                                            // without needing to load messages OLDER than the target
-                                            let reachedTarget = false
-                                            for (const m of messages.value) {
-                                                if (!idsBefore.has(m.id) && new Date(m.date).getTime() <= targetTime) {
-                                                    reachedTarget = true
-                                                    break
-                                                }
-                                            }
-                                            if (reachedTarget) {
-                                                break
-                                            }
-
-                                            // Small delay between requests
-                                            await new Promise(resolve => setTimeout(resolve, 50))
-                                        }
-                                    }
-
-                                    // Start filling gap after a short delay
-                                    setTimeout(fillGap, 200)
-                                }
-                            }
+                            return
                         }
+
+                        // Load a detached window centered on the target — the same path as
+                        // the media-gallery jump (#213). The previous push-into-tail +
+                        // fill-the-gap approach capped at 20 pages, so dates further back
+                        // than ~1000 messages never got their gap filled, and the realtime
+                        // poll's near-bottom autoscroll could snap the view back to the
+                        // tail mid-fill.
+                        await loadMessagesAroundId(message.id)
                     } catch (e) {
                         console.error('Error jumping to date:', e)
                         closeDatePicker()
@@ -4542,6 +4532,7 @@
                     formatMediaDate,
                     formatFileSize,
                     loadMessagesAroundId,
+                    viewingPinnedWindow,
                     searchMessages,
                     isOwnMessage,
                     getSenderName,

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -2090,6 +2090,51 @@ class TestGetMessagesPaginated:
         assert result == []
 
     @pytest.mark.asyncio
+    async def test_lone_before_id_bounds_window_by_id(self):
+        """A lone before_id must bound the query by id — not silently fall back to the
+        latest offset-0 page, which made every jump-to-message land on the newest
+        messages (#213)."""
+        db_manager, mock_session = _make_mock_db_manager()
+        adapter = DatabaseAdapter(db_manager)
+
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter([]))
+        mock_session.execute.return_value = mock_result
+        adapter.get_reactions = AsyncMock(return_value=[])
+
+        await adapter.get_messages_paginated(chat_id=100, before_id=224, limit=50)
+
+        stmt = mock_session.execute.await_args_list[0].args[0]
+        assert "messages.id <" in str(stmt.whereclause)
+        order_by = list(stmt._order_by_clauses)
+        assert str(order_by[0]) == str(Message.date.desc())
+        assert str(order_by[1]) == str(Message.id.desc())
+        assert stmt._offset_clause is None
+
+    @pytest.mark.asyncio
+    async def test_after_id_selects_nearest_rows_and_returns_newest_first(self):
+        """after_id takes the rows closest to the target (ascending LIMIT) and reverses
+        them so the response keeps the newest-first contract of every other mode."""
+        db_manager, mock_session = _make_mock_db_manager()
+        adapter = DatabaseAdapter(db_manager)
+
+        rows = [self._make_message_row(msg_id=225), self._make_message_row(msg_id=226)]
+        mock_result = MagicMock()
+        mock_result.__iter__ = MagicMock(return_value=iter(rows))
+        mock_session.execute.return_value = mock_result
+        adapter.get_reactions = AsyncMock(return_value=[])
+
+        result = await adapter.get_messages_paginated(chat_id=100, after_id=224, limit=50)
+
+        stmt = mock_session.execute.await_args_list[0].args[0]
+        assert "messages.id >" in str(stmt.whereclause)
+        order_by = list(stmt._order_by_clauses)
+        assert str(order_by[0]) == str(Message.date.asc())
+        assert str(order_by[1]) == str(Message.id.asc())
+        # DB returned ascending [225, 226]; the response contract is newest-first.
+        assert [m["id"] for m in result] == [226, 225]
+
+    @pytest.mark.asyncio
     async def test_offset_pagination_orders_same_timestamp_by_id_desc(self):
         """Offset pagination uses the deterministic date DESC, id DESC ordering."""
         db_manager, mock_session = _make_mock_db_manager()

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -2106,9 +2106,10 @@ class TestGetMessagesPaginated:
 
         stmt = mock_session.execute.await_args_list[0].args[0]
         assert "messages.id <" in str(stmt.whereclause)
+        # id-only ordering (monotonic per chat) so the (chat_id, id) index can
+        # seek the bound directly; ordering by date forced a full per-chat scan.
         order_by = list(stmt._order_by_clauses)
-        assert str(order_by[0]) == str(Message.date.desc())
-        assert str(order_by[1]) == str(Message.id.desc())
+        assert str(order_by[0]) == str(Message.id.desc())
         assert stmt._offset_clause is None
 
     @pytest.mark.asyncio
@@ -2129,8 +2130,7 @@ class TestGetMessagesPaginated:
         stmt = mock_session.execute.await_args_list[0].args[0]
         assert "messages.id >" in str(stmt.whereclause)
         order_by = list(stmt._order_by_clauses)
-        assert str(order_by[0]) == str(Message.date.asc())
-        assert str(order_by[1]) == str(Message.id.asc())
+        assert str(order_by[0]) == str(Message.id.asc())
         # DB returned ascending [225, 226]; the response contract is newest-first.
         assert [m["id"] for m in result] == [226, 225]
 

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -230,10 +230,12 @@ def test_jump_to_message_resets_history_pagination():
 
     assert "const myVersion = ++chatVersion" in jump_body
     assert "loading.value = true" in jump_body
-    assert "messages.value = data.messages || data" in jump_body
+    assert "messages.value = [...afterRows, ...windowRows]" in jump_body
     assert "resetMessagePagination()" in jump_body
     assert "setupMessagesScrollObserver()" in jump_body
-    assert jump_body.index("messages.value = data.messages || data") < jump_body.index("resetMessagePagination()")
+    assert jump_body.index("messages.value = [...afterRows, ...windowRows]") < jump_body.index(
+        "resetMessagePagination()"
+    )
     assert jump_body.index("resetMessagePagination()") < jump_body.index("setupMessagesScrollObserver()")
 
 
@@ -248,22 +250,113 @@ def test_jump_window_suppresses_realtime_poll():
     reset_start = html.index("const resetMessagePagination = () =>")
     reset_body = html[reset_start : html.index("// Mirrors backend coalesce", reset_start)]
 
-    assert "let viewingPinnedWindow = false" in html
+    assert "const viewingPinnedWindow = ref(false)" in html
     # The poll bails while a detached window is shown...
-    assert "|| viewingPinnedWindow) return" in refresh_body
-    # ...the jump sets the flag AFTER its own resetMessagePagination()...
-    assert "viewingPinnedWindow = true" in jump_body
-    assert jump_body.index("resetMessagePagination()") < jump_body.index("viewingPinnedWindow = true")
+    assert "|| viewingPinnedWindow.value) return" in refresh_body
+    # ...the jump sets the flag AFTER its own resetMessagePagination() — pinned
+    # unless a short after-context page proved the window already reaches the tail...
+    assert "viewingPinnedWindow.value = !(afterFetchComplete && afterRows.length < windowLimit)" in jump_body
+    assert jump_body.index("resetMessagePagination()") < jump_body.index("viewingPinnedWindow.value = !(")
     # ...and every tail-inclusive view entry clears it via resetMessagePagination.
-    assert "viewingPinnedWindow = false" in reset_body
+    assert "viewingPinnedWindow.value = false" in reset_body
 
     # The "scroll to latest" button must genuinely return to live from a pinned
     # window (reload the tail), not just scroll the stale window (#214 review).
     latest_start = html.index("const scrollToLatest = async () =>")
     latest_body = html[latest_start : html.index("const isOwnMessage = (msg) =>", latest_start)]
-    assert "if (viewingPinnedWindow)" in latest_body
+    assert "if (viewingPinnedWindow.value)" in latest_body
     assert "resetMessagePagination()" in latest_body
     assert "await loadMessages()" in latest_body
+    # While pinned, scrollTop sits at 0 so the scroll-position heuristic alone
+    # would hide the button — the flag must keep the exit affordance rendered.
+    assert 'v-if="showScrollToBottom || unseenMessageCount > 0 || viewingPinnedWindow"' in html
+
+
+def test_jump_window_fetches_context_and_scrolls_to_target():
+    """The jump loads history + after-context scoped to the topic and scrolls to the target (#213)."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    jump_start = html.index("const loadMessagesAroundId = async (messageId) =>")
+    jump_body = html[jump_start : html.index("watch(showMediaGallery", jump_start)]
+
+    # Exclusive bound keeps the target as the newest row of the history half.
+    assert "before_id=${messageId + 1}" in jump_body
+    assert "after_id=${messageId}" in jump_body
+    # Both window fetches must carry the forum-topic scope.
+    assert jump_body.count("${topicParam}") == 2
+    # Target scroll goes through the shared id-anchored helper.
+    assert "scrollToMessage(messageId)" in jump_body
+
+
+def test_message_rows_bind_the_msg_id_anchor():
+    """Both rendered row variants carry data-msg-id, and JS data-* selectors resolve.
+
+    Guards the #213 bug class: v7.21.0 shipped a querySelector for
+    [data-msg-id=...] while no element rendered the attribute, so the jump's
+    scroll/highlight was dead code.
+    """
+    import re
+
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    # service row + regular row
+    assert html.count(':data-msg-id="msg.id"') == 2
+
+    # Generic drift guard: every data-* attribute queried from JS must be
+    # rendered somewhere in the template (as a static or bound attribute).
+    queried = set(re.findall(r"querySelector(?:All)?\([`'\"]\[(data-[a-z-]+)", html))
+    assert "data-msg-id" in queried
+    for attr in queried:
+        assert f":{attr}=" in html or f" {attr}=" in html, f"JS queries [{attr}] but the template never renders it"
+
+
+def test_scroll_to_message_uses_id_anchor_not_positional_index():
+    """scrollToMessage must resolve rows by data-msg-id, not by .message-bubble index.
+
+    Service rows and hidden album rows make the bubble NodeList shorter than
+    sortedMessages, so positional lookups scrolled to the wrong message.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert "querySelectorAll('.message-bubble')" not in html
+
+    helper_start = html.index("const findMessageElement = (msgId) =>")
+    helper_body = html[helper_start : html.index("const scrollToMessage = (msgId) =>", helper_start)]
+    assert '[data-msg-id="${msgId}"]' in helper_body
+    # Album-hidden targets resolve to their visible first-in-album sibling.
+    assert "getGroupedId" in helper_body
+
+    scroll_start = html.index("const scrollToMessage = (msgId) =>")
+    scroll_body = html[scroll_start : html.index("const openDatePicker", scroll_start)]
+    assert "findMessageElement(msgId)" in scroll_body
+    assert "scrollIntoView({ behavior: 'smooth', block: 'center' })" in scroll_body
+
+
+def test_websocket_new_message_respects_pinned_window_and_search():
+    """The WS path must honor the same guards as the poll — it was the ungated snap-back writer (#213)."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    ws_start = html.index("case 'new_message':")
+    ws_body = html[ws_start : html.index("case 'edit':", ws_start)]
+
+    assert "if (viewingPinnedWindow.value || messageSearchQuery.value)" in ws_body
+    # The guard must run before the upsert/autoscroll path.
+    assert ws_body.index("viewingPinnedWindow.value") < ws_body.index("upsertMessages([data.message]")
+    # Desktop notifications still fire while pinned (the guard must not break out early).
+    assert "showNotification(data)" in ws_body
+
+
+def test_jump_to_date_routes_through_window_loader():
+    """Date jumps reuse the jump-window path instead of the capped push+fill-gap machinery."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    date_start = html.index("const jumpToDate = async () =>")
+    date_body = html[date_start : html.index("// Admin panel", date_start)]
+
+    assert "await loadMessagesAroundId(message.id)" in date_body
+    # The 20-page fill-gap loop (failed for targets >1000 messages back) is gone.
+    assert "fillGap" not in html
+    assert "maxIterations" not in date_body
 
 
 def test_realtime_polling_skips_search_results():
@@ -401,6 +494,7 @@ def test_unseen_message_badge_tracks_background_arrivals():
     latest_start = html.index("const scrollToLatest = async () =>")
     latest_body = html[latest_start : html.index("const isOwnMessage = (msg) =>", latest_start)]
     assert "unseenMessageCount.value = 0" in latest_body
-    # Button shows for the badge even before the distance threshold, with an aria-label.
-    assert 'v-if="showScrollToBottom || unseenMessageCount > 0"' in html
+    # Button shows for the badge even before the distance threshold (and always
+    # while a detached jump window is pinned), with an aria-label.
+    assert 'v-if="showScrollToBottom || unseenMessageCount > 0 || viewingPinnedWindow"' in html
     assert "' new message(s) — scroll to latest'" in html

--- a/tests/test_jump_window_backend.py
+++ b/tests/test_jump_window_backend.py
@@ -1,0 +1,89 @@
+"""End-to-end window queries for jump-to-message (#213), real SQLite.
+
+The v7.21.0 jump fetched `?before_id=<target+1>` alone, and the adapter only
+honored before_id inside the before_date branch — the query silently returned
+the latest page and every jump landed on the newest messages. These tests run
+the real SQL so that contract can't regress silently again.
+"""
+
+import os
+import sys
+from datetime import datetime, timedelta
+
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Base, Message
+
+CHAT_ID = -100
+NEWEST_ID = 200
+
+
+@pytest_asyncio.fixture
+async def adapter():
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db_manager = DatabaseManager.__new__(DatabaseManager)
+    db_manager.engine = engine
+    db_manager.database_url = "sqlite+aiosqlite://"
+    db_manager._is_sqlite = True
+    db_manager.async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    adapter = DatabaseAdapter(db_manager)
+    async with db_manager.async_session_factory() as session:
+        base = datetime(2026, 1, 1, 12, 0, 0)
+        for i in range(1, NEWEST_ID + 1):
+            session.add(Message(id=i, chat_id=CHAT_ID, date=base + timedelta(minutes=i), text=f"m{i}"))
+        await session.commit()
+
+    yield adapter
+    await engine.dispose()
+
+
+class TestJumpWindowQueries:
+    async def test_lone_before_id_returns_history_window_not_latest_page(self, adapter):
+        target = 60
+        rows = await adapter.get_messages_paginated(chat_id=CHAT_ID, before_id=target + 1, limit=50)
+        ids = [r["id"] for r in rows]
+
+        # Exclusive bound: the target itself is the newest row of the window.
+        assert ids[0] == target
+        assert ids == list(range(target, target - 50, -1))
+        assert NEWEST_ID not in ids
+
+    async def test_after_id_returns_forward_context_newest_first(self, adapter):
+        rows = await adapter.get_messages_paginated(chat_id=CHAT_ID, after_id=60, limit=50)
+        ids = [r["id"] for r in rows]
+
+        # The LIMIT takes the rows closest to the target (61..110), and the
+        # response keeps the newest-first contract of every other mode.
+        assert ids == list(range(110, 60, -1))
+
+    async def test_after_id_short_page_marks_the_live_tail(self, adapter):
+        rows = await adapter.get_messages_paginated(chat_id=CHAT_ID, after_id=190, limit=50)
+        ids = [r["id"] for r in rows]
+
+        assert ids == list(range(NEWEST_ID, 190, -1))
+        # The viewer relies on a short page to detect that the window already
+        # reaches the newest message (stays in live/tail mode).
+        assert len(rows) < 50
+
+    async def test_after_id_is_chat_scoped(self, adapter):
+        async with adapter.db_manager.async_session_factory() as session:
+            session.add(Message(id=500, chat_id=-999, date=datetime(2026, 2, 1), text="other chat"))
+            await session.commit()
+
+        rows = await adapter.get_messages_paginated(chat_id=CHAT_ID, after_id=190, limit=50)
+        assert all(r["chat_id"] == CHAT_ID for r in rows)
+        assert 500 not in [r["id"] for r in rows]

--- a/tests/test_migration_017.py
+++ b/tests/test_migration_017.py
@@ -1,0 +1,95 @@
+"""Tests for Alembic migration 017 (idx_messages_chat_id_id index)."""
+
+import importlib.util
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parent.parent / "alembic" / "versions" / "20260715_017_add_messages_chat_id_id_index.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("migration_017", _MIGRATION_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(conn, func):
+    ctx = MigrationContext.configure(conn)
+    with Operations.context(ctx):
+        func()
+
+
+def _create_messages_table(conn):
+    conn.execute(
+        sa.text(
+            "CREATE TABLE messages ("
+            "id BIGINT NOT NULL, "
+            "chat_id BIGINT NOT NULL, "
+            "date DATETIME NOT NULL, "
+            "PRIMARY KEY (id, chat_id)"
+            ")"
+        )
+    )
+
+
+def _indexes(conn):
+    return {ix["name"] for ix in sa.inspect(conn).get_indexes("messages")}
+
+
+def test_revision_chain():
+    migration = _load_migration()
+    assert migration.revision == "017"
+    assert migration.down_revision == "016"
+
+
+def test_upgrade_creates_index_and_is_idempotent():
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_messages_table(conn)
+
+        _run(conn, migration.upgrade)
+        assert "idx_messages_chat_id_id" in _indexes(conn)
+
+        # re-run must be a no-op (index already present)
+        _run(conn, migration.upgrade)
+        assert "idx_messages_chat_id_id" in _indexes(conn)
+
+
+def test_upgrade_noop_when_index_already_exists():
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_messages_table(conn)
+        conn.execute(sa.text("CREATE INDEX idx_messages_chat_id_id ON messages (chat_id, id)"))
+
+        _run(conn, migration.upgrade)  # must not raise
+        assert "idx_messages_chat_id_id" in _indexes(conn)
+
+
+def test_downgrade_drops_index_and_is_idempotent():
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_messages_table(conn)
+        _run(conn, migration.upgrade)
+
+        _run(conn, migration.downgrade)
+        assert "idx_messages_chat_id_id" not in _indexes(conn)
+
+        _run(conn, migration.downgrade)  # idempotent
+        assert "idx_messages_chat_id_id" not in _indexes(conn)
+
+
+def test_upgrade_noop_when_messages_table_absent():
+    migration = _load_migration()
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _run(conn, migration.upgrade)  # no messages table → no-op, no raise
+        assert "messages" not in sa.inspect(conn).get_table_names()

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -337,6 +337,21 @@ class TestMessagesEndpoint(_WebTestBase):
         self.assertIsNotNone(call_kwargs["before_date"])
         self.assertEqual(call_kwargs["before_id"], 500)
 
+    async def test_passes_jump_window_cursor_params(self):
+        """get_messages forwards a lone before_id and after_id to db (#213 jump window)."""
+        self.mock_db.get_messages_paginated = AsyncMock(return_value=[])
+        async with self._client() as client:
+            resp_before = await client.get("/api/chats/1/messages?before_id=501&limit=50")
+            resp_after = await client.get("/api/chats/1/messages?after_id=500&limit=50")
+        self.assertEqual(resp_before.status_code, 200)
+        self.assertEqual(resp_after.status_code, 200)
+        first = self.mock_db.get_messages_paginated.call_args_list[0].kwargs
+        second = self.mock_db.get_messages_paginated.call_args_list[1].kwargs
+        self.assertEqual(first["before_id"], 501)
+        self.assertIsNone(first["before_date"])
+        self.assertIsNone(first["after_id"])
+        self.assertEqual(second["after_id"], 500)
+
     async def test_invalid_before_date_returns_400(self):
         """get_messages returns 400 for invalid before_date format."""
         async with self._client() as client:


### PR DESCRIPTION
## Summary

Re-fixes #213 at the actual root cause. v7.21.0 suppressed the realtime poll during a jump, but the jump never showed the target because the backend silently ignored the window request: `get_messages_paginated` only honored `before_id` as a same-date tiebreaker inside the `before_date` branch, so the jump's lone `before_id` fell through to the offset path and returned the **latest 50 messages** with a 200. Every jump literally loaded the newest page.

This also fixes the calendar jump-to-date failures for distant dates reported in the same thread, plus four adjacent defects found while investigating.

## Root causes fixed

1. **Backend ignored a lone `before_id`** (`src/db/adapter.py`) — now honored as an id-only bound (per-chat Telegram ids are monotonic). Added `after_id` (ascending select, reversed to keep the newest-first response contract) so the jump can center the target with context on both sides.
2. **The jump's scroll was dead code** — `document.querySelector('[data-msg-id=...]')` matched nothing because no template element rendered `data-msg-id`. Both row variants (regular + service) now bind it.
3. **`scrollToMessage` used positional `.message-bubble[index]` lookups** that misalign whenever service rows or hidden album rows exist — rewritten on a shared `findMessageElement` that anchors by `data-msg-id` and resolves hidden album members to their visible first-in-album sibling. Fixes reply-click, notification deep-links, and pinned-bar jumps too.
4. **The WebSocket `new_message` path wasn't gated** by the pinned-window flag (only the HTTP poll was), so a live arrival could still snap the window back to newest — now mirrors the poll guard, and also stops injecting unfiltered rows into active search views. Desktop notifications still fire.
5. **`jumpToDate` used a push + fill-the-gap loop capped at 20 pages** — dates further back than ~1000 messages never got their gap filled, and the poll's near-bottom autoscroll raced the fill. It now routes through the same window loader (with a fast path when the target is already rendered). The fillGap machinery is deleted.
6. **Window fetches were missing `topic_id`** — forum-topic jumps no longer leak cross-topic rows.
7. **No exit affordance while pinned** — at `scrollTop=0` the scroll-to-latest button was hidden. `viewingPinnedWindow` is now a reactive ref and keeps the button rendered; if the after-context page comes back short (window provably reaches the live tail), the view stays live instead of pinning.

## Tests

- `tests/test_jump_window_backend.py` (new): real-SQLite end-to-end window queries — lone `before_id` returns the history window (target included via the exclusive `+1` bound), `after_id` returns the nearest forward context newest-first, short page marks the live tail, chat scoping.
- `tests/test_db_adapter.py`: statement-shape tests for both new cursor branches (the exact shape that was wrong).
- `tests/test_web_routes.py`: endpoint passes lone `before_id`/`after_id` through.
- `tests/test_frontend_bootstrap.py`: updated jump-window asserts plus new guards — `data-msg-id` bindings, id-anchored scrolling (no positional lookups anywhere), WS guard ordering, jumpToDate routing, fillGap removal, and a generic drift guard asserting **every `data-*` attribute queried from JS is actually rendered in the template** (the class of bug that shipped twice).

Full suite: 2064 passed. `ruff check` + `ruff format --check` clean.

## Deferred (deliberate)

Continuous forward pagination inside a pinned window (a "load newer" sentinel with auto-heal into live mode) is left as a follow-up; the always-visible scroll-to-latest button is the exit affordance. Reply-jump/notification deep-links to unloaded messages still no-op scroll (pre-existing) — they can route through the window loader in a follow-up.

Fixes #213


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `after_id` cursor pagination to the chat messages API, enabling jump-to-message “after-context” retrieval.
  - Enhanced jump-to-date/message navigation with topic-scoped history, and improved album-aware scrolling behavior.

- **Bug Fixes**
  - Realtime message updates no longer disrupt pinned-window or message search views; unseen counts are updated instead.
  - Corrected cursor pagination behavior and ensured jump/scroll targeting is stable for rendered messages (including album visibility).

- **Chores**
  - Added a supporting database index and improved automatic migration stamping for migration 017.

- **Tests**
  - Expanded backend, frontend, API, and migration coverage for all new/changed pagination and pinned-window behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->