### PR TITLE
chore: whole-repo audit hardening (security, reliability, perf, PII)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,18 @@ DOWNLOAD_MEDIA=true
 # Files larger than this will be skipped
 MAX_MEDIA_SIZE_MB=100
 
+# Maximum usable filename byte budget for downloaded media (the file_id prefix
+# and extension are always preserved; only the decorative part is shortened).
+# Default 143 keeps names writable on Synology/eCryptfs encrypted shares, whose
+# filename encryption overhead caps components below the usual 255 bytes.
+# Raise to 255 on plain ext4/xfs/btrfs if you prefer longer decorative names.
+# MEDIA_MAX_FILENAME_BYTES=143
+
+# Stop retrying a media file's download after this many failed attempts, so a
+# permanently-unwritable file can't tax every backup run forever. Re-requesting
+# the download (e.g. via VERIFY_MEDIA or the admin panel) resets the counter.
+# MEDIA_MAX_DOWNLOAD_ATTEMPTS=5
+
 # Timeout for media downloads (in seconds). 0 disables the timeout.
 # Default is 3600 (60 minutes).
 # DOWNLOAD_TIMEOUT_SECONDS=3600
@@ -227,6 +239,10 @@ DB_PATH=/data/backups/telegram_backup.db
 # VIEWER_USERNAME=admin
 # VIEWER_PASSWORD=your_secure_password
 # AUTH_SESSION_DAYS=30
+#
+# ALLOW_ANONYMOUS_VIEWER grants READ-ONLY access with no login: browsing and
+# search work, but nothing that writes (settings, viewer/token management,
+# deletions, etc.) is reachable without authenticating as the master account.
 # ALLOW_ANONYMOUS_VIEWER=false
 
 # --- Multi-User Access Control (v7.0.0) ---
@@ -239,7 +255,13 @@ DB_PATH=/data/backups/telegram_backup.db
 # For use behind auth proxies like Authelia, Authentik, or Keycloak.
 # The proxy authenticates the user and forwards their identity in a header.
 # Set AUTH_PROXY_HEADER to enable (e.g., "Remote-User" or "X-Forwarded-User").
-# IMPORTANT: Only enable if your reverse proxy strips this header from client requests.
+#
+# !!! WARNING !!!
+# Your reverse proxy MUST strip or overwrite this header on EVERY inbound
+# request before it reaches this app. If a client can set the header itself
+# (because the proxy passes it through untouched), anyone can impersonate any
+# user — including an admin — with a single request header. This is a full
+# authentication bypass, not a hardening nicety.
 # AUTH_PROXY_HEADER=Remote-User
 
 # Comma-separated list of usernames that get admin (master) role.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,12 +30,8 @@ jobs:
       
       - name: Run tests
         run: |
-          python -m pytest tests/ -v --tb=short
-      
-      - name: Run tests with coverage
-        run: |
-          python -m pytest tests/ --cov=src --cov-report=term-missing --cov-report=xml
-      
+          python -m pytest tests/ -v --tb=short --cov=src --cov-report=term-missing --cov-report=xml
+
       - name: Upload coverage reports
         uses: codecov/codecov-action@v7
         with:

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ docker compose up -d
 
 **View your backup** at http://localhost:8000
 
-The default compose binds the viewer to `127.0.0.1`. Put it behind a reverse proxy only after setting `VIEWER_USERNAME` and `VIEWER_PASSWORD`. To deliberately run without auth for a local-only viewer, set `ALLOW_ANONYMOUS_VIEWER=true`.
+The default compose binds the viewer to `127.0.0.1`. Put it behind a reverse proxy only after setting `VIEWER_USERNAME` and `VIEWER_PASSWORD`. To deliberately run without auth for a local-only viewer, set `ALLOW_ANONYMOUS_VIEWER=true` — this grants read-only access only; writes still require the master account.
 
 ### Common Issues
 
@@ -254,6 +254,8 @@ The **Scope** column shows whether each variable applies to the backup scheduler
 | `BACKUP_PATH` | `/data/backups` | B/V | Base path for backup data and media |
 | `DOWNLOAD_MEDIA` | `true` | B | Download media files (photos, videos, documents) |
 | `MAX_MEDIA_SIZE_MB` | `100` | B | Skip media files larger than this (MB) |
+| `MEDIA_MAX_FILENAME_BYTES` | `143` | B | Usable filename byte budget for downloaded media. Raise to `255` on plain ext4/xfs; keep `143` for Synology/eCryptfs encrypted shares |
+| `MEDIA_MAX_DOWNLOAD_ATTEMPTS` | `5` | B | Stop retrying a file's download after this many failed attempts. Re-requesting the download resets the counter |
 | `PARALLEL_DOWNLOAD_ENABLED` | `false` | B | Fetch large files over several connections to lift the single-stream speed cap (see below) |
 | `PARALLEL_DOWNLOAD_MIN_SIZE_MB` | `20` | B | Only files at least this large use the parallel path (min 1) |
 | `PARALLEL_DOWNLOAD_CONNECTIONS` | `4` | B | Concurrent connections per file (clamped 2–8) |
@@ -307,8 +309,11 @@ The **Scope** column shows whether each variable applies to the backup scheduler
 | **Viewer & Authentication** | | | |
 | `VIEWER_USERNAME` | - | V | Master web viewer username |
 | `VIEWER_PASSWORD` | - | V | Master web viewer password |
-| `ALLOW_ANONYMOUS_VIEWER` | `false` | V | Explicitly allow unauthenticated local viewer mode |
+| `ALLOW_ANONYMOUS_VIEWER` | `false` | V | Explicitly allow unauthenticated local viewer mode. Grants **read-only** access — browsing/search work, but settings, viewer/token management, and deletions still require the master account |
 | `AUTH_SESSION_DAYS` | `30` | V | Days before re-authentication is required |
+| `AUTH_PROXY_HEADER` | - | V | Header carrying the authenticated username from a trusted reverse proxy (Authelia, Authentik, Keycloak), e.g. `Remote-User`. See warning below |
+| `AUTH_PROXY_ADMIN_USERS` | - | V | Comma-separated usernames from `AUTH_PROXY_HEADER` that get the admin (master) role |
+| `AUTH_PROXY_DEFAULT_ACCESS` | `none` | V | Default chat access for auto-created proxy users: `none` or `all` |
 | `DISPLAY_CHAT_IDS` | - | V | Restrict viewer to specific chats (comma-separated IDs) |
 | `TRUST_PROXY_HEADERS` | `false` | V | Trust `X-Forwarded-For` / `X-Real-IP` only when your reverse proxy overwrites them |
 | `INTERNAL_PUSH_SECRET` | - | B/V | Shared secret for SQLite backup-to-viewer realtime push over Docker/private networks |
@@ -324,6 +329,8 @@ The **Scope** column shows whether each variable applies to the backup scheduler
 | `VAPID_PRIVATE_KEY` | *auto-generated* | V | Custom VAPID private key for Web Push |
 | `VAPID_PUBLIC_KEY` | *auto-generated* | V | Custom VAPID public key for Web Push |
 | `VAPID_CONTACT` | `mailto:admin@example.com` | V | Contact email included in Web Push requests |
+
+> ⚠️ **`AUTH_PROXY_HEADER` requires a trusted reverse proxy.** Your proxy MUST strip or overwrite this header on **every** inbound request before it reaches the viewer. If it merely passes the header through, any client can set it themselves and impersonate any user — including an admin — with a single request header. This is a full authentication bypass, not a hardening nicety. Only enable this if you've verified your proxy config strips client-supplied values for the header you choose.
 
 ### Chat Filtering
 

--- a/alembic/versions/20260116_002_add_chat_date_index.py
+++ b/alembic/versions/20260116_002_add_chat_date_index.py
@@ -27,6 +27,14 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
+INDEX_NAME = "idx_messages_chat_date_desc"
+TABLE_NAME = "messages"
+
+
+def _index_exists(inspector: sa.Inspector) -> bool:
+    return INDEX_NAME in {ix["name"] for ix in inspector.get_indexes(TABLE_NAME)}
+
+
 def upgrade() -> None:
     """Add composite index on (chat_id, date DESC) for fast message pagination."""
     # This index covers the most common query pattern in the viewer:
@@ -34,9 +42,18 @@ def upgrade() -> None:
     #
     # The DESC on date is important - it matches the ORDER BY direction,
     # allowing PostgreSQL to read the index in order without sorting.
-    op.create_index("idx_messages_chat_date_desc", "messages", ["chat_id", sa.text("date DESC")], unique=False)
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    # Idempotent: create_all()-provisioned databases may already have this index.
+    if TABLE_NAME in inspector.get_table_names() and not _index_exists(inspector):
+        op.create_index(INDEX_NAME, TABLE_NAME, ["chat_id", sa.text("date DESC")], unique=False)
 
 
 def downgrade() -> None:
     """Remove the composite index."""
-    op.drop_index("idx_messages_chat_date_desc", table_name="messages")
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if TABLE_NAME in inspector.get_table_names() and _index_exists(inspector):
+        op.drop_index(INDEX_NAME, table_name=TABLE_NAME)

--- a/alembic/versions/20260117_003_add_push_subscriptions.py
+++ b/alembic/versions/20260117_003_add_push_subscriptions.py
@@ -19,25 +19,48 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
+TABLE_NAME = "push_subscriptions"
+INDEX_NAME = "idx_push_sub_chat"
+
+
+def _index_exists(inspector: sa.Inspector) -> bool:
+    return INDEX_NAME in {ix["name"] for ix in inspector.get_indexes(TABLE_NAME)}
+
+
 def upgrade() -> None:
     """Create push_subscriptions table."""
