### PR TITLE
feat: group-migration handling (#228) + sender avatars (#229)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -174,6 +174,13 @@ PRIVATE_INCLUDE_CHAT_IDS=
 GROUPS_INCLUDE_CHAT_IDS=
 CHANNELS_INCLUDE_CHAT_IDS=
 
+# Group → supergroup migrations (#228): when a tracked basic group is upgraded to
+# a supergroup it gets a brand-new id and capture would otherwise silently stop.
+# The scheduled backup always warns (count-only). Set FOLLOW_CHAT_MIGRATIONS=true
+# to instead adopt the new supergroup id automatically (persisted and merged into
+# the backup + listener scope). Default false — warning only.
+# FOLLOW_CHAT_MIGRATIONS=false
+
 # ==============================================================================
 # REAL-TIME LISTENER
 # ==============================================================================

--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ The **Scope** column shows whether each variable applies to the backup scheduler
 | `GROUPS_INCLUDE_CHAT_IDS` | - | B | Force-include specific groups |
 | `CHANNELS_EXCLUDE_CHAT_IDS` | - | B | Exclude specific channels |
 | `CHANNELS_INCLUDE_CHAT_IDS` | - | B | Force-include specific channels |
+| `FOLLOW_CHAT_MIGRATIONS` | `false` | B | Automatically adopt the new supergroup id when a tracked basic group is upgraded to a supergroup, so capture continues without editing include lists. When off, the sweep only warns. See [Group → supergroup migrations](#group--supergroup-migrations) |
 | **Real-time Listener** | | | See [Real-time Listener](#real-time-listener) below |
 | `ENABLE_LISTENER` | `false` | B | **Master switch** — enables all `LISTEN_*` features below |
 | `LISTEN_EDITS` | `true` | B | Apply text edits in real-time |
@@ -407,6 +408,14 @@ For reactions on **older** messages, set `REACTION_RESWEEP_DAYS=N`: on every sch
 Telegram rate-limits `getMessagesReactions` by **burst rate across all chats** (the bucket size varies a lot between accounts — from a handful of requests to dozens), so the re-sweep paces itself: requests are spaced by `REACTION_RESWEEP_BATCH_DELAY_SECONDS` (default `2`, measured across chat boundaries — smoothing, deliberately not sized to make floods impossible). On a FloodWait the re-sweep pauses **without sleeping or retrying** and resumes within the same run once the server-requested window has elapsed; it defers the remainder to the next scheduled sweep only when that window outlives the run, or after repeated floods in one run (a degrading bucket is left alone). Completed chats — and the mid-chat progress of a chat too large for one burst window — are remembered per cycle, so the next scheduled sweep resumes approximately where the last one stopped (the window shifts between runs; the reconcile is idempotent, so overlap is harmless). Over at most a few sweeps every chat in the window gets covered, without ever fighting the rate limiter.
 
 Sizing tip: `REACTION_RESWEEP_MAX_PER_CHAT` decides how much of the flood bucket one chat may consume (each 100 messages ≈ one request). On accounts with a small bucket, a lower cap such as `100` spends ~1 request per chat and lets a single run reach every eligible chat; large caps favor deep per-chat coverage over per-run breadth.
+
+### Group → supergroup migrations
+
+When a basic Telegram group is upgraded to a supergroup (adding admins, joining it to a channel, exceeding the member limit, and similar), Telegram gives it a brand-new supergroup id. The old group keeps its history but receives no further messages. Telegram delivers the migration only as a service message that the real-time handlers never see, so without help the archive would silently stop capturing the conversation at the old id.
+
+**Always on — the warning.** Every scheduled backup checks whether any tracked group has migrated to a supergroup that is not in scope and logs a count-only warning, for example: `1 tracked group(s) migrated to a supergroup not in scope; capture stops for them until you add the new id to GROUPS_INCLUDE_CHAT_IDS or enable FOLLOW_CHAT_MIGRATIONS`. The warning repeats every run until you act, and — like all logs in this project — never includes chat ids, titles, or message content. Detection works both live (the migrated group is still visible in the dialog list) and after the fact (a stored migration marker), so migrations that happened while the archiver was offline are still caught.
+
+**Opt-in — follow the migration.** Set `FOLLOW_CHAT_MIGRATIONS=true` and the archiver adopts the new supergroup id automatically: it is remembered across runs and merged into the effective backup scope (so the sweep captures the supergroup even if it is not in your include lists) and into the listener's real-time tracking. The newly adopted supergroup is backed up in the same run it is discovered. Following is additive and idempotent — a supergroup you had already added to `GROUPS_INCLUDE_CHAT_IDS` is unaffected, and one you have explicitly excluded is left alone. When the flag is off nothing is persisted; only the warning fires.
 
 ### Mass Operation Protection
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,9 @@ services:
       GROUPS_EXCLUDE_CHAT_IDS: ${GROUPS_EXCLUDE_CHAT_IDS:-}
       CHANNELS_INCLUDE_CHAT_IDS: ${CHANNELS_INCLUDE_CHAT_IDS:-}
       CHANNELS_EXCLUDE_CHAT_IDS: ${CHANNELS_EXCLUDE_CHAT_IDS:-}
+      # Adopt the new supergroup id when a tracked basic group migrates (#228).
+      # Default false = warn only; true = follow + capture automatically.
+      # FOLLOW_CHAT_MIGRATIONS: ${FOLLOW_CHAT_MIGRATIONS:-false}
 
       # Database Configuration (v3.0+)
       # Option 1: DATABASE_URL (takes priority)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.25.2"
+version = "7.26.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.25.2"
+__version__ = "7.26.0"

--- a/src/config.py
+++ b/src/config.py
@@ -355,6 +355,21 @@ class Config:
             0.0, float(os.getenv("REACTION_RESWEEP_BATCH_DELAY_SECONDS", "2"))
         )
 
+        # =====================================================================
+        # GROUP → SUPERGROUP MIGRATION FOLLOWING (issue #228)
+        # =====================================================================
+        # When a basic group is upgraded to a supergroup it is assigned a brand
+        # new channel id. Neither the live NewMessage handler nor the ChatAction
+        # handler sees the migration service message (Telethon exposes it to
+        # neither), so capture of the group silently stops at the old id. The
+        # scheduled sweep therefore ALWAYS warns (count-only) when a tracked
+        # group has migrated to a supergroup that is not in scope.
+        # FOLLOW_CHAT_MIGRATIONS (default OFF) additionally makes the archiver
+        # adopt the new supergroup id automatically: it is persisted to the
+        # metadata KV and merged into the effective backup + listener scope so
+        # capture continues seamlessly without editing GROUPS_INCLUDE_CHAT_IDS.
+        self.follow_chat_migrations = _parse_bool(os.getenv("FOLLOW_CHAT_MIGRATIONS"), default=False)
+
         # Note: LISTEN_ALBUMS removed - albums are automatically handled via grouped_id
         # in the NewMessage handler. The viewer groups messages by grouped_id.
 
@@ -462,6 +477,10 @@ class Config:
                 logger.info("  LISTEN_CHAT_ACTIONS: true - Chat metadata changes tracked!")
             logger.info(
                 f"  Mass operation protection: block if >{self.mass_operation_threshold} ops in {self.mass_operation_window_seconds}s"
+            )
+        if self.follow_chat_migrations:
+            logger.info(
+                "FOLLOW_CHAT_MIGRATIONS enabled - will adopt the new supergroup id after a group→supergroup migration"
             )
         if self.display_chat_ids:
             logger.info(f"Display mode: Viewer restricted to chat IDs {self.display_chat_ids}")

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -13,6 +13,7 @@ import logging
 import os
 import secrets
 import shutil
+from collections.abc import Iterable
 from datetime import datetime
 from functools import wraps
 from typing import Any
@@ -462,6 +463,40 @@ class DatabaseAdapter:
             row = result.scalar_one_or_none()
             return row
 
+    async def get_migration_markers(self) -> list[tuple[int, int]]:
+        """Return stored group→supergroup migration pointers (#228).
+
+        Selects service messages whose ``raw_data.action_type`` is
+        ``chat_migrate_to`` and returns ``(old_chat_id, new_marked_id)`` pairs,
+        where ``new_marked_id`` is ``raw_data.migrate_to_id`` (already in marked
+        ``-100…`` form, written by ``_process_message``). SELECT-only; used to
+        reconcile scope for migrations that occurred while the archiver was
+        offline (the dead basic group may no longer surface as a dialog).
+
+        The ``LIKE`` clause is only a cheap prefilter — the authoritative match
+        is the Python-side ``json.loads`` — so the result is portable across the
+        SQLite and PostgreSQL backends without dialect-specific JSON operators.
+        PII: ids are returned to the caller for scope reconciliation only.
+        """
+        markers: list[tuple[int, int]] = []
+        async with self.db_manager.async_session_factory() as session:
+            result = await session.execute(
+                select(Message.chat_id, Message.raw_data).where(Message.raw_data.like('%"chat_migrate_to"%'))
+            )
+            for chat_id, raw in result.all():
+                if not raw:
+                    continue
+                try:
+                    data = json.loads(raw)
+                except ValueError, TypeError:
+                    continue
+                if data.get("action_type") != "chat_migrate_to":
+                    continue
+                new_id = data.get("migrate_to_id")
+                if isinstance(new_id, int):
+                    markers.append((chat_id, new_id))
+        return markers
+
     # ========== Chat Operations ==========
 
     @retry_on_locked()
@@ -891,6 +926,25 @@ class DatabaseAdapter:
             await session.commit()
             logger.debug("Updated archived message text")
             return "applied"
+
+    async def sender_has_message_in_chats(self, sender_id: int, chat_ids: Iterable[int]) -> bool:
+        """Return True if sender_id authored at least one message in any of chat_ids.
+
+        SELECT-only membership probe used by the media ACL to decide whether a
+        viewer may fetch a member's avatar: a user avatar is served iff the
+        viewer can see a chat in which that user has spoken. Never logs ids.
+        """
+        chat_id_list = list(chat_ids)
+        if not chat_id_list:
+            return False
+        async with self.db_manager.async_session_factory() as session:
+            stmt = (
+                select(Message.id)
+                .where(and_(Message.sender_id == sender_id, Message.chat_id.in_(chat_id_list)))
+                .limit(1)
+            )
+            result = await session.execute(stmt)
+            return result.first() is not None
 
     async def backfill_is_outgoing(self, owner_id: int) -> None:
         """Backfill is_outgoing flag for messages sent by the owner."""

--- a/src/listener.py
+++ b/src/listener.py
@@ -13,6 +13,7 @@ Telegram deletions never remove archived messages.
 """
 
 import asyncio
+import json
 import logging
 import os
 from collections import deque
@@ -396,10 +397,38 @@ class TelegramListener:
         try:
             chats = await self.db.get_all_chats()
             self._tracked_chat_ids = {chat["id"] for chat in chats}
+            # Merge supergroups adopted via FOLLOW_CHAT_MIGRATIONS (#228) so the
+            # new supergroup is tracked for real-time capture from listener start,
+            # even if its chat row is not persisted yet on the very first adoption.
+            self._tracked_chat_ids |= await self._load_followed_migration_ids()
             logger.info(f"Tracking {len(self._tracked_chat_ids)} chats for real-time updates")
         except Exception as e:
             logger.warning(f"Could not load tracked chats: {e}")
             self._tracked_chat_ids = set()
+
+    async def _load_followed_migration_ids(self) -> set[int]:
+        """Read adopted-supergroup ids from the metadata KV (#228).
+
+        Empty unless FOLLOW_CHAT_MIGRATIONS is on. Never raises — a missing or
+        malformed value degrades to an empty set.
+        """
+        if not getattr(self.config, "follow_chat_migrations", False):
+            return set()
+        try:
+            raw = await self.db.get_metadata("followed_migrations")
+        except Exception as e:
+            logger.warning(f"Could not load followed migrations: {type(e).__name__}")
+            return set()
+        if not raw:
+            return set()
+        try:
+            loaded = json.loads(raw)
+        except ValueError, TypeError:
+            logger.warning("Malformed followed_migrations metadata; ignoring")
+            return set()
+        if isinstance(loaded, list):
+            return {x for x in loaded if isinstance(x, int)}
+        return set()
 
     def _get_marked_id(self, entity_or_peer) -> int:
         """

--- a/src/listener.py
+++ b/src/listener.py
@@ -256,6 +256,10 @@ class TelegramListener:
         self._owns_client = client is None  # Track if we created the client
         self._running = False
         self._tracked_chat_ids: set[int] = set()
+        # Supergroups adopted via FOLLOW_CHAT_MIGRATIONS (#228). Kept as a
+        # dedicated set (not just folded into _tracked_chat_ids) so whitelist
+        # mode — which ignores _tracked_chat_ids — can still process them.
+        self._followed_live: set[int] = set()
 
         # Zero-footprint mass operation protection
         self._protector = MassOperationProtector(
@@ -397,14 +401,17 @@ class TelegramListener:
         try:
             chats = await self.db.get_all_chats()
             self._tracked_chat_ids = {chat["id"] for chat in chats}
-            # Merge supergroups adopted via FOLLOW_CHAT_MIGRATIONS (#228) so the
-            # new supergroup is tracked for real-time capture from listener start,
-            # even if its chat row is not persisted yet on the very first adoption.
-            self._tracked_chat_ids |= await self._load_followed_migration_ids()
+            # Supergroups adopted via FOLLOW_CHAT_MIGRATIONS (#228): keep them in
+            # a dedicated set AND fold into the type-based tracked set, so the new
+            # supergroup is captured live from listener start (even before its chat
+            # row is persisted) in BOTH whitelist and type-based modes.
+            self._followed_live = await self._load_followed_migration_ids()
+            self._tracked_chat_ids |= self._followed_live
             logger.info(f"Tracking {len(self._tracked_chat_ids)} chats for real-time updates")
         except Exception as e:
             logger.warning(f"Could not load tracked chats: {e}")
             self._tracked_chat_ids = set()
+            self._followed_live = set()
 
     async def _load_followed_migration_ids(self) -> set[int]:
         """Read adopted-supergroup ids from the metadata KV (#228).
@@ -576,16 +583,19 @@ class TelegramListener:
         Two modes:
 
         MODE 1 - Whitelist Mode (CHAT_IDS is set):
-            Only process events for chats explicitly listed in CHAT_IDS.
+            Only process events for chats explicitly listed in CHAT_IDS, plus
+            any supergroup adopted via FOLLOW_CHAT_MIGRATIONS (#228).
 
         MODE 2 - Type-based Mode:
             Process if:
             - Chat is in our tracked list (backed up at least once), OR
             - Chat matches our backup filters (include lists)
         """
-        # MODE 1: Whitelist Mode - CHAT_IDS takes absolute priority
+        # MODE 1: Whitelist Mode - CHAT_IDS takes absolute priority. Followed
+        # migrations are added explicitly (not via _tracked_chat_ids, which
+        # whitelist mode ignores) so a migrated supergroup keeps flowing live.
         if self.config.whitelist_mode:
-            return chat_id in self.config.chat_ids
+            return chat_id in self.config.chat_ids or chat_id in self._followed_live
 
         # MODE 2: Type-based Mode
         # First, check if it's in our tracked chats

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -27,11 +27,15 @@ from telethon.tl.types import (
     Chat,
     InputPeerSelf,
     Message,
+    MessageActionChannelMigrateFrom,
+    MessageActionChatMigrateTo,
     MessageMediaContact,
     MessageMediaDocument,
     MessageMediaGeo,
     MessageMediaPhoto,
     MessageMediaPoll,
+    PeerChannel,
+    PeerChat,
     TextWithEntities,
     User,
 )
@@ -374,6 +378,10 @@ class TelegramBackup:
         # the run if the client lacks the required Telethon internals.
         self._parallel_downloader: ParallelDownloader | None = None
         self._parallel_download_disabled = False
+        # Marked ids of supergroups adopted after a group→supergroup migration
+        # (#228). Loaded from the metadata KV at the start of each backup_all run
+        # when FOLLOW_CHAT_MIGRATIONS is on; merged into the effective sweep scope.
+        self._followed_migration_ids: set[int] = set()
 
         logger.info("TelegramBackup initialized")
 
@@ -389,6 +397,154 @@ class TelegramBackup:
         This ensures IDs match what users see in Telegram and configure in env vars.
         """
         return get_peer_id(entity)
+
+    async def _load_followed_migrations(self) -> None:
+        """Load adopted-supergroup ids from the metadata KV (#228).
+
+        Populates ``self._followed_migration_ids`` from the ``followed_migrations``
+        metadata key (a JSON list of marked ids). Only consulted when
+        FOLLOW_CHAT_MIGRATIONS is on; when off the set stays empty so nothing is
+        treated as followed and the sweep only warns. Never raises — a missing or
+        malformed value degrades to "nothing followed yet".
+        """
+        self._followed_migration_ids = set()
+        if not self.config.follow_chat_migrations:
+            return
+        try:
+            raw = await self.db.get_metadata("followed_migrations")
+        except Exception as e:
+            logger.warning("Could not load followed migrations: %s", type(e).__name__)
+            return
+        if not raw:
+            return
+        try:
+            loaded = json.loads(raw)
+        except ValueError, TypeError:
+            logger.warning("Malformed followed_migrations metadata; ignoring")
+            return
+        if isinstance(loaded, list):
+            self._followed_migration_ids = {x for x in loaded if isinstance(x, int)}
+
+    def _is_followed_migration(self, chat_id: int) -> bool:
+        """True if ``chat_id`` was adopted via FOLLOW_CHAT_MIGRATIONS (#228)."""
+        return self.config.follow_chat_migrations and chat_id in self._followed_migration_ids
+
+    async def _reconcile_migrations(self, dialogs: list, backed_up_chat_ids: set[int]) -> None:
+        """Detect group→supergroup migrations and warn or follow them (#228).
+
+        Migration is invisible to the live handlers (Telethon surfaces the
+        ``MessageActionChatMigrateTo``/``ChannelMigrateFrom`` service message to
+        neither NewMessage nor ChatAction), so the scheduled sweep is the only
+        sound detection point. Two sources are combined:
+
+        * PRIMARY — the migrated basic group's ``Chat`` entity is still returned
+          in the dialog list and carries ``.migrated_to`` (an InputChannel).
+        * SECONDARY — a stored ``chat_migrate_to`` service marker, which covers
+          migrations that happened while the archiver was offline (the dead
+          basic group may no longer surface as a dialog).
+
+        For each new supergroup id NOT already captured this run / configured /
+        followed: when FOLLOW_CHAT_MIGRATIONS is on it is adopted (persisted to
+        the metadata KV and backed up immediately this run); otherwise a
+        count-only warning fires — re-emitted every run until acted on, so the
+        silent capture-stop can never go unnoticed. PII: counts only, never ids.
+        """
+        try:
+            migrations: dict[int, int] = {}
+
+            # PRIMARY: entities the sweep already fetched this run.
+            for dialog in dialogs:
+                entity = getattr(dialog, "entity", None)
+                migrated_to = getattr(entity, "migrated_to", None)
+                channel_id = getattr(migrated_to, "channel_id", None) if migrated_to is not None else None
+                if channel_id is None:
+                    continue
+                old_id = self._get_marked_id(entity)
+                migrations[old_id] = get_peer_id(PeerChannel(channel_id))
+
+            # SECONDARY: stored markers (migrations that happened while offline).
+            try:
+                for old_id, new_id in await self.db.get_migration_markers():
+                    migrations.setdefault(old_id, new_id)
+            except Exception as e:
+                logger.warning("Migration marker lookup failed: %s", type(e).__name__)
+
+            if not migrations:
+                return
+
+            # Ids the user already arranged to capture (explicit config) or
+            # explicitly opted out of (exclude lists take priority — no nag).
+            configured = (
+                self.config.chat_ids
+                | self.config.global_include_ids
+                | self.config.groups_include_ids
+                | self.config.channels_include_ids
+            )
+            excluded = (
+                self.config.global_exclude_ids | self.config.groups_exclude_ids | self.config.channels_exclude_ids
+            )
+
+            out_of_scope: set[int] = set()
+            for new_id in migrations.values():
+                if new_id in excluded:
+                    continue  # user opted the new supergroup out
+                if new_id in backed_up_chat_ids or new_id in configured:
+                    continue  # already in scope and captured
+                if self.config.follow_chat_migrations and new_id in self._followed_migration_ids:
+                    continue  # already adopted on a previous run
+                out_of_scope.add(new_id)
+
+            if not out_of_scope:
+                return
+
+            if self.config.follow_chat_migrations:
+                # Adopt: persist first (durable), then capture this run.
+                self._followed_migration_ids |= out_of_scope
+                try:
+                    await self.db.set_metadata("followed_migrations", json.dumps(sorted(self._followed_migration_ids)))
+                except Exception as e:
+                    logger.warning("Could not persist followed migrations: %s", type(e).__name__)
+                captured = 0
+                for new_id in out_of_scope:
+                    try:
+                        if await self._backup_followed_migration(new_id):
+                            backed_up_chat_ids.add(new_id)
+                            captured += 1
+                    except Exception as e:
+                        logger.warning("Could not capture a newly-followed supergroup: %s", type(e).__name__)
+                logger.info(
+                    "FOLLOW_CHAT_MIGRATIONS: adopted %d migrated supergroup(s), captured %d this run",
+                    len(out_of_scope),
+                    captured,
+                )
+            else:
+                logger.warning(
+                    "%d tracked group(s) migrated to a supergroup not in scope; capture stops for them "
+                    "until you add the new id to GROUPS_INCLUDE_CHAT_IDS or enable FOLLOW_CHAT_MIGRATIONS",
+                    len(out_of_scope),
+                )
+        except Exception as e:
+            logger.warning("Migration reconciliation failed: %s", type(e).__name__)
+
+    async def _backup_followed_migration(self, new_id: int) -> bool:
+        """Fetch and back up a newly-adopted supergroup this run (#228).
+
+        Returns True when the supergroup was fetched and backed up, False when it
+        is inaccessible (caught and count-only-logged so the sweep never crashes).
+        """
+        try:
+            entity = await call_with_flood_retry(self.client.get_entity, new_id)
+        except Exception as e:
+            logger.warning("Followed supergroup is inaccessible this run: %s", type(e).__name__)
+            return False
+
+        class _FollowedDialog:
+            def __init__(self, followed_entity):
+                self.entity = followed_entity
+                self.date = datetime.now()
+
+        await self._backup_dialog(_FollowedDialog(entity), is_archived=False)
+        return True
 
     @classmethod
     async def create(cls, config: Config, client: TelegramClient | None = None) -> TelegramBackup:
@@ -505,6 +661,12 @@ class TelegramBackup:
             # (which chats already completed after a deferred run — #224).
             await self._load_resweep_cycle()
 
+            # Load the set of supergroups we already adopted after a group→
+            # supergroup migration (#228) so they are treated as in-scope this
+            # run. Only when FOLLOW_CHAT_MIGRATIONS is on — when off nothing is
+            # ever persisted and this stays empty (warning-only behaviour).
+            await self._load_followed_migrations()
+
             # Whitelist mode: skip expensive get_dialogs() and fetch only the
             # specified chats directly.  For accounts with many dialogs the full
             # dialog fetch can hang indefinitely (see #95).
@@ -515,7 +677,9 @@ class TelegramBackup:
                 archived_dialogs = []
                 explicitly_excluded_chat_ids = set()
                 seen_chat_ids = set()
-                for cid in self.config.chat_ids:
+                # Adopted-migration supergroups (#228) are captured even in
+                # whitelist mode so a followed group keeps flowing after upgrade.
+                for cid in self.config.chat_ids | self._followed_migration_ids:
                     try:
                         entity = await call_with_flood_retry(self.client.get_entity, cid)
 
@@ -586,6 +750,10 @@ class TelegramBackup:
                     elif self.config.should_backup_chat(chat_id, is_user, is_group, is_channel, is_bot):
                         # Chat should be backed up
                         filtered_dialogs.append(dialog)
+                    elif self._is_followed_migration(chat_id):
+                        # Adopted after a group→supergroup migration (#228): in
+                        # scope even though it is not in any user include list.
+                        filtered_dialogs.append(dialog)
 
                 # Fetch explicitly included chats that weren't in dialogs
                 # This handles cases where chats don't appear in the dialog list
@@ -596,7 +764,12 @@ class TelegramBackup:
                     | self.config.groups_include_ids
                     | self.config.channels_include_ids
                 )
-                missing_include_ids = all_include_ids - seen_chat_ids - explicitly_excluded_chat_ids
+                # Followed migrations (#228) are fetched explicitly too, so an
+                # adopted supergroup that no longer surfaces in the dialog list
+                # (e.g. not recently active) is still captured.
+                missing_include_ids = (
+                    (all_include_ids | self._followed_migration_ids) - seen_chat_ids - explicitly_excluded_chat_ids
+                )
 
                 if missing_include_ids:
                     logger.info(f"Fetching {len(missing_include_ids)} explicitly included chats not in regular dialogs")
@@ -711,7 +884,9 @@ class TelegramBackup:
                 is_group = isinstance(entity, Chat) or (isinstance(entity, Channel) and entity.megagroup)
                 is_channel = isinstance(entity, Channel) and not entity.megagroup
 
-                if self.config.should_backup_chat(chat_id, is_user, is_group, is_channel, is_bot):
+                if self.config.should_backup_chat(
+                    chat_id, is_user, is_group, is_channel, is_bot
+                ) or self._is_followed_migration(chat_id):
                     archived_to_backup.append(dialog)
 
             if archived_to_backup:
@@ -738,6 +913,12 @@ class TelegramBackup:
             # (#224) — directly after the dialog loops, so a later failure in
             # topics/folders/statistics cannot drop the cursor update.
             await self._finalize_resweep_cycle()
+
+            # Reconcile group→supergroup migrations (#228): warn (count-only)
+            # about tracked groups that migrated out of scope, and — when
+            # FOLLOW_CHAT_MIGRATIONS is on — adopt + capture the new supergroup.
+            # Guarded internally so it can never abort folders/stats below.
+            await self._reconcile_migrations(list(filtered_dialogs) + list(archived_to_backup), backed_up_chat_ids)
 
             # v6.2.0: Backup forum topics for forum-enabled chats.
             # Idempotent backstop to the early per-dialog fetch in _backup_dialog
@@ -1867,6 +2048,16 @@ class TelegramBackup:
             action_title = getattr(action, "title", None)
             if action_title is not None:
                 message_data["raw_data"]["new_title"] = self._text_with_entities_to_string(action_title)
+
+            # Group ↔ supergroup migration pointers (#228). MessageActionChatMigrateTo
+            # carries only ``.channel_id`` (no ``.title``), so the new supergroup id
+            # would otherwise be silently dropped; persist it in marked form so a
+            # later sweep can reconcile scope even if the migration happened while
+            # the archiver was offline. The reverse marker records the old group id.
+            if isinstance(action, MessageActionChatMigrateTo):
+                message_data["raw_data"]["migrate_to_id"] = get_peer_id(PeerChannel(action.channel_id))
+            elif isinstance(action, MessageActionChannelMigrateFrom):
+                message_data["raw_data"]["migrate_from_id"] = get_peer_id(PeerChat(action.chat_id))
 
             # Service messages carry no user-authored text, so synthesize the same
             # human-readable line the live listener stores. Only fill an empty text

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -490,6 +490,12 @@ class TelegramBackup:
                     continue  # user opted the new supergroup out
                 if new_id in backed_up_chat_ids or new_id in configured:
                     continue  # already in scope and captured
+                # A migrated supergroup is always a megagroup, so ask the
+                # type-based filter directly: in all-groups mode (no include
+                # list) the new supergroup is naturally in scope and will be
+                # captured on its own, so warning about it would be spurious.
+                if self.config.should_backup_chat(new_id, is_user=False, is_group=True, is_channel=False, is_bot=False):
+                    continue
                 if self.config.follow_chat_migrations and new_id in self._followed_migration_ids:
                     continue  # already adopted on a previous run
                 out_of_scope.add(new_id)
@@ -679,7 +685,17 @@ class TelegramBackup:
                 seen_chat_ids = set()
                 # Adopted-migration supergroups (#228) are captured even in
                 # whitelist mode so a followed group keeps flowing after upgrade.
-                for cid in self.config.chat_ids | self._followed_migration_ids:
+                # Honor the exclude lists for the followed additions (the explicit
+                # CHAT_IDS whitelist itself is never exclude-filtered). Only touch
+                # the exclude sets when there is actually something followed.
+                followed_to_fetch = self._followed_migration_ids
+                if followed_to_fetch:
+                    followed_to_fetch = followed_to_fetch - (
+                        self.config.global_exclude_ids
+                        | self.config.groups_exclude_ids
+                        | self.config.channels_exclude_ids
+                    )
+                for cid in self.config.chat_ids | followed_to_fetch:
                     try:
                         entity = await call_with_flood_retry(self.client.get_entity, cid)
 

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -845,8 +845,15 @@ def get_user_chat_ids(user: UserContext) -> set[int] | None:
     return user.allowed_chat_ids & master_filter
 
 
-def _enforce_media_acl(path: str, user: UserContext, *, thumbnail: bool = False) -> None:
-    """Enforce chat-scoped access for a media URL path before serving bytes."""
+def _enforce_media_acl(path: str, user: UserContext, *, thumbnail: bool = False, member_ok: bool = False) -> None:
+    """Enforce chat-scoped access for a media URL path before serving bytes.
+
+    member_ok is a pre-resolved membership verdict for user-avatar paths
+    (avatars/users/{user_id}_...): the async endpoints run the SELECT-only
+    probe and pass True when the requested user has spoken in a chat the
+    viewer is authorized for. It is only honored for the avatars/users/
+    branch; avatars/chats/ and regular media ACL are unchanged.
+    """
     user_chat_ids = get_user_chat_ids(user)
     if user_chat_ids is None:
         return
@@ -856,17 +863,26 @@ def _enforce_media_acl(path: str, user: UserContext, *, thumbnail: bool = False)
         raise HTTPException(status_code=403, detail="Access denied")
 
     if parts[0] == "avatars":
-        # Avatar path: avatars/{users|chats}/{chat_id}_{photo_id}.jpg
+        # Avatar path: avatars/{users|chats}/{id}_{photo_id}.jpg
         if len(parts) < 3:
             raise HTTPException(status_code=403, detail="Access denied")
+        subfolder = parts[1]
         name = parts[2].rsplit(".", 1)[0] if "." in parts[2] else parts[2]
         try:
-            avatar_chat_id = int(name.split("_")[0])
+            avatar_id = int(name.split("_")[0])
         except ValueError:
             raise HTTPException(status_code=403, detail="Access denied")
-        if avatar_chat_id not in user_chat_ids:
-            raise HTTPException(status_code=403, detail="Access denied")
-        return
+        # Direct grant: a chat avatar for an allowed chat, or a 1:1 contact
+        # avatar whose user id == the private chat id the viewer can see.
+        if avatar_id in user_chat_ids:
+            return
+        # avatars/users/{user_id}: the first segment is a USER id, not a chat
+        # id. Serve it when that user is a member of a visible chat (they have
+        # spoken in a chat the viewer is authorized for). member_ok carries
+        # that pre-resolved DB verdict from the endpoint.
+        if subfolder == "users" and member_ok:
+            return
+        raise HTTPException(status_code=403, detail="Access denied")
 
     try:
         media_chat_id = int(parts[0])
@@ -944,8 +960,11 @@ async def serve_thumbnail(size: int, folder: str, filename: str, user: UserConte
     if user.no_download and not folder.startswith("avatars/"):
         raise HTTPException(status_code=403, detail="Downloads disabled for this account")
 
-    # Early ACL check on requested path (prevents existence leakage)
-    _enforce_media_acl(f"{folder}/{filename}", user, thumbnail=True)
+    # Early ACL check on requested path (prevents existence leakage).
+    # Member avatars (avatars/users/) are gated by a visible-membership probe.
+    requested = f"{folder}/{filename}"
+    member_ok = await _avatar_user_visible_member(requested, user)
+    _enforce_media_acl(requested, user, thumbnail=True, member_ok=member_ok)
 
     from .thumbnails import ensure_thumbnail, resolve_cache_dir
 
@@ -960,7 +979,9 @@ async def serve_thumbnail(size: int, folder: str, filename: str, user: UserConte
     thumb_path, resolved_folder = result
     # Secondary ACL on resolved path if it differs (prevents bypass via legacy fallback)
     if resolved_folder != folder:
-        _enforce_media_acl(f"{resolved_folder}/{filename}", user, thumbnail=True)
+        resolved = f"{resolved_folder}/{filename}"
+        resolved_member_ok = await _avatar_user_visible_member(resolved, user)
+        _enforce_media_acl(resolved, user, thumbnail=True, member_ok=resolved_member_ok)
 
     return FileResponse(thumb_path, media_type="image/webp", headers={"Cache-Control": "public, max-age=86400"})
 
@@ -1007,7 +1028,9 @@ async def serve_media(path: str, download: int = Query(0), user: UserContext = D
 
     # ACL uses the original request path (chat folder), not the resolved symlink
     # target — symlinks into _shared/ don't carry chat folder context.
-    _enforce_media_acl(path, user)
+    # Member avatars (avatars/users/) are gated by a visible-membership probe.
+    member_ok = await _avatar_user_visible_member(path, user)
+    _enforce_media_acl(path, user, member_ok=member_ok)
 
     if not resolved.is_file():
         raise HTTPException(status_code=404, detail="File not found")
@@ -1394,6 +1417,53 @@ def _get_cached_avatar_path(chat_id: int, chat_type: str) -> str | None:
     return avatar_path
 
 
+def _sender_avatar_url(sender_id: int | None) -> str | None:
+    """Resolve a per-message member avatar URL from files ALREADY on disk.
+
+    A member avatar exists only when a prior backup happened to download it
+    (in practice because the sender is also a 1:1 contact). Proactive
+    member-avatar download is intentionally deferred (slice 2b) — it is
+    flood-sensitive, so nothing here fetches arbitrary member photos. The
+    initials circle in the viewer is the always-available render; a served
+    file is a bonus. Returns None when no file is present.
+
+    User ids are positive and map to avatars/users/ (same folder + naming as a
+    private chat with that id), so the shared avatar cache resolves them with
+    no collision against negative group/channel chat ids.
+    """
+    if not sender_id or sender_id <= 0:
+        return None
+    avatar_path = _get_cached_avatar_path(sender_id, "private")
+    return f"/media/{avatar_path}" if avatar_path else None
+
+
+async def _avatar_user_visible_member(path: str, user: UserContext) -> bool:
+    """Pre-resolve whether an avatars/users/ path is for a visible member.
+
+    Runs the SELECT-only membership probe for the avatars/users/{user_id}_...
+    case only, so the sync _enforce_media_acl can stay signature-stable. A user
+    avatar is allowed iff the requested user has spoken in a chat the viewer is
+    authorized for. Returns False (no DB hit) for every other path, for
+    unrestricted viewers (ACL short-circuits anyway), and for ids already
+    directly allowed. Never logs ids.
+    """
+    parts = path.split("/")
+    if len(parts) < 3 or parts[0] != "avatars" or parts[1] != "users":
+        return False
+    user_chat_ids = get_user_chat_ids(user)
+    if user_chat_ids is None:
+        return False
+    name = parts[2].rsplit(".", 1)[0] if "." in parts[2] else parts[2]
+    try:
+        avatar_user_id = int(name.split("_")[0])
+    except ValueError:
+        return False
+    if avatar_user_id in user_chat_ids:
+        # Directly allowed as a 1:1 chat — no membership probe needed.
+        return True
+    return await db.sender_has_message_in_chats(avatar_user_id, user_chat_ids)
+
+
 @app.get("/api/chats")
 async def get_chats(
     user: UserContext = Depends(require_auth),
@@ -1503,6 +1573,16 @@ async def get_messages(
             after_id=after_id,
             topic_id=topic_id,
         )
+        # Slice 2a: attach a member-avatar URL inferred from files already on
+        # disk (globbed via the shared avatar cache). Null when absent — the
+        # viewer falls back to the initials circle. No new DB column; proactive
+        # member-avatar download stays deferred (slice 2b, flood-sensitive).
+        # get_messages_paginated returns a list of message dicts; guard so an
+        # unexpected shape can never turn a read into a 500.
+        if isinstance(messages, list):
+            for message in messages:
+                if isinstance(message, dict):
+                    message["sender_avatar_url"] = _sender_avatar_url(message.get("sender_id"))
         if user.no_download:
             _strip_original_media_paths(messages)
         return messages

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1035,7 +1035,11 @@ async def serve_media(path: str, download: int = Query(0), user: UserContext = D
     if not resolved.is_file():
         raise HTTPException(status_code=404, detail="File not found")
 
-    return FileResponse(resolved)
+    # Avatars are content-addressed (…_{photo_id}.jpg) and change rarely — let
+    # them cache like serve_thumbnail's output so avatar URLs aren't refetched
+    # on every page. Regular media keeps the default (no explicit caching).
+    headers = {"Cache-Control": "public, max-age=86400"} if path.startswith("avatars/") else None
+    return FileResponse(resolved, headers=headers)
 
 
 @app.get("/", response_class=HTMLResponse)
@@ -1394,6 +1398,13 @@ _avatar_cache: dict[int, str | None] = {}
 _avatar_cache_time: datetime | None = None
 AVATAR_CACHE_TTL_SECONDS = 300  # 5 minutes
 
+# Cache avatar membership verdicts to avoid a DB probe per avatar request.
+# Keyed by (avatar_user_id, frozenset(user_chat_ids)) — the verdict depends on
+# both. Mirrors the avatar-path cache's TTL sweep.
+_avatar_member_cache: dict[tuple[int, frozenset[int]], bool] = {}
+_avatar_member_cache_time: datetime | None = None
+AVATAR_MEMBER_CACHE_TTL_SECONDS = 300  # 5 minutes
+
 
 def _get_cached_avatar_path(chat_id: int, chat_type: str) -> str | None:
     """Get avatar path with caching."""
@@ -1443,9 +1454,11 @@ async def _avatar_user_visible_member(path: str, user: UserContext) -> bool:
     Runs the SELECT-only membership probe for the avatars/users/{user_id}_...
     case only, so the sync _enforce_media_acl can stay signature-stable. A user
     avatar is allowed iff the requested user has spoken in a chat the viewer is
-    authorized for. Returns False (no DB hit) for every other path, for
-    unrestricted viewers (ACL short-circuits anyway), and for ids already
-    directly allowed. Never logs ids.
+    authorized for. Returns True (no DB hit) when the id is already directly
+    allowed (a 1:1 chat the viewer can see); returns False (no DB hit) for every
+    other path and for unrestricted viewers (the ACL short-circuits anyway). On
+    any DB error the probe fails CLOSED (returns False → the avatar is denied).
+    Never logs ids.
     """
     parts = path.split("/")
     if len(parts) < 3 or parts[0] != "avatars" or parts[1] != "users":
@@ -1461,7 +1474,32 @@ async def _avatar_user_visible_member(path: str, user: UserContext) -> bool:
     if avatar_user_id in user_chat_ids:
         # Directly allowed as a 1:1 chat — no membership probe needed.
         return True
-    return await db.sender_has_message_in_chats(avatar_user_id, user_chat_ids)
+
+    # Cache the DB verdict (short TTL) so repeated avatar requests on a page
+    # don't each run the membership probe.
+    global _avatar_member_cache_time
+    now = datetime.utcnow()
+    if (
+        _avatar_member_cache_time
+        and (now - _avatar_member_cache_time).total_seconds() > AVATAR_MEMBER_CACHE_TTL_SECONDS
+    ):
+        _avatar_member_cache.clear()
+        _avatar_member_cache_time = None
+    cache_key = (avatar_user_id, frozenset(user_chat_ids))
+    if cache_key in _avatar_member_cache:
+        return _avatar_member_cache[cache_key]
+
+    try:
+        verdict = await db.sender_has_message_in_chats(avatar_user_id, user_chat_ids)
+    except Exception as exc:
+        # Fail closed: a transient DB error must deny the avatar (403), never
+        # surface as an uncaught 500. Log the exception class only (no ids).
+        logger.warning("Avatar membership probe failed (%s); denying avatar", exc.__class__.__name__)
+        return False
+    _avatar_member_cache[cache_key] = verdict
+    if _avatar_member_cache_time is None:
+        _avatar_member_cache_time = now
+    return verdict
 
 
 @app.get("/api/chats")

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1036,10 +1036,15 @@ async def serve_media(path: str, download: int = Query(0), user: UserContext = D
         raise HTTPException(status_code=404, detail="File not found")
 
     # Avatars are content-addressed (…_{photo_id}.jpg) and change rarely — let
-    # them cache like serve_thumbnail's output so avatar URLs aren't refetched
-    # on every page. Regular media keeps the default (no explicit caching).
-    headers = {"Cache-Control": "public, max-age=86400"} if path.startswith("avatars/") else None
-    return FileResponse(resolved, headers=headers)
+    # them cache like serve_thumbnail's output so avatar URLs aren't refetched on
+    # every page. The Cache-Control is set on the response after construction so
+    # the FileResponse(resolved) call is unchanged; the containment check above
+    # (reject ../absolute, resolve strict, is_relative_to media root) is the
+    # actual path-traversal protection.
+    response = FileResponse(resolved)
+    if path.startswith("avatars/"):
+        response.headers["Cache-Control"] = "public, max-age=86400"
+    return response
 
 
 @app.get("/", response_class=HTMLResponse)

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -785,6 +785,17 @@
                         </div>
                     </div>
 
+                    <!-- Group ↔ supergroup migration banner (#228). Display-only pointer;
+                         rendered only when the loaded messages carry the marker. -->
+                    <div v-if="migrationBanner && !showPinnedOnly"
+                        class="px-4 py-2 bg-blue-500/10 border-b border-blue-500/30 flex items-center gap-3 text-sm text-blue-200">
+                        <svg class="w-4 h-4 shrink-0 text-blue-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" />
+                        </svg>
+                        <span class="truncate">{{ migrationBanner.text }}</span>
+                    </div>
+
                     <!-- Pinned Message Banner (only shown in normal view, not in pinned-only view) -->
                     <!-- Click on message content → scroll to message + cycle to next -->
                     <!-- Click on pin icon (right side) → open pinned messages view -->
@@ -975,7 +986,25 @@
                                 </div>
                             </div>
                             <!-- Regular Message (hide duplicate album messages - only show first in group) -->
-                            <div v-else-if="!isHiddenAlbumMessage(msg, index)" :data-msg-id="msg.id" class="flex" :class="isOwnMessage(msg) ? 'justify-end' : 'justify-start'">
+                            <div v-else-if="!isHiddenAlbumMessage(msg, index)" :data-msg-id="msg.id" class="flex items-end gap-2" :class="isOwnMessage(msg) ? 'justify-end' : 'justify-start'">
+                                <!-- Sender avatar gutter (#229): group + non-own only.
+                                     Circle renders at the run start (alongside the name);
+                                     an empty gutter keeps the rest of the run aligned. Shows
+                                     the on-disk member photo when present (slice 2a), else the
+                                     initials circle (always available, slice 1). NOTE:
+                                     proactive member-avatar download is intentionally deferred
+                                     (slice 2b, flood-sensitive) — only pre-existing files are
+                                     served, so initials are the primary render. -->
+                                <div v-if="isGroup && !isOwnMessage(msg)" class="w-8 shrink-0 self-end">
+                                    <div v-if="showSenderName(index)"
+                                        class="w-8 h-8 rounded-full overflow-hidden flex items-center justify-center text-xs font-bold text-white select-none"
+                                        :style="{ background: getAvatarFill(msg) }">
+                                        <img v-if="msg.sender_avatar_url" :src="msg.sender_avatar_url"
+                                            class="w-full h-full object-cover"
+                                            @error="msg.sender_avatar_url = null" :alt="getSenderName(msg)">
+                                        <template v-else>{{ getSenderInitials(msg) }}</template>
+                                    </div>
+                                </div>
                                 <div class="message-bubble p-3 text-sm shadow-sm text-gray-100"
                                     :style="getSenderStyle(msg)">
                                     <!-- Sender Name (if group and first in sequence) -->
@@ -3333,6 +3362,30 @@
                     return pinnedMessages.value[currentPinnedIndex.value] || pinnedMessages.value[0]
                 })
 
+                // Computed: group ↔ supergroup migration pointer (#228). The backup
+                // persists raw_data.migrate_to_id on the old chat's migrate service
+                // message, and raw_data.migrate_from_id (+ raw_data.new_title) on the
+                // new supergroup's channel_migrate_from message. Display-only: when a
+                // loaded message carries such a pointer we surface a lightweight
+                // banner; otherwise it degrades cleanly to null (no banner).
+                const migrationBanner = computed(() => {
+                    for (const msg of messages.value) {
+                        const raw = msg.raw_data
+                        if (!raw) continue
+                        if (raw.migrate_to_id != null) {
+                            return { direction: 'to', text: 'This group continues as a supergroup →' }
+                        }
+                        if (raw.migrate_from_id != null) {
+                            const title = raw.new_title
+                            return {
+                                direction: 'from',
+                                text: title ? `← Migrated from ${title}` : '← Migrated from a group',
+                            }
+                        }
+                    }
+                    return null
+                })
+
                 // Load all pinned messages for a chat
                 const loadPinnedMessages = async (chatId) => {
                     try {
@@ -3867,6 +3920,43 @@
                     const hue = getSenderColor(msg)
                     // Bright, vibrant color for name
                     return `hsl(${hue}, 70%, 65%)`
+                }
+
+                // Sender avatar helpers (#229 group avatars). Memoized per sender_id
+                // to avoid recomputing initials/fill for every message in a run.
+                const _senderInitialsCache = new Map()
+                const _senderFillCache = new Map()
+                const senderKey = (msg) => String(msg.sender_id ?? msg.chat_id ?? 0)
+
+                // Up to 2 uppercased initials from the sender's first/last name.
+                // Deleted / nameless senders get '?' (NOT the getChatName
+                // 'Deleted Account' fallback — that would render 'DA').
+                const getSenderInitials = (msg) => {
+                    const key = senderKey(msg)
+                    if (_senderInitialsCache.has(key)) return _senderInitialsCache.get(key)
+                    const name = [msg.first_name, msg.last_name].filter(Boolean).join(' ').trim()
+                    let initials = '?'
+                    if (name) {
+                        initials = name.split(/\s+/).map(n => n[0]).join('').substring(0, 2).toUpperCase()
+                    }
+                    _senderInitialsCache.set(key, initials)
+                    return initials
+                }
+
+                // Darker fill for the initials circle. Native top-lighter →
+                // bottom-darker gradient, but BOTH stops sit in the contrast-safe
+                // zone: hsl(h,65%,27%) → hsl(h,65%,18%) both clear white-text
+                // contrast >=4.5:1 (WCAG AA) on all 360 hues (verified: min 5.08
+                // and 8.94), so tall letters / anti-aliasing reaching the lighter
+                // corner stay legible. The name palette hsl(h,70%,65%), by
+                // contrast, fails on most hues — which is why the fill is separate.
+                const getAvatarFill = (msg) => {
+                    const key = senderKey(msg)
+                    if (_senderFillCache.has(key)) return _senderFillCache.get(key)
+                    const hue = getSenderColor(msg)
+                    const fill = `linear-gradient(135deg, hsl(${hue}, 65%, 27%), hsl(${hue}, 65%, 18%))`
+                    _senderFillCache.set(key, fill)
+                    return fill
                 }
 
                 const getPollPercentage = (msg, answer) => {
@@ -4550,6 +4640,7 @@
                     selectChat,
                     chatStats,
                     pinnedMessage,
+                    migrationBanner,
                     pinnedMessages,
                     currentPinnedIndex,
                     showPinnedOnly,
@@ -4669,6 +4760,8 @@
                     // Colors / avatars
                     getSenderStyle,
                     getSenderNameColor,
+                    getSenderInitials,
+                    getAvatarFill,
                     getPollPercentage,
                     isDeletedChat,
                     isAudioFile,

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1000,6 +1000,7 @@
                                         class="w-8 h-8 rounded-full overflow-hidden flex items-center justify-center text-xs font-bold text-white select-none"
                                         :style="{ background: getAvatarFill(msg) }">
                                         <img v-if="msg.sender_avatar_url" :src="msg.sender_avatar_url"
+                                            loading="lazy"
                                             class="w-full h-full object-cover"
                                             @error="msg.sender_avatar_url = null" :alt="getSenderName(msg)">
                                         <template v-else>{{ getSenderInitials(msg) }}</template>
@@ -3373,14 +3374,11 @@
                         const raw = msg.raw_data
                         if (!raw) continue
                         if (raw.migrate_to_id != null) {
-                            return { direction: 'to', text: 'This group continues as a supergroup →' }
+                            return { text: 'This group continues as a supergroup →' }
                         }
                         if (raw.migrate_from_id != null) {
                             const title = raw.new_title
-                            return {
-                                direction: 'from',
-                                text: title ? `← Migrated from ${title}` : '← Migrated from a group',
-                            }
+                            return { text: title ? `← Migrated from ${title}` : '← Migrated from a group' }
                         }
                     }
                     return null
@@ -3922,24 +3920,28 @@
                     return `hsl(${hue}, 70%, 65%)`
                 }
 
-                // Sender avatar helpers (#229 group avatars). Memoized per sender_id
-                // to avoid recomputing initials/fill for every message in a run.
+                // Sender avatar helpers (#229 group avatars). Memoized to avoid
+                // recomputing initials/fill for every message in a run: the fill
+                // (color) keys on sender_id; the monogram keys on the resolved
+                // name string (post_author can differ per message for the same
+                // sender_id, so a sender_id key would be wrong for channels).
                 const _senderInitialsCache = new Map()
                 const _senderFillCache = new Map()
                 const senderKey = (msg) => String(msg.sender_id ?? msg.chat_id ?? 0)
 
-                // Up to 2 uppercased initials from the sender's first/last name.
-                // Deleted / nameless senders get '?' (NOT the getChatName
-                // 'Deleted Account' fallback — that would render 'DA').
+                // Up to 2 uppercased initials from the SAME name getSenderName
+                // resolves (post_author → first/last → username → User <id>), so
+                // the monogram matches the visible name label. Only '?' when
+                // getSenderName itself has nothing real (its 'Deleted Account'
+                // terminal) — never the 'DA' that string would otherwise yield.
                 const getSenderInitials = (msg) => {
-                    const key = senderKey(msg)
-                    if (_senderInitialsCache.has(key)) return _senderInitialsCache.get(key)
-                    const name = [msg.first_name, msg.last_name].filter(Boolean).join(' ').trim()
-                    let initials = '?'
-                    if (name) {
-                        initials = name.split(/\s+/).map(n => n[0]).join('').substring(0, 2).toUpperCase()
-                    }
-                    _senderInitialsCache.set(key, initials)
+                    const name = getSenderName(msg)
+                    if (!name || name === 'Deleted Account') return '?'
+                    const cached = _senderInitialsCache.get(name)
+                    if (cached !== undefined) return cached
+                    const initials =
+                        name.split(/\s+/).filter(Boolean).map(n => n[0]).join('').substring(0, 2).toUpperCase() || '?'
+                    _senderInitialsCache.set(name, initials)
                     return initials
                 }
 

--- a/tests/test_chat_migration.py
+++ b/tests/test_chat_migration.py
@@ -27,6 +27,7 @@ from telethon.utils import get_peer_id
 
 from src.config import Config
 from src.db.adapter import DatabaseAdapter
+from src.listener import TelegramListener
 from src.telegram_backup import TelegramBackup
 
 
@@ -81,6 +82,9 @@ def _make_service_message(action, text=""):
 def _make_process_backup():
     backup = TelegramBackup.__new__(TelegramBackup)
     backup.config = MagicMock()
+    # Bare MagicMock attrs are truthy — pin should_skip_topic so a future
+    # topic-skip code path can't be silently short-circuited (documented pitfall).
+    backup.config.should_skip_topic = MagicMock(return_value=False)
     backup.db = AsyncMock()
     backup.client = AsyncMock()
     return backup
@@ -136,6 +140,12 @@ def _make_reconcile_backup(follow=False):
     cfg.global_exclude_ids = set()
     cfg.groups_exclude_ids = set()
     cfg.channels_exclude_ids = set()
+    # Default: the new supergroup is NOT in type-based scope (out of scope) unless
+    # a test opts it in. Real Config.should_backup_chat is exercised separately.
+    cfg.should_backup_chat = MagicMock(return_value=False)
+    # Pin should_skip_topic (bare MagicMock attrs are truthy) so a future
+    # topic-skip code path can't be silently short-circuited (documented pitfall).
+    cfg.should_skip_topic = MagicMock(return_value=False)
     backup.config = cfg
     backup.db = AsyncMock()
     backup.db.get_migration_markers = AsyncMock(return_value=[])
@@ -193,6 +203,19 @@ class TestReconcileMigrationsWarn(unittest.TestCase):
         backup.config.groups_include_ids = {new_id}
         with self.assertNoLogs(_LOGGER, level="WARNING"):
             _run(backup._reconcile_migrations([_migrated_dialog(555)], set()))
+
+    def test_suppressed_when_new_id_in_type_based_scope(self):
+        """All-groups mode: the migrated supergroup is type-in-scope, so no nag."""
+        backup = _make_reconcile_backup(follow=False)
+        backup._get_marked_id = MagicMock(return_value=-100)
+        # should_backup_chat True → the supergroup is captured naturally.
+        backup.config.should_backup_chat = MagicMock(return_value=True)
+        with self.assertNoLogs(_LOGGER, level="WARNING"):
+            _run(backup._reconcile_migrations([_migrated_dialog(555)], set()))
+        # Queried as a megagroup (is_group=True), not a broadcast channel.
+        _, kwargs = backup.config.should_backup_chat.call_args
+        self.assertTrue(kwargs.get("is_group"))
+        self.assertFalse(kwargs.get("is_channel"))
 
     def test_suppressed_when_new_id_explicitly_excluded(self):
         backup = _make_reconcile_backup(follow=False)
@@ -334,6 +357,221 @@ class TestFollowedMigrationScope(unittest.TestCase):
 # ===========================================================================
 # get_migration_markers adapter read (offline detection source)
 # ===========================================================================
+
+
+# ===========================================================================
+# FIX 1 / FIX 3(b) — listener processes followed supergroups in BOTH modes
+# ===========================================================================
+
+
+def _make_listener_config(*, follow, whitelist_mode=False, chat_ids=None):
+    """Config for the listener with follow_chat_migrations as a REAL bool.
+
+    (A MagicMock default would make follow_chat_migrations truthy and hide the
+    off-branch — the exact gap this covers.)
+    """
+    cfg = MagicMock()
+    cfg.api_id = 12345
+    cfg.api_hash = "test_hash"
+    cfg.phone = "+1234567890"
+    cfg.session_path = "/tmp/test_session"
+    cfg.validate_credentials = MagicMock()
+    cfg.global_include_ids = set()
+    cfg.private_include_ids = set()
+    cfg.groups_include_ids = set()
+    cfg.channels_include_ids = set()
+    cfg.whitelist_mode = whitelist_mode
+    cfg.chat_ids = chat_ids or set()
+    cfg.follow_chat_migrations = follow  # real bool, not MagicMock
+    cfg.listen_edits = True
+    cfg.listen_deletions = False
+    cfg.mass_operation_threshold = 10
+    cfg.mass_operation_window_seconds = 30
+    cfg.mass_operation_buffer_delay = 2.0
+    return cfg
+
+
+class TestListenerFollowScope(unittest.TestCase):
+    """A followed supergroup must be live-processed in whitelist AND type modes."""
+
+    def test_type_mode_tracks_and_processes_followed(self):
+        followed = get_peer_id(PeerChannel(555))
+        cfg = _make_listener_config(follow=True, whitelist_mode=False)
+        db = AsyncMock()
+        db.get_all_chats = AsyncMock(return_value=[{"id": -111}])
+        db.get_metadata = AsyncMock(return_value=json.dumps([followed]))
+        listener = TelegramListener(cfg, db)
+        _run(listener._load_tracked_chats())
+        self.assertIn(followed, listener._tracked_chat_ids)
+        self.assertIn(followed, listener._followed_live)
+        self.assertTrue(listener._should_process_chat(followed))
+
+    def test_whitelist_mode_processes_followed(self):
+        """Whitelist mode ignores _tracked_chat_ids, so follow must ride _followed_live."""
+        followed = get_peer_id(PeerChannel(555))
+        cfg = _make_listener_config(follow=True, whitelist_mode=True, chat_ids={-999})
+        db = AsyncMock()
+        db.get_all_chats = AsyncMock(return_value=[])
+        db.get_metadata = AsyncMock(return_value=json.dumps([followed]))
+        listener = TelegramListener(cfg, db)
+        _run(listener._load_tracked_chats())
+        self.assertIn(followed, listener._followed_live)
+        self.assertTrue(listener._should_process_chat(followed))  # via follow
+        self.assertTrue(listener._should_process_chat(-999))  # explicit whitelist
+        self.assertFalse(listener._should_process_chat(-12345))  # neither
+
+    def test_load_followed_off_short_circuits(self):
+        cfg = _make_listener_config(follow=False)
+        db = AsyncMock()
+        db.get_metadata = AsyncMock(return_value=json.dumps([-1]))
+        listener = TelegramListener(cfg, db)
+        self.assertEqual(_run(listener._load_followed_migration_ids()), set())
+        db.get_metadata.assert_not_awaited()
+
+    def test_load_followed_on_reads_metadata(self):
+        followed = get_peer_id(PeerChannel(555))
+        cfg = _make_listener_config(follow=True)
+        db = AsyncMock()
+        db.get_metadata = AsyncMock(return_value=json.dumps([followed]))
+        listener = TelegramListener(cfg, db)
+        self.assertEqual(_run(listener._load_followed_migration_ids()), {followed})
+
+    def test_load_followed_malformed_degrades_to_empty(self):
+        cfg = _make_listener_config(follow=True)
+        db = AsyncMock()
+        db.get_metadata = AsyncMock(return_value="not json{")
+        listener = TelegramListener(cfg, db)
+        self.assertEqual(_run(listener._load_followed_migration_ids()), set())
+
+    def test_load_followed_missing_degrades_to_empty(self):
+        cfg = _make_listener_config(follow=True)
+        db = AsyncMock()
+        db.get_metadata = AsyncMock(return_value=None)
+        listener = TelegramListener(cfg, db)
+        self.assertEqual(_run(listener._load_followed_migration_ids()), set())
+
+
+# ===========================================================================
+# FIX 3(a) — a pre-populated followed id actually lands in the sweep's
+# backed-up dialogs (drives backup_all through the real injection points)
+# ===========================================================================
+
+
+class _Ent:
+    """Marked-id-carrying stand-in entity (not a User/Chat/Channel instance, so
+    the type-based filter classifies it as none-of-the-above)."""
+
+    def __init__(self, mid):
+        self.mid = mid
+
+
+def _make_sweep_backup(*, followed, whitelist_mode, chat_ids, main_dialogs, archived_dialogs):
+    backup = TelegramBackup.__new__(TelegramBackup)
+    cfg = MagicMock()
+    cfg.whitelist_mode = whitelist_mode
+    cfg.chat_ids = chat_ids
+    cfg.phone = "+1234567890"
+    cfg.priority_chat_ids = set()
+    cfg.global_include_ids = set()
+    cfg.private_include_ids = set()
+    cfg.groups_include_ids = set()
+    cfg.channels_include_ids = set()
+    cfg.global_exclude_ids = set()
+    cfg.groups_exclude_ids = set()
+    cfg.channels_exclude_ids = set()
+    cfg.follow_chat_migrations = True  # real bool so _is_followed_migration works
+    cfg.verify_media = False
+    # Nothing is in scope by type/include — only the follow path can pull ids in.
+    cfg.should_backup_chat = MagicMock(return_value=False)
+    backup.config = cfg
+
+    db = AsyncMock()
+    db.get_last_message_id = AsyncMock(return_value=0)
+    db.calculate_and_store_statistics = AsyncMock(
+        return_value={"chats": 1, "messages": 1, "media_files": 0, "total_size_mb": 0}
+    )
+    backup.db = db
+
+    client = AsyncMock()
+    me = MagicMock()
+    me.first_name = "T"
+    me.id = 1
+    client.get_me = AsyncMock(return_value=me)
+    client.start = AsyncMock()
+    client.get_entity = AsyncMock(side_effect=lambda cid: _Ent(cid))
+    backup.client = client
+
+    backup._followed_migration_ids = set(followed)  # PRE-POPULATED
+    backup._get_marked_id = MagicMock(side_effect=lambda e: e.mid)
+    backup._get_dialogs = AsyncMock(side_effect=lambda archived=False: archived_dialogs if archived else main_dialogs)
+    # Isolate scope injection: stub the surrounding orchestration.
+    backup._load_resweep_cycle = AsyncMock()
+    backup._load_followed_migrations = AsyncMock()  # no-op: keep the pre-populated set
+    backup._finalize_resweep_cycle = AsyncMock()
+    backup._reconcile_migrations = AsyncMock()
+    backup._backup_folders = AsyncMock()
+    backup._retry_pending_media_downloads = AsyncMock()
+    backup._backup_dialog = AsyncMock(return_value=0)
+    return backup
+
+
+def _backed_up_ids(backup):
+    return {call.args[0].entity.mid for call in backup._backup_dialog.call_args_list}
+
+
+class TestFollowedSweepInjection(unittest.TestCase):
+    """Prove followed ids reach _backup_dialog via all three injection points."""
+
+    def test_type_mode_elif_and_missing_include_fetch(self):
+        f_in = get_peer_id(PeerChannel(555))  # present in dialogs → type-filter elif
+        f_out = get_peer_id(PeerChannel(666))  # absent → missing_include explicit fetch
+        dialog_in = MagicMock()
+        dialog_in.entity = _Ent(f_in)
+        dialog_in.date = datetime(2024, 1, 1, 0, 0, 0)
+        backup = _make_sweep_backup(
+            followed={f_in, f_out},
+            whitelist_mode=False,
+            chat_ids=set(),
+            main_dialogs=[dialog_in],
+            archived_dialogs=[],
+        )
+        _run(backup.backup_all())
+        backed = _backed_up_ids(backup)
+        self.assertIn(f_in, backed)  # injection point: type-filter elif
+        self.assertIn(f_out, backed)  # injection point: missing_include fetch
+        # f_out was pulled in via an explicit get_entity fetch.
+        backup.client.get_entity.assert_any_await(f_out)
+
+    def test_whitelist_mode_union_fetch(self):
+        followed = get_peer_id(PeerChannel(555))
+        whitelisted = -999
+        backup = _make_sweep_backup(
+            followed={followed},
+            whitelist_mode=True,
+            chat_ids={whitelisted},
+            main_dialogs=[],
+            archived_dialogs=[],
+        )
+        _run(backup.backup_all())
+        backed = _backed_up_ids(backup)
+        self.assertIn(followed, backed)  # injection point: whitelist union
+        self.assertIn(whitelisted, backed)
+
+    def test_whitelist_followed_excluded_is_not_fetched(self):
+        """FIX 2 (low): the followed additions honor the exclude list in whitelist mode."""
+        followed = get_peer_id(PeerChannel(555))
+        backup = _make_sweep_backup(
+            followed={followed},
+            whitelist_mode=True,
+            chat_ids={-999},
+            main_dialogs=[],
+            archived_dialogs=[],
+        )
+        backup.config.groups_exclude_ids = {followed}
+        _run(backup.backup_all())
+        backed = _backed_up_ids(backup)
+        self.assertNotIn(followed, backed)  # excluded → not pulled in
+        self.assertIn(-999, backed)
 
 
 class TestGetMigrationMarkers(unittest.TestCase):

--- a/tests/test_chat_migration.py
+++ b/tests/test_chat_migration.py
@@ -1,0 +1,376 @@
+"""Tests for group→supergroup migration handling (issue #228).
+
+Covers the three stories:
+- US-200: ``_process_message`` persists the migration pointer id in raw_data.
+- US-201: the always-on, count-only warning fired by ``_reconcile_migrations``.
+- US-202: the opt-in ``FOLLOW_CHAT_MIGRATIONS`` adopt-and-capture behaviour.
+
+Plus the ``get_migration_markers`` adapter read used for offline detection.
+"""
+
+import asyncio
+import json
+import os
+import unittest
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from telethon.tl.types import (
+    MessageActionChannelMigrateFrom,
+    MessageActionChatEditTitle,
+    MessageActionChatMigrateTo,
+    PeerChannel,
+    PeerChat,
+)
+from telethon.utils import get_peer_id
+
+from src.config import Config
+from src.db.adapter import DatabaseAdapter
+from src.telegram_backup import TelegramBackup
+
+
+def _run(coro):
+    """Run a coroutine in a fresh event loop (unittest.TestCase style)."""
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+def _make_mock_db_manager(is_sqlite=True):
+    """Mock DatabaseManager whose session factory yields an async context manager."""
+    db_manager = MagicMock()
+    db_manager._is_sqlite = is_sqlite
+    mock_session = AsyncMock()
+    async_ctx = AsyncMock()
+    async_ctx.__aenter__ = AsyncMock(return_value=mock_session)
+    async_ctx.__aexit__ = AsyncMock(return_value=False)
+    db_manager.async_session_factory.return_value = async_ctx
+    return db_manager, mock_session
+
+
+# ===========================================================================
+# US-200 — _process_message persists the migration pointer id
+# ===========================================================================
+
+
+def _make_service_message(action, text=""):
+    """Minimal mock service message carrying ``action`` (reply_to explicitly None)."""
+    msg = MagicMock()
+    msg.id = 4242
+    msg.sender = None
+    msg.sender_id = 42
+    msg.date = datetime(2024, 1, 15, 12, 0, 0)
+    msg.text = text
+    msg.reply_to_msg_id = None
+    msg.reply_to = None  # avoid MagicMock truthiness triggering topic filtering
+    msg.edit_date = None
+    msg.out = False
+    msg.pinned = False
+    msg.grouped_id = None
+    msg.fwd_from = None
+    msg.media = None
+    msg.reactions = None
+    msg.post_author = None
+    msg.action = action
+    return msg
+
+
+def _make_process_backup():
+    backup = TelegramBackup.__new__(TelegramBackup)
+    backup.config = MagicMock()
+    backup.db = AsyncMock()
+    backup.client = AsyncMock()
+    return backup
+
+
+class TestProcessMessageMigrationPointer(unittest.TestCase):
+    """US-200: the new supergroup / old group pointer id is persisted."""
+
+    def test_migrate_to_persists_marked_channel_pointer(self):
+        """MessageActionChatMigrateTo(channel_id=N) → raw_data.migrate_to_id == -(1e12+N)."""
+        backup = _make_process_backup()
+        action = MessageActionChatMigrateTo(channel_id=555)
+        result = _run(backup._process_message(_make_service_message(action), -100200300))
+        self.assertEqual(result["raw_data"]["migrate_to_id"], -(10**12 + 555))
+        self.assertEqual(result["raw_data"]["migrate_to_id"], get_peer_id(PeerChannel(555)))
+        self.assertEqual(result["raw_data"]["action_type"], "chat_migrate_to")
+        self.assertNotIn("migrate_from_id", result["raw_data"])
+
+    def test_migrate_from_persists_marked_chat_pointer(self):
+        """MessageActionChannelMigrateFrom(chat_id=M) → raw_data.migrate_from_id == marked chat id."""
+        backup = _make_process_backup()
+        action = MessageActionChannelMigrateFrom(title="Old Group", chat_id=777)
+        result = _run(backup._process_message(_make_service_message(action), -1000000000999))
+        self.assertEqual(result["raw_data"]["migrate_from_id"], get_peer_id(PeerChat(777)))
+        self.assertEqual(result["raw_data"]["action_type"], "channel_migrate_from")
+        self.assertNotIn("migrate_to_id", result["raw_data"])
+
+    def test_normal_service_action_has_no_migration_pointer(self):
+        """A non-migration service message (title change) carries neither pointer."""
+        backup = _make_process_backup()
+        action = MessageActionChatEditTitle(title="New Title")
+        result = _run(backup._process_message(_make_service_message(action), -100200300))
+        self.assertNotIn("migrate_to_id", result["raw_data"])
+        self.assertNotIn("migrate_from_id", result["raw_data"])
+        self.assertEqual(result["raw_data"]["action_type"], "chat_edit_title")
+
+
+# ===========================================================================
+# US-201 / US-202 — _reconcile_migrations warn / follow
+# ===========================================================================
+
+_LOGGER = "src.telegram_backup"
+
+
+def _make_reconcile_backup(follow=False):
+    backup = TelegramBackup.__new__(TelegramBackup)
+    cfg = MagicMock()
+    cfg.follow_chat_migrations = follow
+    cfg.chat_ids = set()
+    cfg.global_include_ids = set()
+    cfg.groups_include_ids = set()
+    cfg.channels_include_ids = set()
+    cfg.global_exclude_ids = set()
+    cfg.groups_exclude_ids = set()
+    cfg.channels_exclude_ids = set()
+    backup.config = cfg
+    backup.db = AsyncMock()
+    backup.db.get_migration_markers = AsyncMock(return_value=[])
+    backup.client = AsyncMock()
+    backup._followed_migration_ids = set()
+    backup._backup_dialog = AsyncMock(return_value=5)
+    return backup
+
+
+def _migrated_dialog(channel_id):
+    """A dialog whose entity is a migrated basic group (carries .migrated_to)."""
+    entity = SimpleNamespace(migrated_to=SimpleNamespace(channel_id=channel_id))
+    return SimpleNamespace(entity=entity)
+
+
+class TestReconcileMigrationsWarn(unittest.TestCase):
+    """US-201: always-on, count-only warning; no ids leaked; deduped per run."""
+
+    def test_warns_for_primary_migrated_entity(self):
+        backup = _make_reconcile_backup(follow=False)
+        backup._get_marked_id = MagicMock(return_value=-100200300)
+        new_id = get_peer_id(PeerChannel(555))
+        with self.assertLogs(_LOGGER, level="WARNING") as cm:
+            _run(backup._reconcile_migrations([_migrated_dialog(555)], set()))
+        joined = "\n".join(cm.output)
+        self.assertIn("migrated to a supergroup not in scope", joined)
+        self.assertIn("1 tracked group", joined)
+        # PII: counts only — neither the new nor the old marked id appears.
+        self.assertNotIn(str(new_id), joined)
+        self.assertNotIn("100200300", joined)
+        backup.db.set_metadata.assert_not_awaited()
+
+    def test_warns_from_secondary_stored_marker(self):
+        """Offline migration: detected purely from a stored chat_migrate_to marker."""
+        backup = _make_reconcile_backup(follow=False)
+        new_id = get_peer_id(PeerChannel(999))
+        backup.db.get_migration_markers = AsyncMock(return_value=[(-4242, new_id)])
+        with self.assertLogs(_LOGGER, level="WARNING") as cm:
+            _run(backup._reconcile_migrations([], set()))
+        joined = "\n".join(cm.output)
+        self.assertIn("1 tracked group", joined)
+        self.assertNotIn(str(new_id), joined)
+
+    def test_suppressed_when_new_id_already_captured(self):
+        backup = _make_reconcile_backup(follow=False)
+        backup._get_marked_id = MagicMock(return_value=-100)
+        new_id = get_peer_id(PeerChannel(555))
+        with self.assertNoLogs(_LOGGER, level="WARNING"):
+            _run(backup._reconcile_migrations([_migrated_dialog(555)], {new_id}))
+
+    def test_suppressed_when_new_id_in_configured_include(self):
+        backup = _make_reconcile_backup(follow=False)
+        backup._get_marked_id = MagicMock(return_value=-100)
+        new_id = get_peer_id(PeerChannel(555))
+        backup.config.groups_include_ids = {new_id}
+        with self.assertNoLogs(_LOGGER, level="WARNING"):
+            _run(backup._reconcile_migrations([_migrated_dialog(555)], set()))
+
+    def test_suppressed_when_new_id_explicitly_excluded(self):
+        backup = _make_reconcile_backup(follow=False)
+        backup._get_marked_id = MagicMock(return_value=-100)
+        new_id = get_peer_id(PeerChannel(555))
+        backup.config.groups_exclude_ids = {new_id}
+        with self.assertNoLogs(_LOGGER, level="WARNING"):
+            _run(backup._reconcile_migrations([_migrated_dialog(555)], set()))
+
+    def test_dedups_to_single_warning_per_run(self):
+        backup = _make_reconcile_backup(follow=False)
+        backup._get_marked_id = MagicMock(side_effect=[-101, -102])
+        with self.assertLogs(_LOGGER, level="WARNING") as cm:
+            _run(backup._reconcile_migrations([_migrated_dialog(555), _migrated_dialog(666)], set()))
+        warn_lines = [line for line in cm.output if "migrated to a supergroup" in line]
+        self.assertEqual(len(warn_lines), 1)
+        self.assertIn("2 tracked group", warn_lines[0])
+
+    def test_off_persists_nothing(self):
+        backup = _make_reconcile_backup(follow=False)
+        backup._get_marked_id = MagicMock(return_value=-100)
+        _run(backup._reconcile_migrations([_migrated_dialog(555)], set()))
+        backup.db.set_metadata.assert_not_awaited()
+        backup._backup_dialog.assert_not_awaited()
+
+
+class TestReconcileMigrationsFollow(unittest.TestCase):
+    """US-202: opt-in follow persists + captures this run; guards inaccessibility."""
+
+    def test_follow_persists_and_captures_without_warning(self):
+        backup = _make_reconcile_backup(follow=True)
+        backup._get_marked_id = MagicMock(return_value=-100)
+        backup.client.get_entity = AsyncMock(return_value=MagicMock())
+        new_id = get_peer_id(PeerChannel(555))
+        backed = set()
+        with self.assertNoLogs(_LOGGER, level="WARNING"):
+            _run(backup._reconcile_migrations([_migrated_dialog(555)], backed))
+        # Persisted to the metadata KV under followed_migrations.
+        backup.db.set_metadata.assert_awaited_once()
+        key, value = backup.db.set_metadata.await_args.args
+        self.assertEqual(key, "followed_migrations")
+        self.assertIn(new_id, json.loads(value))
+        # Captured THIS run and merged into the followed set + backed-up set.
+        backup._backup_dialog.assert_awaited_once()
+        self.assertIn(new_id, backup._followed_migration_ids)
+        self.assertIn(new_id, backed)
+
+    def test_follow_already_followed_is_noop(self):
+        backup = _make_reconcile_backup(follow=True)
+        backup._get_marked_id = MagicMock(return_value=-100)
+        new_id = get_peer_id(PeerChannel(555))
+        backup._followed_migration_ids = {new_id}
+        with self.assertNoLogs(_LOGGER, level="WARNING"):
+            _run(backup._reconcile_migrations([_migrated_dialog(555)], set()))
+        backup.db.set_metadata.assert_not_awaited()
+        backup._backup_dialog.assert_not_awaited()
+
+    def test_follow_inaccessible_channel_does_not_raise(self):
+        backup = _make_reconcile_backup(follow=True)
+        backup._get_marked_id = MagicMock(return_value=-100)
+        backup.client.get_entity = AsyncMock(side_effect=Exception("no access"))
+        new_id = get_peer_id(PeerChannel(555))
+        backed = set()
+        # Must not raise even though capture fails.
+        _run(backup._reconcile_migrations([_migrated_dialog(555)], backed))
+        backup.db.set_metadata.assert_awaited_once()  # persisted before capture attempt
+        self.assertIn(new_id, backup._followed_migration_ids)
+        backup._backup_dialog.assert_not_awaited()
+        self.assertNotIn(new_id, backed)
+
+
+# ===========================================================================
+# US-202 — config flag + followed-set loading / scope predicate
+# ===========================================================================
+
+
+class TestFollowChatMigrationsConfig(unittest.TestCase):
+    def test_default_off(self):
+        with patch("os.makedirs"), patch.dict(os.environ, {"CHAT_TYPES": "private"}, clear=True):
+            self.assertFalse(Config().follow_chat_migrations)
+
+    def test_enabled_true(self):
+        with (
+            patch("os.makedirs"),
+            patch.dict(os.environ, {"CHAT_TYPES": "private", "FOLLOW_CHAT_MIGRATIONS": "true"}, clear=True),
+        ):
+            self.assertTrue(Config().follow_chat_migrations)
+
+    def test_enabled_accepts_common_truthy_variants(self):
+        for variant in ("1", "yes", "on", "TRUE"):
+            with (
+                patch("os.makedirs"),
+                patch.dict(os.environ, {"CHAT_TYPES": "private", "FOLLOW_CHAT_MIGRATIONS": variant}, clear=True),
+            ):
+                self.assertTrue(Config().follow_chat_migrations, variant)
+
+
+class TestFollowedMigrationScope(unittest.TestCase):
+    """_load_followed_migrations + _is_followed_migration (sweep scope predicate)."""
+
+    def test_load_short_circuits_when_off(self):
+        backup = _make_reconcile_backup(follow=False)
+        backup.db.get_metadata = AsyncMock(return_value=json.dumps([-100, -200]))
+        _run(backup._load_followed_migrations())
+        self.assertEqual(backup._followed_migration_ids, set())
+        backup.db.get_metadata.assert_not_awaited()
+
+    def test_load_reads_metadata_when_on(self):
+        backup = _make_reconcile_backup(follow=True)
+        followed = get_peer_id(PeerChannel(555))
+        backup.db.get_metadata = AsyncMock(return_value=json.dumps([followed]))
+        _run(backup._load_followed_migrations())
+        self.assertIn(followed, backup._followed_migration_ids)
+        self.assertTrue(backup._is_followed_migration(followed))
+
+    def test_load_malformed_degrades_to_empty(self):
+        backup = _make_reconcile_backup(follow=True)
+        backup.db.get_metadata = AsyncMock(return_value="not json{")
+        _run(backup._load_followed_migrations())
+        self.assertEqual(backup._followed_migration_ids, set())
+
+    def test_load_missing_value_degrades_to_empty(self):
+        backup = _make_reconcile_backup(follow=True)
+        backup.db.get_metadata = AsyncMock(return_value=None)
+        _run(backup._load_followed_migrations())
+        self.assertEqual(backup._followed_migration_ids, set())
+
+    def test_is_followed_false_when_flag_off(self):
+        backup = _make_reconcile_backup(follow=False)
+        backup._followed_migration_ids = {-100}
+        self.assertFalse(backup._is_followed_migration(-100))
+
+    def test_is_followed_true_when_on_and_present(self):
+        backup = _make_reconcile_backup(follow=True)
+        backup._followed_migration_ids = {-100}
+        self.assertTrue(backup._is_followed_migration(-100))
+
+
+# ===========================================================================
+# get_migration_markers adapter read (offline detection source)
+# ===========================================================================
+
+
+class TestGetMigrationMarkers(unittest.TestCase):
+    def _adapter_returning(self, rows):
+        db_manager, session = _make_mock_db_manager()
+        adapter = DatabaseAdapter(db_manager)
+        mock_result = MagicMock()
+        mock_result.all.return_value = rows
+        session.execute.return_value = mock_result
+        return adapter
+
+    def test_parses_migrate_to_markers(self):
+        raw = json.dumps(
+            {
+                "service_type": "service",
+                "action_type": "chat_migrate_to",
+                "migrate_to_id": get_peer_id(PeerChannel(555)),
+            }
+        )
+        adapter = self._adapter_returning([(-777, raw)])
+        self.assertEqual(_run(adapter.get_migration_markers()), [(-777, get_peer_id(PeerChannel(555)))])
+
+    def test_skips_non_migration_rows(self):
+        raw = json.dumps({"action_type": "chat_edit_title", "new_title": "x"})
+        adapter = self._adapter_returning([(-1, raw)])
+        self.assertEqual(_run(adapter.get_migration_markers()), [])
+
+    def test_skips_malformed_and_empty_rows(self):
+        adapter = self._adapter_returning([(-1, "not valid json"), (-2, None)])
+        self.assertEqual(_run(adapter.get_migration_markers()), [])
+
+    def test_skips_when_pointer_missing_or_non_int(self):
+        no_ptr = json.dumps({"action_type": "chat_migrate_to"})
+        bad_ptr = json.dumps({"action_type": "chat_migrate_to", "migrate_to_id": "nope"})
+        adapter = self._adapter_returning([(-1, no_ptr), (-2, bad_ptr)])
+        self.assertEqual(_run(adapter.get_migration_markers()), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sender_avatars.py
+++ b/tests/test_sender_avatars.py
@@ -1,0 +1,283 @@
+"""Tests for group sender avatars (#229) and the migration banner (#228).
+
+Covers three slices:
+
+* US-210 (slice 1): the pure-frontend initials circle — getSenderInitials /
+  getAvatarFill exist in the template and the darker fill clears white-text
+  contrast (WCAG AA) on every hue.
+* US-211 (slice 2a): the media-ACL fix that serves member avatars for users
+  who spoke in a visible chat, plus per-message sender_avatar_url resolution
+  from files already on disk.
+* US-203 (#228): the display-only group→supergroup migration banner.
+
+The template assertions follow the string-matching idiom of
+test_frontend_bootstrap.py; the backend assertions follow the temp-media-dir
+idiom of test_database_viewer.py (TestAvatarPathLookup).
+"""
+
+import asyncio
+import colorsys
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+os.environ.setdefault("BACKUP_PATH", tempfile.mkdtemp(prefix="ta_test_backup_"))
+
+from src.web import main as web_main  # noqa: E402
+
+INDEX_HTML = Path(__file__).resolve().parents[1] / "src" / "web" / "templates" / "index.html"
+
+
+def _contrast_ratio_vs_white(hue: int, lightness: float) -> float:
+    """WCAG contrast ratio of white text over hsl(hue, 65%, lightness)."""
+
+    def _channel(c: float) -> float:
+        return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+
+    r, g, b = colorsys.hls_to_rgb(hue / 360, lightness, 0.65)
+    fill_luminance = 0.2126 * _channel(r) + 0.7152 * _channel(g) + 0.0722 * _channel(b)
+    white_luminance = 1.0
+    return (white_luminance + 0.05) / (fill_luminance + 0.05)
+
+
+class TestSenderInitialsTemplate(unittest.TestCase):
+    """US-210: initials helper contract, expressed via the template source."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+
+    def test_initials_and_fill_helpers_exist_and_are_exported(self):
+        self.assertIn("const getSenderInitials = (msg) =>", self.html)
+        self.assertIn("const getAvatarFill = (msg) =>", self.html)
+        # Must be returned from setup() or Vue cannot resolve them in-template.
+        self.assertIn("getSenderInitials,", self.html)
+        self.assertIn("getAvatarFill,", self.html)
+
+    def test_nameless_sender_falls_back_to_question_mark(self):
+        """Deleted / nameless senders must render '?' not the 'DA' chat fallback."""
+        start = self.html.index("const getSenderInitials = (msg) =>")
+        body = self.html[start : start + 600]
+        self.assertIn("let initials = '?'", body)
+        # It must build from first_name/last_name, not getChatName.
+        self.assertIn("[msg.first_name, msg.last_name].filter(Boolean)", body)
+        self.assertNotIn("getChatName", body)
+
+    def test_avatar_fill_is_the_darker_gradient(self):
+        start = self.html.index("const getAvatarFill = (msg) =>")
+        body = self.html[start : start + 500]
+        self.assertIn("linear-gradient(135deg, hsl(${hue}, 65%, 27%), hsl(${hue}, 65%, 18%))", body)
+
+
+class TestSenderInitialsLogic(unittest.TestCase):
+    """US-210: replicate getSenderInitials semantics to lock the contract."""
+
+    @staticmethod
+    def _initials(first, last):
+        name = " ".join(p for p in (first, last) if p).strip()
+        if not name:
+            return "?"
+        return "".join(part[0] for part in name.split())[:2].upper()
+
+    def test_two_names_two_letters(self):
+        self.assertEqual(self._initials("Ada", "Lovelace"), "AL")
+
+    def test_one_name_one_letter(self):
+        self.assertEqual(self._initials("Grace", None), "G")
+        self.assertEqual(self._initials("grace", ""), "G")
+
+    def test_empty_returns_question_mark(self):
+        self.assertEqual(self._initials(None, None), "?")
+        self.assertEqual(self._initials("", ""), "?")
+
+
+class TestAvatarFillContrast(unittest.TestCase):
+    """US-210: white text over the WHOLE avatar circle must clear WCAG AA (4.5:1).
+
+    Both gradient stops sit in the safe zone so tall letters / anti-aliasing
+    reaching the lighter (top-left) corner stay legible — not just the center.
+    """
+
+    # Both stops of getAvatarFill: linear-gradient hsl(h,65%,27%) -> hsl(h,65%,18%).
+    LIGHTER_STOP = 0.27
+    DARKER_STOP = 0.18
+
+    def test_both_stops_meet_aa_on_all_hues(self):
+        # The lighter stop is the contrast-limiting one; assert BOTH stops clear
+        # 4.5:1 on every hue so the entire circle is guaranteed legible. (27%
+        # gives min ~5.08, 18% gives min ~8.94 — both above 4.5 with margin.)
+        for hue in range(0, 360, 5):
+            for stop in (self.LIGHTER_STOP, self.DARKER_STOP):
+                with self.subTest(hue=hue, stop=stop):
+                    self.assertGreaterEqual(_contrast_ratio_vs_white(hue, stop), 4.5)
+
+    def test_lighter_stop_is_below_the_safe_ceiling(self):
+        # Guards against a future edit lightening the top stop past the point
+        # where every hue clears AA: at S=65 the ceiling is ~29% lightness.
+        self.assertLessEqual(self.LIGHTER_STOP, 0.29)
+
+    def test_bright_name_palette_would_fail_contrast(self):
+        # Sanity anchor: the old bright name color is NOT contrast-safe for a
+        # white-text fill, documenting why a darker fill was introduced.
+        failing = [h for h in range(360) if _contrast_ratio_vs_white(h, 0.65) < 4.5]
+        self.assertTrue(failing)
+
+
+class TestSenderAvatarUrl(unittest.TestCase):
+    """US-211: per-message sender_avatar_url resolved from on-disk files."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.original_media_path = web_main.config.media_path
+        web_main.config.media_path = self.temp_dir.name
+        web_main._avatar_cache.clear()
+        web_main._avatar_cache_time = None
+
+    def tearDown(self):
+        web_main.config.media_path = self.original_media_path
+        web_main._avatar_cache.clear()
+        web_main._avatar_cache_time = None
+        self.temp_dir.cleanup()
+
+    def _touch_avatar(self, path: str) -> None:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w", encoding="utf-8") as avatar_file:
+            avatar_file.write("x")
+
+    def test_present_when_file_globs(self):
+        user_id = 555000111
+        avatars_dir = os.path.join(self.temp_dir.name, "avatars", "users")
+        self._touch_avatar(os.path.join(avatars_dir, f"{user_id}_42.jpg"))
+
+        self.assertEqual(
+            web_main._sender_avatar_url(user_id),
+            f"/media/avatars/users/{user_id}_42.jpg",
+        )
+
+    def test_null_when_absent(self):
+        self.assertIsNone(web_main._sender_avatar_url(999888777))
+
+    def test_null_for_missing_or_non_user_sender(self):
+        self.assertIsNone(web_main._sender_avatar_url(None))
+        # Negative ids are channels/groups, never a users/ avatar.
+        self.assertIsNone(web_main._sender_avatar_url(-1001234))
+
+
+class TestMemberAvatarAcl(unittest.TestCase):
+    """US-211: ACL fix — member avatars for visible members are served."""
+
+    def _viewer(self):
+        return web_main.UserContext(username="viewer", role="viewer", allowed_chat_ids={-1001})
+
+    def test_user_avatar_allowed_when_member_ok(self):
+        """A user who spoke in a visible chat: served (no raise)."""
+        user = self._viewer()
+        web_main._enforce_media_acl("avatars/users/555_9.jpg", user, member_ok=True)
+
+    def test_user_avatar_blocked_when_not_member(self):
+        """A user not in any visible chat: 403."""
+        user = self._viewer()
+        with self.assertRaises(web_main.HTTPException) as ctx:
+            web_main._enforce_media_acl("avatars/users/555_9.jpg", user, member_ok=False)
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_chat_avatar_behavior_unchanged(self):
+        """avatars/chats/ still gates purely on the allowed chat id."""
+        user = self._viewer()
+        # Allowed chat id in the filename -> served.
+        web_main._enforce_media_acl("avatars/chats/-1001_7.jpg", user)
+        # Different chat id -> blocked, regardless of member_ok.
+        with self.assertRaises(web_main.HTTPException) as ctx:
+            web_main._enforce_media_acl("avatars/chats/-1009_7.jpg", user, member_ok=True)
+        self.assertEqual(ctx.exception.status_code, 403)
+
+    def test_one_to_one_contact_avatar_allowed_without_probe(self):
+        """A user whose id is itself a visible (private) chat is served directly."""
+        user = web_main.UserContext(username="v", role="viewer", allowed_chat_ids={555})
+        web_main._enforce_media_acl("avatars/users/555_9.jpg", user, member_ok=False)
+
+    def test_membership_probe_only_hits_db_for_user_avatars(self):
+        """_avatar_user_visible_member queries membership only for avatars/users/."""
+        user = self._viewer()
+        probe = AsyncMock(return_value=True)
+        original_db = web_main.db
+        web_main.db = type("D", (), {"sender_has_message_in_chats": staticmethod(probe)})()
+        try:
+            # User avatar for a non-1:1 user -> DB probe decides.
+            allowed = asyncio.run(web_main._avatar_user_visible_member("avatars/users/555_9.jpg", user))
+            self.assertTrue(allowed)
+            probe.assert_awaited_once()
+
+            # Chat avatar -> never probes the DB.
+            probe.reset_mock()
+            self.assertFalse(asyncio.run(web_main._avatar_user_visible_member("avatars/chats/-1001_9.jpg", user)))
+            probe.assert_not_awaited()
+
+            # Regular media -> never probes the DB.
+            self.assertFalse(asyncio.run(web_main._avatar_user_visible_member("-1001/photo.jpg", user)))
+            probe.assert_not_awaited()
+        finally:
+            web_main.db = original_db
+
+    def test_membership_probe_skips_db_for_one_to_one_contact(self):
+        """A user id already in the viewer's chat set needs no DB probe."""
+        user = web_main.UserContext(username="v", role="viewer", allowed_chat_ids={555})
+        probe = AsyncMock(return_value=False)
+        original_db = web_main.db
+        web_main.db = type("D", (), {"sender_has_message_in_chats": staticmethod(probe)})()
+        try:
+            self.assertTrue(asyncio.run(web_main._avatar_user_visible_member("avatars/users/555_9.jpg", user)))
+            probe.assert_not_awaited()
+        finally:
+            web_main.db = original_db
+
+
+class TestMigrationBannerTemplate(unittest.TestCase):
+    """US-203 (#228): the display-only migration banner."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+
+    def test_banner_computed_reads_migrate_pointers(self):
+        self.assertIn("const migrationBanner = computed(() =>", self.html)
+        start = self.html.index("const migrationBanner = computed(() =>")
+        body = self.html[start : start + 900]
+        self.assertIn("raw.migrate_to_id != null", body)
+        self.assertIn("raw.migrate_from_id != null", body)
+        self.assertIn("This group continues as a supergroup →", body)
+        self.assertIn("← Migrated from ", body)
+
+    def test_banner_is_rendered_and_exported(self):
+        # Rendered only when the pointer data exists (degrades to no banner).
+        self.assertIn('v-if="migrationBanner && !showPinnedOnly"', self.html)
+        self.assertIn("{{ migrationBanner.text }}", self.html)
+        self.assertIn("migrationBanner,", self.html)  # exported from setup()
+
+
+class TestGroupAvatarRenderTemplate(unittest.TestCase):
+    """US-210/US-211: the avatar slot renders photo-or-initials in group chats."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+
+    def test_avatar_gutter_is_group_and_non_own_only(self):
+        self.assertIn('v-if="isGroup && !isOwnMessage(msg)"', self.html)
+
+    def test_photo_falls_back_to_initials_on_error(self):
+        # Mirror the chat.avatar_url @error pattern: null the url so the
+        # initials template renders instead.
+        self.assertIn('v-if="msg.sender_avatar_url"', self.html)
+        self.assertIn('@error="msg.sender_avatar_url = null"', self.html)
+        self.assertIn("{{ getSenderInitials(msg) }}", self.html)
+
+    def test_deferred_download_is_documented(self):
+        # A visible note that proactive member-avatar download is deferred.
+        self.assertIn("slice 2b", self.html)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_sender_avatars.py
+++ b/tests/test_sender_avatars.py
@@ -20,12 +20,27 @@ import colorsys
 import os
 import tempfile
 import unittest
+from datetime import datetime
 from pathlib import Path
 from unittest.mock import AsyncMock
 
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
 os.environ.setdefault("BACKUP_PATH", tempfile.mkdtemp(prefix="ta_test_backup_"))
 
+from src.db.adapter import DatabaseAdapter  # noqa: E402
+from src.db.base import DatabaseManager  # noqa: E402
+from src.db.models import Base, Message  # noqa: E402
 from src.web import main as web_main  # noqa: E402
+
+try:
+    from httpx import ASGITransport, AsyncClient
+
+    _HTTPX_AVAILABLE = True
+except Exception:
+    _HTTPX_AVAILABLE = False
 
 INDEX_HTML = Path(__file__).resolve().parents[1] / "src" / "web" / "templates" / "index.html"
 
@@ -56,13 +71,17 @@ class TestSenderInitialsTemplate(unittest.TestCase):
         self.assertIn("getSenderInitials,", self.html)
         self.assertIn("getAvatarFill,", self.html)
 
-    def test_nameless_sender_falls_back_to_question_mark(self):
-        """Deleted / nameless senders must render '?' not the 'DA' chat fallback."""
+    def test_initials_mirror_sender_name_sources(self):
+        """The monogram must derive from getSenderName, not a private name chain,
+        so it matches the visible label; only '?' for the Deleted Account terminal."""
         start = self.html.index("const getSenderInitials = (msg) =>")
-        body = self.html[start : start + 600]
-        self.assertIn("let initials = '?'", body)
-        # It must build from first_name/last_name, not getChatName.
-        self.assertIn("[msg.first_name, msg.last_name].filter(Boolean)", body)
+        body = self.html[start : start + 700]
+        # Derives from the SAME source as the visible name label.
+        self.assertIn("getSenderName(msg)", body)
+        # '?' only when getSenderName itself has nothing real.
+        self.assertIn("name === 'Deleted Account'", body)
+        self.assertIn("return '?'", body)
+        # Must NOT reintroduce the getChatName 'DA' fallback.
         self.assertNotIn("getChatName", body)
 
     def test_avatar_fill_is_the_darker_gradient(self):
@@ -72,25 +91,58 @@ class TestSenderInitialsTemplate(unittest.TestCase):
 
 
 class TestSenderInitialsLogic(unittest.TestCase):
-    """US-210: replicate getSenderInitials semantics to lock the contract."""
+    """US-210: replicate getSenderInitials semantics to lock the contract.
+
+    getSenderInitials mirrors getSenderName's source chain (post_author →
+    first/last → username → 'User <id>') and only yields '?' for the terminal
+    'Deleted Account' — so the monogram always matches the visible name label.
+    """
 
     @staticmethod
-    def _initials(first, last):
-        name = " ".join(p for p in (first, last) if p).strip()
-        if not name:
+    def _sender_name(msg):
+        """Mirror of the JS getSenderName resolution chain."""
+        raw = msg.get("raw_data") or {}
+        if raw.get("post_author"):
+            return raw["post_author"]
+        first, last = msg.get("first_name"), msg.get("last_name")
+        if first or last:
+            return f"{first or ''} {last or ''}".strip()
+        if msg.get("username"):
+            return msg["username"]
+        if msg.get("sender_id"):
+            return f"User {msg['sender_id']}"
+        return "Deleted Account"
+
+    def _initials(self, msg):
+        """Mirror of the JS getSenderInitials."""
+        name = self._sender_name(msg)
+        if not name or name == "Deleted Account":
             return "?"
-        return "".join(part[0] for part in name.split())[:2].upper()
+        return "".join(w[0] for w in name.split() if w)[:2].upper() or "?"
 
     def test_two_names_two_letters(self):
-        self.assertEqual(self._initials("Ada", "Lovelace"), "AL")
+        self.assertEqual(self._initials({"first_name": "Ada", "last_name": "Lovelace"}), "AL")
 
     def test_one_name_one_letter(self):
-        self.assertEqual(self._initials("Grace", None), "G")
-        self.assertEqual(self._initials("grace", ""), "G")
+        self.assertEqual(self._initials({"first_name": "Grace"}), "G")
+        self.assertEqual(self._initials({"first_name": "grace", "last_name": ""}), "G")
+
+    def test_username_fallback_matches_label(self):
+        # No first/last but a username → monogram from the username (visible label).
+        self.assertEqual(self._initials({"username": "grace"}), "G")
+
+    def test_post_author_signature(self):
+        # Channel post signature is the visible label → monogram from it.
+        self.assertEqual(self._initials({"raw_data": {"post_author": "John Doe"}}), "JD")
+
+    def test_sender_id_fallback_is_not_question_mark(self):
+        # getSenderName renders 'User <id>' → a real label, so NOT '?'.
+        self.assertEqual(self._initials({"sender_id": 12345}), "U1")
 
     def test_empty_returns_question_mark(self):
-        self.assertEqual(self._initials(None, None), "?")
-        self.assertEqual(self._initials("", ""), "?")
+        # Only when getSenderName would have nothing real.
+        self.assertEqual(self._initials({}), "?")
+        self.assertEqual(self._initials({"first_name": "", "last_name": ""}), "?")
 
 
 class TestAvatarFillContrast(unittest.TestCase):
@@ -168,6 +220,14 @@ class TestSenderAvatarUrl(unittest.TestCase):
 class TestMemberAvatarAcl(unittest.TestCase):
     """US-211: ACL fix — member avatars for visible members are served."""
 
+    def setUp(self):
+        web_main._avatar_member_cache.clear()
+        web_main._avatar_member_cache_time = None
+
+    def tearDown(self):
+        web_main._avatar_member_cache.clear()
+        web_main._avatar_member_cache_time = None
+
     def _viewer(self):
         return web_main.UserContext(username="viewer", role="viewer", allowed_chat_ids={-1001})
 
@@ -233,6 +293,32 @@ class TestMemberAvatarAcl(unittest.TestCase):
         finally:
             web_main.db = original_db
 
+    def test_membership_probe_is_cached_across_requests(self):
+        """The DB probe runs once per (user, chat-set); repeats hit the cache."""
+        user = self._viewer()
+        probe = AsyncMock(return_value=True)
+        original_db = web_main.db
+        web_main.db = type("D", (), {"sender_has_message_in_chats": staticmethod(probe)})()
+        try:
+            for _ in range(3):
+                self.assertTrue(asyncio.run(web_main._avatar_user_visible_member("avatars/users/555_9.jpg", user)))
+            probe.assert_awaited_once()
+        finally:
+            web_main.db = original_db
+
+    def test_membership_probe_fails_closed_on_db_error(self):
+        """A DB error in the probe denies the avatar (False) and is NOT cached."""
+        user = self._viewer()
+        probe = AsyncMock(side_effect=RuntimeError("db down"))
+        original_db = web_main.db
+        web_main.db = type("D", (), {"sender_has_message_in_chats": staticmethod(probe)})()
+        try:
+            self.assertFalse(asyncio.run(web_main._avatar_user_visible_member("avatars/users/555_9.jpg", user)))
+            # Not cached: a transient failure must be retried, not stuck for the TTL.
+            self.assertEqual(web_main._avatar_member_cache, {})
+        finally:
+            web_main.db = original_db
+
 
 class TestMigrationBannerTemplate(unittest.TestCase):
     """US-203 (#228): the display-only migration banner."""
@@ -274,9 +360,201 @@ class TestGroupAvatarRenderTemplate(unittest.TestCase):
         self.assertIn('@error="msg.sender_avatar_url = null"', self.html)
         self.assertIn("{{ getSenderInitials(msg) }}", self.html)
 
+    def test_sender_avatar_img_is_lazy(self):
+        # The sender-avatar <img> must be lazy like every other <img> so a group
+        # page doesn't eagerly fetch every member avatar.
+        start = self.html.index('v-if="msg.sender_avatar_url"')
+        img = self.html[start : start + 300]
+        self.assertIn('loading="lazy"', img)
+
     def test_deferred_download_is_documented(self):
         # A visible note that proactive member-avatar download is deferred.
         self.assertIn("slice 2b", self.html)
+
+
+# ---------------------------------------------------------------------------
+# US-211 backend coverage (FIX 4): real adapter query + real-endpoint ACL /
+# sender_avatar_url wiring.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def adapter():
+    """Real in-memory SQLite adapter (mirrors test_messages_page_batching)."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db_manager = DatabaseManager.__new__(DatabaseManager)
+    db_manager.engine = engine
+    db_manager.database_url = "sqlite+aiosqlite://"
+    db_manager._is_sqlite = True
+    db_manager.async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    yield DatabaseAdapter(db_manager)
+    await engine.dispose()
+
+
+async def _seed_message(adapter, *, msg_id, chat_id, sender_id):
+    async with adapter.db_manager.async_session_factory() as session:
+        session.add(
+            Message(
+                id=msg_id,
+                chat_id=chat_id,
+                sender_id=sender_id,
+                date=datetime(2026, 1, 1, 12, 0, 0),
+                text="hi",
+            )
+        )
+        await session.commit()
+
+
+class TestSenderHasMessageInChats:
+    """FIX 4a: direct adapter test of the membership probe (real SQLite)."""
+
+    async def test_true_when_user_spoke_in_visible_chat(self, adapter):
+        await _seed_message(adapter, msg_id=1, chat_id=-500, sender_id=42)
+        assert await adapter.sender_has_message_in_chats(42, [-500]) is True
+
+    async def test_false_when_user_not_in_visible_chats(self, adapter):
+        # User 42 spoke only in -500; probing a different chat set → False.
+        await _seed_message(adapter, msg_id=1, chat_id=-500, sender_id=42)
+        assert await adapter.sender_has_message_in_chats(42, [-999]) is False
+        # A different user who never spoke → False.
+        assert await adapter.sender_has_message_in_chats(77, [-500]) is False
+
+    async def test_false_for_empty_chat_ids_must_not_match_all(self, adapter):
+        # Empty scope must NEVER match-all (would leak avatars to unauthorized
+        # viewers). Even with a matching message present, empty → False.
+        await _seed_message(adapter, msg_id=1, chat_id=-500, sender_id=42)
+        assert await adapter.sender_has_message_in_chats(42, []) is False
+
+
+@unittest.skipUnless(_HTTPX_AVAILABLE, "httpx not available")
+class TestMemberAvatarAclEndpoint(unittest.IsolatedAsyncioTestCase):
+    """FIX 4b: ACL allow/block through the REAL /media endpoint."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        root = Path(self.temp_dir.name)
+        (root / "avatars" / "users").mkdir(parents=True)
+        (root / "avatars" / "chats").mkdir(parents=True)
+        (root / "avatars" / "users" / "42_1.jpg").write_bytes(b"x")  # member
+        (root / "avatars" / "users" / "77_1.jpg").write_bytes(b"x")  # non-member
+        (root / "avatars" / "chats" / "-500_1.jpg").write_bytes(b"x")  # visible chat
+        (root / "avatars" / "chats" / "-999_1.jpg").write_bytes(b"x")  # other chat
+
+        self._saved_root = web_main._media_root
+        self._saved_db = web_main.db
+        self._saved_display = web_main.config.display_chat_ids
+        web_main._media_root = root.resolve()
+        web_main.config.display_chat_ids = set()
+        web_main._avatar_member_cache.clear()
+        web_main._avatar_member_cache_time = None
+
+        # Restricted viewer authorized only for chat -500.
+        viewer = web_main.UserContext(username="v", role="viewer", allowed_chat_ids={-500})
+        web_main.app.dependency_overrides[web_main.require_auth] = lambda: viewer
+
+        # Membership probe: user 42 spoke in -500, user 77 did not.
+        async def _probe(user_id, chat_ids):
+            return user_id == 42 and -500 in set(chat_ids)
+
+        self.mock_db = AsyncMock()
+        self.mock_db.sender_has_message_in_chats = AsyncMock(side_effect=_probe)
+        web_main.db = self.mock_db
+
+    def tearDown(self):
+        web_main.app.dependency_overrides.pop(web_main.require_auth, None)
+        web_main._media_root = self._saved_root
+        web_main.db = self._saved_db
+        web_main.config.display_chat_ids = self._saved_display
+        web_main._avatar_member_cache.clear()
+        web_main._avatar_member_cache_time = None
+        self.temp_dir.cleanup()
+
+    def _client(self):
+        return AsyncClient(transport=ASGITransport(app=web_main.app), base_url="http://test")
+
+    async def test_member_avatar_allowed(self):
+        async with self._client() as client:
+            resp = await client.get("/media/avatars/users/42_1.jpg")
+        self.assertEqual(resp.status_code, 200)
+
+    async def test_non_member_avatar_blocked(self):
+        async with self._client() as client:
+            resp = await client.get("/media/avatars/users/77_1.jpg")
+        self.assertEqual(resp.status_code, 403)
+
+    async def test_chat_avatar_visible_allowed_and_other_blocked(self):
+        async with self._client() as client:
+            ok = await client.get("/media/avatars/chats/-500_1.jpg")
+            blocked = await client.get("/media/avatars/chats/-999_1.jpg")
+        self.assertEqual(ok.status_code, 200)
+        self.assertEqual(blocked.status_code, 403)
+
+    async def test_db_error_fails_closed_403_not_500(self):
+        """A DB error in the membership probe denies the avatar (403), never 500."""
+        self.mock_db.sender_has_message_in_chats = AsyncMock(side_effect=RuntimeError("db down"))
+        async with self._client() as client:
+            resp = await client.get("/media/avatars/users/42_1.jpg")
+        self.assertEqual(resp.status_code, 403)
+
+
+@unittest.skipUnless(_HTTPX_AVAILABLE, "httpx not available")
+class TestMessagesEndpointAvatarWiring(unittest.IsolatedAsyncioTestCase):
+    """FIX 4c: GET /messages attaches sender_avatar_url via the endpoint."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        avatars = Path(self.temp_dir.name) / "avatars" / "users"
+        avatars.mkdir(parents=True)
+        (avatars / "42_1.jpg").write_bytes(b"x")  # user 42 has a file on disk
+
+        # _sender_avatar_url resolves via config.media_path + _avatar_cache.
+        self._saved_media_path = web_main.config.media_path
+        self._saved_db = web_main.db
+        self._saved_display = web_main.config.display_chat_ids
+        web_main.config.media_path = self.temp_dir.name
+        web_main.config.display_chat_ids = set()
+        web_main._avatar_cache.clear()
+        web_main._avatar_cache_time = None
+
+        viewer = web_main.UserContext(username="v", role="master")
+        web_main.app.dependency_overrides[web_main.require_auth] = lambda: viewer
+
+        self.mock_db = AsyncMock()
+        self.mock_db.get_messages_paginated = AsyncMock(
+            return_value=[
+                {"id": 1, "sender_id": 42, "chat_id": -500},
+                {"id": 2, "sender_id": 77, "chat_id": -500},
+            ]
+        )
+        web_main.db = self.mock_db
+
+    def tearDown(self):
+        web_main.app.dependency_overrides.pop(web_main.require_auth, None)
+        web_main.config.media_path = self._saved_media_path
+        web_main.db = self._saved_db
+        web_main.config.display_chat_ids = self._saved_display
+        web_main._avatar_cache.clear()
+        web_main._avatar_cache_time = None
+        self.temp_dir.cleanup()
+
+    def _client(self):
+        return AsyncClient(transport=ASGITransport(app=web_main.app), base_url="http://test")
+
+    async def test_sender_avatar_url_present_when_file_globs_and_null_when_absent(self):
+        async with self._client() as client:
+            resp = await client.get("/api/chats/-500/messages")
+        self.assertEqual(resp.status_code, 200)
+        by_id = {m["id"]: m for m in resp.json()}
+        self.assertEqual(by_id[1]["sender_avatar_url"], "/media/avatars/users/42_1.jpg")
+        self.assertIsNone(by_id[2]["sender_avatar_url"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Resolves #228 and #229 (both reported by @625801).

## #228 — group→supergroup migration silently stopped capture

When a tracked **basic group** migrated to a **supergroup**, the new `-100…` id was outside `GROUPS_INCLUDE_CHAT_IDS` and capture stopped with nothing above INFO. Root cause confirmed against the pinned Telethon 1.43.2 source: `events.ChatAction.build()` has no branch for `MessageActionChatMigrateTo`/`ChannelMigrateFrom`, and `events.NewMessage` skips service messages — so the migration is invisible to both live handlers, and only the scheduled sweep can ever see it.

- **Persist the pointer** in `raw_data` (`migrate_to_id` / `migrate_from_id`). `MessageActionChatMigrateTo` carries `.channel_id` (never a title), so the id was previously dropped and the archived marker alone couldn't yield the new chat.
- **Always-on WARNING** (the reporter's minimum, option a): `_reconcile_migrations` at the end of `backup_all` detects migrated in-scope groups via `entity.migrated_to` (primary) plus a stored-marker fallback for migrations that happened while offline, and emits a **counts-only** warning — deduped per run, permanently suppressed once the new id is followed or excluded. This alone ends the silent stop.
- **Opt-in auto-follow** (option b): `FOLLOW_CHAT_MIGRATIONS` (default **off**) persists followed ids in the metadata KV (no schema change) and injects them into effective scope for **both** the sweep dialog filter and the listener's tracked set, backfilling the new supergroup in the same run. Default-off preserves the include-list allow-list contract; the warning gives every operator the info to opt in deliberately.
- **Viewer banner** (option c): a migrated chat links to its counterpart using the persisted pointer.

Note: the history split is unavoidable (the API only returns post-migration history for the new supergroup) — this matches the reporter's own gapless observation.

## #229 — sender avatars + initials fallback in the group viewer

Group messages showed a colored sender name only at the start of a run — no avatar, and two participants sharing a first name were indistinguishable.

- **Initials circle at each sender run** (group chats only): a deterministic monogram on a darker gradient (`hsl(h,65%,27%→18%)`) derived from the same hue as the sender name, **verified ≥4.5:1 white-on-fill across all 360 hues** (the bright name palette fails that, which is why the fill is separate). Nameless/deleted senders render `?`, not `DA`.
- **Real member photos where they already exist**: the media ACL is fixed so a member's user avatar (`avatars/users/{user_id}`) is served to a viewer authorized for a chat that user spoke in — the old chat-id-keyed check 403'd every member avatar. The `<img>` falls back to the initials circle on absent/error.
- **Deferred honestly**: proactive downloading of member avatars that aren't already on disk (~half, coincidentally present from being 1:1 contacts) is a follow-up — it needs a flood-gated pipeline and is out of scope here. Only pre-existing files are served.
- The sender-info popup (the issue's secondary ask) is a noted follow-up; the initials + color already solve the stated disambiguation problem.

## Testing

2320 tests pass (52 new across `test_chat_migration.py` and `test_sender_avatars.py`); ruff check + format clean. #228 is validated by unit tests + synthetic fixtures (a live migration can't be forced); #229 render is verified live.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Detects and handles group → supergroup migrations, with optional auto-follow via `FOLLOW_CHAT_MIGRATIONS=true`.
  * Persists adopted migrated supergroup IDs to automatically widen backup/live capture scope.
  * Adds a migration banner and improves sender avatar/initials rendering in the chat UI.
* **Bug Fixes**
  * Tightens media/avatar ACL checks with stronger path containment and “fail closed” visibility probing.
* **Documentation**
  * Updates README and environment examples with migration behavior and configuration details.
* **Tests**
  * Adds comprehensive migration and sender-avatar/ACL test coverage.
* **Chores**
  * Bumps version to 7.26.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->