-    op.create_table(
-        "push_subscriptions",
-        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
-        sa.Column("endpoint", sa.Text(), nullable=False),
-        sa.Column("p256dh", sa.String(255), nullable=False),
-        sa.Column("auth", sa.String(255), nullable=False),
-        sa.Column("chat_id", sa.BigInteger(), nullable=True),
-        sa.Column("user_agent", sa.String(500), nullable=True),
-        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
-        sa.Column("last_used_at", sa.DateTime(), nullable=True),
-        sa.PrimaryKeyConstraint("id"),
-        sa.UniqueConstraint("endpoint"),
-    )
-    op.create_index("idx_push_sub_chat", "push_subscriptions", ["chat_id"])
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    # Idempotent: create_all()-provisioned databases may already have this table.
+    if TABLE_NAME not in inspector.get_table_names():
+        op.create_table(
+            TABLE_NAME,
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("endpoint", sa.Text(), nullable=False),
+            sa.Column("p256dh", sa.String(255), nullable=False),
+            sa.Column("auth", sa.String(255), nullable=False),
+            sa.Column("chat_id", sa.BigInteger(), nullable=True),
+            sa.Column("user_agent", sa.String(500), nullable=True),
+            sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+            sa.Column("last_used_at", sa.DateTime(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("endpoint"),
+        )
+        inspector = sa.inspect(conn)
+
+    if not _index_exists(inspector):
+        op.create_index(INDEX_NAME, TABLE_NAME, ["chat_id"])
 
 
 def downgrade() -> None:
     """Remove push_subscriptions table."""
-    op.drop_index("idx_push_sub_chat", table_name="push_subscriptions")
-    op.drop_table("push_subscriptions")
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if TABLE_NAME not in inspector.get_table_names():
+        return
+
+    if _index_exists(inspector):
+        op.drop_index(INDEX_NAME, table_name=TABLE_NAME)
+    op.drop_table(TABLE_NAME)

--- a/alembic/versions/20260125_004_add_is_pinned_column.py
+++ b/alembic/versions/20260125_004_add_is_pinned_column.py
@@ -19,16 +19,49 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
+TABLE_NAME = "messages"
+COLUMN_NAME = "is_pinned"
+INDEX_NAME = "idx_messages_chat_pinned"
+
+
+def _column_exists(inspector: sa.Inspector) -> bool:
+    return COLUMN_NAME in {c["name"] for c in inspector.get_columns(TABLE_NAME)}
+
+
+def _index_exists(inspector: sa.Inspector) -> bool:
+    return INDEX_NAME in {ix["name"] for ix in inspector.get_indexes(TABLE_NAME)}
+
+
 def upgrade() -> None:
     """Add is_pinned column and index for pinned message queries."""
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if TABLE_NAME not in inspector.get_table_names():
+        return
+
     # Add is_pinned column with default 0 (not pinned)
-    op.add_column("messages", sa.Column("is_pinned", sa.Integer(), nullable=False, server_default="0"))
+    # Idempotent: create_all()-provisioned databases may already have this column.
+    if not _column_exists(inspector):
+        op.add_column(TABLE_NAME, sa.Column(COLUMN_NAME, sa.Integer(), nullable=False, server_default="0"))
+        inspector = sa.inspect(conn)
 
     # Create composite index for efficient pinned message queries per chat
-    op.create_index("idx_messages_chat_pinned", "messages", ["chat_id", "is_pinned"])
+    if not _index_exists(inspector):
+        op.create_index(INDEX_NAME, TABLE_NAME, ["chat_id", "is_pinned"])
 
 
 def downgrade() -> None:
     """Remove is_pinned column and index."""
-    op.drop_index("idx_messages_chat_pinned", table_name="messages")
-    op.drop_column("messages", "is_pinned")
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if TABLE_NAME not in inspector.get_table_names():
+        return
+
+    if _index_exists(inspector):
+        op.drop_index(INDEX_NAME, table_name=TABLE_NAME)
+        inspector = sa.inspect(conn)
+
+    if _column_exists(inspector):
+        op.drop_column(TABLE_NAME, COLUMN_NAME)

--- a/alembic/versions/20260128_005_v6_schema_normalization.py
+++ b/alembic/versions/20260128_005_v6_schema_normalization.py
@@ -28,256 +28,340 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
+def _table_exists(inspector: sa.Inspector, table: str) -> bool:
+    return table in inspector.get_table_names()
+
+
+def _column_exists(inspector: sa.Inspector, table: str, column: str) -> bool:
+    if not _table_exists(inspector, table):
+        return False
+    return column in {c["name"] for c in inspector.get_columns(table)}
+
+
+def _index_exists(inspector: sa.Inspector, table: str, index: str) -> bool:
+    if not _table_exists(inspector, table):
+        return False
+    return index in {ix["name"] for ix in inspector.get_indexes(table)}
+
+
+def _fk_to_table_exists(inspector: sa.Inspector, table: str, referred_table: str) -> bool:
+    """True if `table` has any FK referencing `referred_table`.
+
+    Name-agnostic on purpose: a create_all()-provisioned DB names FKs
+    differently (or auto-generates a name) than the explicit names this
+    migration uses, so matching by referred table is what actually detects
+    "already normalized" rather than "already named exactly like this".
+    """
+    if not _table_exists(inspector, table):
+        return False
+    return any(fk.get("referred_table") == referred_table for fk in inspector.get_foreign_keys(table))
+
+
+def _fk_name_exists(inspector: sa.Inspector, table: str, name: str) -> bool:
+    if not _table_exists(inspector, table):
+        return False
+    return any(fk.get("name") == name for fk in inspector.get_foreign_keys(table))
+
+
 def upgrade() -> None:
     """Normalize schema: move media data to media table, add FKs and indexes."""
 
     # Get connection and dialect
     conn = op.get_bind()
     dialect = conn.dialect.name
+    inspector = sa.inspect(conn)
+
+    # Idempotency anchor: the CURRENT models.py no longer declares
+    # media_type/media_id/media_path on Message (they were normalized away in
+    # v6.0.0), so a create_all()-provisioned database never has them. Their
+    # presence is therefore exactly the pre-normalization legacy shape this
+    # migration expects to fix; their absence means either an already-normalized
+    # fresh schema or a prior run of this migration - steps 1-3 are no-ops either way.
+    legacy_media_cols_present = _column_exists(inspector, "messages", "media_type")
 
     # =========================================================================
     # STEP 1: Data Migration - Ensure all media data exists in media table
     # =========================================================================
 
-    # Insert missing media records from messages table
-    # This handles cases where messages have media_id but no corresponding media record
-    # Use ON CONFLICT DO NOTHING for PostgreSQL to handle duplicate keys gracefully
-    # Note: downloaded column is Integer (0/1), not Boolean
-    if dialect == "postgresql":
-        conn.execute(
-            text("""
-            INSERT INTO media (id, message_id, chat_id, type, file_path, downloaded, created_at)
-            SELECT
-                m.media_id,
-                m.id,
-                m.chat_id,
-                m.media_type,
-                m.media_path,
-                CASE WHEN m.media_path IS NOT NULL AND m.media_path != '' THEN 1 ELSE 0 END,
-                m.created_at
-            FROM messages m
-            WHERE m.media_id IS NOT NULL
-              AND m.media_id != ''
-            ON CONFLICT (id) DO NOTHING
-        """)
-        )
-    else:
-        # SQLite: Use INSERT OR IGNORE
-        conn.execute(
-            text("""
-            INSERT OR IGNORE INTO media (id, message_id, chat_id, type, file_path, downloaded, created_at)
-            SELECT
-                m.media_id,
-                m.id,
-                m.chat_id,
-                m.media_type,
-                m.media_path,
-                CASE WHEN m.media_path IS NOT NULL AND m.media_path != '' THEN 1 ELSE 0 END,
-                m.created_at
-            FROM messages m
-            WHERE m.media_id IS NOT NULL
-              AND m.media_id != ''
-        """)
-        )
+    if legacy_media_cols_present and _table_exists(inspector, "media"):
+        # Insert missing media records from messages table
+        # This handles cases where messages have media_id but no corresponding media record
+        # Use ON CONFLICT DO NOTHING for PostgreSQL to handle duplicate keys gracefully
+        # Note: downloaded column is Integer (0/1), not Boolean
+        if dialect == "postgresql":
+            conn.execute(
+                text("""
+                INSERT INTO media (id, message_id, chat_id, type, file_path, downloaded, created_at)
+                SELECT
+                    m.media_id,
+                    m.id,
+                    m.chat_id,
+                    m.media_type,
+                    m.media_path,
+                    CASE WHEN m.media_path IS NOT NULL AND m.media_path != '' THEN 1 ELSE 0 END,
+                    m.created_at
+                FROM messages m
+                WHERE m.media_id IS NOT NULL
+                  AND m.media_id != ''
+                ON CONFLICT (id) DO NOTHING
+            """)
+            )
+        else:
+            # SQLite: Use INSERT OR IGNORE
+            conn.execute(
+                text("""
+                INSERT OR IGNORE INTO media (id, message_id, chat_id, type, file_path, downloaded, created_at)
+                SELECT
+                    m.media_id,
+                    m.id,
+                    m.chat_id,
+                    m.media_type,
+                    m.media_path,
+                    CASE WHEN m.media_path IS NOT NULL AND m.media_path != '' THEN 1 ELSE 0 END,
+                    m.created_at
+                FROM messages m
+                WHERE m.media_id IS NOT NULL
+                  AND m.media_id != ''
+            """)
+            )
 
-    # Update existing media records that might be missing message_id/chat_id
-    conn.execute(
-        text("""
-        UPDATE media
-        SET message_id = (
-            SELECT m.id FROM messages m WHERE m.media_id = media.id LIMIT 1
-        ),
-        chat_id = (
-            SELECT m.chat_id FROM messages m WHERE m.media_id = media.id LIMIT 1
+        # Update existing media records that might be missing message_id/chat_id
+        # (Naturally idempotent: an UPDATE ... WHERE message_id IS NULL only ever
+        # touches rows that still need it, so re-running is a no-op.)
+        conn.execute(
+            text("""
+            UPDATE media
+            SET message_id = (
+                SELECT m.id FROM messages m WHERE m.media_id = media.id LIMIT 1
+            ),
+            chat_id = (
+                SELECT m.chat_id FROM messages m WHERE m.media_id = media.id LIMIT 1
+            )
+            WHERE message_id IS NULL
+              AND EXISTS (SELECT 1 FROM messages m WHERE m.media_id = media.id)
+        """)
         )
-        WHERE message_id IS NULL
-          AND EXISTS (SELECT 1 FROM messages m WHERE m.media_id = media.id)
-    """)
-    )
 
     # =========================================================================
     # STEP 2: Create backup table for rollback (stores dropped columns)
     # =========================================================================
 
-    op.execute(
-        text("""
-        CREATE TABLE IF NOT EXISTS _messages_media_backup AS
-        SELECT id, chat_id, media_type, media_id, media_path
-        FROM messages
-        WHERE media_id IS NOT NULL AND media_id != ''
-    """)
-    )
+    if legacy_media_cols_present:
+        op.execute(
+            text("""
+            CREATE TABLE IF NOT EXISTS _messages_media_backup AS
+            SELECT id, chat_id, media_type, media_id, media_path
+            FROM messages
+            WHERE media_id IS NOT NULL AND media_id != ''
+        """)
+        )
 
     # =========================================================================
     # STEP 3: Drop the media columns from messages table
     # =========================================================================
 
-    # SQLite doesn't support DROP COLUMN directly in older versions
-    # We need to handle this differently based on dialect
-    if dialect == "sqlite":
-        # SQLite: Recreate table without the columns
-        # First, create new table structure
-        # NOTE: sender_id FK is NOT enforced because sender_id can be channel/group IDs
-        # that aren't in the users table. The relationship is maintained at ORM level.
-        op.execute(
-            text("""
-            CREATE TABLE messages_new (
-                id INTEGER NOT NULL,
-                chat_id INTEGER NOT NULL,
-                sender_id INTEGER,
-                date DATETIME NOT NULL,
-                text TEXT,
-                reply_to_msg_id INTEGER,
-                reply_to_text TEXT,
-                forward_from_id INTEGER,
-                edit_date DATETIME,
-                raw_data TEXT,
-                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                is_outgoing INTEGER DEFAULT 0 NOT NULL,
-                is_pinned INTEGER DEFAULT 0 NOT NULL,
-                PRIMARY KEY (id, chat_id),
-                FOREIGN KEY(chat_id) REFERENCES chats (id)
+    if legacy_media_cols_present:
+        # SQLite doesn't support DROP COLUMN directly in older versions
+        # We need to handle this differently based on dialect
+        if dialect == "sqlite":
+            # SQLite: Recreate table without the columns
+            # First, create new table structure
+            # NOTE: sender_id FK is NOT enforced because sender_id can be channel/group IDs
+            # that aren't in the users table. The relationship is maintained at ORM level.
+            op.execute(
+                text("""
+                CREATE TABLE messages_new (
+                    id INTEGER NOT NULL,
+                    chat_id INTEGER NOT NULL,
+                    sender_id INTEGER,
+                    date DATETIME NOT NULL,
+                    text TEXT,
+                    reply_to_msg_id INTEGER,
+                    reply_to_text TEXT,
+                    forward_from_id INTEGER,
+                    edit_date DATETIME,
+                    raw_data TEXT,
+                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    is_outgoing INTEGER DEFAULT 0 NOT NULL,
+                    is_pinned INTEGER DEFAULT 0 NOT NULL,
+                    PRIMARY KEY (id, chat_id),
+                    FOREIGN KEY(chat_id) REFERENCES chats (id)
+                )
+            """)
             )
-        """)
-        )
 
-        # Copy data
-        op.execute(
-            text("""
-            INSERT INTO messages_new (
-                id, chat_id, sender_id, date, text, reply_to_msg_id,
-                reply_to_text, forward_from_id, edit_date, raw_data,
-                created_at, is_outgoing, is_pinned
+            # Copy data
+            op.execute(
+                text("""
+                INSERT INTO messages_new (
+                    id, chat_id, sender_id, date, text, reply_to_msg_id,
+                    reply_to_text, forward_from_id, edit_date, raw_data,
+                    created_at, is_outgoing, is_pinned
+                )
+                SELECT
+                    id, chat_id, sender_id, date, text, reply_to_msg_id,
+                    reply_to_text, forward_from_id, edit_date, raw_data,
+                    created_at, is_outgoing, is_pinned
+                FROM messages
+            """)
             )
-            SELECT
-                id, chat_id, sender_id, date, text, reply_to_msg_id,
-                reply_to_text, forward_from_id, edit_date, raw_data,
-                created_at, is_outgoing, is_pinned
-            FROM messages
-        """)
-        )
 
-        # Drop old table and rename new
-        op.execute(text("DROP TABLE messages"))
-        op.execute(text("ALTER TABLE messages_new RENAME TO messages"))
+            # Drop old table and rename new
+            op.execute(text("DROP TABLE messages"))
+            op.execute(text("ALTER TABLE messages_new RENAME TO messages"))
 
-        # Recreate indexes
-        op.create_index("idx_messages_chat_id", "messages", ["chat_id"])
-        op.create_index("idx_messages_date", "messages", ["date"])
-        op.create_index("idx_messages_sender_id", "messages", ["sender_id"])
-        op.create_index("idx_messages_chat_date_desc", "messages", ["chat_id", sa.text("date DESC")])
-        op.create_index("idx_messages_chat_pinned", "messages", ["chat_id", "is_pinned"])
-    else:
-        # PostgreSQL: Direct column drops
-        # NOTE: sender_id FK is NOT added because sender_id can be channel/group IDs
-        # that aren't in the users table. The relationship is maintained at ORM level.
-        op.drop_column("messages", "media_type")
-        op.drop_column("messages", "media_id")
-        op.drop_column("messages", "media_path")
+            # Recreate indexes (table is brand new, so these are always absent)
+            op.create_index("idx_messages_chat_id", "messages", ["chat_id"])
+            op.create_index("idx_messages_date", "messages", ["date"])
+            op.create_index("idx_messages_sender_id", "messages", ["sender_id"])
+            op.create_index("idx_messages_chat_date_desc", "messages", ["chat_id", sa.text("date DESC")])
+            op.create_index("idx_messages_chat_pinned", "messages", ["chat_id", "is_pinned"])
+        else:
+            # PostgreSQL: Direct column drops
+            # NOTE: sender_id FK is NOT added because sender_id can be channel/group IDs
+            # that aren't in the users table. The relationship is maintained at ORM level.
+            if _column_exists(inspector, "messages", "media_type"):
+                op.drop_column("messages", "media_type")
+            if _column_exists(inspector, "messages", "media_id"):
+                op.drop_column("messages", "media_id")
+            if _column_exists(inspector, "messages", "media_path"):
+                op.drop_column("messages", "media_path")
+
+    # Refresh after any table rebuild above.
+    inspector = sa.inspect(conn)
 
     # =========================================================================
     # STEP 4: Clean up orphan data before adding FK constraints
     # =========================================================================
 
-    # Delete orphan media records (where message doesn't exist)
-    conn.execute(
-        text("""
-        DELETE FROM media
-        WHERE message_id IS NOT NULL
-          AND chat_id IS NOT NULL
-          AND NOT EXISTS (
-              SELECT 1 FROM messages
-              WHERE messages.id = media.message_id
-                AND messages.chat_id = media.chat_id
-          )
-    """)
-    )
+    # Delete orphan media records (where message doesn't exist).
+    # Naturally idempotent: re-running finds no orphans left to delete.
+    if _table_exists(inspector, "media") and _table_exists(inspector, "messages"):
+        conn.execute(
+            text("""
+            DELETE FROM media
+            WHERE message_id IS NOT NULL
+              AND chat_id IS NOT NULL
+              AND NOT EXISTS (
+                  SELECT 1 FROM messages
+                  WHERE messages.id = media.message_id
+                    AND messages.chat_id = media.chat_id
+              )
+        """)
+        )
 
-    # Set user_id to NULL for orphan reactions (where user doesn't exist)
-    # This preserves the reaction counts while removing invalid FK references
-    conn.execute(
-        text("""
-        UPDATE reactions
-        SET user_id = NULL
-        WHERE user_id IS NOT NULL
-          AND NOT EXISTS (SELECT 1 FROM users WHERE users.id = reactions.user_id)
-    """)
-    )
+    # Set user_id to NULL for orphan reactions (where user doesn't exist).
+    # This preserves the reaction counts while removing invalid FK references.
+    # Naturally idempotent: re-running finds no orphans left to null out.
+    if _table_exists(inspector, "reactions") and _table_exists(inspector, "users"):
+        conn.execute(
+            text("""
+            UPDATE reactions
+            SET user_id = NULL
+            WHERE user_id IS NOT NULL
+              AND NOT EXISTS (SELECT 1 FROM users WHERE users.id = reactions.user_id)
+        """)
+        )
 
     # =========================================================================
     # STEP 5: Add FK constraint for media -> messages
     # =========================================================================
 
-    if dialect == "sqlite":
-        # SQLite: Recreate media table with FK
-        op.execute(
-            text("""
-            CREATE TABLE media_new (
-                id VARCHAR(255) NOT NULL PRIMARY KEY,
-                message_id INTEGER,
-                chat_id INTEGER,
-                type VARCHAR(50),
-                file_path TEXT,
-                file_name VARCHAR(255),
-                file_size INTEGER,
-                mime_type VARCHAR(100),
-                width INTEGER,
-                height INTEGER,
-                duration INTEGER,
-                downloaded INTEGER DEFAULT 0 NOT NULL,
-                download_date DATETIME,
-                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                FOREIGN KEY(message_id, chat_id) REFERENCES messages (id, chat_id) ON DELETE CASCADE
+    if (
+        _table_exists(inspector, "media")
+        and _table_exists(inspector, "messages")
+        and not _fk_to_table_exists(inspector, "media", "messages")
+    ):
+        if dialect == "sqlite":
+            # SQLite: Recreate media table with FK
+            op.execute(
+                text("""
+                CREATE TABLE media_new (
+                    id VARCHAR(255) NOT NULL PRIMARY KEY,
+                    message_id INTEGER,
+                    chat_id INTEGER,
+                    type VARCHAR(50),
+                    file_path TEXT,
+                    file_name VARCHAR(255),
+                    file_size INTEGER,
+                    mime_type VARCHAR(100),
+                    width INTEGER,
+                    height INTEGER,
+                    duration INTEGER,
+                    downloaded INTEGER DEFAULT 0 NOT NULL,
+                    download_date DATETIME,
+                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    FOREIGN KEY(message_id, chat_id) REFERENCES messages (id, chat_id) ON DELETE CASCADE
+                )
+            """)
             )
-        """)
-        )
 
-        op.execute(
-            text("""
-            INSERT INTO media_new
-            SELECT * FROM media
-        """)
-        )
+            op.execute(
+                text("""
+                INSERT INTO media_new
+                SELECT * FROM media
+            """)
+            )
 
-        op.execute(text("DROP TABLE media"))
-        op.execute(text("ALTER TABLE media_new RENAME TO media"))
+            op.execute(text("DROP TABLE media"))
+            op.execute(text("ALTER TABLE media_new RENAME TO media"))
 
-        # Recreate media indexes
-        op.create_index("idx_media_message", "media", ["message_id", "chat_id"])
-    else:
-        # PostgreSQL: Add FK directly
-        op.create_foreign_key(
-            "fk_media_message", "media", "messages", ["message_id", "chat_id"], ["id", "chat_id"], ondelete="CASCADE"
-        )
+            # Recreate media indexes (table is brand new, so this is always absent)
+            op.create_index("idx_media_message", "media", ["message_id", "chat_id"])
+        else:
+            # PostgreSQL: Add FK directly
+            op.create_foreign_key(
+                "fk_media_message",
+                "media",
+                "messages",
+                ["message_id", "chat_id"],
+                ["id", "chat_id"],
+                ondelete="CASCADE",
+            )
+
+    inspector = sa.inspect(conn)
 
     # =========================================================================
     # STEP 6: Add FK for reactions.user_id -> users.id
     # =========================================================================
 
-    if dialect != "sqlite":
+    if (
+        dialect != "sqlite"
+        and _table_exists(inspector, "reactions")
+        and _table_exists(inspector, "users")
+        and not _fk_to_table_exists(inspector, "reactions", "users")
+    ):
         op.create_foreign_key("fk_reactions_user", "reactions", "users", ["user_id"], ["id"], ondelete="SET NULL")
 
     # =========================================================================
     # STEP 7: Add new performance indexes
     # =========================================================================
 
+    inspector = sa.inspect(conn)
+
     # Index for reply lookups
-    op.create_index("idx_messages_reply_to", "messages", ["chat_id", "reply_to_msg_id"])
+    if not _index_exists(inspector, "messages", "idx_messages_reply_to"):
+        op.create_index("idx_messages_reply_to", "messages", ["chat_id", "reply_to_msg_id"])
 
     # Index for finding undownloaded media
-    op.create_index("idx_media_downloaded", "media", ["chat_id", "downloaded"])
+    if not _index_exists(inspector, "media", "idx_media_downloaded"):
+        op.create_index("idx_media_downloaded", "media", ["chat_id", "downloaded"])
 
     # Index for filtering by media type
-    op.create_index("idx_media_type", "media", ["type"])
+    if not _index_exists(inspector, "media", "idx_media_type"):
+        op.create_index("idx_media_type", "media", ["type"])
 
     # Index for user reaction queries
-    op.create_index("idx_reactions_user", "reactions", ["user_id"])
+    if not _index_exists(inspector, "reactions", "idx_reactions_user"):
+        op.create_index("idx_reactions_user", "reactions", ["user_id"])
 
     # Index for chat username lookups
-    op.create_index("idx_chats_username", "chats", ["username"])
+    if not _index_exists(inspector, "chats", "idx_chats_username"):
+        op.create_index("idx_chats_username", "chats", ["username"])
 
     # Index for user username lookups
-    op.create_index("idx_users_username", "users", ["username"])
+    if not _index_exists(inspector, "users", "idx_users_username"):
+        op.create_index("idx_users_username", "users", ["username"])
 
 
 def downgrade() -> None:
@@ -285,83 +369,110 @@ def downgrade() -> None:
 
     conn = op.get_bind()
     dialect = conn.dialect.name
+    inspector = sa.inspect(conn)
 
     # =========================================================================
     # STEP 1: Drop new indexes
     # =========================================================================
 
-    op.drop_index("idx_users_username", table_name="users")
-    op.drop_index("idx_chats_username", table_name="chats")
-    op.drop_index("idx_reactions_user", table_name="reactions")
-    op.drop_index("idx_media_type", table_name="media")
-    op.drop_index("idx_media_downloaded", table_name="media")
-    op.drop_index("idx_messages_reply_to", table_name="messages")
+    for table, index in (
+        ("users", "idx_users_username"),
+        ("chats", "idx_chats_username"),
+        ("reactions", "idx_reactions_user"),
+        ("media", "idx_media_type"),
+        ("media", "idx_media_downloaded"),
+        ("messages", "idx_messages_reply_to"),
+    ):
+        if _index_exists(inspector, table, index):
+            op.drop_index(index, table_name=table)
 
     # =========================================================================
     # STEP 2: Drop foreign keys (PostgreSQL only)
     # =========================================================================
 
     if dialect != "sqlite":
-        op.drop_constraint("fk_reactions_user", "reactions", type_="foreignkey")
-        op.drop_constraint("fk_media_message", "media", type_="foreignkey")
-        # NOTE: fk_messages_sender was never created (sender_id can be channel/group IDs)
+        inspector = sa.inspect(conn)
+        # NOTE: fk_messages_sender was never created (sender_id can be channel/group IDs).
+        # Name-based (not referred-table-based) on purpose: only undo the specific
+        # constraints *this migration* created under these names.
+        if _fk_name_exists(inspector, "reactions", "fk_reactions_user"):
+            op.drop_constraint("fk_reactions_user", "reactions", type_="foreignkey")
+        if _fk_name_exists(inspector, "media", "fk_media_message"):
+            op.drop_constraint("fk_media_message", "media", type_="foreignkey")
 
     # =========================================================================
     # STEP 3: Restore media columns to messages
     # =========================================================================
 
-    if dialect == "sqlite":
-        # SQLite: Recreate messages table with media columns
-        op.execute(
-            text("""
-            CREATE TABLE messages_new (
-                id INTEGER NOT NULL,
-                chat_id INTEGER NOT NULL,
-                sender_id INTEGER,
-                date DATETIME NOT NULL,
-                text TEXT,
-                reply_to_msg_id INTEGER,
-                reply_to_text TEXT,
-                forward_from_id INTEGER,
-                edit_date DATETIME,
-                media_type VARCHAR(50),
-                media_id VARCHAR(255),
-                media_path VARCHAR(500),
-                raw_data TEXT,
-                created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-                is_outgoing INTEGER DEFAULT 0 NOT NULL,
-                is_pinned INTEGER DEFAULT 0 NOT NULL,
-                PRIMARY KEY (id, chat_id),
-                FOREIGN KEY(chat_id) REFERENCES chats (id)
+    inspector = sa.inspect(conn)
+    legacy_media_cols_present = _column_exists(inspector, "messages", "media_type")
+
+    if not legacy_media_cols_present and _table_exists(inspector, "messages"):
+        if dialect == "sqlite":
+            # SQLite: Recreate messages table with media columns
+            op.execute(
+                text("""
+                CREATE TABLE messages_new (
+                    id INTEGER NOT NULL,
+                    chat_id INTEGER NOT NULL,
+                    sender_id INTEGER,
+                    date DATETIME NOT NULL,
+                    text TEXT,
+                    reply_to_msg_id INTEGER,
+                    reply_to_text TEXT,
+                    forward_from_id INTEGER,
+                    edit_date DATETIME,
+                    media_type VARCHAR(50),
+                    media_id VARCHAR(255),
+                    media_path VARCHAR(500),
+                    raw_data TEXT,
+                    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                    is_outgoing INTEGER DEFAULT 0 NOT NULL,
+                    is_pinned INTEGER DEFAULT 0 NOT NULL,
+                    PRIMARY KEY (id, chat_id),
+                    FOREIGN KEY(chat_id) REFERENCES chats (id)
+                )
+            """)
             )
-        """)
-        )
 
-        op.execute(
-            text("""
-            INSERT INTO messages_new (
-                id, chat_id, sender_id, date, text, reply_to_msg_id,
-                reply_to_text, forward_from_id, edit_date, raw_data,
-                created_at, is_outgoing, is_pinned
+            op.execute(
+                text("""
+                INSERT INTO messages_new (
+                    id, chat_id, sender_id, date, text, reply_to_msg_id,
+                    reply_to_text, forward_from_id, edit_date, raw_data,
+                    created_at, is_outgoing, is_pinned
+                )
+                SELECT
+                    id, chat_id, sender_id, date, text, reply_to_msg_id,
+                    reply_to_text, forward_from_id, edit_date, raw_data,
+                    created_at, is_outgoing, is_pinned
+                FROM messages
+            """)
             )
-            SELECT
-                id, chat_id, sender_id, date, text, reply_to_msg_id,
-                reply_to_text, forward_from_id, edit_date, raw_data,
-                created_at, is_outgoing, is_pinned
-            FROM messages
-        """)
-        )
 
-        op.execute(text("DROP TABLE messages"))
-        op.execute(text("ALTER TABLE messages_new RENAME TO messages"))
+            op.execute(text("DROP TABLE messages"))
+            op.execute(text("ALTER TABLE messages_new RENAME TO messages"))
 
-        # Recreate indexes
-        op.create_index("idx_messages_chat_id", "messages", ["chat_id"])
-        op.create_index("idx_messages_date", "messages", ["date"])
-        op.create_index("idx_messages_sender_id", "messages", ["sender_id"])
-        op.create_index("idx_messages_chat_date_desc", "messages", ["chat_id", sa.text("date DESC")])
-        op.create_index("idx_messages_chat_pinned", "messages", ["chat_id", "is_pinned"])
+            # Recreate indexes (table is brand new, so these are always absent)
+            op.create_index("idx_messages_chat_id", "messages", ["chat_id"])
+            op.create_index("idx_messages_date", "messages", ["date"])
+            op.create_index("idx_messages_sender_id", "messages", ["sender_id"])
+            op.create_index("idx_messages_chat_date_desc", "messages", ["chat_id", sa.text("date DESC")])
+            op.create_index("idx_messages_chat_pinned", "messages", ["chat_id", "is_pinned"])
+        else:
+            # PostgreSQL: Add columns back
+            if not _column_exists(inspector, "messages", "media_type"):
+                op.add_column("messages", sa.Column("media_type", sa.String(50)))
+            if not _column_exists(inspector, "messages", "media_id"):
+                op.add_column("messages", sa.Column("media_id", sa.String(255)))
+            if not _column_exists(inspector, "messages", "media_path"):
+                op.add_column("messages", sa.Column("media_path", sa.String(500)))
 
+    inspector = sa.inspect(conn)
+
+    # SQLite media table: drop the FK by recreating without it, only if the FK is
+    # actually there (i.e. STEP 5 of upgrade() actually ran against this DB).
+    if dialect == "sqlite" and _fk_to_table_exists(inspector, "media", "messages"):
         # Recreate media table without FK
         op.execute(
             text("""
@@ -388,29 +499,26 @@ def downgrade() -> None:
         op.execute(text("DROP TABLE media"))
         op.execute(text("ALTER TABLE media_new RENAME TO media"))
         op.create_index("idx_media_message", "media", ["message_id", "chat_id"])
-    else:
-        # PostgreSQL: Add columns back
-        op.add_column("messages", sa.Column("media_type", sa.String(50)))
-        op.add_column("messages", sa.Column("media_id", sa.String(255)))
-        op.add_column("messages", sa.Column("media_path", sa.String(500)))
 
     # =========================================================================
     # STEP 4: Restore data from backup table
     # =========================================================================
 
-    conn.execute(
-        text("""
-        UPDATE messages
-        SET
-            media_type = (SELECT media_type FROM _messages_media_backup b WHERE b.id = messages.id AND b.chat_id = messages.chat_id),
-            media_id = (SELECT media_id FROM _messages_media_backup b WHERE b.id = messages.id AND b.chat_id = messages.chat_id),
-            media_path = (SELECT media_path FROM _messages_media_backup b WHERE b.id = messages.id AND b.chat_id = messages.chat_id)
-        WHERE EXISTS (
-            SELECT 1 FROM _messages_media_backup b
-            WHERE b.id = messages.id AND b.chat_id = messages.chat_id
+    inspector = sa.inspect(conn)
+    if _table_exists(inspector, "_messages_media_backup"):
+        conn.execute(
+            text("""
+            UPDATE messages
+            SET
+                media_type = (SELECT media_type FROM _messages_media_backup b WHERE b.id = messages.id AND b.chat_id = messages.chat_id),
+                media_id = (SELECT media_id FROM _messages_media_backup b WHERE b.id = messages.id AND b.chat_id = messages.chat_id),
+                media_path = (SELECT media_path FROM _messages_media_backup b WHERE b.id = messages.id AND b.chat_id = messages.chat_id)
+            WHERE EXISTS (
+                SELECT 1 FROM _messages_media_backup b
+                WHERE b.id = messages.id AND b.chat_id = messages.chat_id
+            )
+        """)
         )
-    """)
-    )
 
     # =========================================================================
     # STEP 5: Drop backup table

--- a/alembic/versions/20260206_006_add_topics_folders_archived.py
+++ b/alembic/versions/20260206_006_add_topics_folders_archived.py
@@ -25,91 +25,144 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 
+def _column_exists(inspector: sa.Inspector, table: str, column: str) -> bool:
+    return column in {c["name"] for c in inspector.get_columns(table)}
+
+
+def _index_exists(inspector: sa.Inspector, table: str, index: str) -> bool:
+    return index in {ix["name"] for ix in inspector.get_indexes(table)}
+
+
 def upgrade() -> None:
     """Add topics, folders, and archived chat support."""
 
     conn = op.get_bind()
-    dialect = conn.dialect.name
+    inspector = sa.inspect(conn)
 
     # =========================================================================
     # STEP 1: Add columns to chats table
     # =========================================================================
 
-    # is_forum: whether the chat is a forum with topics
-    op.add_column("chats", sa.Column("is_forum", sa.Integer(), nullable=True, server_default="0"))
-    # is_archived: whether the chat is in the archive folder
-    op.add_column("chats", sa.Column("is_archived", sa.Integer(), nullable=True, server_default="0"))
+    if "chats" in inspector.get_table_names():
+        # is_forum: whether the chat is a forum with topics
+        if not _column_exists(inspector, "chats", "is_forum"):
+            op.add_column("chats", sa.Column("is_forum", sa.Integer(), nullable=True, server_default="0"))
+        # is_archived: whether the chat is in the archive folder
+        if not _column_exists(inspector, "chats", "is_archived"):
+            op.add_column("chats", sa.Column("is_archived", sa.Integer(), nullable=True, server_default="0"))
+        inspector = sa.inspect(conn)
 
     # =========================================================================
     # STEP 2: Add reply_to_top_id to messages table
     # =========================================================================
 
-    op.add_column("messages", sa.Column("reply_to_top_id", sa.BigInteger(), nullable=True))
+    if "messages" in inspector.get_table_names():
+        if not _column_exists(inspector, "messages", "reply_to_top_id"):
+            op.add_column("messages", sa.Column("reply_to_top_id", sa.BigInteger(), nullable=True))
+            inspector = sa.inspect(conn)
 
-    # Index for fast topic message lookups
-    op.create_index("idx_messages_topic", "messages", ["chat_id", "reply_to_top_id"])
+        # Index for fast topic message lookups
+        if not _index_exists(inspector, "messages", "idx_messages_topic"):
+            op.create_index("idx_messages_topic", "messages", ["chat_id", "reply_to_top_id"])
+        inspector = sa.inspect(conn)
 
     # =========================================================================
     # STEP 3: Create forum_topics table
     # =========================================================================
 
-    op.create_table(
-        "forum_topics",
-        sa.Column("id", sa.BigInteger(), nullable=False),
-        sa.Column("chat_id", sa.BigInteger(), sa.ForeignKey("chats.id", ondelete="CASCADE"), nullable=False),
-        sa.Column("title", sa.String(500), nullable=False),
-        sa.Column("icon_color", sa.Integer(), nullable=True),
-        sa.Column("icon_emoji_id", sa.BigInteger(), nullable=True),
-        sa.Column("icon_emoji", sa.String(32), nullable=True),
-        sa.Column("is_closed", sa.Integer(), server_default="0"),
-        sa.Column("is_pinned", sa.Integer(), server_default="0"),
-        sa.Column("is_hidden", sa.Integer(), server_default="0"),
-        sa.Column("date", sa.DateTime(), nullable=True),
-        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
-        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now()),
-        sa.PrimaryKeyConstraint("id", "chat_id"),
-    )
-    op.create_index("idx_forum_topics_chat", "forum_topics", ["chat_id"])
+    if "forum_topics" not in inspector.get_table_names():
+        op.create_table(
+            "forum_topics",
+            sa.Column("id", sa.BigInteger(), nullable=False),
+            sa.Column("chat_id", sa.BigInteger(), sa.ForeignKey("chats.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("title", sa.String(500), nullable=False),
+            sa.Column("icon_color", sa.Integer(), nullable=True),
+            sa.Column("icon_emoji_id", sa.BigInteger(), nullable=True),
+            sa.Column("icon_emoji", sa.String(32), nullable=True),
+            sa.Column("is_closed", sa.Integer(), server_default="0"),
+            sa.Column("is_pinned", sa.Integer(), server_default="0"),
+            sa.Column("is_hidden", sa.Integer(), server_default="0"),
+            sa.Column("date", sa.DateTime(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now()),
+            sa.PrimaryKeyConstraint("id", "chat_id"),
+        )
+        inspector = sa.inspect(conn)
+    if not _index_exists(inspector, "forum_topics", "idx_forum_topics_chat"):
+        op.create_index("idx_forum_topics_chat", "forum_topics", ["chat_id"])
+    inspector = sa.inspect(conn)
 
     # =========================================================================
     # STEP 4: Create chat_folders table
     # =========================================================================
 
-    op.create_table(
-        "chat_folders",
-        sa.Column("id", sa.Integer(), nullable=False, autoincrement=False),
-        sa.Column("title", sa.String(255), nullable=False),
-        sa.Column("emoticon", sa.String(50), nullable=True),
-        sa.Column("sort_order", sa.Integer(), server_default="0"),
-        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
-        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now()),
-        sa.PrimaryKeyConstraint("id"),
-    )
+    if "chat_folders" not in inspector.get_table_names():
+        op.create_table(
+            "chat_folders",
+            sa.Column("id", sa.Integer(), nullable=False, autoincrement=False),
+            sa.Column("title", sa.String(255), nullable=False),
+            sa.Column("emoticon", sa.String(50), nullable=True),
+            sa.Column("sort_order", sa.Integer(), server_default="0"),
+            sa.Column("created_at", sa.DateTime(), server_default=sa.func.now()),
+            sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now()),
+            sa.PrimaryKeyConstraint("id"),
+        )
+        inspector = sa.inspect(conn)
 
     # =========================================================================
     # STEP 5: Create chat_folder_members table
     # =========================================================================
 
-    op.create_table(
-        "chat_folder_members",
-        sa.Column("folder_id", sa.Integer(), sa.ForeignKey("chat_folders.id", ondelete="CASCADE"), nullable=False),
-        sa.Column("chat_id", sa.BigInteger(), sa.ForeignKey("chats.id", ondelete="CASCADE"), nullable=False),
-        sa.PrimaryKeyConstraint("folder_id", "chat_id"),
-    )
-    op.create_index("idx_folder_members_chat", "chat_folder_members", ["chat_id"])
-    op.create_index("idx_folder_members_folder", "chat_folder_members", ["folder_id"])
+    if "chat_folder_members" not in inspector.get_table_names():
+        op.create_table(
+            "chat_folder_members",
+            sa.Column("folder_id", sa.Integer(), sa.ForeignKey("chat_folders.id", ondelete="CASCADE"), nullable=False),
+            sa.Column("chat_id", sa.BigInteger(), sa.ForeignKey("chats.id", ondelete="CASCADE"), nullable=False),
+            sa.PrimaryKeyConstraint("folder_id", "chat_id"),
+        )
+        inspector = sa.inspect(conn)
+    if not _index_exists(inspector, "chat_folder_members", "idx_folder_members_chat"):
+        op.create_index("idx_folder_members_chat", "chat_folder_members", ["chat_id"])
+    inspector = sa.inspect(conn)
+    if not _index_exists(inspector, "chat_folder_members", "idx_folder_members_folder"):
+        op.create_index("idx_folder_members_folder", "chat_folder_members", ["folder_id"])
 
 
 def downgrade() -> None:
     """Remove topics, folders, and archived chat support."""
 
-    op.drop_index("idx_folder_members_folder", table_name="chat_folder_members")
-    op.drop_index("idx_folder_members_chat", table_name="chat_folder_members")
-    op.drop_table("chat_folder_members")
-    op.drop_table("chat_folders")
-    op.drop_index("idx_forum_topics_chat", table_name="forum_topics")
-    op.drop_table("forum_topics")
-    op.drop_index("idx_messages_topic", table_name="messages")
-    op.drop_column("messages", "reply_to_top_id")
-    op.drop_column("chats", "is_archived")
-    op.drop_column("chats", "is_forum")
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if "chat_folder_members" in inspector.get_table_names():
+        if _index_exists(inspector, "chat_folder_members", "idx_folder_members_folder"):
+            op.drop_index("idx_folder_members_folder", table_name="chat_folder_members")
+        if _index_exists(inspector, "chat_folder_members", "idx_folder_members_chat"):
+            op.drop_index("idx_folder_members_chat", table_name="chat_folder_members")
+        op.drop_table("chat_folder_members")
+        inspector = sa.inspect(conn)
+
+    if "chat_folders" in inspector.get_table_names():
+        op.drop_table("chat_folders")
+        inspector = sa.inspect(conn)
+
+    if "forum_topics" in inspector.get_table_names():
+        if _index_exists(inspector, "forum_topics", "idx_forum_topics_chat"):
+            op.drop_index("idx_forum_topics_chat", table_name="forum_topics")
+        op.drop_table("forum_topics")
+        inspector = sa.inspect(conn)
+
+    if "messages" in inspector.get_table_names():
+        if _index_exists(inspector, "messages", "idx_messages_topic"):
+            op.drop_index("idx_messages_topic", table_name="messages")
+            inspector = sa.inspect(conn)
+        if _column_exists(inspector, "messages", "reply_to_top_id"):
+            op.drop_column("messages", "reply_to_top_id")
+        inspector = sa.inspect(conn)
+
+    if "chats" in inspector.get_table_names():
+        if _column_exists(inspector, "chats", "is_archived"):
+            op.drop_column("chats", "is_archived")
+            inspector = sa.inspect(conn)
+        if _column_exists(inspector, "chats", "is_forum"):
+            op.drop_column("chats", "is_forum")

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [7.22.0] - 2026-07-15
+
+### Fixed
+- **Jumping to a message (from the media gallery, a reply, or the calendar) now actually lands on the target instead of the latest messages.** The window request was silently ignored by the backend and returned the newest page; the target row also had no scroll anchor, so even a correct window wasn't scrolled to. The window is now fetched correctly (with context on both sides of the target), the target is anchored and highlighted, the realtime poll and the WebSocket live-update path are both paused while viewing a detached window, and calendar date-jumps use the same path (removing an older gap-fill loop that failed for dates far back). ([#213](https://github.com/GeiserX/Telegram-Archive/issues/213))
+- **Anonymous access is now read-only.** When the viewer is exposed without authentication, it no longer grants administrative capabilities (creating viewers, minting share tokens, reading the audit log, changing settings) — those require the master account.
+- **Push subscriptions can no longer point the server at internal addresses.** Subscription endpoints are validated by resolving the host and rejecting private/loopback/link-local addresses.
+- **Media captured by the scheduled backup is now timestamped in UTC** like the realtime and import paths (it was previously written in the host's local time).
+- **Realtime updates survive database blips.** The Postgres notification listener no longer leaks a connection on each reconnect and is retried correctly after a failed restart.
+- Database-unavailable conditions (including "database is locked") now return 503 instead of 500, and chat-search wildcard characters are handled literally.
+
+### Added
+- Message-list API accepts `after_id` (newer-than cursor) and honors a lone `before_id` (older-than cursor) for jump-to-message windows.
+
+### Changed
+- **Loading a page of messages is dramatically cheaper** — reactions and reply previews are fetched in two batched queries per page instead of one-per-message (previously up to ~100 queries for a 50-message page, on an endpoint the viewer polls every few seconds). Opening a chat's statistics is cached briefly. Logs no longer include chat, topic, or message identifiers or message content.
+
+### Upgrade note
+- Migration `017` (adds an index for jump-to-message lookups) runs automatically on first start; it is idempotent and requires no action.
+
 ## [7.21.0] - 2026-07-14
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.21.0"
+version = "7.22.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.21.0"
+__version__ = "7.22.0"

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -472,14 +472,14 @@ class DatabaseAdapter:
                 "participants_count": chat_data.get("participants_count"),
                 "is_forum": chat_data.get("is_forum", 0),
                 "is_archived": chat_data.get("is_archived", 0),
-                "updated_at": datetime.utcnow(),
+                "updated_at": utcnow_naive(),
             }
 
             # Build update set from only the fields explicitly provided in chat_data.
             # This prevents partial upserts (e.g. from the listener) from resetting
             # is_forum/is_archived to their defaults.
             update_set = {
-                "updated_at": datetime.utcnow(),
+                "updated_at": utcnow_naive(),
             }
             # Always update these basic metadata fields
             for field in (
@@ -552,13 +552,14 @@ class DatabaseAdapter:
 
             # Apply search filter if provided
             if search:
-                search_pattern = f"%{search}%"
+                escaped = search.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+                search_pattern = f"%{escaped}%"
                 stmt = stmt.where(
                     or_(
-                        Chat.title.ilike(search_pattern),
-                        Chat.first_name.ilike(search_pattern),
-                        Chat.last_name.ilike(search_pattern),
-                        Chat.username.ilike(search_pattern),
+                        Chat.title.ilike(search_pattern, escape="\\"),
+                        Chat.first_name.ilike(search_pattern, escape="\\"),
+                        Chat.last_name.ilike(search_pattern, escape="\\"),
+                        Chat.username.ilike(search_pattern, escape="\\"),
                     )
                 )
 
@@ -616,13 +617,14 @@ class DatabaseAdapter:
                 stmt = stmt.where(or_(Chat.is_archived == 0, Chat.is_archived.is_(None)))
 
             if search:
-                search_pattern = f"%{search}%"
+                escaped = search.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+                search_pattern = f"%{escaped}%"
                 stmt = stmt.where(
                     or_(
-                        Chat.title.ilike(search_pattern),
-                        Chat.first_name.ilike(search_pattern),
-                        Chat.last_name.ilike(search_pattern),
-                        Chat.username.ilike(search_pattern),
+                        Chat.title.ilike(search_pattern, escape="\\"),
+                        Chat.first_name.ilike(search_pattern, escape="\\"),
+                        Chat.last_name.ilike(search_pattern, escape="\\"),
+                        Chat.username.ilike(search_pattern, escape="\\"),
                     )
                 )
 
@@ -642,7 +644,7 @@ class DatabaseAdapter:
                 "last_name": user_data.get("last_name"),
                 "phone": user_data.get("phone"),
                 "is_bot": 1 if user_data.get("is_bot") else 0,
-                "updated_at": datetime.utcnow(),
+                "updated_at": utcnow_naive(),
             }
 
             if self._is_sqlite:
@@ -655,7 +657,7 @@ class DatabaseAdapter:
                         "last_name": stmt.excluded.last_name,
                         "phone": stmt.excluded.phone,
                         "is_bot": stmt.excluded.is_bot,
-                        "updated_at": datetime.utcnow(),
+                        "updated_at": utcnow_naive(),
                     },
                 )
             else:
@@ -668,7 +670,7 @@ class DatabaseAdapter:
                         "last_name": stmt.excluded.last_name,
                         "phone": stmt.excluded.phone,
                         "is_bot": stmt.excluded.is_bot,
-                        "updated_at": datetime.utcnow(),
+                        "updated_at": utcnow_naive(),
                     },
                 )
 
@@ -1258,7 +1260,10 @@ class DatabaseAdapter:
                 return
 
     async def get_pending_media_downloads(
-        self, max_media_size_bytes: int | None = None, max_attempts: int | None = None
+        self,
+        max_media_size_bytes: int | None = None,
+        max_attempts: int | None = None,
+        limit: int | None = 1000,
     ) -> list[dict[str, Any]]:
         """Get media records that failed to download and need retry.
 
@@ -1268,6 +1273,12 @@ class DatabaseAdapter:
         infinite retry of over-limit media. Records whose download_attempts have
         reached max_attempts are also excluded, so a permanently-failing file
         (e.g. an unwritable filename) can't be re-fetched every run forever (#212).
+
+        ``limit`` bounds a single retry pass so this can't materialize the whole
+        pending-media table in memory (the same OOM class fixed in
+        ``iter_media_paths_for_repair``); pass ``None`` to restore the old
+        unbounded behavior. Ordered by (download_attempts, id) so a bounded pass
+        makes progress on the least-retried rows first.
         """
         async with self.db_manager.async_session_factory() as session:
             conditions = [
@@ -1278,8 +1289,19 @@ class DatabaseAdapter:
                 conditions.append(or_(Media.file_size.is_(None), Media.file_size <= max_media_size_bytes))
             if max_attempts is not None:
                 conditions.append(Media.download_attempts < max_attempts)
-            stmt = select(Media).where(and_(*conditions)).order_by(Media.chat_id, Media.message_id)
+            where_clause = and_(*conditions)
+            stmt = select(Media).where(where_clause).order_by(Media.download_attempts.asc(), Media.id.asc())
+            if limit is not None:
+                stmt = stmt.limit(limit)
             result = await session.execute(stmt)
+            rows = result.scalars().all()
+
+            if limit is not None and len(rows) == limit:
+                total_stmt = select(func.count(Media.id)).where(where_clause)
+                total = (await session.execute(total_stmt)).scalar() or 0
+                if total > limit:
+                    logger.info("media retry: processing %d of %d pending", limit, total)
+
             return [
                 {
                     "id": m.id,
@@ -1292,7 +1314,7 @@ class DatabaseAdapter:
                     "downloaded": m.downloaded,
                     "download_attempts": m.download_attempts,
                 }
-                for m in result.scalars()
+                for m in rows
             ]
 
     @retry_on_locked()
@@ -1432,7 +1454,7 @@ class DatabaseAdapter:
     async def update_sync_status(self, chat_id: int, last_message_id: int, message_count: int) -> None:
         """Update sync status for a chat using atomic upsert."""
         async with self.db_manager.async_session_factory() as session:
-            now = datetime.utcnow()
+            now = utcnow_naive()
             values = {
                 "chat_id": chat_id,
                 "last_message_id": last_message_id,
@@ -1555,7 +1577,6 @@ class DatabaseAdapter:
         """
         import asyncio
         import json
-        from datetime import datetime
 
         async with self.db_manager.async_session_factory() as session:
             logger.info("Calculating statistics (this may take a while)...")
@@ -1609,7 +1630,7 @@ class DatabaseAdapter:
 
         # Store in metadata
         await self.set_metadata("cached_stats", json.dumps(stats))
-        await self.set_metadata("stats_calculated_at", datetime.utcnow().isoformat())
+        await self.set_metadata("stats_calculated_at", utcnow_naive().isoformat())
 
         return stats
 
@@ -1794,7 +1815,8 @@ class DatabaseAdapter:
                 if msg.get("raw_data"):
                     try:
                         msg["raw_data"] = json.loads(msg["raw_data"])
-                    except:
+                    except ValueError, TypeError:
+                        logger.debug("Malformed raw_data JSON for a message row; substituting empty dict")
                         msg["raw_data"] = {}
 
                 messages.append(msg)
@@ -1804,14 +1826,14 @@ class DatabaseAdapter:
                 messages.reverse()
 
             version_counts = {msg["id"]: 0 for msg in messages}
-            version_count_message_ids = [msg["id"] for msg in messages]
-            if version_count_message_ids:
+            page_message_ids = [msg["id"] for msg in messages]
+            if page_message_ids:
                 count_stmt = (
                     select(MessageVersion.message_id, func.count(MessageVersion.id).label("version_count"))
                     .where(
                         and_(
                             MessageVersion.chat_id == chat_id,
-                            MessageVersion.message_id.in_(version_count_message_ids),
+                            MessageVersion.message_id.in_(page_message_ids),
                         )
                     )
                     .group_by(MessageVersion.message_id)
@@ -1819,24 +1841,47 @@ class DatabaseAdapter:
                 count_result = await session.execute(count_stmt)
                 version_counts.update({row.message_id: int(row.version_count or 0) for row in count_result})
 
-            # Get reply texts and reactions for each message
+            # Batch reply-text backfill: one query for the whole page instead of one
+            # SELECT per reply row (previously up to `limit` round-trips per page).
+            reply_ids_needed = {
+                msg["reply_to_msg_id"]
+                for msg in messages
+                if msg.get("reply_to_msg_id") and not msg.get("reply_to_text")
+            }
+            reply_texts: dict[int, str] = {}
+            if reply_ids_needed:
+                reply_stmt = select(Message.id, Message.text).where(
+                    and_(Message.chat_id == chat_id, Message.id.in_(reply_ids_needed))
+                )
+                reply_result = await session.execute(reply_stmt)
+                reply_texts = {row.id: row.text for row in reply_result if row.text}
+
+            # Batch reactions: one query for the whole page instead of one
+            # get_reactions() call per message. Ties within the same emoji are
+            # broken by Reaction.id to match get_reactions' de-facto row order.
+            reactions_by_message: dict[int, list[dict[str, Any]]] = {mid: [] for mid in page_message_ids}
+            if page_message_ids:
+                reactions_stmt = (
+                    select(Reaction)
+                    .where(and_(Reaction.chat_id == chat_id, Reaction.message_id.in_(page_message_ids)))
+                    .order_by(Reaction.message_id, Reaction.emoji, Reaction.id)
+                )
+                reactions_result = await session.execute(reactions_stmt)
+                for r in reactions_result.scalars():
+                    reactions_by_message[r.message_id].append(
+                        {"emoji": r.emoji, "user_id": r.user_id, "count": r.count}
+                    )
+
             for msg in messages:
                 msg["version_count"] = version_counts.get(msg["id"], 0)
 
                 if msg.get("reply_to_msg_id") and not msg.get("reply_to_text"):
-                    reply_result = await session.execute(
-                        select(Message.text).where(
-                            and_(Message.chat_id == chat_id, Message.id == msg["reply_to_msg_id"])
-                        )
-                    )
-                    reply_text = reply_result.scalar_one_or_none()
+                    reply_text = reply_texts.get(msg["reply_to_msg_id"])
                     if reply_text:
                         msg["reply_to_text"] = reply_text[:100]
 
-                # Get reactions
-                reactions = await self.get_reactions(msg["id"], chat_id)
                 reactions_by_emoji = {}
-                for reaction in reactions:
+                for reaction in reactions_by_message.get(msg["id"], []):
                     emoji = reaction["emoji"]
                     if emoji not in reactions_by_emoji:
                         reactions_by_emoji[emoji] = {"emoji": emoji, "count": 0, "user_ids": []}
@@ -1927,7 +1972,8 @@ class DatabaseAdapter:
             if msg.get("raw_data"):
                 try:
                     msg["raw_data"] = json.loads(msg["raw_data"])
-                except:
+                except ValueError, TypeError:
+                    logger.debug("Malformed raw_data JSON for a message row; substituting empty dict")
                     msg["raw_data"] = {}
 
             # Get reply text
@@ -2033,7 +2079,8 @@ class DatabaseAdapter:
                 if msg.get("raw_data"):
                     try:
                         msg["raw_data"] = json.loads(msg["raw_data"])
-                    except:
+                    except ValueError, TypeError:
+                        logger.debug("Malformed raw_data JSON for a message row; substituting empty dict")
                         msg["raw_data"] = {}
 
                 messages.append(msg)
@@ -2190,7 +2237,7 @@ class DatabaseAdapter:
                 "is_pinned": topic_data.get("is_pinned", 0),
                 "is_hidden": topic_data.get("is_hidden", 0),
                 "date": _strip_tz(topic_data.get("date")),
-                "updated_at": datetime.utcnow(),
+                "updated_at": utcnow_naive(),
             }
 
             update_set = {
@@ -2202,7 +2249,7 @@ class DatabaseAdapter:
                 "is_pinned": values["is_pinned"],
                 "is_hidden": values["is_hidden"],
                 "date": values["date"],
-                "updated_at": datetime.utcnow(),
+                "updated_at": utcnow_naive(),
             }
 
             if self._is_sqlite:
@@ -2274,14 +2321,14 @@ class DatabaseAdapter:
                 "title": folder_data["title"],
                 "emoticon": folder_data.get("emoticon"),
                 "sort_order": folder_data.get("sort_order", 0),
-                "updated_at": datetime.utcnow(),
+                "updated_at": utcnow_naive(),
             }
 
             update_set = {
                 "title": values["title"],
                 "emoticon": values["emoticon"],
                 "sort_order": values["sort_order"],
-                "updated_at": datetime.utcnow(),
+                "updated_at": utcnow_naive(),
             }
 
             if self._is_sqlite:
@@ -2470,7 +2517,7 @@ class DatabaseAdapter:
             for key, value in kwargs.items():
                 if hasattr(account, key):
                     setattr(account, key, value)
-            account.updated_at = datetime.utcnow()
+            account.updated_at = utcnow_naive()
             await session.commit()
             await session.refresh(account)
             return self._viewer_account_to_dict(account)
@@ -2697,13 +2744,13 @@ class DatabaseAdapter:
         async with self.db_manager.async_session_factory() as session:
             result = await session.execute(select(ViewerToken).where(ViewerToken.is_revoked == 0))
             for record in result.scalars().all():
-                if record.expires_at and record.expires_at < datetime.utcnow():
+                if record.expires_at and record.expires_at < utcnow_naive():
                     continue
                 computed = hashlib.pbkdf2_hmac(
                     "sha256", plaintext_token.encode(), bytes.fromhex(record.token_salt), 600_000
                 ).hex()
                 if secrets.compare_digest(computed, record.token_hash):
-                    record.last_used_at = datetime.utcnow()
+                    record.last_used_at = utcnow_naive()
                     record.use_count = (record.use_count or 0) + 1
                     await session.commit()
                     return self._viewer_token_to_dict(record)
@@ -2758,16 +2805,16 @@ class DatabaseAdapter:
         """Set a key-value setting (upsert)."""
         async with self.db_manager.async_session_factory() as session:
             if self._is_sqlite:
-                stmt = sqlite_insert(AppSettings).values(key=key, value=value, updated_at=datetime.utcnow())
+                stmt = sqlite_insert(AppSettings).values(key=key, value=value, updated_at=utcnow_naive())
                 stmt = stmt.on_conflict_do_update(
                     index_elements=["key"],
-                    set_={"value": value, "updated_at": datetime.utcnow()},
+                    set_={"value": value, "updated_at": utcnow_naive()},
                 )
             else:
-                stmt = pg_insert(AppSettings).values(key=key, value=value, updated_at=datetime.utcnow())
+                stmt = pg_insert(AppSettings).values(key=key, value=value, updated_at=utcnow_naive())
                 stmt = stmt.on_conflict_do_update(
                     index_elements=["key"],
-                    set_={"value": value, "updated_at": datetime.utcnow()},
+                    set_={"value": value, "updated_at": utcnow_naive()},
                 )
             await session.execute(stmt)
             await session.commit()

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -48,9 +48,9 @@ class Chat(Base):
     is_forum: Mapped[int] = mapped_column(Integer, default=0, server_default="0")  # v6.2.0: forum with topics
     is_archived: Mapped[int] = mapped_column(Integer, default=0, server_default="0")  # v6.2.0: archived chat
     last_synced_message_id: Mapped[int] = mapped_column(BigInteger, default=0)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, server_default=func.now()
+        DateTime, default=utcnow_naive, onupdate=utcnow_naive, server_default=func.now()
     )
 
     # Relationships
@@ -83,7 +83,7 @@ class Message(Base):
     edit_date: Mapped[datetime | None] = mapped_column(DateTime)
     # v6.0.0: media_type, media_id, media_path REMOVED - normalized to media table
     raw_data: Mapped[str | None] = mapped_column(Text)  # JSON string
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
     is_outgoing: Mapped[int] = mapped_column(Integer, default=0)  # 0 or 1
     is_pinned: Mapped[int] = mapped_column(Integer, default=0)  # 0 or 1 - whether this message is pinned
     is_deleted: Mapped[int] = mapped_column(Integer, default=0, server_default="0")  # 0 or 1 - deleted on Telegram
@@ -168,9 +168,9 @@ class User(Base):
     last_name: Mapped[str | None] = mapped_column(String(255))
     phone: Mapped[str | None] = mapped_column(String(50))
     is_bot: Mapped[int] = mapped_column(Integer, default=0)  # 0 or 1
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, server_default=func.now()
+        DateTime, default=utcnow_naive, onupdate=utcnow_naive, server_default=func.now()
     )
 
     # Relationships
@@ -212,7 +212,7 @@ class Media(Base):
     # at/above MEDIA_MAX_DOWNLOAD_ATTEMPTS so a permanently-unwritable file stops re-fetching.
     download_attempts: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
     download_date: Mapped[datetime | None] = mapped_column(DateTime)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
 
     # Relationship to message
     message: Mapped[Message | None] = relationship(
@@ -245,7 +245,7 @@ class Reaction(Base):
     emoji: Mapped[str] = mapped_column(String(50), nullable=False)
     user_id: Mapped[int | None] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="SET NULL"))
     count: Mapped[int] = mapped_column(Integer, default=1)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
 
     # Relationship to message (composite foreign key)
     message: Mapped[Message] = relationship(
@@ -272,7 +272,7 @@ class SyncStatus(Base):
 
     chat_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("chats.id"), primary_key=True)
     last_message_id: Mapped[int] = mapped_column(BigInteger, default=0)
-    last_sync_date: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
+    last_sync_date: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
     message_count: Mapped[int] = mapped_column(Integer, default=0)
 
     # Relationship
@@ -303,7 +303,7 @@ class PushSubscription(Base):
         Text
     )  # JSON snapshot of user's allowed chats at subscribe time
     user_agent: Mapped[str | None] = mapped_column(String(500))  # Browser info for debugging
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
     last_used_at: Mapped[datetime | None] = mapped_column(DateTime)  # Track activity
 
     __table_args__ = (Index("idx_push_sub_chat", "chat_id"), Index("idx_push_sub_username", "username"))
@@ -327,8 +327,8 @@ class ForumTopic(Base):
     is_pinned: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
     is_hidden: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
     date: Mapped[datetime | None] = mapped_column(DateTime)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
-    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
 
     # Relationships
     chat: Mapped[Chat] = relationship("Chat", back_populates="forum_topics")
@@ -348,8 +348,8 @@ class ChatFolder(Base):
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     emoticon: Mapped[str | None] = mapped_column(String(50))
     sort_order: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
-    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
 
     # Relationships
     members: Mapped[list[ChatFolderMember]] = relationship(
@@ -395,9 +395,9 @@ class ViewerAccount(Base):
     is_active: Mapped[int] = mapped_column(Integer, default=1, server_default="1")
     no_download: Mapped[int] = mapped_column(Integer, default=0, server_default="0")  # v7.2.0
     created_by: Mapped[str | None] = mapped_column(String(255))
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, server_default=func.now()
+        DateTime, default=utcnow_naive, onupdate=utcnow_naive, server_default=func.now()
     )
 
 
@@ -418,7 +418,7 @@ class ViewerAuditLog(Base):
     chat_id: Mapped[int | None] = mapped_column(BigInteger)
     ip_address: Mapped[str | None] = mapped_column(String(45))
     user_agent: Mapped[str | None] = mapped_column(Text)
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
 
 
 class ViewerSession(Base):
@@ -466,7 +466,7 @@ class ViewerToken(Base):
     expires_at: Mapped[datetime | None] = mapped_column(DateTime)  # NULL = no expiry
     last_used_at: Mapped[datetime | None] = mapped_column(DateTime)
     use_count: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
-    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, server_default=func.now())
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
 
     __table_args__ = (
         Index("idx_viewer_tokens_created_by", "created_by"),
@@ -485,5 +485,5 @@ class AppSettings(Base):
     key: Mapped[str] = mapped_column(String(255), primary_key=True)
     value: Mapped[str] = mapped_column(Text, nullable=False)
     updated_at: Mapped[datetime] = mapped_column(
-        DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, server_default=func.now()
+        DateTime, default=utcnow_naive, onupdate=utcnow_naive, server_default=func.now()
     )

--- a/src/export_backup.py
+++ b/src/export_backup.py
@@ -9,7 +9,7 @@ import argparse
 import asyncio
 import json
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 from pathlib import Path
 
 from .config import Config, setup_logging
@@ -75,7 +75,7 @@ class BackupExporter:
 
         # Build export data
         export_data = {
-            "export_date": datetime.now().isoformat(),
+            "export_date": datetime.now(UTC).isoformat(),
             "filters": {"chat_id": chat_id, "start_date": start_date, "end_date": end_date},
             "statistics": {
                 "total_messages": len(messages),

--- a/src/listener.py
+++ b/src/listener.py
@@ -40,6 +40,7 @@ from .message_utils import (
     compute_file_hash,
     download_and_shard_media,
     extract_topic_id,
+    fallback_media_filename,
     finalize_atomic_download,
     sanitize_media_filename,
     utcnow_naive,
@@ -122,7 +123,7 @@ class MassOperationProtector:
             else:
                 # Block expired
                 del self._blocked[chat_id]
-                logger.info(f"🔓 Rate limit expired for chat {chat_id}")
+                logger.info("🔓 Rate limit expired for chat")
         return False, ""
 
     def _count_ops_in_window(self, chat_id: int) -> int:
@@ -179,7 +180,6 @@ class MassOperationProtector:
 
             logger.warning("=" * 70)
             logger.warning("🛡️ RATE LIMIT TRIGGERED")
-            logger.warning(f"   Chat: {chat_id}")
             logger.warning(f"   Operation type: {operation_type}")
             logger.warning(f"   Operations in {self.window_seconds}s: {ops_in_window} (max: {self.threshold})")
             logger.warning(f"   First {self.threshold} were applied, remaining blocked")
@@ -439,7 +439,7 @@ class TelegramListener:
         if deletion_mode == "soft":
             deleted_at = utcnow_naive()
             await self.db.mark_message_deleted(chat_id, message_id, deleted_at=deleted_at)
-            logger.debug(f"🗑️ Deletion marked: msg={message_id}")
+            logger.debug("🗑️ Deletion marked")
             await self._notify_update(
                 "delete",
                 {
@@ -452,7 +452,7 @@ class TelegramListener:
             return
 
         await self.db.delete_message(chat_id, message_id)
-        logger.debug(f"🗑️ Deletion applied: msg={message_id}")
+        logger.debug("🗑️ Deletion applied")
         await self._notify_update(
             "delete",
             {"chat_id": chat_id, "message_id": message_id, "deletion_mode": "hard"},
@@ -520,7 +520,7 @@ class TelegramListener:
             avatar_path, _legacy_path = get_avatar_paths(self.config.media_path, entity, chat_id)
 
             if avatar_path is None:
-                logger.debug(f"No avatar set for {chat_id}")
+                logger.debug("No avatar set")
                 return
 
             # lexists short-circuits when an avatar (even a symlink whose
@@ -533,11 +533,11 @@ class TelegramListener:
 
             result = await self.client.download_profile_photo(entity, file=avatar_path, download_big=False)
             if result:
-                logger.info(f"📷 Avatar downloaded: {avatar_path}")
+                logger.info("📷 Avatar downloaded")
             else:
-                logger.debug(f"No avatar available for {chat_id}")
+                logger.debug("No avatar available")
         except Exception as e:
-            logger.warning(f"Failed to download avatar for {chat_id}: {e}")
+            logger.warning(f"Failed to download avatar: {e}")
 
     def _get_media_type(self, media) -> str | None:
         """Get media type as string."""
@@ -574,30 +574,27 @@ class TelegramListener:
     def _get_media_filename(self, message, media_type: str, telegram_file_id: str | None = None) -> str:
         """Generate a filename for media."""
         # Try to get original filename from document
+        original_name = None
+        mime_type = None
+
         if hasattr(message.media, "document") and message.media.document:
-            for attr in message.media.document.attributes:
+            doc = message.media.document
+            mime_type = getattr(doc, "mime_type", None)
+            for attr in doc.attributes:
                 if hasattr(attr, "file_name") and attr.file_name:
-                    # Use Telegram file ID + original name for deduplication.
-                    # Length-budget the decorative name for constrained filesystems (#212).
-                    if telegram_file_id:
-                        return build_media_filename(telegram_file_id, attr.file_name, self.config.max_filename_bytes)
-                    return sanitize_media_filename(attr.file_name)
+                    original_name = attr.file_name
+                    break
 
-        # Generate filename based on type
-        extensions = {
-            "photo": ".jpg",
-            "video": ".mp4",
-            "animation": ".mp4",
-            "voice": ".ogg",
-            "audio": ".mp3",
-            "sticker": ".webp",
-            "document": "",
-        }
-        ext = extensions.get(media_type, "")
+        # Use Telegram file ID + original name for deduplication.
+        # Length-budget the decorative name for constrained filesystems (#212).
+        if original_name and telegram_file_id:
+            return build_media_filename(telegram_file_id, original_name, self.config.max_filename_bytes)
+        if original_name:
+            return sanitize_media_filename(original_name)
 
-        if telegram_file_id:
-            return f"{telegram_file_id}{ext}"
-        return f"{message.id}_{media_type}{ext}"
+        # No usable original name — shared fallback (message_utils) keeps this
+        # identical to the backup module's ingest path for the same inputs.
+        return fallback_media_filename(telegram_file_id, media_type, mime_type, message.id)
 
     async def _download_media(self, message, chat_id: int) -> tuple[str, str, str | None] | None:
         """
@@ -805,7 +802,7 @@ class TelegramListener:
                         try:
                             resolved = await self.db.resolve_message_chat_id(msg_id)
                             if resolved is None:
-                                logger.debug(f"⚠️ Deletion skipped (not found or ambiguous): msg={msg_id}")
+                                logger.debug("⚠️ Deletion skipped (not found or ambiguous)")
                                 continue
 
                             if not self._should_process_chat(resolved):
@@ -821,7 +818,7 @@ class TelegramListener:
                             self.stats["deletions_applied"] += 1
                         except Exception as e:
                             self.stats["errors"] += 1
-                            logger.warning(f"Could not apply deletion for msg {msg_id}: {e}")
+                            logger.warning(f"Could not apply deletion: {e}")
                         continue
 
                     if not self._should_process_chat(effective_chat_id):
@@ -857,7 +854,7 @@ class TelegramListener:
                 if chat_id not in self._tracked_chat_ids:
                     if self._should_process_chat(chat_id):
                         self._tracked_chat_ids.add(chat_id)
-                        logger.debug(f"Added chat {chat_id} to tracking list")
+                        logger.debug("Added chat to tracking list")
 
                 # Skip if not in tracked chats
                 if not self._should_process_chat(chat_id):
@@ -872,7 +869,7 @@ class TelegramListener:
 
                 # Skip messages in excluded forum topics
                 if self.config.should_skip_topic(chat_id, reply_to_top_id):
-                    logger.debug(f"⏭️ Skipping message in excluded topic {reply_to_top_id}: chat={chat_id}")
+                    logger.debug("⏭️ Skipping message in excluded topic")
                     return
 
                 self.stats["new_messages_received"] += 1
@@ -961,10 +958,10 @@ class TelegramListener:
                                         "file_name": media_file_name,
                                         "content_hash": content_hash,
                                         "downloaded": True,
-                                        "download_date": datetime.utcnow(),
+                                        "download_date": utcnow_naive(),
                                     }
                                 )
-                                logger.debug(f"📎 Downloaded media: {media_path}")
+                                logger.debug("📎 Downloaded media")
                                 # Mirror the DB row: insert_media leaves file_size/mime_type/width/
                                 # height/duration as None in this path (not passed above), so the
                                 # WS row matches what the next poll will return.
@@ -996,14 +993,9 @@ class TelegramListener:
                     }
                     await self._notifier.notify(NotificationType.NEW_MESSAGE, chat_id, {"message": ws_message})
 
-                # Log the new message (truncate text for logging)
-                text_preview = (message.text or "")[:50]
-                if len(message.text or "") > 50:
-                    text_preview += "..."
+                # Log the new message (no chat_id/msg_id/text — PII)
                 media_indicator = f" [{media_type}]" if media_type else ""
-                logger.info(
-                    f"📩 New message saved: chat={chat_id} msg={message.id}{media_indicator} text='{text_preview}'"
-                )
+                logger.info(f"📩 New message saved{media_indicator}")
 
             except Exception as e:
                 self.stats["errors"] += 1
@@ -1034,26 +1026,26 @@ class TelegramListener:
                 action_type = None
                 if event.new_photo:
                     action_type = "photo_changed"
-                    logger.info(f"📷 Chat photo changed: chat={chat_id}")
+                    logger.info("📷 Chat photo changed")
                 elif getattr(event, "photo", None) is None and not event.new_photo:
                     # Photo removed - Telethon doesn't have photo_removed attr in all versions
                     action_type = "photo_removed"
-                    logger.info(f"📷 Chat photo removed: chat={chat_id}")
+                    logger.info("📷 Chat photo removed")
                 elif event.new_title:
                     action_type = "title_changed"
-                    logger.info(f"📝 Chat title changed to '{event.new_title}': chat={chat_id}")
+                    logger.info("📝 Chat title changed")
                 elif event.user_joined:
                     action_type = "user_joined"
-                    logger.debug(f"👤 User joined: chat={chat_id}")
+                    logger.debug("👤 User joined")
                 elif event.user_left:
                     action_type = "user_left"
-                    logger.debug(f"👤 User left: chat={chat_id}")
+                    logger.debug("👤 User left")
                 elif event.user_added:
                     action_type = "user_added"
-                    logger.debug(f"👤 User added: chat={chat_id}")
+                    logger.debug("👤 User added")
                 elif event.user_kicked:
                     action_type = "user_kicked"
-                    logger.debug(f"👤 User kicked: chat={chat_id}")
+                    logger.debug("👤 User kicked")
 
                 # Save service message for display in viewer
                 if action_type:
@@ -1068,7 +1060,7 @@ class TelegramListener:
                                 actor_name = getattr(actor, "first_name", "") or getattr(actor, "title", "")
                                 if hasattr(actor, "last_name") and actor.last_name:
                                     actor_name += f" {actor.last_name}"
-                            except:
+                            except Exception:
                                 pass
 
                         # Build service message text
@@ -1108,7 +1100,7 @@ class TelegramListener:
                                 "id": service_msg_id,
                                 "chat_id": chat_id,
                                 "sender_id": actor_id,
-                                "date": datetime.now(),
+                                "date": utcnow_naive(),
                                 "text": service_text,
                                 "reply_to_msg_id": None,
                                 "reply_to_text": None,
@@ -1140,13 +1132,13 @@ class TelegramListener:
                                 "username": getattr(entity, "username", None),
                             }
                             await self.db.upsert_chat(chat_data)
-                            logger.info(f"✅ Chat {chat_id} metadata updated")
+                            logger.info("✅ Chat metadata updated")
 
                             # Download new avatar if photo changed
                             if action_type == "photo_changed":
                                 await self._download_avatar(entity, chat_id)
                     except Exception as e:
-                        logger.warning(f"Failed to update chat metadata for {chat_id}: {e}")
+                        logger.warning(f"Failed to update chat metadata: {e}")
 
             except Exception as e:
                 self.stats["errors"] += 1
@@ -1200,7 +1192,7 @@ class TelegramListener:
                     await self.db.update_message_pinned(chat_id, msg_id, is_pinning)
 
                 action = "📌 Pinned" if is_pinning else "📌 Unpinned"
-                logger.info(f"{action}: chat={chat_id} messages={pinned_messages}")
+                logger.info(f"{action}: {len(pinned_messages)} message(s)")
 
                 # Notify viewer of the update
                 await self._notify_update(
@@ -1327,8 +1319,8 @@ class TelegramListener:
             if blocked:
                 logger.warning("")
                 logger.warning(f"   🚫 Currently blocked chats: {len(blocked)}")
-                for chat_id, (reason, discarded) in blocked.items():
-                    logger.warning(f"      Chat {chat_id}: {discarded} ops discarded - {reason}")
+                for _chat_id, (reason, discarded) in blocked.items():
+                    logger.warning(f"      {discarded} ops discarded - {reason}")
 
             logger.info("=" * 70)
 

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -4,6 +4,7 @@ import asyncio
 import errno
 import hashlib
 import logging
+import mimetypes
 import os
 import re
 import stat
@@ -112,6 +113,55 @@ def build_media_filename(file_id: str, original_name: str, name_max_bytes: int) 
     return f"{safe_id}_{safe_stem}{ext}"
 
 
+# Per-media-type extension used only when mime_type is missing/unrecognized.
+_FALLBACK_MEDIA_EXTENSIONS = {
+    "photo": "jpg",
+    "video": "mp4",
+    "animation": "mp4",
+    "voice": "ogg",
+    "audio": "mp3",
+    "sticker": "webp",
+    "document": "bin",
+}
+
+
+def fallback_media_filename(
+    telegram_file_id: str | None,
+    media_type: str,
+    mime_type: str | None,
+    message_id: int | str | None = None,
+) -> str:
+    """Build a filename for media with no usable original name.
+
+    Canonical fallback shared by the backup and listener ingest paths so both
+    produce IDENTICAL names for the same media (previously they diverged: one
+    used mime-type-derived extensions, the other a hardcoded per-type table with
+    a different last-resort shape). The extension is derived from ``mime_type``
+    via ``mimetypes.guess_extension`` (correcting the common ``jpe`` -> ``jpg``
+    quirk), falling back to a per-``media_type`` default when the MIME type is
+    missing or unrecognized. With a Telegram file ID, the name is
+    ``<file_id>.<ext>``; without one, ``<message_id>_<media_type>.<ext>`` keeps
+    retries deterministic.
+    """
+    extension = None
+    if mime_type:
+        guessed = mimetypes.guess_extension(mime_type)
+        if guessed:
+            extension = guessed.lstrip(".")
+            if extension == "jpe":
+                extension = "jpg"
+
+    if not extension:
+        extension = _FALLBACK_MEDIA_EXTENSIONS.get(media_type, "bin")
+
+    if telegram_file_id:
+        safe_id = str(telegram_file_id).replace("/", "_").replace("\\", "_")
+        return f"{safe_id}.{extension}"
+
+    safe_message_id = message_id if message_id is not None else "unknown"
+    return f"{safe_message_id}_{media_type}.{extension}"
+
+
 def get_shared_file_path(shared_dir: str, file_name: str, content_hash: str | None) -> str:
     """Build the sharded path for a file in the shared store.
 
@@ -195,7 +245,7 @@ async def deduplicate_shared_file(
     except FileNotFoundError:
         pass
 
-    logger.debug(f"Content-hash dedup: {os.path.basename(shared_file_path)} matches existing {existing['file_name']}")
+    logger.debug("Content-hash dedup: matched existing file")
     return existing_shared, content_hash, True
 
 
@@ -291,7 +341,7 @@ async def download_and_shard_media(
                     os.symlink(rel_path, file_path)
                 else:
                     raise
-            logger.debug(f"Created symlink for deduplicated media: {file_name}")
+            logger.debug("Created symlink for deduplicated media")
         except OSError as e:
             logger.warning(f"Symlink not supported, using direct path: {e}")
             import shutil
@@ -314,7 +364,7 @@ async def download_and_shard_media(
     if not tmp_shared_file_path or not os.path.exists(tmp_shared_file_path):
         logger.warning("Media download did not produce a file")
         return None, None
-    logger.debug(f"Downloaded media to shared: {file_name}")
+    logger.debug("Downloaded media to shared")
 
     # Content-hash dedup: check if identical content already exists
     tmp_shared_file_path, content_hash, reused = await deduplicate_shared_file(db, tmp_shared_file_path, shared_dir)

--- a/src/realtime.py
+++ b/src/realtime.py
@@ -10,6 +10,7 @@ from the backup/listener components to the viewer.
 """
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
@@ -221,6 +222,10 @@ class RealtimeListener:
         self._is_postgresql = False
         self._running = False
         self._task: asyncio.Task | None = None
+        # Keeps references to in-flight callback tasks so they aren't
+        # garbage-collected mid-run and so their exceptions are retrieved
+        # (an un-referenced task's exception is otherwise silently dropped).
+        self._callback_tasks: set[asyncio.Task] = set()
 
     async def init(self):
         """Initialize and detect database type."""
@@ -264,6 +269,7 @@ class RealtimeListener:
         url = url.replace("postgresql+asyncpg://", "postgresql://")
 
         while self._running:
+            conn = None
             try:
                 conn = await asyncpg.connect(url)
                 await conn.add_listener("telegram_updates", self._pg_callback)
@@ -273,24 +279,48 @@ class RealtimeListener:
                 while self._running:
                     await asyncio.sleep(1)
 
-                await conn.remove_listener("telegram_updates", self._pg_callback)
-                await conn.close()
-
             except asyncio.CancelledError:
                 break
             except Exception as e:
                 logger.error(f"PostgreSQL LISTEN error: {e}")
                 await asyncio.sleep(5)  # Retry after 5 seconds
+            finally:
+                # Always tear down the connection, even when CancelledError or
+                # another exception interrupts the "keep connection alive" loop --
+                # otherwise a flapping DB leaks one connection per retry.
+                if conn is not None:
+                    with contextlib.suppress(Exception):
+                        await conn.remove_listener("telegram_updates", self._pg_callback)
+                    with contextlib.suppress(Exception):
+                        await conn.close()
 
     def _pg_callback(self, connection, pid, channel, payload):
         """Handle PostgreSQL notification."""
-        if self._callback:
-            try:
-                data = json.loads(payload)
-                # Schedule the async callback
-                asyncio.create_task(self._callback(data))
-            except json.JSONDecodeError:
-                logger.warning(f"Invalid JSON in notification: {payload}")
+        if not self._callback:
+            return
+
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as e:
+            # Never log the raw payload -- it may contain message content (PII rule).
+            logger.warning(f"Invalid JSON in notification: {type(e).__name__}: {e}")
+            return
+
+        # Keep a reference so the task isn't GC'd mid-flight, and retrieve its
+        # exception via the done callback instead of letting it vanish silently.
+        task = asyncio.create_task(self._callback(data))
+        self._callback_tasks.add(task)
+        task.add_done_callback(self._on_callback_task_done)
+
+    def _on_callback_task_done(self, task: asyncio.Task) -> None:
+        """Clean up a finished callback task and surface any exception it raised."""
+        self._callback_tasks.discard(task)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            # Never log notification payload/data here (PII rule) -- exception class/message only.
+            logger.warning(f"Realtime callback failed: {type(exc).__name__}: {exc}")
 
     async def handle_http_push(self, payload: dict):
         """Handle HTTP push notification (for SQLite mode)."""

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -51,6 +51,11 @@ class BackupScheduler:
         # Real-time listener (optional)
         self._listener = None
         self._listener_task: asyncio.Task | None = None
+        # Set once (in run_forever) when the listener is supposed to be running for
+        # the life of the process. Unlike checking config directly, this lets the
+        # watchdog keep retrying after a failed start -- _start_listener resets
+        # _listener_task to None on failure, but the listener is still "enabled".
+        self._listener_enabled = False
 
         # Setup signal handlers for graceful shutdown
         signal.signal(signal.SIGINT, self._signal_handler)
@@ -238,7 +243,8 @@ class BackupScheduler:
         # Start scheduler
         self.start()
 
-        # Start real-time listener if enabled (uses shared connection)
+        # Start real-time listener if enabled (uses shared connection).
+        self._listener_enabled = self.config.enable_listener
         await self._start_listener()
 
         # Run initial backup immediately on startup (uses shared connection)
@@ -272,9 +278,13 @@ class BackupScheduler:
             while self.running:
                 await asyncio.sleep(1)
 
-                # Check if listener task died unexpectedly and restart it
-                if self.config.enable_listener and self._listener_task:
-                    if self._listener_task.done():
+                # Check if the listener task died, or never came up at all (a failed
+                # restart leaves _listener_task as None -- see _start_listener), and
+                # restart it either way. Retrying on None (not just "died") is what
+                # keeps a flapping listener from being permanently disabled after a
+                # single failed restart attempt.
+                if self._listener_enabled and (self._listener_task is None or self._listener_task.done()):
+                    if self._listener_task is not None and self._listener_task.done():
                         # Check if there was an exception
                         try:
                             exc = self._listener_task.exception()
@@ -283,10 +293,10 @@ class BackupScheduler:
                         except asyncio.CancelledError:
                             pass
 
-                        logger.warning("Listener task died, restarting...")
-                        await self._stop_listener()
-                        await asyncio.sleep(5)  # Brief pause before restart
-                        await self._start_listener()
+                    logger.warning("Listener task not running, attempting restart...")
+                    await self._stop_listener()
+                    await asyncio.sleep(5)  # Brief pause before restart
+                    await self._start_listener()
 
         except KeyboardInterrupt:
             logger.info("Keyboard interrupt received")

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -45,9 +45,11 @@ from .message_utils import (
     compute_file_hash,
     download_and_shard_media,
     extract_topic_id,
+    fallback_media_filename,
     finalize_atomic_download,
     resolve_shared_file_path,
     service_action_type,
+    utcnow_naive,
 )
 from .parallel_download import (
     ParallelDownloader,
@@ -155,8 +157,8 @@ def _pre_generate_thumbnail(source_path: str, media_root: str) -> None:
         with Image.open(source) as img:
             img.thumbnail((200, 200), Image.LANCZOS)
             img.save(dest, "WEBP", quality=WEBP_QUALITY)
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug("Thumbnail pre-generation failed: %s", e)
 
 
 async def call_with_flood_retry(
@@ -479,7 +481,7 @@ class TelegramBackup:
             start_time = datetime.now()
 
             # Store last backup time in UTC at the START of backup (not when it finishes)
-            last_backup_time = datetime.utcnow().isoformat() + "Z"
+            last_backup_time = utcnow_naive().isoformat() + "Z"
             await self.db.set_metadata("last_backup_time", last_backup_time)
 
             # Mark a backup as in progress so the viewer can show a "backing up"
@@ -508,9 +510,9 @@ class TelegramBackup:
 
                         filtered_dialogs.append(SimpleDialog(entity))
                         seen_chat_ids.add(cid)
-                        logger.info(f"  → Fetched: {self._get_chat_name(entity)} (ID: {cid})")
+                        logger.info("  → Fetched chat")
                     except Exception as e:
-                        logger.warning(f"  → Could not fetch chat {cid}: {e}")
+                        logger.warning(f"  → Could not fetch chat: {e}")
 
             else:
                 # Type-based mode: fetch full dialog list and filter
@@ -529,9 +531,13 @@ class TelegramBackup:
                 archived_chat_ids = set()
                 for dialog in archived_dialogs:
                     archived_chat_ids.add(self._get_marked_id(dialog.entity))
-                logger.info(
-                    f"Archived chat IDs from Telegram: {archived_chat_ids & (self.config.global_include_ids | self.config.private_include_ids | self.config.groups_include_ids | self.config.channels_include_ids) if archived_chat_ids else 'none matching includes'}"
+                archived_matching_includes = archived_chat_ids & (
+                    self.config.global_include_ids
+                    | self.config.private_include_ids
+                    | self.config.groups_include_ids
+                    | self.config.channels_include_ids
                 )
+                logger.info(f"Archived chats matching includes: {len(archived_matching_includes)}")
 
                 # Filter dialogs based on chat type and ID filters
                 # Also delete explicitly excluded chats from database
@@ -577,9 +583,7 @@ class TelegramBackup:
                 missing_include_ids = all_include_ids - seen_chat_ids - explicitly_excluded_chat_ids
 
                 if missing_include_ids:
-                    logger.info(
-                        f"Fetching {len(missing_include_ids)} explicitly included chats not in regular dialogs: {missing_include_ids}"
-                    )
+                    logger.info(f"Fetching {len(missing_include_ids)} explicitly included chats not in regular dialogs")
                     for include_id in missing_include_ids:
                         is_in_archive = include_id in archived_chat_ids
                         try:
@@ -592,10 +596,10 @@ class TelegramBackup:
 
                             filtered_dialogs.append(SimpleDialog(entity))
                             logger.info(
-                                f"  → Added: {self._get_chat_name(entity)} (ID: {include_id}){' [in archive]' if is_in_archive else ' [not in any dialog list]'}"
+                                f"  → Added chat{' [in archive]' if is_in_archive else ' [not in any dialog list]'}"
                             )
                         except Exception as e:
-                            logger.warning(f"  → Could not fetch included chat {include_id}: {e}")
+                            logger.warning(f"  → Could not fetch included chat: {e}")
 
                 # Delete only explicitly excluded chats from database
                 if explicitly_excluded_chat_ids:
@@ -606,7 +610,7 @@ class TelegramBackup:
                         try:
                             await self.db.delete_chat_and_related_data(chat_id, self.config.media_path)
                         except Exception as e:
-                            logger.error(f"Error deleting chat {chat_id}: {e}", exc_info=True)
+                            logger.error(f"Error deleting chat: {e}", exc_info=True)
 
             logger.info(f"Backing up {len(filtered_dialogs)} dialogs after filtering")
 
@@ -654,14 +658,12 @@ class TelegramBackup:
             for i, dialog in enumerate(filtered_dialogs, 1):
                 entity = dialog.entity
                 chat_id = self._get_marked_id(entity)
-                chat_name = self._get_chat_name(entity)
                 is_archived = chat_id in archived_chat_ids and chat_id not in seen_chat_ids
                 if chat_id in archived_chat_ids and chat_id in seen_chat_ids:
                     logger.warning(
-                        f"  Chat {chat_name} (ID: {chat_id}) appears in both regular and archived dialog lists - treating as NOT archived"
+                        "  Chat appears in both regular and archived dialog lists - treating as NOT archived"
                     )
-                label = f"[{i}/{len(filtered_dialogs)}] Backing up{' (archived)' if is_archived else ''}: {chat_name} (ID: {chat_id})"
-                logger.info(label)
+                logger.info(f"[{i}/{len(filtered_dialogs)}] Backing up{' (archived)' if is_archived else ''}")
 
                 try:
                     message_count = await self._backup_dialog(dialog, is_archived=is_archived)
@@ -675,7 +677,7 @@ class TelegramBackup:
                 except (ChannelPrivateError, ChatForbiddenError, UserBannedInChannelError) as e:
                     logger.warning(f"  → Skipped (no access): {e.__class__.__name__}")
                 except Exception as e:
-                    logger.error(f"  → Error backing up {chat_name}: {e}", exc_info=True)
+                    logger.error(f"  → Error backing up chat: {e}", exc_info=True)
 
             # v6.2.0: Backup archived dialogs that weren't already processed above.
             # Apply the same chat type/ID filters so we don't back up unintended chats.
@@ -701,8 +703,7 @@ class TelegramBackup:
                 for i, dialog in enumerate(archived_to_backup, 1):
                     entity = dialog.entity
                     chat_id = self._get_marked_id(entity)
-                    chat_name = self._get_chat_name(entity)
-                    logger.info(f"  [Archived {i}/{len(archived_to_backup)}] {chat_name} (ID: {chat_id})")
+                    logger.info(f"  [Archived {i}/{len(archived_to_backup)}]")
 
                     try:
                         message_count = await self._backup_dialog(dialog, is_archived=True)
@@ -882,7 +883,7 @@ class TelegramBackup:
         for chat_id, records in by_chat.items():
             # Skip media verification for chats in skip list
             if chat_id in self.config.skip_media_chat_ids:
-                logger.debug(f"Skipping media verification for chat {chat_id} (in SKIP_MEDIA_CHAT_IDS)")
+                logger.debug("Skipping media verification for chat (in SKIP_MEDIA_CHAT_IDS)")
                 continue
 
             try:
@@ -895,7 +896,7 @@ class TelegramBackup:
                 try:
                     messages = await call_with_flood_retry(self.client.get_messages, chat_id, ids=message_ids)
                 except Exception as e:
-                    logger.warning(f"Cannot access chat {chat_id} for media verification: {e}")
+                    logger.warning(f"Cannot access chat for media verification: {e}")
                     failed += len(records)
                     continue
 
@@ -911,12 +912,12 @@ class TelegramBackup:
                     msg = msg_map.get(msg_id)
 
                     if not msg:
-                        logger.warning(f"Message {msg_id} in chat {chat_id} was deleted - cannot recover media")
+                        logger.warning("Message was deleted - cannot recover media")
                         failed += 1
                         continue
 
                     if not msg.media:
-                        logger.warning(f"Message {msg_id} no longer has media - cannot recover")
+                        logger.warning("Message no longer has media - cannot recover")
                         failed += 1
                         continue
 
@@ -932,16 +933,16 @@ class TelegramBackup:
                             # Insert media record (message already exists for re-downloads)
                             await self.db.insert_media(result)
                             redownloaded += 1
-                            logger.debug(f"Re-downloaded media for message {msg_id}")
+                            logger.debug("Re-downloaded media for message")
                         else:
                             failed += 1
-                            logger.warning(f"Failed to re-download media for message {msg_id}")
+                            logger.warning("Failed to re-download media for message")
                     except Exception as e:
                         failed += 1
-                        logger.error(f"Error re-downloading media for message {msg_id}: {e}")
+                        logger.error(f"Error re-downloading media for message: {e}")
 
             except Exception as e:
-                logger.error(f"Error processing chat {chat_id} for media verification: {e}")
+                logger.error(f"Error processing chat for media verification: {e}")
                 failed += len(records)
 
         logger.info("=" * 60)
@@ -1091,7 +1092,7 @@ class TelegramBackup:
         try:
             await self._ensure_profile_photo(entity, chat_id)
         except Exception as e:
-            logger.error(f"Error downloading profile photo for {chat_id}: {e}", exc_info=True)
+            logger.error(f"Error downloading profile photo: {e}", exc_info=True)
 
         # Get last synced message ID for incremental backup
         last_message_id = await self.db.get_last_message_id(chat_id)
@@ -1268,10 +1269,10 @@ class TelegramBackup:
             try:
                 entity = await call_with_flood_retry(self.client.get_entity, cid)
             except (ChannelPrivateError, ChatForbiddenError, UserBannedInChannelError) as e:
-                logger.warning(f"Gap-fill: skipping chat {cid} (no access): {e.__class__.__name__}")
+                logger.warning(f"Gap-fill: skipping chat (no access): {e.__class__.__name__}")
                 continue
             except Exception as e:
-                logger.error(f"Gap-fill: failed to get entity for chat {cid}: {e}")
+                logger.error(f"Gap-fill: failed to get entity for chat: {e}")
                 summary["errors"] += 1
                 continue
 
@@ -1280,7 +1281,7 @@ class TelegramBackup:
             try:
                 gaps = await self.db.detect_message_gaps(cid, threshold)
             except Exception as e:
-                logger.error(f"Gap-fill: failed to detect gaps for {chat_name} ({cid}): {e}")
+                logger.error(f"Gap-fill: failed to detect gaps for chat: {e}")
                 summary["errors"] += 1
                 continue
 
@@ -1290,16 +1291,16 @@ class TelegramBackup:
             summary["chats_with_gaps"] += 1
             chat_recovered = 0
 
-            logger.info(f"Gap-fill: {chat_name} (ID: {cid}) has {len(gaps)} gap(s)")
+            logger.info(f"Gap-fill: chat has {len(gaps)} gap(s)")
 
             for gap_start, gap_end, gap_size in gaps:
-                logger.info(f"  → Filling gap: {gap_start}..{gap_end} (size {gap_size})")
+                logger.info(f"  → Filling gap (size {gap_size})")
                 try:
                     recovered = await self._fill_gap_range(entity, cid, gap_start, gap_end)
                     chat_recovered += recovered
                     logger.info(f"    Recovered {recovered} messages")
                 except Exception as e:
-                    logger.error(f"    Error filling gap {gap_start}..{gap_end}: {e}")
+                    logger.error(f"    Error filling gap (size {gap_size}): {e}")
                     summary["errors"] += 1
 
             summary["total_gaps"] += len(gaps)
@@ -1330,7 +1331,7 @@ class TelegramBackup:
             chat_id: Chat ID to sync
             entity: Telegram entity
         """
-        logger.info(f"  → Syncing deletions and edits for chat {chat_id}...")
+        logger.info("  → Syncing deletions and edits for chat...")
 
         # Get all local message IDs and their edit dates
         local_messages = await self.db.get_messages_sync_data(chat_id)
@@ -1383,7 +1384,7 @@ class TelegramBackup:
                             total_updated += 1
 
             except Exception as e:
-                logger.error(f"Error syncing batch for chat {chat_id}: {e}")
+                logger.error(f"Error syncing batch for chat: {e}")
 
             total_checked += len(batch_ids)
             if total_checked % 1000 == 0:
@@ -1674,7 +1675,7 @@ class TelegramBackup:
 
         # Nothing to download (no avatar set)
         if avatar_path is None:
-            logger.debug(f"No avatar available for {file_id}")
+            logger.debug("No avatar available")
             return
 
         try:
@@ -1697,9 +1698,9 @@ class TelegramBackup:
                 download_big=False,  # Small size is usually sufficient
             )
             if result:
-                logger.info(f"📷 Avatar downloaded: {avatar_path}")
+                logger.info("📷 Avatar downloaded")
         except Exception as e:
-            logger.warning(f"Failed to download avatar for {file_id}: {e}")
+            logger.warning(f"Failed to download avatar: {e}")
 
     async def _cleanup_existing_media(self, chat_id: int) -> None:
         """
@@ -1716,7 +1717,7 @@ class TelegramBackup:
         try:
             media_records = await self.db.get_media_for_chat(chat_id)
             if not media_records:
-                logger.debug(f"No existing media found for chat {chat_id}")
+                logger.debug("No existing media found for chat")
                 return
 
             deleted_files = 0
@@ -1736,7 +1737,7 @@ class TelegramBackup:
                             os.remove(file_path)
                             deleted_files += 1
                     except Exception as e:
-                        logger.warning(f"Failed to delete media file {file_path}: {e}")
+                        logger.warning(f"Failed to delete media file: {e}")
 
             # Delete all media records from database for this chat
             deleted_records = await self.db.delete_media_for_chat(chat_id)
@@ -1748,9 +1749,9 @@ class TelegramBackup:
                     remaining = os.listdir(chat_media_dir)
                     if not remaining:
                         os.rmdir(chat_media_dir)
-                        logger.debug(f"Removed empty media directory for chat {chat_id}")
+                        logger.debug("Removed empty media directory for chat")
                 except Exception as e:
-                    logger.debug(f"Could not remove media directory for chat {chat_id}: {e}")
+                    logger.debug(f"Could not remove media directory for chat: {e}")
 
             if deleted_files > 0 or deleted_symlinks > 0 or deleted_records > 0:
                 freed_mb = freed_bytes / (1024 * 1024)
@@ -1760,12 +1761,11 @@ class TelegramBackup:
                 if deleted_symlinks > 0:
                     parts.append(f"{deleted_symlinks} symlinks removed")
                 logger.info(
-                    f"Cleaned up existing media for chat {chat_id}: "
-                    f"{', '.join(parts)}, {deleted_records} DB records deleted"
+                    f"Cleaned up existing media for chat: {', '.join(parts)}, {deleted_records} DB records deleted"
                 )
 
         except Exception as e:
-            logger.error(f"Error cleaning up existing media for chat {chat_id}: {e}", exc_info=True)
+            logger.error(f"Error cleaning up existing media for chat: {e}", exc_info=True)
 
     async def _refresh_message_for_media(self, chat_id: int, message: Message) -> Message | None:
         """Best-effort re-fetch so Telegram issues an updated media reference/location.
@@ -2028,7 +2028,7 @@ class TelegramBackup:
                 "mime_type": getattr(media, "mime_type", None),
                 "content_hash": content_hash,
                 "downloaded": True,
-                "download_date": datetime.now(),
+                "download_date": utcnow_naive(),
             }
 
             # Add type-specific metadata
@@ -2172,8 +2172,6 @@ class TelegramBackup:
         Generate a unique filename using Telegram's file_id.
         Properly handles files sent "as documents" by checking mime_type and original filename.
         """
-        import mimetypes
-
         # First, try to get original filename from document attributes
         original_name = None
         mime_type = None
@@ -2194,30 +2192,9 @@ class TelegramBackup:
         if original_name and telegram_file_id:
             return build_media_filename(telegram_file_id, original_name, self.config.max_filename_bytes)
 
-        # Determine extension from mime_type, then fall back to media_type
-        extension = None
-
-        if mime_type:
-            # Use mimetypes to get proper extension from mime_type
-            ext = mimetypes.guess_extension(mime_type)
-            if ext:
-                extension = ext.lstrip(".")
-                # Fix common mimetypes oddities
-                if extension == "jpe":
-                    extension = "jpg"
-
-        # Fall back to media_type-based extension
-        if not extension:
-            extension = self._get_media_extension(media_type)
-
-        # Build filename
-        if telegram_file_id:
-            safe_id = str(telegram_file_id).replace("/", "_").replace("\\", "_")
-            return f"{safe_id}.{extension}"
-
-        # Last resort: timestamp-based
-        timestamp = message.date.strftime("%Y%m%d_%H%M%S")
-        return f"{message.id}_{timestamp}.{extension}"
+        # No usable original name — shared fallback (message_utils) keeps this
+        # identical to the listener's ingest path for the same inputs.
+        return fallback_media_filename(telegram_file_id, media_type, mime_type, message.id)
 
     def _get_media_extension(self, media_type: str) -> str:
         """Get file extension for media type (fallback only)."""
@@ -2475,7 +2452,7 @@ class TelegramBackup:
                         await self.db.upsert_forum_topic(topic_data)
                         topics_count += 1
                 except Exception as e:
-                    logger.debug(f"Could not fetch topic {topic_id} metadata: {e}")
+                    logger.debug(f"Could not fetch topic metadata: {e}")
 
             if topics_count > 0:
                 logger.info(f"  → Inferred {topics_count} forum topics from messages")
@@ -2624,7 +2601,7 @@ class TelegramBackup:
                 await self.db.sync_folder_members(folder_id, list(member_ids))
 
                 folder_count += 1
-                logger.debug(f"  → Folder '{title}' (ID: {folder_id}): {len(member_ids)} chats")
+                logger.debug(f"  → Folder: {len(member_ids)} chats")
 
             # Remove folders that no longer exist
             await self.db.cleanup_stale_folders(active_folder_ids)

--- a/src/telegram_import.py
+++ b/src/telegram_import.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from .db import DatabaseAdapter, close_database, get_adapter, init_database
+from .message_utils import utcnow_naive
 
 logger = logging.getLogger(__name__)
 
@@ -714,7 +715,7 @@ class TelegramImporter:
                             "height": msg.get("height"),
                             "duration": msg.get("duration_seconds"),
                             "downloaded": True,
-                            "download_date": datetime.now(UTC).replace(tzinfo=None),
+                            "download_date": utcnow_naive(),
                             "_source": str(source),
                             "_dest": str(dest_file),
                         }

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -27,6 +27,7 @@ from fastapi import Cookie, Depends, FastAPI, HTTPException, Query, Request, Web
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
+from sqlalchemy.exc import DBAPIError, OperationalError
 
 from ..config import Config
 from ..db import DatabaseAdapter, close_database, get_db_manager, init_database
@@ -564,13 +565,31 @@ def _websocket_origin_allowed(websocket: WebSocket) -> bool:
     return origin in allowed_origins
 
 
+try:
+    from asyncpg import CannotConnectNowError, PostgresConnectionError, TooManyConnectionsError
+
+    _ASYNCPG_CONNECTION_ERRORS: tuple[type[Exception], ...] = (
+        PostgresConnectionError,
+        TooManyConnectionsError,
+        CannotConnectNowError,
+    )
+except ImportError:  # asyncpg may be absent when running SQLite-only installs
+    _ASYNCPG_CONNECTION_ERRORS = ()
+
+
 def _is_db_connection_error(exc: Exception) -> bool:
-    """Check if an exception indicates the database is unreachable."""
+    """Check if an exception indicates the database is unreachable (vs. e.g. a constraint violation)."""
     current: BaseException | None = exc
     for _ in range(10):
         if current is None:
             break
         if isinstance(current, OSError):
+            return True
+        if isinstance(current, OperationalError):
+            return True
+        if isinstance(current, DBAPIError) and current.connection_invalidated:
+            return True
+        if _ASYNCPG_CONNECTION_ERRORS and isinstance(current, _ASYNCPG_CONNECTION_ERRORS):
             return True
         current = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
     return False
@@ -755,7 +774,9 @@ async def require_auth(
     """Dependency that enforces session-based auth. Returns UserContext."""
     if not AUTH_ENABLED and not _PROXY_AUTH_ENABLED:
         if ALLOW_ANONYMOUS_VIEWER:
-            return UserContext(username="anonymous", role="master", allowed_chat_ids=None)
+            # Read-only viewer, not master: anonymous internet users must never get
+            # admin capabilities (create viewers, mint tokens, read audit log, settings).
+            return UserContext(username="anonymous", role="viewer", allowed_chat_ids=None, no_download=False)
         raise HTTPException(status_code=503, detail="Viewer authentication is not configured")
 
     # Trusted proxy header authentication (v7.9.0)
@@ -1040,7 +1061,13 @@ async def check_auth(request: Request, auth_cookie: str | None = Cookie(default=
 
     if not AUTH_ENABLED and not _PROXY_AUTH_ENABLED:
         if ALLOW_ANONYMOUS_VIEWER:
-            return {"authenticated": True, "auth_required": False, "role": "master", "username": "anonymous"}
+            return {
+                "authenticated": True,
+                "auth_required": False,
+                "role": "viewer",
+                "username": "anonymous",
+                "no_download": False,
+            }
         return {"authenticated": False, "auth_required": True, "setup_required": True}
 
     if not auth_cookie:
@@ -1774,6 +1801,14 @@ async def push_subscribe(request: Request, user: UserContext = Depends(require_a
         if not endpoint or not p256dh or not auth:
             raise HTTPException(status_code=400, detail="Missing required subscription data")
 
+        from .push import validate_push_endpoint
+
+        # validate_push_endpoint resolves the hostname (blocking DNS lookup),
+        # so it must run off the event loop rather than block other requests.
+        if not await asyncio.to_thread(validate_push_endpoint, endpoint):
+            logger.warning("Rejected push subscription with invalid endpoint")
+            raise HTTPException(status_code=400, detail="Invalid subscription endpoint")
+
         if chat_id:
             user_chat_ids = get_user_chat_ids(user)
             if user_chat_ids is not None and chat_id not in user_chat_ids:
@@ -1898,15 +1933,43 @@ async def internal_push(request: Request):
         return {"status": "error", "detail": "Internal push processing failed"}
 
 
+# Cache chat stats to avoid re-running 3 aggregate queries on every chat open
+_chat_stats_cache: dict[int, tuple[float, dict]] = {}
+CHAT_STATS_CACHE_TTL_SECONDS = 60
+
+
+def _get_cached_chat_stats(chat_id: int) -> dict | None:
+    """Return cached stats for chat_id if still fresh, else None."""
+    entry = _chat_stats_cache.get(chat_id)
+    if entry is None:
+        return None
+    cached_at, stats = entry
+    if time.monotonic() - cached_at > CHAT_STATS_CACHE_TTL_SECONDS:
+        _chat_stats_cache.pop(chat_id, None)
+        return None
+    return stats
+
+
+def _set_cached_chat_stats(chat_id: int, stats: dict) -> None:
+    _chat_stats_cache[chat_id] = (time.monotonic(), stats)
+
+
 @app.get("/api/chats/{chat_id}/stats")
 async def get_chat_stats(chat_id: int, user: UserContext = Depends(require_auth)):
     """Get statistics for a specific chat (message count, media files, size)."""
+    # ACL check runs unconditionally, before any cache lookup, so a cache hit
+    # never bypasses access control.
     user_chat_ids = get_user_chat_ids(user)
     if user_chat_ids is not None and chat_id not in user_chat_ids:
         raise HTTPException(status_code=403, detail="Access denied")
 
+    cached = _get_cached_chat_stats(chat_id)
+    if cached is not None:
+        return cached
+
     try:
         stats = await db.get_chat_stats(chat_id)
+        _set_cached_chat_stats(chat_id, stats)
         return stats
     except Exception as e:
         logger.error(f"Error getting chat stats: {e}", exc_info=True)

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1803,9 +1803,15 @@ async def push_subscribe(request: Request, user: UserContext = Depends(require_a
 
         from .push import validate_push_endpoint
 
-        # validate_push_endpoint resolves the hostname (blocking DNS lookup),
-        # so it must run off the event loop rather than block other requests.
-        if not await asyncio.to_thread(validate_push_endpoint, endpoint):
+        # validate_push_endpoint resolves the hostname (blocking DNS lookup), so it
+        # runs off the event loop. This endpoint is reachable without auth when
+        # ALLOW_ANONYMOUS_VIEWER is set, so bound the resolution: a hostile host that
+        # stalls DNS must fail fast (reject) rather than tie up an executor worker.
+        try:
+            endpoint_ok = await asyncio.wait_for(asyncio.to_thread(validate_push_endpoint, endpoint), timeout=5.0)
+        except TimeoutError:
+            endpoint_ok = False
+        if not endpoint_ok:
             logger.warning("Rejected push subscription with invalid endpoint")
             raise HTTPException(status_code=400, detail="Invalid subscription endpoint")
 

--- a/src/web/push.py
+++ b/src/web/push.py
@@ -7,17 +7,89 @@ This module handles:
 - Sending push notifications to subscribed clients
 """
 
+import ipaddress
 import json
 import logging
-from datetime import datetime
+import socket
 from typing import Any
+from urllib.parse import urlparse
 
 from cryptography.hazmat.primitives import serialization
 from py_vapid import Vapid
 from py_vapid.utils import b64urlencode
 from pywebpush import WebPushException, webpush
 
+from ..message_utils import utcnow_naive
+
 logger = logging.getLogger(__name__)
+
+_LOCAL_HOSTNAME_SUFFIXES = (".local", ".internal")
+
+
+def validate_push_endpoint(endpoint: str) -> bool:
+    """Check that a push subscription endpoint is a public https URL.
+
+    The endpoint is POSTed to by the server later (see send_notification), so an
+    unvalidated value is a blind SSRF vector into internal networks. Real browser
+    push services (FCM, Mozilla autopush, WNS, Apple) are always public https
+    hosts, so rejecting anything else breaks no legitimate client.
+
+    This resolves the hostname and inspects the actual IP address(es) rather
+    than pattern-matching the literal string: alternate numeric encodings
+    (decimal/hex/octal IPv4, "127.1" shorthand) and trailing-dot FQDNs all
+    resolve, at the OS level, to the same address a browser would connect to,
+    so checking the resolved address is the only way to catch all of them.
+    This is a blocking call (DNS/resolver lookup) — callers on an event loop
+    must run it off-thread (see push_subscribe's asyncio.to_thread usage).
+
+    Residual gap, accepted as out of scope: this is a point-in-time check, so
+    a TOCTOU/DNS-rebind attack (the name resolves differently at send time)
+    isn't closed here. Closing that needs pinning the webpush connection to
+    the address validated here, which is a larger change — tracked as a
+    follow-up, not implemented now.
+    """
+    try:
+        parsed = urlparse(endpoint)
+    except ValueError:
+        return False
+
+    if parsed.scheme != "https":
+        return False
+    if parsed.username or parsed.password:
+        return False
+
+    hostname = parsed.hostname
+    if not hostname:
+        return False
+
+    hostname = hostname.lower().rstrip(".")
+    if not hostname:
+        return False
+    if hostname == "localhost" or hostname.endswith(_LOCAL_HOSTNAME_SUFFIXES):
+        return False
+
+    try:
+        addr_infos = socket.getaddrinfo(hostname, 443, type=socket.SOCK_STREAM)
+    except OSError:
+        # Unresolvable — can't prove it's safe to contact, so reject.
+        return False
+
+    for *_rest, sockaddr in addr_infos:
+        try:
+            resolved_ip = ipaddress.ip_address(sockaddr[0])
+        except ValueError:
+            return False
+        if (
+            resolved_ip.is_private
+            or resolved_ip.is_loopback
+            or resolved_ip.is_link_local
+            or resolved_ip.is_reserved
+            or resolved_ip.is_multicast
+            or resolved_ip.is_unspecified
+        ):
+            return False
+
+    return True
 
 
 class PushNotificationManager:
@@ -151,7 +223,7 @@ class PushNotificationManager:
                     existing.user_agent = user_agent
                     existing.username = username
                     existing.allowed_chat_ids = allowed_json
-                    existing.last_used_at = datetime.utcnow()
+                    existing.last_used_at = utcnow_naive()
                 else:
                     sub = PushSubscription(
                         endpoint=endpoint,
@@ -161,7 +233,7 @@ class PushNotificationManager:
                         user_agent=user_agent,
                         username=username,
                         allowed_chat_ids=allowed_json,
-                        created_at=datetime.utcnow(),
+                        created_at=utcnow_naive(),
                     )
                     session.add(sub)
 
@@ -269,7 +341,7 @@ class PushNotificationManager:
             "icon": icon or "/static/favicon.ico",
             "tag": tag or f"telegram-archive-{chat_id or 'all'}",
             "data": data or {},
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": utcnow_naive().isoformat(),
         }
 
         sent = 0
@@ -307,7 +379,7 @@ class PushNotificationManager:
             await self.unsubscribe(endpoint)
 
         if sent > 0:
-            logger.info(f"Sent {sent} push notifications for chat {chat_id}")
+            logger.info(f"Sent {sent} push notifications")
 
         return sent
 

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1598,6 +1598,12 @@
                 </div>
             </div>
         </div>
+
+        <!-- Toast notification for background failures -->
+        <div v-if="toastMessage"
+            class="fixed bottom-6 left-1/2 -translate-x-1/2 bg-gray-900 text-white text-sm px-4 py-2 rounded-lg shadow-lg z-[9999]">
+            {{ toastMessage }}
+        </div>
     </div>
 
     <script>
@@ -1611,6 +1617,9 @@
                 const versionsMessage = ref(null)
                 const messageVersionsLoading = ref({})
                 const messageVersionsErrors = ref({})
+                // Per-message-keyed staleness counter (chatVersion is chat-scoped, so it
+                // can't tell two versions-drawer loads for different messages in the same
+                // chat apart — this needs its own key per message id instead).
                 const messageVersionsRequestSeq = ref({})
                 const versionsCloseBtn = ref(null)
                 const selectedChat = ref(null)
@@ -1678,7 +1687,22 @@
                 const infiniteScrollSentinel = ref(null)
                 let infiniteScrollObserver = null
                 let messagesScrollObserver = null  // Observer for loading older messages
+                // Two idioms share chatVersion: `++chatVersion` invalidates other in-flight
+                // work (view entries/jumps) so their post-await guards discard themselves,
+                // while a bare capture (`const myVersion = chatVersion`) is a passive read
+                // used by background polls so they never cancel a user-initiated action.
+                // This asymmetry is deliberate — polls follow, they don't preempt.
                 let chatVersion = 0  // Incremented on each selectChat to invalidate stale requests
+
+                // Minimal toast for surfacing background failures that would otherwise be
+                // console-only (and thus invisible to the user, who just sees a stalled UI).
+                const toastMessage = ref(null)
+                let toastTimer = null
+                const showToast = (message, ms = 4000) => {
+                    toastMessage.value = message
+                    if (toastTimer) clearTimeout(toastTimer)
+                    toastTimer = setTimeout(() => { toastMessage.value = null }, ms)
+                }
 
                 // Server-side search
                 const searchResults = ref([])
@@ -1971,6 +1995,7 @@
                             isAuthenticated.value = false
                         } else {
                             chatsError.value = 'Failed to load chats. Please try again.'
+                            showToast('Failed to load chats')
                         }
                     } finally {
                         loadingChats.value = false
@@ -2199,7 +2224,6 @@
                         (entries) => {
                             // When sentinel becomes visible, load more messages
                             if (entries[0].isIntersecting && hasMore.value && !loading.value) {
-                                console.log('>>> Loading more messages (sentinel visible)')
                                 loadMessages()
                             }
                         },
@@ -2236,7 +2260,6 @@
                         })
                         if (res.ok) {
                             const stats = await res.json()
-                            console.log('Stats loaded:', stats)
 
                             // Store stats data
                             statsData.value = {
@@ -2322,22 +2345,17 @@
 
                 // Auth check on mount
                 onMounted(async () => {
-                    console.log('[DEBUG] onMounted started')
                     try {
-                        console.log('[DEBUG] Fetching /api/auth/check...')
                         const res = await fetch('/api/auth/check', {
                             credentials: 'include'
                         })
-                        console.log('[DEBUG] Fetch response:', res.status, res.ok)
                         if (res.ok) {
                             const data = await res.json()
-                            console.log('[DEBUG] Auth response data:', JSON.stringify(data))
                             authRequired.value = !!data.auth_required
                             isAuthenticated.value = !!data.authenticated
                             userRole.value = data.role || ''
                             currentUsername.value = data.username || ''
                             noDownload.value = !!data.no_download
-                            console.log('[DEBUG] authRequired:', authRequired.value, 'isAuthenticated:', isAuthenticated.value)
 
                             // Auto-login via token URL. Prefer #token= so bearer-equivalent
                             // share tokens are not sent to servers/proxies in request logs.
@@ -3100,7 +3118,10 @@
                             credentials: 'include'
                         })
                         if (chatVersion !== myVersion) return
-                        if (!res.ok) return
+                        if (!res.ok) {
+                            showToast('Could not load messages around that message')
+                            return
+                        }
                         const data = await res.json()
                         if (chatVersion !== myVersion) return
                         const windowRows = data.messages || data
@@ -3135,6 +3156,9 @@
                         if (chatVersion !== myVersion) return
                         setupMessagesScrollObserver()
                         scrollToMessage(messageId)
+                    } catch (e) {
+                        console.error('[Jump] Failed to load messages around id', e)
+                        showToast('Could not load messages around that message')
                     } finally {
                         if (chatVersion === myVersion) {
                             loading.value = false
@@ -3584,6 +3608,7 @@
                         page.value++  // Still increment for search pagination
                     } catch (e) {
                         console.error("Failed to load messages", e)
+                        showToast('Failed to load messages')
                     } finally {
                         // Only reset loading if this is still the current chat
                         if (chatVersion === myVersion) {
@@ -4276,7 +4301,7 @@
                         if (!res.ok) {
                             if (res.status === 404) {
                                 closeDatePicker()
-                                alert('No messages found for this date')
+                                showToast('No messages found for this date')
                                 return
                             }
                             throw new Error('Failed to find message')
@@ -4308,7 +4333,7 @@
                     } catch (e) {
                         console.error('Error jumping to date:', e)
                         closeDatePicker()
-                        alert('Failed to jump to date. Please try again.')
+                        showToast('Failed to jump to date. Please try again.')
                     }
                 }
 
@@ -4493,6 +4518,8 @@
                 }
 
                 return {
+                    toastMessage,
+                    showToast,
                     chats,
                     filteredChats,
                     selectedChat,

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -2232,12 +2232,18 @@ class TestGetMessagesPaginated:
         version_count_result = MagicMock()
         version_count_result.__iter__ = MagicMock(return_value=iter([]))
 
-        # Third execute call returns the reply text
+        # Third execute call: batched reply-text lookup returns (id, text) rows.
+        reply_row = MagicMock()
+        reply_row.id = 39
+        reply_row.text = "Original message text"
         reply_result = MagicMock()
-        reply_result.scalar_one_or_none.return_value = "Original message text"
+        reply_result.__iter__ = MagicMock(return_value=iter([reply_row]))
 
-        mock_session.execute.side_effect = [mock_result, version_count_result, reply_result]
-        adapter.get_reactions = AsyncMock(return_value=[])
+        # Fourth execute call: batched reactions lookup, empty for this message.
+        reactions_result = MagicMock()
+        reactions_result.scalars.return_value = []
+
+        mock_session.execute.side_effect = [mock_result, version_count_result, reply_result, reactions_result]
 
         result = await adapter.get_messages_paginated(chat_id=100)
         assert result[0]["reply_to_text"] == "Original message text"[:100]
@@ -2251,15 +2257,24 @@ class TestGetMessagesPaginated:
         row = self._make_message_row(msg_id=50)
         mock_result = MagicMock()
         mock_result.__iter__ = MagicMock(return_value=iter([row]))
-        mock_session.execute.return_value = mock_result
 
-        adapter.get_reactions = AsyncMock(
-            return_value=[
-                {"emoji": "thumbsup", "count": 2, "user_id": 1},
-                {"emoji": "thumbsup", "count": 1, "user_id": 2},
-                {"emoji": "heart", "count": 1, "user_id": 3},
-            ]
-        )
+        def _mock_reaction(emoji, count, user_id):
+            r = MagicMock()
+            r.message_id = 50
+            r.emoji = emoji
+            r.count = count
+            r.user_id = user_id
+            return r
+
+        # The batched reactions query reuses the same execute() mock, so both
+        # the row iteration (main query) and .scalars() (reactions query) are
+        # configured on this one result object.
+        mock_result.scalars.return_value = [
+            _mock_reaction("heart", 1, 3),
+            _mock_reaction("thumbsup", 2, 1),
+            _mock_reaction("thumbsup", 1, 2),
+        ]
+        mock_session.execute.return_value = mock_result
 
         result = await adapter.get_messages_paginated(chat_id=100)
         reactions = result[0]["reactions"]

--- a/tests/test_entrypoint_schema_detection.py
+++ b/tests/test_entrypoint_schema_detection.py
@@ -1,16 +1,223 @@
-"""Regression tests for container entrypoint schema stamping guards."""
+"""Tests for the SQLite pre-Alembic stamping logic embedded in scripts/entrypoint.sh.
 
+The stamping logic runs inside a bash-double-quoted `python -c "..."` heredoc, so
+embedded double quotes are escaped as `\\"`. These tests extract the real block
+straight out of the shipped script, de-escape it, and exec() it against real
+sqlite3 databases seeded to look like historical schema shapes -- so a wrong
+boolean in the has_0XX ladder fails the test, not just a missing substring.
+
+The extraction deliberately stops at the `conn.close()` that follows the
+stamping block, excluding the trailing `Config(...)/command.upgrade(...)` tail.
+That tail invokes real Alembic against a hardcoded `/app/alembic.ini` Docker
+path that doesn't exist in this environment and is orthogonal to the
+detection/stamping logic under test here.
+"""
+
+import sqlite3
 from pathlib import Path
 
-ENTRYPOINT = Path(__file__).resolve().parents[1] / "scripts" / "entrypoint.sh"
+ENTRYPOINT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "entrypoint.sh"
 
 
-def test_entrypoint_detects_message_versions_for_revision_015():
-    """Pre-Alembic stamp detection should use the revision-015 table name."""
-    script = ENTRYPOINT.read_text(encoding="utf-8")
+def _extract_sqlite_stamping_block(script: str) -> str:
+    """Slice the pure schema-detection/stamping logic out of the SQLite python heredoc."""
+    start_marker = "database_url = os.getenv('DATABASE_URL', '')"
+    end_marker = "conn.close()"
+    start = script.index(start_marker)
+    end = script.index(end_marker, start) + len(end_marker)
+    block = script[start:end]
+    return block.replace('\\"', '"')
+
+
+_ENTRYPOINT_SOURCE = ENTRYPOINT_PATH.read_text(encoding="utf-8")
+SQLITE_STAMPING_SOURCE = _extract_sqlite_stamping_block(_ENTRYPOINT_SOURCE)
+
+
+def _run_stamping(db_path: Path) -> dict:
+    """Execute the real extracted stamping logic against a seeded sqlite file.
+
+    Sets DB_PATH the same way the shipped script's os.getenv() fallback chain
+    reads it, runs the extracted source, and returns the exec() globals so
+    tests can inspect `stamp_version` (only set if the stamping branch ran).
+    """
+    import os
+
+    exec_globals = {"os": os, "sqlite3": sqlite3}
+    saved_database_url = os.environ.get("DATABASE_URL")
+    saved_db_path = os.environ.get("DB_PATH")
+    os.environ.pop("DATABASE_URL", None)
+    os.environ["DB_PATH"] = str(db_path)
+    try:
+        exec(compile(SQLITE_STAMPING_SOURCE, str(ENTRYPOINT_PATH), "exec"), exec_globals)
+    finally:
+        if saved_database_url is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = saved_database_url
+        if saved_db_path is None:
+            os.environ.pop("DB_PATH", None)
+        else:
+            os.environ["DB_PATH"] = saved_db_path
+    return exec_globals
+
+
+def _seed_pre_alembic_db(
+    db_path: Path,
+    *,
+    omit_017_index: bool = False,
+    omit_016_download_attempts: bool = False,
+    omit_015_message_versions: bool = False,
+    omit_014_soft_delete: bool = False,
+    include_push_subscriptions: bool = False,
+) -> None:
+    """Seed a SQLite file with the specific artifacts entrypoint.sh's has_0XX checks inspect.
+
+    This mirrors what Base.metadata.create_all() leaves behind at various points
+    along the migration ladder -- not the full ORM schema, just the tables,
+    columns, and indexes the stamping logic actually queries for.
+    """
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE chats (id INTEGER PRIMARY KEY)")
+
+    messages_cols = ["id INTEGER PRIMARY KEY", "chat_id INTEGER"]
+    if not omit_014_soft_delete:
+        messages_cols += ["is_deleted BOOLEAN", "deleted_at TEXT"]
+    conn.execute(f"CREATE TABLE messages ({', '.join(messages_cols)})")
+
+    if not omit_017_index:
+        conn.execute("CREATE INDEX idx_messages_chat_id_id ON messages (chat_id, id)")
+
+    if not omit_015_message_versions:
+        conn.execute("CREATE TABLE message_versions (id INTEGER PRIMARY KEY)")
+
+    # file_path must exist whenever the media table exists: the has_013_paths
+    # check unconditionally queries it once has_media_table is True.
+    media_cols = ["id INTEGER PRIMARY KEY", "chat_id INTEGER", "file_path TEXT"]
+    if not omit_016_download_attempts:
+        media_cols.append("download_attempts INTEGER")
+    conn.execute(f"CREATE TABLE media ({', '.join(media_cols)})")
+
+    if include_push_subscriptions:
+        conn.execute("CREATE TABLE push_subscriptions (id INTEGER PRIMARY KEY)")
+
+    conn.commit()
+    conn.close()
+
+
+def _stamped_version(db_path: Path) -> str:
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute("SELECT version_num FROM alembic_version").fetchone()
+    conn.close()
+    return row[0] if row else None
+
+
+def test_fully_modern_schema_stamps_017(tmp_path):
+    """create_all() shape: soft-delete cols + message_versions + download_attempts + 017 index."""
+    db_path = tmp_path / "modern.db"
+    _seed_pre_alembic_db(db_path)
+
+    result = _run_stamping(db_path)
+
+    assert result["stamp_version"] == "017"
+    assert _stamped_version(db_path) == "017"
+
+
+def test_missing_017_index_stamps_016(tmp_path):
+    """Same as fully-modern minus the idx_messages_chat_id_id index."""
+    db_path = tmp_path / "no_017_index.db"
+    _seed_pre_alembic_db(db_path, omit_017_index=True)
+
+    result = _run_stamping(db_path)
+
+    assert result["stamp_version"] == "016"
+    assert _stamped_version(db_path) == "016"
+
+
+def test_missing_download_attempts_stamps_015(tmp_path):
+    """Same as fully-modern minus media.download_attempts."""
+    db_path = tmp_path / "no_016_download_attempts.db"
+    _seed_pre_alembic_db(db_path, omit_016_download_attempts=True)
+
+    result = _run_stamping(db_path)
+
+    assert result["stamp_version"] == "015"
+    assert _stamped_version(db_path) == "015"
+
+
+def test_missing_message_versions_stamps_014(tmp_path):
+    """Same as fully-modern minus the message_versions table."""
+    db_path = tmp_path / "no_015_message_versions.db"
+    _seed_pre_alembic_db(db_path, omit_015_message_versions=True)
+
+    result = _run_stamping(db_path)
+
+    assert result["stamp_version"] == "014"
+    assert _stamped_version(db_path) == "014"
+
+
+def test_pre_010_shape_stamps_003(tmp_path):
+    """Old database: push_subscriptions table exists but messages.is_pinned does not.
+
+    None of the 014-017 artifacts are present, so the ladder falls all the way
+    down to has_push_subs (migration 003), the last has_0XX rung above the
+    unconditional '002' fallback.
+    """
+    db_path = tmp_path / "pre_010.db"
+    _seed_pre_alembic_db(
+        db_path,
+        omit_017_index=True,
+        omit_016_download_attempts=True,
+        omit_015_message_versions=True,
+        omit_014_soft_delete=True,
+        include_push_subscriptions=True,
+    )
+
+    result = _run_stamping(db_path)
+
+    assert result["stamp_version"] == "003"
+    assert _stamped_version(db_path) == "003"
+
+
+def test_existing_alembic_version_skips_stamping(tmp_path):
+    """When alembic_version already exists, the stamping branch never runs at all."""
+    db_path = tmp_path / "already_stamped.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE chats (id INTEGER PRIMARY KEY)")
+    conn.execute(
+        "CREATE TABLE alembic_version ("
+        "version_num VARCHAR(32) NOT NULL, "
+        "CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num))"
+    )
+    conn.execute("INSERT INTO alembic_version (version_num) VALUES ('005')")
+    conn.commit()
+    conn.close()
+
+    result = _run_stamping(db_path)
+
+    assert "stamp_version" not in result
+    assert _stamped_version(db_path) == "005"
+
+
+# ============================================================================
+# PostgreSQL ladder: substring-only checks
+# ============================================================================
+#
+# The PostgreSQL stamping branch can't be executed here -- it needs a live
+# PostgreSQL server plus psycopg2 connectivity, unlike the SQLite branch above
+# which now runs for real against seeded files. These keep light textual
+# coverage so the two branches don't silently drift apart.
+
+
+def test_postgres_branch_checks_message_versions_table():
+    assert "has_015_message_versions" in _ENTRYPOINT_SOURCE
+    assert "if has_015_message_versions and has_014_soft_delete:" in _ENTRYPOINT_SOURCE
+
+
+def test_postgres_branch_checks_017_index_via_pg_indexes():
+    assert "idx_messages_chat_id_id" in _ENTRYPOINT_SOURCE
+    assert "FROM pg_indexes" in _ENTRYPOINT_SOURCE
+
+
+def test_postgres_branch_does_not_use_old_table_name():
     old_table_name = "message_" + "edit_history"
-
-    assert old_table_name not in script
-    assert "message_versions" in script
-    assert "has_015_message_versions" in script
-    assert "if has_015_message_versions and has_014_soft_delete:" in script
+    assert old_table_name not in _ENTRYPOINT_SOURCE

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -473,6 +473,54 @@ def test_gallery_close_restores_reading_position_and_focus():
     )
 
 
+def test_toast_exists_and_is_wired_into_jump_failure_path():
+    """A minimal toast must surface the jump-window failure instead of failing silently."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert "const toastMessage = ref(null)" in html
+    assert "const showToast = (message, ms = 4000) =>" in html
+    assert 'v-if="toastMessage"' in html
+    assert "toastMessage," in html
+    assert "showToast," in html
+
+    jump_start = html.index("const loadMessagesAroundId = async (messageId) =>")
+    jump_body = html[jump_start : html.index("watch(showMediaGallery", jump_start)]
+    assert "showToast('Could not load messages around that message')" in jump_body
+    # Both the primary-fetch !res.ok branch and a thrown network error must toast.
+    assert jump_body.count("showToast('Could not load messages around that message')") == 2
+
+    chats_start = html.index("const loadChats = async (append = false) =>")
+    chats_body = html[chats_start : html.index("const loadMessages = async () =>", chats_start)]
+    assert "showToast('Failed to load chats')" in chats_body
+
+    load_start = html.index("const loadMessages = async () =>")
+    load_body = html[load_start : html.index("const searchMessages = async () =>", load_start)]
+    assert "showToast('Failed to load messages')" in load_body
+
+    refresh_start = html.index("const checkForNewMessages = async () =>")
+    refresh_body = html[refresh_start : html.index("const loadMessages = async () =>", refresh_start)]
+    assert "showToast(" not in refresh_body
+
+    date_start = html.index("const jumpToDate = async () =>")
+    date_body = html[date_start : html.index("// Admin panel", date_start)]
+    assert "showToast('No messages found for this date')" in date_body
+    assert "showToast('Failed to jump to date. Please try again.')" in date_body
+    assert "alert(" not in date_body
+
+
+def test_shipped_debug_logs_are_absent():
+    """Debug instrumentation left over from troubleshooting must not ship."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert "'>>> Loading more messages" not in html
+    assert "console.log('Stats loaded:'" not in html
+    assert "console.log('[DEBUG] onMounted started')" not in html
+    assert "console.log('[DEBUG] Fetching /api/auth/check...')" not in html
+    assert "console.log('[DEBUG] Fetch response:'" not in html
+    assert "console.log('[DEBUG] Auth response data:'" not in html
+    assert "console.log('[DEBUG] authRequired:'" not in html
+
+
 def test_unseen_message_badge_tracks_background_arrivals():
     """Messages arriving while scrolled up must surface a count on the jump button."""
     html = INDEX_HTML.read_text(encoding="utf-8")

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -550,7 +550,7 @@ class TestGetMediaFilename:
             "voice": ".ogg",
             "audio": ".mp3",
             "sticker": ".webp",
-            "document": "",
+            "document": ".bin",
         }
         for media_type, ext in expected.items():
             result = listener._get_media_filename(msg, media_type, telegram_file_id="id1")

--- a/tests/test_media_filename.py
+++ b/tests/test_media_filename.py
@@ -1,6 +1,9 @@
-"""Regression tests for build_media_filename (#212 — Synology eCryptfs filename limits)."""
+"""Regression tests for build_media_filename (#212 — Synology eCryptfs filename limits)
+and fallback_media_filename (backup/listener ingest-path parity)."""
 
-from src.message_utils import _MEDIA_PART_SUFFIX_RESERVE, build_media_filename
+from unittest.mock import MagicMock, patch
+
+from src.message_utils import _MEDIA_PART_SUFFIX_RESERVE, build_media_filename, fallback_media_filename
 
 SYNOLOGY_BUDGET = 143
 
@@ -97,3 +100,97 @@ def test_reserved_suffix_is_accounted_for():
     # Must have actually been truncated (reserve eats into the raw-fits budget).
     assert len(encoded_result) + _MEDIA_PART_SUFFIX_RESERVE <= SYNOLOGY_BUDGET
     assert len(result) < len(f"1_{name}")
+
+
+# ===========================================================================
+# fallback_media_filename — shared no-original-name path (backup/listener parity)
+# ===========================================================================
+
+
+def test_fallback_with_file_id_and_mime_type():
+    """A recognized mime_type wins over the media_type default."""
+    assert fallback_media_filename("99", "photo", "image/png", message_id=1) == "99.png"
+
+
+def test_fallback_jpe_corrected_to_jpg():
+    """The image/jpeg -> .jpe mimetypes quirk is corrected to .jpg."""
+    with patch("mimetypes.guess_extension", return_value=".jpe"):
+        result = fallback_media_filename("50", "photo", "image/jpeg", message_id=1)
+    assert result == "50.jpg"
+
+
+def test_fallback_unknown_mime_type_uses_media_type_default():
+    """An unrecognized mime_type falls back to the per-media_type default extension."""
+    assert fallback_media_filename("77", "video", "application/x-not-a-real-type", message_id=1) == "77.mp4"
+
+
+def test_fallback_no_mime_type_uses_media_type_default():
+    assert fallback_media_filename("42", "voice", None, message_id=1) == "42.ogg"
+
+
+def test_fallback_file_id_slashes_sanitized():
+    assert fallback_media_filename("a/b\\c", "document", None, message_id=1) == "a_b_c.bin"
+
+
+def test_fallback_without_file_id_uses_message_id():
+    """No telegram_file_id falls back to a deterministic <message_id>_<media_type> name."""
+    assert fallback_media_filename(None, "video", None, message_id=42) == "42_video.mp4"
+
+
+def test_fallback_extension_table_matches_for_all_media_types():
+    """Every known media_type maps to its expected extension, with and without a file_id."""
+    expected = {
+        "photo": "jpg",
+        "video": "mp4",
+        "animation": "mp4",
+        "voice": "ogg",
+        "audio": "mp3",
+        "sticker": "webp",
+        "document": "bin",
+    }
+    for media_type, ext in expected.items():
+        assert fallback_media_filename("id1", media_type, None, message_id=1) == f"id1.{ext}"
+        assert fallback_media_filename(None, media_type, None, message_id=7) == f"7_{media_type}.{ext}"
+
+
+def test_fallback_unknown_media_type_defaults_to_bin():
+    assert fallback_media_filename("id1", "some_new_type", None, message_id=1) == "id1.bin"
+
+
+# ===========================================================================
+# Cross-module parity: TelegramBackup and TelegramListener must produce the
+# SAME filename for the SAME inputs when there is no usable original name.
+# ===========================================================================
+
+
+def _make_media_message(*, msg_id, mime_type=None):
+    """A mock message with document media but no file_name attribute (no original name)."""
+    msg = MagicMock()
+    msg.id = msg_id
+    doc = MagicMock()
+    doc.mime_type = mime_type
+    attr = MagicMock(spec=[])  # no file_name attribute
+    doc.attributes = [attr]
+    msg.media.document = doc
+    return msg
+
+
+def test_backup_and_listener_fallback_filenames_match():
+    """The two ingest paths must converge on identical names (#issue)."""
+    from src.listener import TelegramListener
+    from src.telegram_backup import TelegramBackup
+
+    backup = TelegramBackup.__new__(TelegramBackup)
+    listener = TelegramListener.__new__(TelegramListener)
+
+    cases = [
+        ("photo", "image/png", "12345"),
+        ("video", None, "999"),
+        ("document", None, None),
+        ("sticker", "image/webp", "1"),
+    ]
+    for media_type, mime_type, telegram_file_id in cases:
+        msg = _make_media_message(msg_id=123, mime_type=mime_type)
+        backup_result = backup._get_media_filename(msg, media_type, telegram_file_id)
+        listener_result = listener._get_media_filename(msg, media_type, telegram_file_id)
+        assert backup_result == listener_result, f"Mismatch for {media_type}/{mime_type}/{telegram_file_id}"

--- a/tests/test_messages_page_batching.py
+++ b/tests/test_messages_page_batching.py
@@ -1,0 +1,200 @@
+"""Real-SQLite regression tests for the get_messages_paginated batching fix.
+
+Before this fix, get_messages_paginated's per-message loop awaited
+get_reactions() once per row and issued a reply-text fallback SELECT per reply
+row -- up to ~100 sequential round-trips per 50-row page. These tests pin the
+response shape (so the batched queries produce byte-identical output to the
+old per-row calls) and pin the query count (so the N+1 pattern can't regress
+silently), plus cover the new get_pending_media_downloads(limit=...) bound.
+"""
+
+import logging
+import os
+import sys
+from datetime import datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Base, Media, Message, Reaction
+
+CHAT_ID = -500
+LONG_REPLY_TEXT = "L" * 150
+
+
+@pytest_asyncio.fixture
+async def adapter():
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db_manager = DatabaseManager.__new__(DatabaseManager)
+    db_manager.engine = engine
+    db_manager.database_url = "sqlite+aiosqlite://"
+    db_manager._is_sqlite = True
+    db_manager.async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    yield DatabaseAdapter(db_manager)
+    await engine.dispose()
+
+
+async def _seed_page(adapter):
+    """60 messages (ids 1-60); a 50-row newest-first page covers ids 11-60.
+
+    - Message 6 carries a >100 char body so the reply-truncation rule is exercised.
+    - Message 12 replies to message 3 (short text) with reply_to_text unset.
+    - Message 44 replies to message 6 (long text) with reply_to_text unset.
+    - Messages 20 and 35 carry reactions across multiple emoji/users.
+    """
+    async with adapter.db_manager.async_session_factory() as session:
+        base = datetime(2026, 1, 1, 12, 0, 0)
+        for i in range(1, 61):
+            text = LONG_REPLY_TEXT if i == 6 else f"message {i}"
+            reply_to_msg_id = {12: 3, 44: 6}.get(i)
+            session.add(
+                Message(
+                    id=i,
+                    chat_id=CHAT_ID,
+                    date=base + timedelta(minutes=i),
+                    text=text,
+                    reply_to_msg_id=reply_to_msg_id,
+                    reply_to_text=None,
+                )
+            )
+        await session.commit()
+
+        session.add_all(
+            [
+                Reaction(message_id=20, chat_id=CHAT_ID, emoji="thumbsup", user_id=1001, count=1),
+                Reaction(message_id=20, chat_id=CHAT_ID, emoji="thumbsup", user_id=1002, count=1),
+                Reaction(message_id=20, chat_id=CHAT_ID, emoji="heart", user_id=1003, count=1),
+                Reaction(message_id=35, chat_id=CHAT_ID, emoji="fire", user_id=1004, count=2),
+            ]
+        )
+        await session.commit()
+
+
+class TestMessagesPageBatchingShape:
+    @pytest.mark.asyncio
+    async def test_batched_page_matches_expected_reactions_and_replies(self, adapter):
+        await _seed_page(adapter)
+
+        rows = await adapter.get_messages_paginated(chat_id=CHAT_ID, limit=50)
+        by_id = {r["id"]: r for r in rows}
+
+        assert len(rows) == 50
+        assert set(by_id) == set(range(11, 61))
+
+        # Reactions: grouped by emoji, counts summed, user_ids collected.
+        msg20 = by_id[20]
+        reactions_by_emoji = {r["emoji"]: r for r in msg20["reactions"]}
+        assert reactions_by_emoji["thumbsup"]["count"] == 2
+        assert set(reactions_by_emoji["thumbsup"]["user_ids"]) == {1001, 1002}
+        assert reactions_by_emoji["heart"]["count"] == 1
+        assert reactions_by_emoji["heart"]["user_ids"] == [1003]
+
+        msg35 = by_id[35]
+        reactions_by_emoji_35 = {r["emoji"]: r for r in msg35["reactions"]}
+        assert reactions_by_emoji_35["fire"]["count"] == 2
+        assert reactions_by_emoji_35["fire"]["user_ids"] == [1004]
+
+        # Messages with no reactions still get an empty (not missing) list.
+        assert by_id[11]["reactions"] == []
+
+        # Reply-text backfill: short text copied verbatim, long text truncated to 100.
+        assert by_id[12]["reply_to_text"] == "message 3"
+        assert by_id[44]["reply_to_text"] == LONG_REPLY_TEXT[:100]
+        assert len(by_id[44]["reply_to_text"]) == 100
+
+        # version_count is still populated (untouched by this fix, but part of
+        # the same per-message assembly loop -- guards against a regression there).
+        assert by_id[20]["version_count"] == 0
+
+    @pytest.mark.asyncio
+    async def test_page_fetch_issues_constant_number_of_queries(self, adapter):
+        await _seed_page(adapter)
+
+        statements = []
+
+        def _capture(conn, cursor, statement, parameters, context, executemany):
+            statements.append(statement)
+
+        sync_engine = adapter.db_manager.engine.sync_engine
+        event.listen(sync_engine, "before_cursor_execute", _capture)
+        try:
+            rows = await adapter.get_messages_paginated(chat_id=CHAT_ID, limit=50)
+        finally:
+            event.remove(sync_engine, "before_cursor_execute", _capture)
+
+        assert len(rows) == 50
+        select_count = sum(1 for s in statements if s.strip().upper().startswith("SELECT"))
+        # Main page query + version-count query + batched reply-text query +
+        # batched reactions query == 4. Anything approaching 50+ would mean the
+        # N+1 per-row pattern (get_reactions/reply SELECT per row) came back.
+        assert select_count <= 6, f"expected a small constant query count, got {select_count}: {statements}"
+
+
+class TestPendingMediaDownloadsLimit:
+    async def _add_media(self, adapter, media_id, attempts):
+        async with adapter.db_manager.async_session_factory() as session:
+            session.add(
+                Media(
+                    id=media_id,
+                    message_id=1,
+                    chat_id=CHAT_ID,
+                    type="document",
+                    downloaded=0,
+                    download_attempts=attempts,
+                )
+            )
+            await session.commit()
+
+    @pytest.mark.asyncio
+    async def test_honors_limit_and_deterministic_ordering(self, adapter):
+        # Inserted out of (attempts, id) order to prove the ORDER BY drives results.
+        await self._add_media(adapter, "c", attempts=2)
+        await self._add_media(adapter, "a", attempts=0)
+        await self._add_media(adapter, "b", attempts=0)
+        await self._add_media(adapter, "d", attempts=1)
+
+        limited = await adapter.get_pending_media_downloads(limit=2)
+        assert [m["id"] for m in limited] == ["a", "b"]
+
+        unlimited = await adapter.get_pending_media_downloads(limit=None)
+        assert [m["id"] for m in unlimited] == ["a", "b", "d", "c"]
+
+    @pytest.mark.asyncio
+    async def test_default_limit_is_bounded(self, adapter):
+        for i in range(5):
+            await self._add_media(adapter, f"m{i}", attempts=0)
+
+        # Default limit=1000 is well above 5 rows, so nothing gets truncated.
+        pending = await adapter.get_pending_media_downloads()
+        assert len(pending) == 5
+
+    @pytest.mark.asyncio
+    async def test_logs_only_when_truncation_actually_happens(self, adapter, caplog):
+        for i in range(5):
+            await self._add_media(adapter, f"m{i}", attempts=0)
+
+        with caplog.at_level(logging.INFO, logger="src.db.adapter"):
+            limited = await adapter.get_pending_media_downloads(limit=3)
+        assert len(limited) == 3
+        assert any("media retry: processing 3 of 5 pending" in r.getMessage() for r in caplog.records)
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="src.db.adapter"):
+            not_truncated = await adapter.get_pending_media_downloads(limit=5)
+        assert len(not_truncated) == 5
+        assert not any("media retry" in r.getMessage() for r in caplog.records)

--- a/tests/test_migrations_002_006_idempotency.py
+++ b/tests/test_migrations_002_006_idempotency.py
@@ -1,0 +1,551 @@
+"""Tests for Alembic migrations 002-006 idempotency guards.
+
+These migrations predate the inspector-guard convention introduced later in the
+chain (007+). A database provisioned via ``Base.metadata.create_all()`` and then
+stamped at a revision below the migration in question already has every object
+the migration would otherwise (unconditionally) try to create - so each of these
+migrations must detect existing tables/columns/indexes/FKs and no-op instead of
+crash-looping. See CLAUDE.md's "Alembic Migrations - Critical Reminders" section.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+_VERSIONS_DIR = Path(__file__).resolve().parent.parent / "alembic" / "versions"
+
+
+def _load_migration(filename: str, module_name: str):
+    spec = importlib.util.spec_from_file_location(module_name, _VERSIONS_DIR / filename)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(conn, func):
+    ctx = MigrationContext.configure(conn)
+    with Operations.context(ctx):
+        func()
+
+
+def _columns(conn, table):
+    return {c["name"] for c in sa.inspect(conn).get_columns(table)}
+
+
+def _indexes(conn, table):
+    return {ix["name"] for ix in sa.inspect(conn).get_indexes(table)}
+
+
+def _fk_referred_tables(conn, table):
+    return {fk.get("referred_table") for fk in sa.inspect(conn).get_foreign_keys(table)}
+
+
+# ============================================================================
+# Migration 002 - idx_messages_chat_date_desc
+# ============================================================================
+
+migration_002 = _load_migration("20260116_002_add_chat_date_index.py", "migration_002")
+
+
+def _create_messages_table_002(conn):
+    conn.execute(sa.text("CREATE TABLE messages (id BIGINT NOT NULL, chat_id BIGINT NOT NULL, date DATETIME NOT NULL)"))
+
+
+def test_002_revision_chain():
+    assert migration_002.revision == "002"
+    assert migration_002.down_revision == "001"
+
+
+def test_002_upgrade_creates_index_and_is_idempotent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_messages_table_002(conn)
+
+        _run(conn, migration_002.upgrade)
+        assert "idx_messages_chat_date_desc" in _indexes(conn, "messages")
+
+        _run(conn, migration_002.upgrade)  # re-run must be a no-op
+        assert "idx_messages_chat_date_desc" in _indexes(conn, "messages")
+
+
+def test_002_upgrade_noop_when_index_already_exists():
+    """Simulates create_all(): the Message model's Index() already made this."""
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_messages_table_002(conn)
+        conn.execute(sa.text("CREATE INDEX idx_messages_chat_date_desc ON messages (chat_id, date DESC)"))
+
+        _run(conn, migration_002.upgrade)  # must not raise
+        assert "idx_messages_chat_date_desc" in _indexes(conn, "messages")
+
+
+def test_002_downgrade_drops_index_and_is_idempotent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_messages_table_002(conn)
+        _run(conn, migration_002.upgrade)
+
+        _run(conn, migration_002.downgrade)
+        assert "idx_messages_chat_date_desc" not in _indexes(conn, "messages")
+
+        _run(conn, migration_002.downgrade)  # idempotent
+        assert "idx_messages_chat_date_desc" not in _indexes(conn, "messages")
+
+
+def test_002_upgrade_noop_when_messages_table_absent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _run(conn, migration_002.upgrade)  # no messages table -> no-op, no raise
+        assert "messages" not in sa.inspect(conn).get_table_names()
+
+
+# ============================================================================
+# Migration 003 - push_subscriptions table + idx_push_sub_chat
+# ============================================================================
+
+migration_003 = _load_migration("20260117_003_add_push_subscriptions.py", "migration_003")
+
+
+def test_003_revision_chain():
+    assert migration_003.revision == "003"
+    assert migration_003.down_revision == "002"
+
+
+def test_003_upgrade_creates_table_and_is_idempotent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _run(conn, migration_003.upgrade)
+        assert "push_subscriptions" in sa.inspect(conn).get_table_names()
+        assert "idx_push_sub_chat" in _indexes(conn, "push_subscriptions")
+
+        _run(conn, migration_003.upgrade)  # re-run must be a no-op
+        assert "push_subscriptions" in sa.inspect(conn).get_table_names()
+
+
+def test_003_upgrade_noop_when_table_already_exists():
+    """Simulates create_all(): the PushSubscription model already made this."""
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE push_subscriptions ("
+                "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                "endpoint TEXT NOT NULL UNIQUE, "
+                "p256dh VARCHAR(255) NOT NULL, "
+                "auth VARCHAR(255) NOT NULL, "
+                "chat_id BIGINT, "
+                "user_agent VARCHAR(500), "
+                "created_at DATETIME DEFAULT CURRENT_TIMESTAMP, "
+                "last_used_at DATETIME"
+                ")"
+            )
+        )
+        conn.execute(sa.text("CREATE INDEX idx_push_sub_chat ON push_subscriptions (chat_id)"))
+
+        _run(conn, migration_003.upgrade)  # must not raise
+        assert "idx_push_sub_chat" in _indexes(conn, "push_subscriptions")
+
+
+def test_003_downgrade_drops_table_and_is_idempotent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _run(conn, migration_003.upgrade)
+
+        _run(conn, migration_003.downgrade)
+        assert "push_subscriptions" not in sa.inspect(conn).get_table_names()
+
+        _run(conn, migration_003.downgrade)  # idempotent
+        assert "push_subscriptions" not in sa.inspect(conn).get_table_names()
+
+
+# ============================================================================
+# Migration 004 - messages.is_pinned column + idx_messages_chat_pinned
+# ============================================================================
+
+migration_004 = _load_migration("20260125_004_add_is_pinned_column.py", "migration_004")
+
+
+def _create_messages_table_004(conn):
+    conn.execute(sa.text("CREATE TABLE messages (id BIGINT NOT NULL, chat_id BIGINT NOT NULL, date DATETIME NOT NULL)"))
+
+
+def test_004_revision_chain():
+    assert migration_004.revision == "004"
+    assert migration_004.down_revision == "003"
+
+
+def test_004_upgrade_adds_column_and_is_idempotent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_messages_table_004(conn)
+
+        _run(conn, migration_004.upgrade)
+        assert "is_pinned" in _columns(conn, "messages")
+        assert "idx_messages_chat_pinned" in _indexes(conn, "messages")
+
+        _run(conn, migration_004.upgrade)  # re-run must be a no-op
+        assert "is_pinned" in _columns(conn, "messages")
+
+
+def test_004_upgrade_noop_when_column_and_index_already_exist():
+    """Simulates create_all(): the Message model already declares is_pinned + index."""
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE messages (id BIGINT NOT NULL, chat_id BIGINT NOT NULL, "
+                "date DATETIME NOT NULL, is_pinned INTEGER NOT NULL DEFAULT 0)"
+            )
+        )
+        conn.execute(sa.text("CREATE INDEX idx_messages_chat_pinned ON messages (chat_id, is_pinned)"))
+
+        _run(conn, migration_004.upgrade)  # must not raise
+        assert "is_pinned" in _columns(conn, "messages")
+        assert "idx_messages_chat_pinned" in _indexes(conn, "messages")
+
+
+def test_004_downgrade_drops_column_and_is_idempotent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_messages_table_004(conn)
+        _run(conn, migration_004.upgrade)
+
+        _run(conn, migration_004.downgrade)
+        assert "is_pinned" not in _columns(conn, "messages")
+
+        _run(conn, migration_004.downgrade)  # idempotent
+        assert "is_pinned" not in _columns(conn, "messages")
+
+
+def test_004_upgrade_noop_when_messages_table_absent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _run(conn, migration_004.upgrade)  # no messages table -> no-op, no raise
+        assert "messages" not in sa.inspect(conn).get_table_names()
+
+
+# ============================================================================
+# Migration 005 - v6 schema normalization (the big one)
+# ============================================================================
+
+migration_005 = _load_migration("20260128_005_v6_schema_normalization.py", "migration_005")
+
+
+def _create_legacy_pre005_schema(conn):
+    """Schema shape as of migrations 001-004 applied (pre-normalization)."""
+    conn.execute(sa.text("CREATE TABLE chats (id BIGINT NOT NULL PRIMARY KEY, username VARCHAR(255))"))
+    conn.execute(sa.text("CREATE TABLE users (id BIGINT NOT NULL PRIMARY KEY, username VARCHAR(255))"))
+    conn.execute(
+        sa.text("""
+        CREATE TABLE messages (
+            id BIGINT NOT NULL,
+            chat_id BIGINT NOT NULL,
+            sender_id BIGINT,
+            date DATETIME NOT NULL,
+            text TEXT,
+            reply_to_msg_id BIGINT,
+            reply_to_text TEXT,
+            forward_from_id BIGINT,
+            edit_date DATETIME,
+            media_type VARCHAR(50),
+            media_id VARCHAR(255),
+            media_path VARCHAR(500),
+            raw_data TEXT,
+            created_at DATETIME,
+            is_outgoing INTEGER DEFAULT 0,
+            is_pinned INTEGER DEFAULT 0 NOT NULL,
+            PRIMARY KEY (id, chat_id),
+            FOREIGN KEY(chat_id) REFERENCES chats (id)
+        )
+    """)
+    )
+    conn.execute(
+        sa.text("""
+        CREATE TABLE media (
+            id VARCHAR(255) NOT NULL PRIMARY KEY,
+            message_id BIGINT,
+            chat_id BIGINT,
+            type VARCHAR(50),
+            file_path VARCHAR(500),
+            file_name VARCHAR(255),
+            file_size BIGINT,
+            mime_type VARCHAR(100),
+            width INTEGER,
+            height INTEGER,
+            duration INTEGER,
+            downloaded INTEGER DEFAULT 0,
+            download_date DATETIME,
+            created_at DATETIME
+        )
+    """)
+    )
+    conn.execute(
+        sa.text("""
+        CREATE TABLE reactions (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            message_id BIGINT NOT NULL,
+            chat_id BIGINT NOT NULL,
+            emoji VARCHAR(50) NOT NULL,
+            user_id BIGINT,
+            count INTEGER DEFAULT 1,
+            created_at DATETIME
+        )
+    """)
+    )
+
+
+def test_005_revision_chain():
+    assert migration_005.revision == "005"
+    assert migration_005.down_revision == "004"
+
+
+def test_005_upgrade_migrates_legacy_data_and_is_idempotent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_legacy_pre005_schema(conn)
+
+        conn.execute(sa.text("INSERT INTO chats (id, username) VALUES (1, 'c')"))
+        conn.execute(sa.text("INSERT INTO users (id, username) VALUES (10, 'u')"))
+        # Message with media_id but no corresponding media row yet (Step 1 must create it).
+        conn.execute(
+            sa.text(
+                "INSERT INTO messages (id, chat_id, date, media_type, media_id, media_path) "
+                "VALUES (100, 1, '2026-01-01 00:00:00', 'photo', 'file_abc', '/data/file_abc.jpg')"
+            )
+        )
+        # Orphan media row (no matching message) - Step 4 must delete it.
+        conn.execute(
+            sa.text("INSERT INTO media (id, message_id, chat_id, type) VALUES ('orphan_media', 999, 1, 'photo')")
+        )
+        # Orphan reaction (user doesn't exist) - Step 4 must null out user_id.
+        conn.execute(
+            sa.text("INSERT INTO reactions (message_id, chat_id, emoji, user_id) VALUES (100, 1, '\U0001f44d', 12345)")
+        )
+
+        _run(conn, migration_005.upgrade)
+
+        # Step 1/3: media columns removed from messages, data migrated to media table.
+        assert "media_type" not in _columns(conn, "messages")
+        migrated = conn.execute(sa.text("SELECT chat_id, type FROM media WHERE id = 'file_abc'")).fetchone()
+        assert migrated == (1, "photo")
+
+        # Step 4: orphan media deleted, orphan reaction's user_id nulled.
+        assert conn.execute(sa.text("SELECT 1 FROM media WHERE id = 'orphan_media'")).fetchone() is None
+        reaction_user = conn.execute(sa.text("SELECT user_id FROM reactions WHERE message_id = 100")).scalar()
+        assert reaction_user is None
+
+        # Step 5: FK from media to messages now exists.
+        assert "messages" in _fk_referred_tables(conn, "media")
+
+        # Step 7: new indexes present.
+        assert "idx_messages_reply_to" in _indexes(conn, "messages")
+        assert "idx_media_downloaded" in _indexes(conn, "media")
+        assert "idx_media_type" in _indexes(conn, "media")
+        assert "idx_reactions_user" in _indexes(conn, "reactions")
+        assert "idx_chats_username" in _indexes(conn, "chats")
+        assert "idx_users_username" in _indexes(conn, "users")
+
+        # Re-run must be a no-op (already normalized by the first run).
+        _run(conn, migration_005.upgrade)
+        assert "media_type" not in _columns(conn, "messages")
+        assert "messages" in _fk_referred_tables(conn, "media")
+
+
+def test_005_upgrade_noop_against_already_normalized_schema():
+    """Simulates create_all(): DB stamped below 005 but built from current models.py,
+    so messages never had media_type/media_id/media_path and media already has its FK.
+    """
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        conn.execute(sa.text("CREATE TABLE chats (id BIGINT NOT NULL PRIMARY KEY, username VARCHAR(255))"))
+        conn.execute(sa.text("CREATE INDEX idx_chats_username ON chats (username)"))
+        conn.execute(sa.text("CREATE TABLE users (id BIGINT NOT NULL PRIMARY KEY, username VARCHAR(255))"))
+        conn.execute(sa.text("CREATE INDEX idx_users_username ON users (username)"))
+        conn.execute(
+            sa.text("""
+            CREATE TABLE messages (
+                id BIGINT NOT NULL,
+                chat_id BIGINT NOT NULL,
+                date DATETIME NOT NULL,
+                reply_to_msg_id BIGINT,
+                is_pinned INTEGER DEFAULT 0 NOT NULL,
+                PRIMARY KEY (id, chat_id)
+            )
+        """)
+        )
+        conn.execute(sa.text("CREATE INDEX idx_messages_reply_to ON messages (chat_id, reply_to_msg_id)"))
+        conn.execute(
+            sa.text("""
+            CREATE TABLE media (
+                id VARCHAR(255) NOT NULL PRIMARY KEY,
+                message_id BIGINT,
+                chat_id BIGINT,
+                type VARCHAR(50),
+                downloaded INTEGER DEFAULT 0 NOT NULL,
+                FOREIGN KEY(message_id, chat_id) REFERENCES messages (id, chat_id) ON DELETE CASCADE
+            )
+        """)
+        )
+        conn.execute(sa.text("CREATE INDEX idx_media_downloaded ON media (chat_id, downloaded)"))
+        conn.execute(sa.text("CREATE INDEX idx_media_type ON media (type)"))
+        conn.execute(
+            sa.text("""
+            CREATE TABLE reactions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                message_id BIGINT NOT NULL,
+                chat_id BIGINT NOT NULL,
+                user_id BIGINT,
+                FOREIGN KEY(user_id) REFERENCES users (id)
+            )
+        """)
+        )
+        conn.execute(sa.text("CREATE INDEX idx_reactions_user ON reactions (user_id)"))
+
+        _run(conn, migration_005.upgrade)  # must not raise
+        assert "media_type" not in _columns(conn, "messages")
+        assert "messages" in _fk_referred_tables(conn, "media")
+
+        _run(conn, migration_005.upgrade)  # idempotent
+        assert "media_type" not in _columns(conn, "messages")
+
+
+def test_005_downgrade_restores_legacy_columns_and_is_idempotent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_legacy_pre005_schema(conn)
+        conn.execute(sa.text("INSERT INTO chats (id, username) VALUES (1, 'c')"))
+        conn.execute(
+            sa.text(
+                "INSERT INTO messages (id, chat_id, date, media_type, media_id, media_path) "
+                "VALUES (100, 1, '2026-01-01 00:00:00', 'photo', 'file_abc', '/data/file_abc.jpg')"
+            )
+        )
+        _run(conn, migration_005.upgrade)
+
+        _run(conn, migration_005.downgrade)
+        assert "media_type" in _columns(conn, "messages")
+        assert "messages" not in _fk_referred_tables(conn, "media")
+        restored = conn.execute(sa.text("SELECT media_type, media_id FROM messages WHERE id = 100")).fetchone()
+        assert restored == ("photo", "file_abc")
+
+        _run(conn, migration_005.downgrade)  # idempotent
+        assert "media_type" in _columns(conn, "messages")
+
+
+# ============================================================================
+# Migration 006 - forum topics, chat folders, archived chats
+# ============================================================================
+
+migration_006 = _load_migration("20260206_006_add_topics_folders_archived.py", "migration_006")
+
+
+def _create_pre006_schema(conn):
+    conn.execute(sa.text("CREATE TABLE chats (id BIGINT NOT NULL PRIMARY KEY)"))
+    conn.execute(
+        sa.text(
+            "CREATE TABLE messages (id BIGINT NOT NULL, chat_id BIGINT NOT NULL, "
+            "date DATETIME NOT NULL, PRIMARY KEY (id, chat_id))"
+        )
+    )
+
+
+def test_006_revision_chain():
+    assert migration_006.revision == "006"
+    assert migration_006.down_revision == "005"
+
+
+def test_006_upgrade_creates_everything_and_is_idempotent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_pre006_schema(conn)
+
+        _run(conn, migration_006.upgrade)
+        assert "is_forum" in _columns(conn, "chats")
+        assert "is_archived" in _columns(conn, "chats")
+        assert "reply_to_top_id" in _columns(conn, "messages")
+        assert "idx_messages_topic" in _indexes(conn, "messages")
+        table_names = sa.inspect(conn).get_table_names()
+        assert "forum_topics" in table_names
+        assert "chat_folders" in table_names
+        assert "chat_folder_members" in table_names
+        assert "idx_forum_topics_chat" in _indexes(conn, "forum_topics")
+        assert "idx_folder_members_chat" in _indexes(conn, "chat_folder_members")
+        assert "idx_folder_members_folder" in _indexes(conn, "chat_folder_members")
+
+        _run(conn, migration_006.upgrade)  # re-run must be a no-op
+        assert "is_forum" in _columns(conn, "chats")
+
+
+def test_006_upgrade_noop_when_everything_already_exists():
+    """Simulates create_all(): all v6.2.0 columns/tables/indexes already declared."""
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        conn.execute(
+            sa.text(
+                "CREATE TABLE chats (id BIGINT NOT NULL PRIMARY KEY, "
+                "is_forum INTEGER DEFAULT 0, is_archived INTEGER DEFAULT 0)"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "CREATE TABLE messages (id BIGINT NOT NULL, chat_id BIGINT NOT NULL, "
+                "date DATETIME NOT NULL, reply_to_top_id BIGINT, PRIMARY KEY (id, chat_id))"
+            )
+        )
+        conn.execute(sa.text("CREATE INDEX idx_messages_topic ON messages (chat_id, reply_to_top_id)"))
+        conn.execute(
+            sa.text(
+                "CREATE TABLE forum_topics (id BIGINT NOT NULL, chat_id BIGINT NOT NULL, "
+                "title VARCHAR(500) NOT NULL, PRIMARY KEY (id, chat_id))"
+            )
+        )
+        conn.execute(sa.text("CREATE INDEX idx_forum_topics_chat ON forum_topics (chat_id)"))
+        conn.execute(
+            sa.text("CREATE TABLE chat_folders (id INTEGER NOT NULL PRIMARY KEY, title VARCHAR(255) NOT NULL)")
+        )
+        conn.execute(
+            sa.text(
+                "CREATE TABLE chat_folder_members (folder_id INTEGER NOT NULL, chat_id BIGINT NOT NULL, "
+                "PRIMARY KEY (folder_id, chat_id))"
+            )
+        )
+        conn.execute(sa.text("CREATE INDEX idx_folder_members_chat ON chat_folder_members (chat_id)"))
+        conn.execute(sa.text("CREATE INDEX idx_folder_members_folder ON chat_folder_members (folder_id)"))
+
+        _run(conn, migration_006.upgrade)  # must not raise
+        assert "is_forum" in _columns(conn, "chats")
+
+
+def test_006_downgrade_removes_everything_and_is_idempotent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_pre006_schema(conn)
+        _run(conn, migration_006.upgrade)
+
+        _run(conn, migration_006.downgrade)
+        assert "is_forum" not in _columns(conn, "chats")
+        assert "is_archived" not in _columns(conn, "chats")
+        assert "reply_to_top_id" not in _columns(conn, "messages")
+        table_names = sa.inspect(conn).get_table_names()
+        assert "forum_topics" not in table_names
+        assert "chat_folders" not in table_names
+        assert "chat_folder_members" not in table_names
+
+        _run(conn, migration_006.downgrade)  # idempotent
+        assert "is_forum" not in _columns(conn, "chats")
+
+
+def test_006_upgrade_noop_when_chats_and_messages_absent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _run(conn, migration_006.upgrade)  # no chats/messages tables -> no-op on those steps
+        table_names = sa.inspect(conn).get_table_names()
+        assert "chats" not in table_names
+        assert "messages" not in table_names
+        # forum_topics/chat_folders/chat_folder_members are still created independently
+        assert "forum_topics" in table_names
+        assert "chat_folders" in table_names
+        assert "chat_folder_members" in table_names

--- a/tests/test_multi_user_auth.py
+++ b/tests/test_multi_user_auth.py
@@ -107,7 +107,9 @@ class TestAuthDisabled:
         data = resp.json()
         assert data["authenticated"] is True
         assert data["auth_required"] is False
-        assert data["role"] == "master"
+        # Anonymous access is read-only viewer, never master (#H1 security fix):
+        # exposing the archive publicly must not hand out admin capabilities.
+        assert data["role"] == "viewer"
 
     def test_endpoints_accessible_without_cookies(self, no_auth_env):
         client, _, _ = _get_client()

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -3,6 +3,7 @@ Tests for the realtime notification module (src/realtime.py).
 """
 
 import asyncio
+import contextlib
 import json
 import os
 import unittest
@@ -741,6 +742,56 @@ class TestRealtimeListenerHttpPush:
         await listener.handle_http_push({"type": "test"})
 
 
+class TestPgCallbackTaskTracking(unittest.IsolatedAsyncioTestCase):
+    """Tests for callback task bookkeeping in _pg_callback (task-leak fix).
+
+    Previously ``asyncio.create_task(self._callback(data))`` was fired without
+    keeping a reference, so the task could be garbage-collected mid-flight and
+    any exception it raised was silently dropped.
+    """
+
+    async def test_callback_task_tracked_then_discarded_on_success(self):
+        """A successful callback task is tracked while running, then discarded."""
+
+        async def ok_callback(data):
+            return None
+
+        listener = RealtimeListener(callback=ok_callback)
+        payload = json.dumps({"type": "new_message", "chat_id": 123})
+
+        listener._pg_callback(None, 0, "telegram_updates", payload)
+        self.assertEqual(len(listener._callback_tasks), 1)
+
+        task = next(iter(listener._callback_tasks))
+        await task
+        await asyncio.sleep(0)  # let the done-callback (call_soon) run
+
+        self.assertEqual(listener._callback_tasks, set())
+
+    async def test_callback_task_exception_logged_without_payload(self):
+        """A callback exception is logged (class/message only) and the task set
+        is cleaned up -- the notification payload must never appear in the log
+        (PII rule: no message content)."""
+
+        async def failing_callback(data):
+            raise ValueError("callback boom")
+
+        listener = RealtimeListener(callback=failing_callback)
+        secret_payload = json.dumps({"type": "new_message", "chat_id": 123, "message": {"text": "super secret text"}})
+
+        with self.assertLogs("src.realtime", level="WARNING") as ctx:
+            listener._pg_callback(None, 0, "telegram_updates", secret_payload)
+            task = next(iter(listener._callback_tasks))
+            with contextlib.suppress(ValueError):
+                await task
+            await asyncio.sleep(0)  # let the done-callback fire
+
+        self.assertEqual(listener._callback_tasks, set())
+        messages = ctx.output
+        self.assertTrue(any("ValueError" in m and "callback boom" in m for m in messages))
+        self.assertFalse(any("super secret text" in m for m in messages))
+
+
 # ===========================================================================
 # _notify_http non-200 response (line 149)
 # ===========================================================================
@@ -861,6 +912,48 @@ class TestListenPostgres:
             await listener._listen_postgres()
 
         assert attempt[0] >= 2
+
+    async def test_listen_postgres_closes_connection_on_exception_after_connect(self):
+        """Regression: an exception raised after connect() succeeds (inside the
+        "keep connection alive" loop) must still close the connection. Previously
+        remove_listener/close only ran on the normal-completion path, so a
+        flapping DB leaked one connection per 5s retry."""
+        mock_db = MagicMock()
+        mock_db._is_sqlite = False
+        mock_db.database_url = "postgresql+asyncpg://user:pass@localhost/db"
+
+        listener = RealtimeListener(db_manager=mock_db, callback=AsyncMock())
+        listener._is_postgresql = True
+        listener._running = True
+
+        mock_conn = AsyncMock()
+        mock_conn.add_listener = AsyncMock()
+        mock_conn.remove_listener = AsyncMock()
+        mock_conn.close = AsyncMock()
+
+        mock_asyncpg = MagicMock()
+        mock_asyncpg.connect = AsyncMock(return_value=mock_conn)
+
+        call_count = 0
+
+        async def sleep_side_effect(seconds):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                # First sleep is the inner "keep connection alive" sleep(1);
+                # simulate something going wrong while the connection is open.
+                raise Exception("keep-alive loop broke")
+            # Second sleep is the outer retry-backoff sleep(5); stop the loop.
+            listener._running = False
+
+        with (
+            patch.dict("sys.modules", {"asyncpg": mock_asyncpg}),
+            patch("asyncio.sleep", side_effect=sleep_side_effect),
+        ):
+            await listener._listen_postgres()
+
+        mock_conn.remove_listener.assert_awaited_once()
+        mock_conn.close.assert_awaited_once()
 
     async def test_listen_postgres_handles_cancelled_error(self):
         """_listen_postgres breaks on CancelledError (lines 238-239)."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -931,6 +931,67 @@ class TestRunForeverListenerRestart:
             assert scheduler._stop_listener.await_count >= 1
             assert scheduler._start_listener.await_count >= 1
 
+    async def test_watchdog_retries_after_failed_start_until_success(self):
+        """Regression: a failed restart must not permanently disable the listener.
+
+        _start_listener resets _listener_task to None on failure. The old watchdog
+        condition (`self.config.enable_listener and self._listener_task`) is falsy
+        once _listener_task is None, so it never attempted another restart -- only
+        a container restart could recover. The fixed watchdog keeps retrying based
+        on `self._listener_enabled` regardless of whether the task is None or done.
+        """
+        with patch("src.scheduler.signal.signal"):
+            from src.scheduler import BackupScheduler
+
+            config = MagicMock()
+            config.fill_gaps = False
+            config.enable_listener = True
+            scheduler = BackupScheduler(config)
+
+            mock_connection = AsyncMock()
+            mock_connection.client = MagicMock()
+
+            scheduler._connect = AsyncMock()
+            scheduler._connection = mock_connection
+            # scheduler.start() is mocked out, so it never sets self.running -- set it
+            # directly to actually enter the `while self.running:` watchdog loop below.
+            scheduler.start = MagicMock(side_effect=lambda: setattr(scheduler, "running", True))
+            scheduler._stop_listener = AsyncMock()
+            scheduler._disconnect = AsyncMock()
+
+            attempt = [0]
+
+            async def flaky_start_listener():
+                attempt[0] += 1
+                if attempt[0] < 3:
+                    # Mirrors the real _start_listener failure path: task/listener stay None.
+                    scheduler._listener_task = None
+                    scheduler._listener = None
+                else:
+                    scheduler._listener_task = MagicMock(done=MagicMock(return_value=False))
+                    scheduler._listener = AsyncMock()
+
+            scheduler._start_listener = AsyncMock(side_effect=flaky_start_listener)
+
+            call_count = 0
+
+            async def fake_sleep(seconds):
+                nonlocal call_count
+                call_count += 1
+                if call_count >= 3:
+                    scheduler.running = False
+
+            with (
+                patch("src.scheduler.run_backup", new_callable=AsyncMock),
+                patch("src.scheduler.asyncio.sleep", side_effect=fake_sleep),
+            ):
+                await scheduler.run_forever()
+
+            # Initial start (attempt 1) plus at least one watchdog-triggered retry
+            # while the task stayed None -- proves the watchdog didn't give up after one try.
+            assert attempt[0] >= 2
+            assert scheduler._listener_task is not None
+
     async def test_listener_task_cancelled_restart(self):
         """Cancelled listener task is restarted during the main loop."""
         with patch("src.scheduler.signal.signal"):

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -975,11 +975,11 @@ class TestGetMediaFilename(unittest.TestCase):
         result = self.backup._get_media_filename(msg, "video", "77")
         self.assertEqual(result, "77.mp4")
 
-    def test_no_file_id_uses_timestamp(self):
-        """No telegram_file_id uses timestamp-based filename."""
+    def test_no_file_id_uses_message_id(self):
+        """No telegram_file_id falls back to the shared message-id-based filename."""
         msg = self._make_doc_message(msg_id=42, date=datetime(2024, 3, 15, 10, 30, 0))
         result = self.backup._get_media_filename(msg, "photo", None)
-        self.assertEqual(result, "42_20240315_103000.jpg")
+        self.assertEqual(result, "42_photo.jpg")
 
     def test_file_id_with_slashes_sanitized(self):
         """Slashes in file_id are replaced with underscores."""

--- a/tests/test_web_coverage.py
+++ b/tests/test_web_coverage.py
@@ -122,6 +122,7 @@ class _WebTestBase(unittest.IsolatedAsyncioTestCase):
         self._saved_display = web_main.config.display_chat_ids
         self._saved_avatar_cache = dict(web_main._avatar_cache)
         self._saved_avatar_cache_time = web_main._avatar_cache_time
+        self._saved_chat_stats_cache = dict(web_main._chat_stats_cache)
         self._saved_media_root = web_main._media_root
         self._saved_realtime = web_main.realtime_listener
 
@@ -134,6 +135,7 @@ class _WebTestBase(unittest.IsolatedAsyncioTestCase):
         web_main.config.display_chat_ids = set()
         web_main._avatar_cache.clear()
         web_main._avatar_cache_time = None
+        web_main._chat_stats_cache.clear()
 
     def tearDown(self):
         if not _WEB_AVAILABLE:
@@ -148,12 +150,36 @@ class _WebTestBase(unittest.IsolatedAsyncioTestCase):
         web_main._avatar_cache.clear()
         web_main._avatar_cache.update(self._saved_avatar_cache)
         web_main._avatar_cache_time = self._saved_avatar_cache_time
+        web_main._chat_stats_cache.clear()
+        web_main._chat_stats_cache.update(self._saved_chat_stats_cache)
         web_main._media_root = self._saved_media_root
         web_main.realtime_listener = self._saved_realtime
 
     def _client(self):
         transport = ASGITransport(app=web_main.app)
         return AsyncClient(transport=transport, base_url="http://test")
+
+
+class _MasterTestBase(_WebTestBase):
+    """Base for endpoints gated by require_master.
+
+    Anonymous mode is now a read-only viewer (not master), so tests that
+    exercise master-only admin endpoints need an explicit master identity
+    rather than relying on the old anonymous-is-master fallback.
+    """
+
+    def setUp(self):
+        super().setUp()
+        if not _WEB_AVAILABLE:
+            return
+        web_main.app.dependency_overrides[web_main.require_master] = lambda: web_main.UserContext(
+            username="admin-test", role="master"
+        )
+
+    def tearDown(self):
+        if _WEB_AVAILABLE:
+            web_main.app.dependency_overrides.pop(web_main.require_master, None)
+        super().tearDown()
 
 
 # ============================================================================
@@ -918,7 +944,7 @@ class TestExportEndpoint(_WebTestBase):
 
 
 @_skip_unless_web
-class TestAdminViewerUpdateEdgeCases(_WebTestBase):
+class TestAdminViewerUpdateEdgeCases(_MasterTestBase):
     """Test /api/admin/viewers/{id} PUT edge cases."""
 
     async def test_update_viewer_password(self):
@@ -1003,7 +1029,7 @@ class TestAdminViewerUpdateEdgeCases(_WebTestBase):
 
 
 @_skip_unless_web
-class TestAdminTokenEdgeCases(_WebTestBase):
+class TestAdminTokenEdgeCases(_MasterTestBase):
     """Test /api/admin/tokens edge cases."""
 
     async def test_create_token_with_expiry(self):
@@ -1125,7 +1151,7 @@ class TestAdminTokenEdgeCases(_WebTestBase):
 
 
 @_skip_unless_web
-class TestAdminSettingsEdgeCases(_WebTestBase):
+class TestAdminSettingsEdgeCases(_MasterTestBase):
     """Test /api/admin/settings edge cases."""
 
     async def test_set_setting_invalid_json_returns_400(self):
@@ -1167,14 +1193,15 @@ class TestPushEndpointEdgeCases(_WebTestBase):
         mock_pm.is_enabled = True
         mock_pm.subscribe = AsyncMock(return_value=False)
         web_main.push_manager = mock_pm
-        async with self._client() as client:
-            resp = await client.post(
-                "/api/push/subscribe",
-                json={
-                    "endpoint": "https://push.example.com/sub",
-                    "keys": {"p256dh": "k", "auth": "a"},
-                },
-            )
+        with patch("src.web.push.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("8.8.8.8", 443))]):
+            async with self._client() as client:
+                resp = await client.post(
+                    "/api/push/subscribe",
+                    json={
+                        "endpoint": "https://push.example.com/sub",
+                        "keys": {"p256dh": "k", "auth": "a"},
+                    },
+                )
         self.assertEqual(resp.status_code, 500)
 
     async def test_subscribe_with_chat_id_restricted(self):
@@ -1185,16 +1212,17 @@ class TestPushEndpointEdgeCases(_WebTestBase):
         mock_pm = MagicMock()
         mock_pm.is_enabled = True
         web_main.push_manager = mock_pm
-        async with self._client() as client:
-            resp = await client.post(
-                "/api/push/subscribe",
-                json={
-                    "endpoint": "https://push.example.com/sub",
-                    "keys": {"p256dh": "k", "auth": "a"},
-                    "chat_id": 999,
-                },
-                cookies={"viewer_auth": token},
-            )
+        with patch("src.web.push.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("8.8.8.8", 443))]):
+            async with self._client() as client:
+                resp = await client.post(
+                    "/api/push/subscribe",
+                    json={
+                        "endpoint": "https://push.example.com/sub",
+                        "keys": {"p256dh": "k", "auth": "a"},
+                        "chat_id": 999,
+                    },
+                    cookies={"viewer_auth": token},
+                )
         self.assertEqual(resp.status_code, 403)
 
     async def test_subscribe_db_connection_error(self):
@@ -1203,14 +1231,15 @@ class TestPushEndpointEdgeCases(_WebTestBase):
         mock_pm.is_enabled = True
         mock_pm.subscribe = AsyncMock(side_effect=OSError("db down"))
         web_main.push_manager = mock_pm
-        async with self._client() as client:
-            resp = await client.post(
-                "/api/push/subscribe",
-                json={
-                    "endpoint": "https://push.example.com/sub",
-                    "keys": {"p256dh": "k", "auth": "a"},
-                },
-            )
+        with patch("src.web.push.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("8.8.8.8", 443))]):
+            async with self._client() as client:
+                resp = await client.post(
+                    "/api/push/subscribe",
+                    json={
+                        "endpoint": "https://push.example.com/sub",
+                        "keys": {"p256dh": "k", "auth": "a"},
+                    },
+                )
         self.assertEqual(resp.status_code, 503)
 
     async def test_unsubscribe_missing_endpoint(self):
@@ -1453,7 +1482,7 @@ class TestChatsAvatarErrors(_WebTestBase):
 
 
 @_skip_unless_web
-class TestEndpointDbErrors(_WebTestBase):
+class TestEndpointDbErrors(_MasterTestBase):
     """Test DB error handling in various endpoints."""
 
     async def test_folders_db_connection_error(self):

--- a/tests/test_web_main.py
+++ b/tests/test_web_main.py
@@ -326,6 +326,41 @@ class TestIsDbConnectionError(unittest.TestCase):
         e3.__cause__ = e2
         self.assertTrue(web_main._is_db_connection_error(e3))
 
+    def test_returns_true_for_operational_error(self):
+        """_is_db_connection_error treats sqlalchemy OperationalError as DB-down (e.g. 'database is locked')."""
+        from sqlalchemy.exc import OperationalError
+
+        exc = OperationalError("statement", {}, Exception("database is locked"))
+        self.assertTrue(web_main._is_db_connection_error(exc))
+
+    def test_returns_true_for_dbapi_error_with_connection_invalidated(self):
+        """_is_db_connection_error treats a DBAPIError with connection_invalidated=True as DB-down."""
+        from sqlalchemy.exc import DBAPIError
+
+        exc = DBAPIError("statement", {}, Exception("server closed the connection"), connection_invalidated=True)
+        self.assertTrue(web_main._is_db_connection_error(exc))
+
+    def test_returns_false_for_dbapi_error_without_connection_invalidated(self):
+        """_is_db_connection_error does not classify a plain DBAPIError as DB-down."""
+        from sqlalchemy.exc import DBAPIError
+
+        exc = DBAPIError("statement", {}, Exception("weird error"), connection_invalidated=False)
+        self.assertFalse(web_main._is_db_connection_error(exc))
+
+    def test_returns_false_for_integrity_error(self):
+        """_is_db_connection_error must NOT classify constraint violations as DB-down."""
+        from sqlalchemy.exc import IntegrityError
+
+        exc = IntegrityError("statement", {}, Exception("UNIQUE constraint failed"))
+        self.assertFalse(web_main._is_db_connection_error(exc))
+
+    def test_returns_true_for_asyncpg_connection_errors(self):
+        """_is_db_connection_error treats asyncpg connection-level errors as DB-down."""
+        asyncpg = __import__("asyncpg")
+        self.assertTrue(web_main._is_db_connection_error(asyncpg.PostgresConnectionError("conn lost")))
+        self.assertTrue(web_main._is_db_connection_error(asyncpg.TooManyConnectionsError("too many clients")))
+        self.assertTrue(web_main._is_db_connection_error(asyncpg.CannotConnectNowError("starting up")))
+
 
 @_skip_unless_web_main
 class TestGetSecureCookies(unittest.TestCase):
@@ -528,6 +563,34 @@ class TestGetCachedAvatarPath(unittest.TestCase):
         result = web_main._get_cached_avatar_path(42, "private")
         # Since no actual avatar file exists, it should be None now
         self.assertIsNone(result)
+
+
+@_skip_unless_web_main
+class TestChatStatsCache(unittest.TestCase):
+    """Test _get_cached_chat_stats / _set_cached_chat_stats TTL caching."""
+
+    def setUp(self):
+        web_main._chat_stats_cache.clear()
+
+    def tearDown(self):
+        web_main._chat_stats_cache.clear()
+
+    def test_returns_none_when_not_cached(self):
+        """_get_cached_chat_stats returns None for an unseen chat_id."""
+        self.assertIsNone(web_main._get_cached_chat_stats(999))
+
+    def test_returns_cached_value_within_ttl(self):
+        """_get_cached_chat_stats returns the stored stats before TTL expires."""
+        web_main._set_cached_chat_stats(1, {"messages": 42})
+        self.assertEqual(web_main._get_cached_chat_stats(1), {"messages": 42})
+
+    def test_invalidates_after_ttl(self):
+        """_get_cached_chat_stats returns None once the TTL has elapsed."""
+        stale_time = time.monotonic() - web_main.CHAT_STATS_CACHE_TTL_SECONDS - 1
+        web_main._chat_stats_cache[2] = (stale_time, {"messages": 1})
+        self.assertIsNone(web_main._get_cached_chat_stats(2))
+        # Expired entry should also be evicted from the dict
+        self.assertNotIn(2, web_main._chat_stats_cache)
 
 
 # ============================================================================

--- a/tests/test_web_push.py
+++ b/tests/test_web_push.py
@@ -11,13 +11,14 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 try:
     import src.web.push as push_mod
-    from src.web.push import PushNotificationManager
+    from src.web.push import PushNotificationManager, validate_push_endpoint
 
     _PUSH_AVAILABLE = True
 except Exception:
     _PUSH_AVAILABLE = False
     push_mod = None  # type: ignore[assignment]
     PushNotificationManager = None  # type: ignore[assignment, misc]
+    validate_push_endpoint = None  # type: ignore[assignment]
 
 
 def _skip_unless_push(cls_or_fn):
@@ -34,6 +35,121 @@ def _make_manager(push_setting="full", vapid_private=None, vapid_public=None):
     cfg.vapid_public_key = vapid_public or ""
     cfg.vapid_contact = "mailto:test@example.com"
     return PushNotificationManager(db, cfg)
+
+
+# ============================================================================
+# validate_push_endpoint (SSRF guard)
+# ============================================================================
+
+
+def _addrinfo(ip: str, port: int = 443):
+    """Build a minimal socket.getaddrinfo()-shaped result for a single resolved IP."""
+    family = 10 if ":" in ip else 2  # AF_INET6 : AF_INET
+    return [(family, 1, 6, "", (ip, port) if family == 2 else (ip, port, 0, 0))]
+
+
+@_skip_unless_push
+class TestValidatePushEndpoint(unittest.TestCase):
+    """Test validate_push_endpoint accepts real push services, rejects internal/private targets.
+
+    Resolution-dependent cases mock socket.getaddrinfo so results are deterministic
+    and don't require real network access, matching what the OS resolver would
+    actually return for these hosts/literals.
+    """
+
+    def test_accepts_fcm_endpoint(self):
+        """A real FCM push endpoint resolving to a public IP is accepted."""
+        with patch("src.web.push.socket.getaddrinfo", return_value=_addrinfo("142.250.0.1")):
+            self.assertTrue(validate_push_endpoint("https://fcm.googleapis.com/fcm/send/abc123"))
+
+    def test_accepts_mozilla_endpoint(self):
+        """A real Mozilla autopush endpoint resolving to a public IP is accepted."""
+        with patch("src.web.push.socket.getaddrinfo", return_value=_addrinfo("34.0.0.1")):
+            self.assertTrue(validate_push_endpoint("https://updates.push.services.mozilla.com/wpush/v2/xyz"))
+
+    def test_accepts_endpoint_resolving_to_public_ip(self):
+        """Any hostname resolving only to public IPs is accepted."""
+        with patch("src.web.push.socket.getaddrinfo", return_value=_addrinfo("8.8.8.8")):
+            self.assertTrue(validate_push_endpoint("https://push.example.com/sub"))
+
+    def test_rejects_non_https_scheme(self):
+        """Plain http is rejected."""
+        self.assertFalse(validate_push_endpoint("http://push.example.com/sub"))
+
+    def test_rejects_ipv4_literal(self):
+        """IPv4 literal hosts are rejected (loopback resolves to itself, no mock needed)."""
+        self.assertFalse(validate_push_endpoint("https://192.168.1.5/sub"))
+
+    def test_rejects_ipv6_literal(self):
+        """IPv6 literal hosts are rejected."""
+        self.assertFalse(validate_push_endpoint("https://[::1]/sub"))
+
+    def test_rejects_localhost(self):
+        """localhost is rejected."""
+        self.assertFalse(validate_push_endpoint("https://localhost/sub"))
+
+    def test_rejects_dot_local_suffix(self):
+        """.local mDNS hostnames are rejected."""
+        self.assertFalse(validate_push_endpoint("https://printer.local/sub"))
+
+    def test_rejects_dot_internal_suffix(self):
+        """.internal hostnames are rejected."""
+        self.assertFalse(validate_push_endpoint("https://api.internal/sub"))
+
+    def test_rejects_userinfo_in_url(self):
+        """Embedded credentials in the URL are rejected."""
+        self.assertFalse(validate_push_endpoint("https://user:pass@push.example.com/sub"))
+
+    def test_rejects_empty_string(self):
+        """Empty endpoint is rejected."""
+        self.assertFalse(validate_push_endpoint(""))
+
+    def test_rejects_missing_hostname(self):
+        """URL with no hostname is rejected."""
+        self.assertFalse(validate_push_endpoint("https:///sub"))
+
+    def test_rejects_unresolvable_hostname(self):
+        """A hostname that can't be resolved is rejected (can't prove it's safe)."""
+        import socket
+
+        with patch("src.web.push.socket.getaddrinfo", side_effect=socket.gaierror("nodename nor servname provided")):
+            self.assertFalse(validate_push_endpoint("https://does-not-exist.invalid/sub"))
+
+    # -- Confirmed SSRF bypass payloads (encoding tricks defeat naive string checks) --
+
+    def test_rejects_decimal_ipv4_loopback_encoding(self):
+        """Decimal-encoded IPv4 (2130706433 == 127.0.0.1) resolves to loopback and is rejected."""
+        with patch("src.web.push.socket.getaddrinfo", return_value=_addrinfo("127.0.0.1")):
+            self.assertFalse(validate_push_endpoint("https://2130706433/x"))
+
+    def test_rejects_decimal_ipv4_metadata_encoding(self):
+        """Decimal-encoded cloud metadata IP (2852039166 == 169.254.169.254) is rejected."""
+        with patch("src.web.push.socket.getaddrinfo", return_value=_addrinfo("169.254.169.254")):
+            self.assertFalse(validate_push_endpoint("https://2852039166/x"))
+
+    def test_rejects_hex_ipv4_encoding(self):
+        """Hex-encoded IPv4 (0x7f.0.0.1 == 127.0.0.1) resolves to loopback and is rejected."""
+        with patch("src.web.push.socket.getaddrinfo", return_value=_addrinfo("127.0.0.1")):
+            self.assertFalse(validate_push_endpoint("https://0x7f.0.0.1/x"))
+
+    def test_rejects_octal_ipv4_encoding(self):
+        """Octal-encoded IPv4 (0177.0.0.1 == 127.0.0.1) resolves to loopback and is rejected."""
+        with patch("src.web.push.socket.getaddrinfo", return_value=_addrinfo("127.0.0.1")):
+            self.assertFalse(validate_push_endpoint("https://0177.0.0.1/x"))
+
+    def test_rejects_shorthand_ipv4_encoding(self):
+        """Shorthand IPv4 (127.1 == 127.0.0.1) resolves to loopback and is rejected."""
+        with patch("src.web.push.socket.getaddrinfo", return_value=_addrinfo("127.0.0.1")):
+            self.assertFalse(validate_push_endpoint("https://127.1/x"))
+
+    def test_rejects_trailing_dot_localhost(self):
+        """A trailing dot (localhost.) must not defeat the localhost string check."""
+        self.assertFalse(validate_push_endpoint("https://localhost./x"))
+
+    def test_rejects_trailing_dot_loopback_ip(self):
+        """A trailing dot (127.0.0.1.) must not defeat resolution-based rejection."""
+        with patch("src.web.push.socket.getaddrinfo", return_value=_addrinfo("127.0.0.1")):
+            self.assertFalse(validate_push_endpoint("https://127.0.0.1./x"))
 
 
 # ============================================================================

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -98,6 +98,7 @@ class _WebTestBase(unittest.IsolatedAsyncioTestCase):
         self._saved_display = web_main.config.display_chat_ids
         self._saved_avatar_cache = dict(web_main._avatar_cache)
         self._saved_avatar_cache_time = web_main._avatar_cache_time
+        self._saved_chat_stats_cache = dict(web_main._chat_stats_cache)
 
         self.mock_db = _mock_db()
         web_main.db = self.mock_db
@@ -108,6 +109,7 @@ class _WebTestBase(unittest.IsolatedAsyncioTestCase):
         web_main.config.display_chat_ids = set()
         web_main._avatar_cache.clear()
         web_main._avatar_cache_time = None
+        web_main._chat_stats_cache.clear()
 
     def tearDown(self):
         web_main.db = self._saved_db
@@ -120,10 +122,31 @@ class _WebTestBase(unittest.IsolatedAsyncioTestCase):
         web_main._avatar_cache.clear()
         web_main._avatar_cache.update(self._saved_avatar_cache)
         web_main._avatar_cache_time = self._saved_avatar_cache_time
+        web_main._chat_stats_cache.clear()
+        web_main._chat_stats_cache.update(self._saved_chat_stats_cache)
 
     def _client(self):
         transport = ASGITransport(app=web_main.app)
         return AsyncClient(transport=transport, base_url="http://test")
+
+
+class _MasterTestBase(_WebTestBase):
+    """Base for endpoints gated by require_master.
+
+    Anonymous mode is now a read-only viewer (not master), so tests that
+    exercise master-only admin endpoints need an explicit master identity
+    rather than relying on the old anonymous-is-master fallback.
+    """
+
+    def setUp(self):
+        super().setUp()
+        web_main.app.dependency_overrides[web_main.require_master] = lambda: web_main.UserContext(
+            username="admin-test", role="master"
+        )
+
+    def tearDown(self):
+        web_main.app.dependency_overrides.pop(web_main.require_master, None)
+        super().tearDown()
 
 
 # ============================================================================
@@ -166,14 +189,14 @@ class TestAuthCheckEndpoint(_WebTestBase):
     """Test /api/auth/check endpoint."""
 
     async def test_returns_authenticated_when_auth_disabled(self):
-        """auth check returns anonymous master only with explicit anonymous opt-in."""
+        """auth check returns anonymous read-only viewer only with explicit anonymous opt-in."""
         async with self._client() as client:
             resp = await client.get("/api/auth/check")
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
         self.assertTrue(data["authenticated"])
         self.assertFalse(data["auth_required"])
-        self.assertEqual(data["role"], "master")
+        self.assertEqual(data["role"], "viewer")
 
     async def test_returns_setup_required_when_auth_missing_without_opt_in(self):
         """auth check fails closed when credentials are missing and anonymous mode is not explicit."""
@@ -220,6 +243,57 @@ class TestAuthCheckEndpoint(_WebTestBase):
             resp = await client.get("/api/auth/check", cookies={"viewer_auth": token})
         data = resp.json()
         self.assertFalse(data["authenticated"])
+
+
+# ============================================================================
+# Anonymous viewer access boundaries (security fix: anonymous must be a
+# read-only viewer, never master)
+# ============================================================================
+
+
+@_skip_unless_web
+class TestAnonymousViewerAccess(_WebTestBase):
+    """Anonymous mode (ALLOW_ANONYMOUS_VIEWER=true, no credentials) grants
+    read-only viewer access and must never grant admin/master capabilities."""
+
+    async def test_anonymous_can_read_chats(self):
+        """Anonymous users can list chats."""
+        self.mock_db.get_all_chats = AsyncMock(return_value=[{"id": 1, "title": "Chat", "type": "private"}])
+        self.mock_db.get_chat_count = AsyncMock(return_value=1)
+        async with self._client() as client:
+            resp = await client.get("/api/chats")
+        self.assertEqual(resp.status_code, 200)
+
+    async def test_anonymous_can_read_messages(self):
+        """Anonymous users can read chat messages."""
+        self.mock_db.get_messages_paginated = AsyncMock(return_value=[{"id": 1, "text": "hi"}])
+        async with self._client() as client:
+            resp = await client.get("/api/chats/1/messages")
+        self.assertEqual(resp.status_code, 200)
+
+    async def test_anonymous_forbidden_from_admin_viewers(self):
+        """Anonymous users get 403 on /api/admin/viewers."""
+        async with self._client() as client:
+            resp = await client.get("/api/admin/viewers")
+        self.assertEqual(resp.status_code, 403)
+
+    async def test_anonymous_forbidden_from_admin_tokens(self):
+        """Anonymous users get 403 on /api/admin/tokens."""
+        async with self._client() as client:
+            resp = await client.get("/api/admin/tokens")
+        self.assertEqual(resp.status_code, 403)
+
+    async def test_anonymous_forbidden_from_admin_audit(self):
+        """Anonymous users get 403 on /api/admin/audit."""
+        async with self._client() as client:
+            resp = await client.get("/api/admin/audit")
+        self.assertEqual(resp.status_code, 403)
+
+    async def test_anonymous_forbidden_from_admin_settings(self):
+        """Anonymous users get 403 on /api/admin/settings."""
+        async with self._client() as client:
+            resp = await client.get("/api/admin/settings")
+        self.assertEqual(resp.status_code, 403)
 
 
 # ============================================================================
@@ -618,8 +692,11 @@ class TestStatsRefreshEndpoint(_WebTestBase):
     async def test_refresh_stats_returns_result(self):
         """refresh_stats triggers recalculation and returns result."""
         self.mock_db.calculate_and_store_statistics = AsyncMock(return_value={"chats": 5})
+        web_main.AUTH_ENABLED = True
+        token = "master-tok"
+        web_main._sessions[token] = web_main.SessionData(username="admin", role="master")
         async with self._client() as client:
-            resp = await client.post("/api/stats/refresh")
+            resp = await client.post("/api/stats/refresh", cookies={"viewer_auth": token})
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
         self.assertIn("timezone", data)
@@ -658,6 +735,31 @@ class TestChatStatsEndpoint(_WebTestBase):
         async with self._client() as client:
             resp = await client.get("/api/chats/999/stats", cookies={"viewer_auth": token})
         self.assertEqual(resp.status_code, 403)
+
+    async def test_chat_stats_cache_hit_avoids_second_db_call(self):
+        """A second request within the TTL is served from cache without hitting the db."""
+        self.mock_db.get_chat_stats = AsyncMock(return_value={"messages": 5, "media": 1})
+        async with self._client() as client:
+            first = await client.get("/api/chats/42/stats")
+            second = await client.get("/api/chats/42/stats")
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+        self.assertEqual(first.json(), second.json())
+        self.mock_db.get_chat_stats.assert_awaited_once()
+
+    async def test_chat_stats_cache_hit_still_enforces_acl(self):
+        """A cached stats entry must not leak to a viewer without access to that chat."""
+        self.mock_db.get_chat_stats = AsyncMock(return_value={"messages": 5, "media": 1})
+        web_main.AUTH_ENABLED = True
+        master_token = "cs-master"
+        web_main._sessions[master_token] = web_main.SessionData(username="admin", role="master")
+        restricted_token = "cs-restricted"
+        web_main._sessions[restricted_token] = web_main.SessionData(username="v", role="viewer", allowed_chat_ids={1})
+        async with self._client() as client:
+            warm = await client.get("/api/chats/42/stats", cookies={"viewer_auth": master_token})
+            blocked = await client.get("/api/chats/42/stats", cookies={"viewer_auth": restricted_token})
+        self.assertEqual(warm.status_code, 200)
+        self.assertEqual(blocked.status_code, 403)
 
 
 # ============================================================================
@@ -758,14 +860,15 @@ class TestPushSubscribeEndpoint(_WebTestBase):
         mock_pm.is_enabled = True
         mock_pm.subscribe = AsyncMock(return_value=True)
         web_main.push_manager = mock_pm
-        async with self._client() as client:
-            resp = await client.post(
-                "/api/push/subscribe",
-                json={
-                    "endpoint": "https://push.example.com/sub",
-                    "keys": {"p256dh": "key1", "auth": "auth1"},
-                },
-            )
+        with patch("src.web.push.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("8.8.8.8", 443))]):
+            async with self._client() as client:
+                resp = await client.post(
+                    "/api/push/subscribe",
+                    json={
+                        "endpoint": "https://push.example.com/sub",
+                        "keys": {"p256dh": "key1", "auth": "auth1"},
+                    },
+                )
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()["status"], "subscribed")
 
@@ -977,7 +1080,7 @@ class TestTokenAuthEndpoint(_WebTestBase):
 
 
 @_skip_unless_web
-class TestAdminViewersEndpoint(_WebTestBase):
+class TestAdminViewersEndpoint(_MasterTestBase):
     """Test /api/admin/viewers endpoints."""
 
     async def test_list_viewers_returns_empty(self):
@@ -1078,7 +1181,7 @@ class TestAdminViewersEndpoint(_WebTestBase):
 
 
 @_skip_unless_web
-class TestAdminTokensEndpoint(_WebTestBase):
+class TestAdminTokensEndpoint(_MasterTestBase):
     """Test /api/admin/tokens endpoints."""
 
     async def test_list_tokens_returns_empty(self):
@@ -1160,7 +1263,7 @@ class TestAdminTokensEndpoint(_WebTestBase):
 
 
 @_skip_unless_web
-class TestAdminSettingsEndpoint(_WebTestBase):
+class TestAdminSettingsEndpoint(_MasterTestBase):
     """Test /api/admin/settings endpoints."""
 
     async def test_get_settings(self):
@@ -1200,7 +1303,7 @@ class TestAdminSettingsEndpoint(_WebTestBase):
 
 
 @_skip_unless_web
-class TestAuditLogEndpoint(_WebTestBase):
+class TestAuditLogEndpoint(_MasterTestBase):
     """Test /api/admin/audit endpoint."""
 
     async def test_returns_audit_logs(self):
@@ -1228,7 +1331,7 @@ class TestAuditLogEndpoint(_WebTestBase):
 
 
 @_skip_unless_web
-class TestAdminChatsEndpoint(_WebTestBase):
+class TestAdminChatsEndpoint(_MasterTestBase):
     """Test /api/admin/chats endpoint."""
 
     async def test_returns_all_chats(self):
@@ -1509,11 +1612,13 @@ class TestRequireAuth(_WebTestBase):
         req.headers = headers or {}
         return req
 
-    async def test_returns_anonymous_master_when_auth_disabled(self):
-        """require_auth returns anonymous master only with explicit anonymous opt-in."""
+    async def test_returns_anonymous_viewer_when_auth_disabled(self):
+        """require_auth returns a read-only anonymous viewer, never master, on explicit opt-in."""
         result = await web_main.require_auth(request=self._mock_request(), auth_cookie=None)
         self.assertEqual(result.username, "anonymous")
-        self.assertEqual(result.role, "master")
+        self.assertEqual(result.role, "viewer")
+        self.assertIsNone(result.allowed_chat_ids)
+        self.assertFalse(result.no_download)
 
     async def test_auth_disabled_without_opt_in_fails_closed(self):
         """require_auth raises setup error when auth is missing and anonymous mode is not explicit."""

--- a/tests/test_websocket_route.py
+++ b/tests/test_websocket_route.py
@@ -55,7 +55,7 @@ def auth_env():
     """Real VIEWER_USERNAME/PASSWORD so AUTH_ENABLED is True after module reload."""
     with patch.dict(
         os.environ,
-        {"VIEWER_USERNAME": "admin", "VIEWER_PASSWORD": "testpass123", "SECURE_COOKIES": "false"},
+        {"VIEWER_USERNAME": "admin", "VIEWER_PASSWORD": "test@value/here", "SECURE_COOKIES": "false"},
     ):
         yield
 

--- a/tests/test_websocket_route.py
+++ b/tests/test_websocket_route.py
@@ -1,0 +1,141 @@
+"""End-to-end tests for the @app.websocket("/ws/updates") route in src/web/main.py.
+
+Before this file, only ConnectionManager's plain-async methods had unit coverage
+(tests/test_web_main.py); nothing exercised the actual route handler -- origin
+checks, cookie/session auth gating, or the subscribe/unsubscribe message loop.
+
+Uses FastAPI's synchronous TestClient.websocket_connect, following the same
+module-reload + mock-db pattern as tests/test_multi_user_auth.py so that
+AUTH_ENABLED reflects real env vars rather than mocked module attributes.
+"""
+
+import importlib
+import os
+import tempfile
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Config() creates BACKUP_PATH on import (default /data/backups, read-only in
+# this sandbox). Must be set before src.web.main is ever imported, including
+# by the first module-level import below and every later importlib.reload().
+os.environ.setdefault("BACKUP_PATH", tempfile.mkdtemp(prefix="ta_test_ws_"))
+
+try:
+    from fastapi.testclient import TestClient
+    from starlette.websockets import WebSocketDisconnect
+
+    _WS_AVAILABLE = True
+except Exception:
+    _WS_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not _WS_AVAILABLE, reason="fastapi/starlette TestClient import failed")
+
+
+def _make_mock_db():
+    db = AsyncMock()
+    db.get_all_chats = AsyncMock(return_value=[])
+    db.get_session = AsyncMock(return_value=None)
+    db.delete_session = AsyncMock()
+    return db
+
+
+@pytest.fixture(autouse=True)
+def _reset_sessions():
+    import src.web.main as main_mod
+
+    main_mod._sessions.clear()
+    yield
+    main_mod._sessions.clear()
+
+
+@pytest.fixture
+def auth_env():
+    """Real VIEWER_USERNAME/PASSWORD so AUTH_ENABLED is True after module reload."""
+    with patch.dict(
+        os.environ,
+        {"VIEWER_USERNAME": "admin", "VIEWER_PASSWORD": "testpass123", "SECURE_COOKIES": "false"},
+    ):
+        yield
+
+
+def _get_client():
+    """Create a fresh TestClient by reloading the module with current env, like test_multi_user_auth.py."""
+    import src.web.main as main_mod
+
+    importlib.reload(main_mod)
+    main_mod.db = _make_mock_db()
+    return TestClient(main_mod.app, raise_server_exceptions=False), main_mod
+
+
+class TestWebSocketAuthGate:
+    """The route validates auth from the cookie during the WS upgrade, before accept()."""
+
+    def test_authenticated_connect_succeeds_and_round_trips_ping(self, auth_env):
+        """A valid session cookie is accepted; the connection is live (ping -> pong)."""
+        client, mod = _get_client()
+        token = "ws-valid-session"
+        mod._sessions[token] = mod.SessionData(username="admin", role="master", created_at=time.time())
+        client.cookies.set("viewer_auth", token)
+
+        with client.websocket_connect("/ws/updates") as ws:
+            ws.send_json({"action": "ping"})
+            reply = ws.receive_json()
+
+        assert reply == {"type": "pong"}
+
+    def test_unauthenticated_connect_is_rejected(self, auth_env):
+        """No cookie + AUTH_ENABLED closes the socket with 4001 before it is ever accepted."""
+        client, _mod = _get_client()
+
+        with pytest.raises(WebSocketDisconnect) as exc_info, client.websocket_connect("/ws/updates"):
+            pass
+
+        assert exc_info.value.code == 4001
+
+    def test_expired_session_is_rejected(self, auth_env):
+        """A session older than AUTH_SESSION_SECONDS is rejected the same way as no cookie."""
+        client, mod = _get_client()
+        token = "ws-expired-session"
+        mod._sessions[token] = mod.SessionData(
+            username="admin",
+            role="master",
+            created_at=time.time() - mod.AUTH_SESSION_SECONDS - 100,
+        )
+        client.cookies.set("viewer_auth", token)
+
+        with pytest.raises(WebSocketDisconnect) as exc_info, client.websocket_connect("/ws/updates"):
+            pass
+
+        assert exc_info.value.code == 4001
+
+
+class TestWebSocketSubscribeFlow:
+    """Once connected, the route accepts subscribe/unsubscribe action messages."""
+
+    def test_subscribe_and_unsubscribe_round_trip(self, auth_env):
+        client, mod = _get_client()
+        token = "ws-subscribe-session"
+        mod._sessions[token] = mod.SessionData(username="admin", role="master", created_at=time.time())
+        client.cookies.set("viewer_auth", token)
+
+        with client.websocket_connect("/ws/updates") as ws:
+            ws.send_json({"action": "subscribe", "chat_id": 42})
+            assert ws.receive_json() == {"type": "subscribed", "chat_id": 42}
+
+            ws.send_json({"action": "unsubscribe", "chat_id": 42})
+            assert ws.receive_json() == {"type": "unsubscribed", "chat_id": 42}
+
+    def test_subscribe_denied_for_chat_outside_allowed_ids(self, auth_env):
+        """A viewer session restricted to specific chats gets subscribe_denied for others."""
+        client, mod = _get_client()
+        token = "ws-restricted-viewer"
+        mod._sessions[token] = mod.SessionData(
+            username="v1", role="viewer", allowed_chat_ids={1, 2}, created_at=time.time()
+        )
+        client.cookies.set("viewer_auth", token)
+
+        with client.websocket_connect("/ws/updates") as ws:
+            ws.send_json({"action": "subscribe", "chat_id": 999})
+            assert ws.receive_json() == {"type": "subscribe_denied", "chat_id": 999}


### PR DESCRIPTION
## Summary

Whole-repo health audit (`/review-code!`) run by a panel of specialized reviewers, with every actionable finding fixed here. **Stacked on #217** — review that first; this branch is based on it, so the diff below is audit work only. GitHub will retarget this PR to `main` automatically when #217 merges.

Full suite: **2161 passed**, `ruff check` + `ruff format --check` clean across the repo. An independent verifier pass reviewed the combined diff; the one blocker it found (an SSRF-filter encoding bypass) is fixed and re-verified in this branch.

## What was fixed

**Security**
- `ALLOW_ANONYMOUS_VIEWER` no longer grants **master/admin** to anonymous requests — it now yields a read-only viewer. Previously any anonymous request could create viewers, mint share tokens, read the audit log, and change settings.
- Push-subscribe endpoint (`/api/push/subscribe`) validates the target by **resolving the host and rejecting private/loopback/link-local/reserved addresses**, off the event loop. The prior fix used string matching, which was bypassable via decimal/hex/octal/shorthand IP encodings and trailing dots (blind SSRF into internal networks / cloud metadata).
- Chat-search `ILIKE` wildcards (`%`/`_`/`\`) are now escaped, matching the message-search path.

**Reliability**
- Realtime Postgres LISTEN connection is closed on every exit path (previously leaked one connection per retry while the DB flapped); callback tasks are tracked so their exceptions surface.
- Scheduler watchdog retries a listener that failed to start (previously one failed restart permanently disabled realtime capture until a container restart).

**Data correctness**
- `download_date` was written in host-local time by the backup path while the listener/import paths wrote UTC — now uniformly `utcnow_naive()`.
- Migrations **002–006** are now idempotent (inspector-guarded), matching the repo's mandate; unguarded creates could crash-loop `create_all()`-provisioned databases.

**Performance**
- The messages page endpoint issued up to ~100 sequential queries per 50-row page (per-message reactions + reply-text); now **4 queries per page** via batched `IN` lookups. Since the viewer polls this endpoint every 3s per open tab, this was continuous load.
- Per-chat stats gain a 60s TTL cache (ACL still enforced before any cache hit).
- `get_pending_media_downloads` is bounded (was materializing every pending row — a prior OOM class).

**Observability / PII**
- Scrubbed chat ids, topic ids, message ids, chat/topic titles, message text, and file paths from logs across listener/backup/import/realtime/push (the repo's own logging policy) — including one log line that interpolated verbatim message text and another that logged the raw notification payload.
- `_is_db_connection_error` now maps SQLite "database is locked" and asyncpg connection errors to 503 (were 500). Silent `json.loads`/`get_entity` bare-excepts narrowed and logged.

**Consistency / hygiene**
- Single shared `fallback_media_filename()` so the backup and listener ingest paths produce identical names for media with no usable original name (the #212 divergence class, moved into the fallback tier).
- Removed shipped frontend debug logs; documented the dual `chatVersion`/`requestSeq` staleness idioms.
- `models.py` datetime defaults on `utcnow_naive`; export timestamp in UTC; CI runs the suite once (was twice).

**Docs**
- Documented `MEDIA_MAX_FILENAME_BYTES` and `MEDIA_MAX_DOWNLOAD_ATTEMPTS`; added a loud warning that the reverse proxy MUST strip `AUTH_PROXY_HEADER` inbound (else header-forged auth bypass); documented `ALLOW_ANONYMOUS_VIEWER` as read-only.

## New test coverage (real, not shape-only)
- `test_jump_window_backend.py`, `test_messages_page_batching.py` (asserts the ≤6-query count via an engine event listener), `test_migrations_002_006_idempotency.py`, `test_migration_017.py`, `test_websocket_route.py` (real `websocket_connect`, incl. ACL-denial), and a rewritten `test_entrypoint_schema_detection.py` that **executes** the shipped SQLite stamping heredoc against seeded DBs (with a mutation check proving it isn't tautological). Frontend adds a generic drift guard: every `data-*` attribute queried from JS must actually be rendered in the template.

## Deliberately deferred (recommendations for maintainer decision — not in this PR)
Structural refactors (`backup_all`/listener decomposition, `DatabaseAdapter` split, `index.html` composables), a Playwright browser test (new dependency + CI browser install), vendoring the 5 CDN assets + tightening CSP, an FTS search index, a Postgres service in CI, API list-response-shape standardization, and send-time IP pinning for the push path (defense-in-depth beyond the resolution check here). The dead-code audit's "unused symbol" findings were **refuted during verification** (all had live call sites) — nothing was deleted on that basis.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable media filename byte limits and per-file download retry limits.
  - Added toast-based UI notifications for common background failures.
  - Added cached per-chat statistics and `after_id`/`before_id` jump-to-message windows.
  - Added proxy authentication options for safer deployments.

- **Bug Fixes**
  - Made anonymous viewing strictly read-only (no master/admin privileges).
  - Hardened search wildcard handling and improved message pagination consistency.
  - Improved realtime reliability during database blips; DB-unavailable now returns 503.

- **Documentation**
  - Clarified anonymous access and reverse-proxy header security requirements, plus environment variables.

- **Chores/Tests**
  - Expanded coverage and added regression tests around batching, caching, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->