### PR TITLE
fix: absorb mid-download FloodWaits (#232) + whitelist DM resolution (#234)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,10 @@ MAX_MEDIA_SIZE_MB=100
 # Default is 3600 (60 minutes).
 # DOWNLOAD_TIMEOUT_SECONDS=3600
 
+# Absorb mid-download FloodWaits up to this many seconds so the transfer resumes
+# in place instead of restarting from byte 0 (issue #232). 0 = raise immediately.
+# MEDIA_FLOOD_SLEEP_THRESHOLD=60
+
 # --- Parallel chunked downloads (advanced, default OFF) ---
 # Splits one large file into chunks fetched concurrently over several MTProto
 # connections to a single datacenter, lifting the ~10 MB/s single-stream cap.
@@ -154,6 +158,10 @@ SESSION_NAME=telegram_backup
 # When set, ONLY these chats are backed up. All other filtering is ignored.
 # Example: CHAT_IDS=-1001234567890,-1009876543210
 CHAT_IDS=
+
+# If a CHAT_IDS entry can't be resolved (typically a DM on a fresh session),
+# scan up to this many dialogs once to warm the entity cache (issue #234). 0 disables.
+# WHITELIST_RESOLVE_DIALOG_LIMIT=1000
 
 # MODE 2: TYPE-BASED (Default) — Use CHAT_TYPES to backup by type
 # Options: private, groups, channels, bots (comma-separated)

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ The **Scope** column shows whether each variable applies to the backup scheduler
 | `MAX_MEDIA_SIZE_MB` | `100` | B | Skip media files larger than this (MB) |
 | `MEDIA_MAX_FILENAME_BYTES` | `143` | B | Usable filename byte budget for downloaded media. Raise to `255` on plain ext4/xfs; keep `143` for Synology/eCryptfs encrypted shares |
 | `MEDIA_MAX_DOWNLOAD_ATTEMPTS` | `5` | B | Stop retrying a file's download after this many failed attempts. Re-requesting the download resets the counter |
+| `MEDIA_FLOOD_SLEEP_THRESHOLD` | `60` | B | Mid-download FloodWaits up to this many seconds are absorbed in place so the transfer resumes instead of restarting from byte 0 (issue #232). `0` restores the old raise-immediately behavior. Absorbed pauses count toward `DOWNLOAD_TIMEOUT_SECONDS` |
 | `PARALLEL_DOWNLOAD_ENABLED` | `false` | B | Fetch large files over several connections to lift the single-stream speed cap (see below) |
 | `PARALLEL_DOWNLOAD_MIN_SIZE_MB` | `20` | B | Only files at least this large use the parallel path (min 1) |
 | `PARALLEL_DOWNLOAD_CONNECTIONS` | `4` | B | Concurrent connections per file (clamped 2–8) |
@@ -275,6 +276,7 @@ The **Scope** column shows whether each variable applies to the backup scheduler
 | `LOG_LEVEL` | `INFO` | B/V | Logging verbosity: `DEBUG`, `INFO`, `WARNING`/`WARN`, `ERROR` |
 | **Chat Filtering** | | | See [Chat Filtering](#chat-filtering) below |
 | `CHAT_IDS` | - | B | **Whitelist mode**: backup ONLY these chats (ignores all other filters) |
+| `WHITELIST_RESOLVE_DIALOG_LIMIT` | `1000` | B | When a `CHAT_IDS` entry cannot be resolved (typically a DM on a fresh session), scan up to this many dialogs once to warm the entity cache — it then resolves permanently (issue #234). `0` disables |
 | `CHAT_TYPES` | `private,groups,channels` | B | **Type-based mode**: comma-separated chat types to backup |
 | `GLOBAL_EXCLUDE_CHAT_IDS` | - | B | Exclude specific chats (any type) |
 | `GLOBAL_INCLUDE_CHAT_IDS` | - | B | Force-include specific chats (any type) |
@@ -372,6 +374,8 @@ CHANNELS_INCLUDE_CHAT_IDS=-1001234567890
 
 Find a chat's ID by forwarding a message to [@userinfobot](https://t.me/userinfobot).
 
+> **DMs in `CHAT_IDS`** — a positive user id only resolves after your session has "seen" that peer (Telegram requires a cached access hash for users; channels don't need one). On a fresh session an unseen DM would otherwise never archive. The backup handles this automatically: when a `CHAT_IDS` entry cannot be resolved, it scans up to `WHITELIST_RESOLVE_DIALOG_LIMIT` dialogs (default 1000, archived folders included) once to warm the cache, after which the id resolves permanently (issue #234). If an id still fails: message the peer once, add them to contacts, or run once without `CHAT_IDS`; for a dormant DM buried deeper than the newest 1000 dialogs, raise `WHITELIST_RESOLVE_DIALOG_LIMIT`.
+
 **Topic filtering** — For forum-enabled supergroups, you can exclude specific topics without excluding the entire chat using `SKIP_TOPIC_IDS`:
 
 ```bash
@@ -408,6 +412,10 @@ For reactions on **older** messages, set `REACTION_RESWEEP_DAYS=N`: on every sch
 Telegram rate-limits `getMessagesReactions` by **burst rate across all chats** (the bucket size varies a lot between accounts — from a handful of requests to dozens), so the re-sweep paces itself: requests are spaced by `REACTION_RESWEEP_BATCH_DELAY_SECONDS` (default `2`, measured across chat boundaries — smoothing, deliberately not sized to make floods impossible). On a FloodWait the re-sweep pauses **without sleeping or retrying** and resumes within the same run once the server-requested window has elapsed; it defers the remainder to the next scheduled sweep only when that window outlives the run, or after repeated floods in one run (a degrading bucket is left alone). Completed chats — and the mid-chat progress of a chat too large for one burst window — are remembered per cycle, so the next scheduled sweep resumes approximately where the last one stopped (the window shifts between runs; the reconcile is idempotent, so overlap is harmless). Over at most a few sweeps every chat in the window gets covered, without ever fighting the rate limiter.
 
 Sizing tip: `REACTION_RESWEEP_MAX_PER_CHAT` decides how much of the flood bucket one chat may consume (each 100 messages ≈ one request). On accounts with a small bucket, a lower cap such as `100` spends ~1 request per chat and lets a single run reach every eligible chat; large caps favor deep per-chat coverage over per-run breadth.
+
+#### FloodWaits during media downloads
+
+The client runs with `flood_sleep_threshold=0` so every rate limit surfaces in the logs instead of pausing silently. For media transfers that visibility used to be self-defeating: a FloodWait in the middle of a download aborted the file, and the retry restarted it from byte 0 — a file larger than one flood-free window could never finish. Media downloads (scheduled sweeps and the live listener alike) therefore absorb short floods in place: pauses up to `MEDIA_FLOOD_SLEEP_THRESHOLD` seconds (default 60) happen inside the transfer, which then resumes at its current offset (issue #232). Longer floods still surface and retry as before, and everything outside media transfers keeps the raise-immediately behavior for full log visibility. Absorbed pauses count toward `DOWNLOAD_TIMEOUT_SECONDS`, so raise both together on flood-heavy accounts; `MEDIA_FLOOD_SLEEP_THRESHOLD=0` restores the old behavior.
 
 ### Group → supergroup migrations
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,9 @@ services:
       BACKUP_PATH: /data/backups
       DOWNLOAD_MEDIA: ${DOWNLOAD_MEDIA:-true}
       MAX_MEDIA_SIZE_MB: ${MAX_MEDIA_SIZE_MB:-100}
+      # Absorb mid-download FloodWaits up to N seconds so large files resume
+      # in place instead of restarting from byte 0 (issue #232). 0 disables.
+      # MEDIA_FLOOD_SLEEP_THRESHOLD: ${MEDIA_FLOOD_SLEEP_THRESHOLD:-60}
       BATCH_SIZE: ${BATCH_SIZE:-100}
       CHECKPOINT_INTERVAL: ${CHECKPOINT_INTERVAL:-1}
       # DEDUPLICATE_MEDIA: ${DEDUPLICATE_MEDIA:-true}
@@ -44,6 +47,9 @@ services:
       #   CHAT_TYPES: "private,groups,channels"  # All chats of these types
       # =======================================================================
       CHAT_IDS: ${CHAT_IDS:-}
+      # If a CHAT_IDS entry can't be resolved (typically a DM on a fresh
+      # session), scan up to N dialogs once to warm the entity cache (#234).
+      # WHITELIST_RESOLVE_DIALOG_LIMIT: ${WHITELIST_RESOLVE_DIALOG_LIMIT:-1000}
       CHAT_TYPES: ${CHAT_TYPES:-private,groups,channels}
 
       # Granular Filtering (only used in type-based mode)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.26.0"
+version = "7.27.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.26.0"
+__version__ = "7.27.0"

--- a/src/config.py
+++ b/src/config.py
@@ -94,7 +94,13 @@ def build_telegram_proxy_from_env() -> dict | None:
 
 
 def build_telegram_client_kwargs() -> dict:
-    """Build common Telethon client keyword arguments from environment configuration."""
+    """Build common Telethon client keyword arguments from environment configuration.
+
+    ``flood_sleep_threshold`` stays 0: media downloads temporarily raise the
+    client threshold via ``absorb_media_floods`` (#232,
+    MEDIA_FLOOD_SLEEP_THRESHOLD); everything else keeps 0 so floods stay
+    visible in app logs (#124).
+    """
     kwargs: dict = {"flood_sleep_threshold": 0}
     proxy = build_telegram_proxy_from_env()
     if proxy is not None:
@@ -121,6 +127,10 @@ class Config:
         self.max_media_size_mb = int(os.getenv("MAX_MEDIA_SIZE_MB", "100"))
         # Timeout for media downloads (seconds). 0 disables the timeout.
         self.download_timeout_seconds = int(os.getenv("DOWNLOAD_TIMEOUT_SECONDS", "3600"))
+        # Absorb short mid-download FloodWaits (up to this many seconds) so the
+        # chunk stream resumes in place instead of restarting from byte 0;
+        # 0 = pre-7.27 raise-immediately behavior (#232).
+        self.media_flood_sleep_threshold = int(os.getenv("MEDIA_FLOOD_SLEEP_THRESHOLD", "60"))
         # Max usable filename-component length in BYTES for the media store. Default 143
         # keeps names writable on Synology/eCryptfs encrypted shares (whose filename-
         # encryption overhead caps components at ~143 bytes, not the usual 255); the temp
@@ -187,6 +197,9 @@ class Config:
         # When set, ONLY these chats are backed up - nothing else
         self.chat_ids = self._parse_id_list(os.getenv("CHAT_IDS", ""))
         self.whitelist_mode = len(self.chat_ids) > 0
+        # Bounded dialog scan warming the session entity cache when a whitelisted
+        # id cannot be resolved (typically a cache-cold DM); 0 disables (#234).
+        self.whitelist_resolve_dialog_limit = int(os.getenv("WHITELIST_RESOLVE_DIALOG_LIMIT", "1000"))
 
         # Type-based mode (only used if CHAT_IDS is not set)
         chat_types_env = os.environ.get("CHAT_TYPES")
@@ -754,7 +767,10 @@ class Config:
 
         ``flood_sleep_threshold=0`` forces Telethon to raise FloodWaitError
         instead of silently sleeping, so long waits become visible in the log
-        via ``iter_messages_with_flood_retry``.
+        via ``iter_messages_with_flood_retry``. Media downloads temporarily
+        raise the client threshold via ``absorb_media_floods`` (#232,
+        MEDIA_FLOOD_SLEEP_THRESHOLD); everything else keeps 0 so floods stay
+        visible in app logs (#124).
         """
         kwargs: dict = {"flood_sleep_threshold": 0}
         if self.telegram_proxy is not None:

--- a/src/listener.py
+++ b/src/listener.py
@@ -51,7 +51,7 @@ from .message_utils import (
     utcnow_naive,
 )
 from .realtime import NotificationType, RealtimeNotifier
-from .telegram_backup import call_with_flood_retry
+from .telegram_backup import absorb_media_floods, call_with_flood_retry
 
 logger = logging.getLogger(__name__)
 
@@ -772,7 +772,8 @@ class TelegramListener:
                 os.makedirs(shared_dir, exist_ok=True)
 
                 async def _download_fn(tmp_path):
-                    return await call_with_flood_retry(self.client.download_media, message, tmp_path)
+                    async with absorb_media_floods(self.client, getattr(self.config, "media_flood_sleep_threshold", 0)):
+                        return await call_with_flood_retry(self.client.download_media, message, tmp_path)
 
                 shared_file_path, content_hash = await download_and_shard_media(
                     db=self.db,
@@ -794,7 +795,8 @@ class TelegramListener:
                     tmp_file_path = f"{file_path}.{os.getpid()}.{task_id}.part"
                     if os.path.exists(tmp_file_path):
                         os.remove(tmp_file_path)
-                    actual_path = await call_with_flood_retry(self.client.download_media, message, tmp_file_path)
+                    async with absorb_media_floods(self.client, getattr(self.config, "media_flood_sleep_threshold", 0)):
+                        actual_path = await call_with_flood_retry(self.client.download_media, message, tmp_file_path)
                     file_path = finalize_atomic_download(
                         actual_path if isinstance(actual_path, str) else None,
                         tmp_file_path,

--- a/src/parallel_download.py
+++ b/src/parallel_download.py
@@ -35,7 +35,12 @@ import logging
 import os
 
 from telethon import utils
-from telethon.errors import FileMigrateError, FileReferenceExpiredError, FloodWaitError
+from telethon.errors import (
+    FileMigrateError,
+    FileReferenceExpiredError,
+    FloodPremiumWaitError,
+    FloodWaitError,
+)
 from telethon.network import MTProtoSender
 from telethon.tl import functions
 from telethon.tl.alltlobjects import LAYER
@@ -233,7 +238,7 @@ class ParallelDownloader:
             request = functions.upload.GetFileRequest(location, offset=offset, limit=self._part_size)
             try:
                 result = await self._client._call(sender, request)
-            except FloodWaitError:
+            except FloodWaitError, FloodPremiumWaitError:
                 # Must propagate unchanged so the caller's single flood budget
                 # (call_with_flood_retry) governs it — never a second backoff.
                 raise

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -311,8 +311,10 @@ async def absorb_media_floods(client, threshold):
     per-request threshold kwarg, so the client attribute is the only lever).
     Ref-counted so overlapping transfers (sweep + listener) restore correctly;
     the counter updates have no awaits between read and write, so the single-
-    threaded event loop keeps them atomic. No-ops for a non-positive or
-    non-int threshold (keeps MagicMock-config tests inert).
+    threaded event loop keeps them atomic. When contexts overlap, the FIRST
+    (outermost) threshold stays in effect — a nested different value is
+    deliberately ignored. No-ops for a non-positive or non-int threshold
+    (keeps MagicMock-config tests inert).
     """
     if not isinstance(threshold, int) or threshold <= 0:
         yield
@@ -486,31 +488,53 @@ class TelegramBackup:
         """True if ``chat_id`` was adopted via FOLLOW_CHAT_MIGRATIONS (#228)."""
         return self.config.follow_chat_migrations and chat_id in self._followed_migration_ids
 
-    async def _load_whitelist_unresolved(self) -> set[int]:
+    async def _load_whitelist_unresolved(self) -> tuple[int, set[int]]:
         """Load whitelist ids that already failed the #234 dialog-scan fallback.
 
-        Stored under the ``whitelist_unresolved_ids`` metadata key (a JSON list
-        of ids) so a dead CHAT_IDS entry (deleted account, typo) does not
-        re-trigger the bounded dialog scan on every run. Never raises — a
-        missing or malformed value degrades to "no known failures".
+        Stored under the ``whitelist_unresolved_ids`` metadata key as a JSON
+        object ``{"limit": N, "ids": [...]}`` so a dead CHAT_IDS entry (deleted
+        account, typo) does not re-trigger the bounded dialog scan on every
+        run. ``limit`` records the scan bound the absence was proven under:
+        callers must discard the suppression when the configured limit is now
+        HIGHER (a bigger scan may find the peer — this is what makes the
+        "raise WHITELIST_RESOLVE_DIALOG_LIMIT" advice in the warning actually
+        work). Returns ``(proof_limit, ids)``; never raises — a missing,
+        legacy-format, or malformed value degrades to ``(0, ids-if-parseable)``
+        and a zero proof-limit always invalidates.
         """
         try:
             raw = await self.db.get_metadata("whitelist_unresolved_ids")
         except Exception as e:
             logger.debug("Could not load unresolved whitelist ids (%s)", type(e).__name__)
-            return set()
+            return 0, set()
         if not isinstance(raw, str) or not raw:
-            return set()
+            return 0, set()
         try:
             data = json.loads(raw)
-            return {int(x) for x in data} if isinstance(data, list) else set()
         except ValueError, TypeError:
-            return set()
+            return 0, set()
+        if isinstance(data, dict):
+            ids = data.get("ids")
+            limit = data.get("limit")
+            return (
+                limit if isinstance(limit, int) and limit > 0 else 0,
+                {x for x in ids if isinstance(x, int)} if isinstance(ids, list) else set(),
+            )
+        if isinstance(data, list):  # legacy plain-list format: proof bound unknown
+            return 0, {x for x in data if isinstance(x, int)}
+        return 0, set()
 
-    async def _save_whitelist_unresolved(self, ids: set[int]) -> None:
-        """Persist the still-unresolvable whitelist ids (#234). Never raises."""
+    async def _save_whitelist_unresolved(self, ids: set[int], limit: int) -> None:
+        """Persist the still-unresolvable whitelist ids (#234). Never raises.
+
+        ``limit`` is the scan bound the ids' absence was proven under (see
+        ``_load_whitelist_unresolved``).
+        """
         try:
-            await self.db.set_metadata("whitelist_unresolved_ids", json.dumps(sorted(ids)))
+            await self.db.set_metadata(
+                "whitelist_unresolved_ids",
+                json.dumps({"limit": limit, "ids": sorted(ids)}),
+            )
         except Exception as e:
             logger.debug("Could not persist unresolved whitelist ids (%s)", type(e).__name__)
 
@@ -808,26 +832,40 @@ class TelegramBackup:
                 # (MagicMock ordering comparisons raise TypeError). Strictly
                 # best-effort: nothing below may escape the whitelist branch.
                 limit = getattr(self.config, "whitelist_resolve_dialog_limit", 0)
+                if isinstance(limit, int) and limit > 0:
+                    proof_limit, known_failed = await self._load_whitelist_unresolved()
+                    if limit > proof_limit:
+                        # The stored ids' absence was only proven under a smaller
+                        # scan bound — a bigger scan may find them. Discarding the
+                        # suppression here is what makes the warning's "raise
+                        # WHITELIST_RESOLVE_DIALOG_LIMIT" advice actually work.
+                        known_failed = set()
                 if unresolved and isinstance(limit, int) and limit > 0:
-                    known_failed = await self._load_whitelist_unresolved()
                     # Only NEW failures justify a scan — ids that already failed
-                    # one must not re-trigger a sweep every run. The running
-                    # sweep still matches ALL unresolved ids, incl. known-failed
-                    # ones: that extra coverage is free.
+                    # a COMPLETED scan at this bound must not re-trigger one
+                    # every run. The running sweep still matches ALL unresolved
+                    # ids, incl. known-failed ones: that extra coverage is free.
                     to_sweep = unresolved - known_failed
                     pending = set(unresolved)
                     resolved_in_sweep = 0
+                    # Only a sweep that ran to completion (iterator exhausted, or
+                    # every pending id found) PROVES absence up to `limit`. An
+                    # aborted sweep (flood/timeout/error) proves nothing — its
+                    # unfound ids must not be suppressed, or one unlucky run
+                    # would permanently disarm this fallback and reintroduce the
+                    # #234 silent skip.
+                    sweep_completed = False
                     if to_sweep:
                         logger.info(
                             "Whitelist: %d of %d configured chat(s) unresolved; "
                             "scanning up to %d dialogs to warm the entity cache (#234)",
-                            len(to_sweep),
+                            len(unresolved),
                             len(self.config.chat_ids | followed_to_fetch),
                             limit,
                         )
 
                         async def _sweep() -> None:
-                            nonlocal resolved_in_sweep
+                            nonlocal resolved_in_sweep, sweep_completed
                             # No folder/archived kwarg ON PURPOSE: with folder
                             # unspecified, Telethon returns ALL dialogs including
                             # archived ones — an unresolved DM may well be
@@ -843,7 +881,10 @@ class TelegramBackup:
                                     pending.discard(dialog.id)
                                     resolved_in_sweep += 1
                                     if not pending:
+                                        sweep_completed = True
                                         break
+                            else:
+                                sweep_completed = True
 
                         try:
                             await asyncio.wait_for(_sweep(), timeout=WHITELIST_RESOLVE_SWEEP_TIMEOUT_SECONDS)
@@ -881,10 +922,19 @@ class TelegramBackup:
                         except Exception:
                             still_failed.add(cid)
 
-                    # Persist exactly the post-retry still-failed set: resolved
-                    # ids drop out, ids removed from CHAT_IDS drop out next run,
-                    # and a still-failed id stays so it won't re-trigger sweeps.
-                    await self._save_whitelist_unresolved(still_failed)
+                    # Persist the suppression set. Resolved ids drop out either
+                    # way. New ids are added only when the sweep COMPLETED (their
+                    # absence is proven up to `limit`); after an abort only the
+                    # previously-proven ids are retained, at their original proof
+                    # bound. Followed-migration ids are never persisted: they are
+                    # not CHAT_IDS entries (the operator guidance below does not
+                    # apply to them) and an unresolvable one stays eligible for
+                    # the next run's scan instead.
+                    still_failed_config = still_failed & self.config.chat_ids
+                    if sweep_completed:
+                        await self._save_whitelist_unresolved(still_failed_config, limit)
+                    else:
+                        await self._save_whitelist_unresolved(still_failed_config & known_failed, proof_limit)
                     if resolved_in_sweep or resolved_in_retry:
                         logger.info(
                             "Whitelist: resolved %d of %d unresolved chat(s) (sweep %d, retry %d)",
@@ -893,7 +943,7 @@ class TelegramBackup:
                             resolved_in_sweep,
                             resolved_in_retry,
                         )
-                    if still_failed:
+                    if still_failed_config:
                         logger.warning(
                             "Whitelist: %d configured chat(s) remain unresolvable and were "
                             "skipped this run. A DM (positive user id) becomes resolvable once "
@@ -903,9 +953,15 @@ class TelegramBackup:
                             "remove it from CHAT_IDS. A dormant peer older than the newest %d "
                             "dialogs may need a higher WHITELIST_RESOLVE_DIALOG_LIMIT. "
                             "See issue #234.",
-                            len(still_failed),
+                            len(still_failed_config),
                             limit,
                         )
+                elif isinstance(limit, int) and limit > 0 and known_failed:
+                    # Everything resolved in the direct pass — clear stale
+                    # suppressions so an id that later goes cache-cold again
+                    # (e.g. after a session reset) gets a fresh scan instead of
+                    # being silently retry-only forever.
+                    await self._save_whitelist_unresolved(set(), limit)
 
             else:
                 # Type-based mode: fetch full dialog list and filter
@@ -2646,17 +2702,19 @@ class TelegramBackup:
                         attempt + 1,
                         MEDIA_REFRESH_MAX_ATTEMPTS,
                     )
-                except ValueError:
+                except ValueError as e:
                     # Telethon raises a bare ValueError ("Request was unsuccessful
                     # N time(s)") when one request exhausts its internal retry
                     # budget — e.g. >= request_retries FloodWaits absorbed inside
                     # a single chunk call, a failure mode that exists once
-                    # absorb_media_floods is active (#232).
-                    logger.warning(
-                        "Media download gave up after repeated in-request retries "
-                        "(likely sustained FloodWaits within one request); "
-                        "leaving it for a future backup run"
-                    )
+                    # absorb_media_floods is active (#232). Match its message so
+                    # unrelated ValueErrors are not mislabeled as flood exhaustion.
+                    if str(e).startswith("Request was unsuccessful"):
+                        logger.warning(
+                            "Media download gave up after repeated in-request retries "
+                            "(likely sustained FloodWaits within one request); "
+                            "leaving it for a future backup run"
+                        )
                     raise
             # Defensive: the loop returns on success or raises on the final attempt.
             raise FileReferenceExpiredError(request=None)

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -11,6 +11,7 @@ import os
 import random
 import time
 from collections.abc import Callable
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
 
 from telethon import TelegramClient
@@ -18,6 +19,7 @@ from telethon.errors import (
     ChannelPrivateError,
     ChatForbiddenError,
     FileReferenceExpiredError,
+    FloodPremiumWaitError,
     FloodWaitError,
     RPCError,
     UserBannedInChannelError,
@@ -109,6 +111,9 @@ FLOOD_WAIT_LOG_THRESHOLD = _get_int_env("FLOOD_WAIT_LOG_THRESHOLD", 10)
 MEDIA_REFRESH_MAX_ATTEMPTS = _get_int_env("MEDIA_REFRESH_MAX_ATTEMPTS", 3)
 # Upper bound on a single message-refresh round-trip so it can never hang.
 MEDIA_REFRESH_TIMEOUT_SECONDS = _get_int_env("MEDIA_REFRESH_TIMEOUT_SECONDS", 120)
+# Hard wall-clock bound on the #234 whitelist dialog scan — the count limit alone
+# cannot prevent a wedged-connection hang, which is what #95 was about.
+WHITELIST_RESOLVE_SWEEP_TIMEOUT_SECONDS = 300
 
 
 def _media_retry_backoff_seconds(attempt: int) -> float:
@@ -127,7 +132,11 @@ def _is_non_retryable_media_op(exc: BaseException) -> bool:
     and backs off) and a per-operation ``TimeoutError`` (the outer loop decides).
 
     Keeping these out of ``call_with_flood_retry`` also means the per-operation
-    timeout never wraps — and so never cancels — its FloodWait sleeps.
+    timeout never wraps — and so never cancels — its FloodWait sleeps. One
+    caveat since #232: floods absorbed inside Telethon by ``absorb_media_floods``
+    (up to MEDIA_FLOOD_SLEEP_THRESHOLD seconds each) DO sleep inside the
+    per-operation timeout; only above-threshold floods still raise before the
+    timeout can cancel them.
     """
     return is_media_location_error(exc) or isinstance(exc, TimeoutError)
 
@@ -200,7 +209,7 @@ async def call_with_flood_retry(
     while True:
         try:
             return await coro_fn(*args, **kwargs)
-        except FloodWaitError as e:
+        except (FloodWaitError, FloodPremiumWaitError) as e:
             retries += 1
             if retries > max_retries:
                 logger.error(
@@ -282,12 +291,60 @@ async def call_with_flood_retry(
             await asyncio.sleep(sleep_duration)
 
 
+@asynccontextmanager
+async def absorb_media_floods(client, threshold):
+    """Temporarily raise the client's flood_sleep_threshold for a media transfer.
+
+    With the app-wide ``flood_sleep_threshold=0`` (#124) any mid-download
+    FloodWait aborts ``download_media`` entirely and the outer retry restarts
+    from byte 0, so a file whose transfer outlives one flood-free window can
+    never finish (#232). Inside this context Telethon absorbs floods up to
+    ``threshold`` seconds: it sleeps and re-issues the SAME chunk request, so
+    the transfer resumes at the current offset (Telethon logs each absorbed
+    sleep at INFO on its own logger). Floods above the threshold still raise
+    and follow the normal ``call_with_flood_retry`` path.
+
+    The threshold is a client-wide attribute and the client is shared with the
+    real-time listener, so a request that floods on another task while a media
+    transfer holds this context is absorbed too — a deliberate, bounded
+    dilution of #124's per-call visibility (Telethon's ``__call__`` drops its
+    per-request threshold kwarg, so the client attribute is the only lever).
+    Ref-counted so overlapping transfers (sweep + listener) restore correctly;
+    the counter updates have no awaits between read and write, so the single-
+    threaded event loop keeps them atomic. No-ops for a non-positive or
+    non-int threshold (keeps MagicMock-config tests inert).
+    """
+    if not isinstance(threshold, int) or threshold <= 0:
+        yield
+        return
+    depth = getattr(client, "_ta_media_flood_depth", 0)
+    if not isinstance(depth, int):
+        depth = 0  # Mock clients auto-create attributes; normalize to a real counter
+    if depth == 0:
+        client._ta_media_flood_base = client.flood_sleep_threshold
+        client.flood_sleep_threshold = threshold
+        logger.debug("Media flood absorption active (threshold=%ss)", threshold)
+    client._ta_media_flood_depth = depth + 1
+    try:
+        yield
+    finally:
+        # Re-read the live counter — using the value captured at entry would
+        # corrupt the count when transfers overlap (sweep + listener).
+        depth = client._ta_media_flood_depth - 1
+        client._ta_media_flood_depth = depth
+        if depth == 0:
+            client.flood_sleep_threshold = client._ta_media_flood_base
+            logger.debug("Media flood absorption restored")
+
+
 async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
     """Wrap ``client.iter_messages`` so FloodWaitError is logged and retried.
 
     With ``flood_sleep_threshold=0`` on the client, every flood-wait bubbles up
-    as an exception. We log the wait and resume iteration from the last yielded
-    message id so progress isn't lost.
+    as an exception (media downloads are the one scoped exception: they raise
+    the threshold via ``absorb_media_floods`` for the transfer window — #232).
+    We log the wait and resume iteration from the last yielded message id so
+    progress isn't lost.
 
     Bounded retries: the inner ``while`` is capped at ``MAX_FLOOD_RETRIES``
     *consecutive* flood-waits without progress, and the counter resets every
@@ -316,7 +373,7 @@ async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
                     resume_from = max(resume_from, msg.id)
                 retries = 0
             return
-        except FloodWaitError as e:
+        except (FloodWaitError, FloodPremiumWaitError) as e:
             retries += 1
             if retries > MAX_FLOOD_RETRIES:
                 logger.error(
@@ -428,6 +485,34 @@ class TelegramBackup:
     def _is_followed_migration(self, chat_id: int) -> bool:
         """True if ``chat_id`` was adopted via FOLLOW_CHAT_MIGRATIONS (#228)."""
         return self.config.follow_chat_migrations and chat_id in self._followed_migration_ids
+
+    async def _load_whitelist_unresolved(self) -> set[int]:
+        """Load whitelist ids that already failed the #234 dialog-scan fallback.
+
+        Stored under the ``whitelist_unresolved_ids`` metadata key (a JSON list
+        of ids) so a dead CHAT_IDS entry (deleted account, typo) does not
+        re-trigger the bounded dialog scan on every run. Never raises — a
+        missing or malformed value degrades to "no known failures".
+        """
+        try:
+            raw = await self.db.get_metadata("whitelist_unresolved_ids")
+        except Exception as e:
+            logger.debug("Could not load unresolved whitelist ids (%s)", type(e).__name__)
+            return set()
+        if not isinstance(raw, str) or not raw:
+            return set()
+        try:
+            data = json.loads(raw)
+            return {int(x) for x in data} if isinstance(data, list) else set()
+        except ValueError, TypeError:
+            return set()
+
+    async def _save_whitelist_unresolved(self, ids: set[int]) -> None:
+        """Persist the still-unresolvable whitelist ids (#234). Never raises."""
+        try:
+            await self.db.set_metadata("whitelist_unresolved_ids", json.dumps(sorted(ids)))
+        except Exception as e:
+            logger.debug("Could not persist unresolved whitelist ids (%s)", type(e).__name__)
 
     async def _reconcile_migrations(self, dialogs: list, backed_up_chat_ids: set[int]) -> None:
         """Detect group→supergroup migrations and warn or follow them (#228).
@@ -695,20 +780,132 @@ class TelegramBackup:
                         | self.config.groups_exclude_ids
                         | self.config.channels_exclude_ids
                     )
+
+                class SimpleDialog:
+                    def __init__(self, entity):
+                        self.entity = entity
+                        self.date = datetime.now()
+
+                unresolved: set[int] = set()
                 for cid in self.config.chat_ids | followed_to_fetch:
                     try:
                         entity = await call_with_flood_retry(self.client.get_entity, cid)
-
-                        class SimpleDialog:
-                            def __init__(self, entity):
-                                self.entity = entity
-                                self.date = datetime.now()
-
                         filtered_dialogs.append(SimpleDialog(entity))
                         seen_chat_ids.add(cid)
                         logger.info("  → Fetched chat")
                     except Exception as e:
                         logger.warning(f"  → Could not fetch chat: {e}")
+                        unresolved.add(cid)
+
+                # Fallback for unresolved entries (#234): a bare positive user id
+                # (a DM) only resolves once the session has the peer's access_hash
+                # cached — channels get a hash-0 probe, users don't — so a DM the
+                # session has never "seen" silently never archives. One bounded
+                # iter_dialogs pass persists every seen entity's access_hash into
+                # the session (a permanent self-heal) and adopts matching dialogs
+                # directly. Guard order is load-bearing: `unresolved` first (most
+                # runs never get here), isinstance before any comparison
+                # (MagicMock ordering comparisons raise TypeError). Strictly
+                # best-effort: nothing below may escape the whitelist branch.
+                limit = getattr(self.config, "whitelist_resolve_dialog_limit", 0)
+                if unresolved and isinstance(limit, int) and limit > 0:
+                    known_failed = await self._load_whitelist_unresolved()
+                    # Only NEW failures justify a scan — ids that already failed
+                    # one must not re-trigger a sweep every run. The running
+                    # sweep still matches ALL unresolved ids, incl. known-failed
+                    # ones: that extra coverage is free.
+                    to_sweep = unresolved - known_failed
+                    pending = set(unresolved)
+                    resolved_in_sweep = 0
+                    if to_sweep:
+                        logger.info(
+                            "Whitelist: %d of %d configured chat(s) unresolved; "
+                            "scanning up to %d dialogs to warm the entity cache (#234)",
+                            len(to_sweep),
+                            len(self.config.chat_ids | followed_to_fetch),
+                            limit,
+                        )
+
+                        async def _sweep() -> None:
+                            nonlocal resolved_in_sweep
+                            # No folder/archived kwarg ON PURPOSE: with folder
+                            # unspecified, Telethon returns ALL dialogs including
+                            # archived ones — an unresolved DM may well be
+                            # archived (#234). Do NOT reuse _get_dialogs() here:
+                            # it pins folder=0/folder=1.
+                            async for dialog in self.client.iter_dialogs(limit=limit):
+                                if dialog.id in pending:
+                                    # The dialog already carries the entity
+                                    # get_entity would return — grab it directly
+                                    # and skip a second API call.
+                                    filtered_dialogs.append(SimpleDialog(dialog.entity))
+                                    seen_chat_ids.add(dialog.id)
+                                    pending.discard(dialog.id)
+                                    resolved_in_sweep += 1
+                                    if not pending:
+                                        break
+
+                        try:
+                            await asyncio.wait_for(_sweep(), timeout=WHITELIST_RESOLVE_SWEEP_TIMEOUT_SECONDS)
+                        except FloodWaitError, FloodPremiumWaitError:
+                            logger.warning(
+                                "Whitelist resolve: dialog scan hit a FloodWait; recovered %d chat(s) before stopping",
+                                resolved_in_sweep,
+                            )
+                        except TimeoutError:
+                            logger.warning(
+                                "Whitelist resolve: dialog scan timed out after %ss; recovered %d chat(s)",
+                                WHITELIST_RESOLVE_SWEEP_TIMEOUT_SECONDS,
+                                resolved_in_sweep,
+                            )
+                        except Exception as e:
+                            logger.warning(
+                                "Whitelist resolve: dialog scan failed (%s); recovered %d chat(s)",
+                                type(e).__name__,
+                                resolved_in_sweep,
+                            )
+
+                    # Cheap per-id retry — even when the sweep was suppressed:
+                    # the scan (or any other traffic, e.g. the listener caching
+                    # the sender of an incoming DM) may have warmed the entity
+                    # cache since the first pass, so a known-failed id
+                    # self-heals here permanently.
+                    still_failed: set[int] = set()
+                    resolved_in_retry = 0
+                    for cid in sorted(pending):
+                        try:
+                            entity = await call_with_flood_retry(self.client.get_entity, cid)
+                            filtered_dialogs.append(SimpleDialog(entity))
+                            seen_chat_ids.add(cid)
+                            resolved_in_retry += 1
+                        except Exception:
+                            still_failed.add(cid)
+
+                    # Persist exactly the post-retry still-failed set: resolved
+                    # ids drop out, ids removed from CHAT_IDS drop out next run,
+                    # and a still-failed id stays so it won't re-trigger sweeps.
+                    await self._save_whitelist_unresolved(still_failed)
+                    if resolved_in_sweep or resolved_in_retry:
+                        logger.info(
+                            "Whitelist: resolved %d of %d unresolved chat(s) (sweep %d, retry %d)",
+                            resolved_in_sweep + resolved_in_retry,
+                            len(unresolved),
+                            resolved_in_sweep,
+                            resolved_in_retry,
+                        )
+                    if still_failed:
+                        logger.warning(
+                            "Whitelist: %d configured chat(s) remain unresolvable and were "
+                            "skipped this run. A DM (positive user id) becomes resolvable once "
+                            "this account has seen the peer — message them once, add them to "
+                            "contacts, or run once without CHAT_IDS; it then self-heals "
+                            "permanently. If the entry is stale (deleted account or a typo), "
+                            "remove it from CHAT_IDS. A dormant peer older than the newest %d "
+                            "dialogs may need a higher WHITELIST_RESOLVE_DIALOG_LIMIT. "
+                            "See issue #234.",
+                            len(still_failed),
+                            limit,
+                        )
 
             else:
                 # Type-based mode: fetch full dialog list and filter
@@ -2361,6 +2558,13 @@ class TelegramBackup:
         never cancelled by the download timeout. A timed-out operation raises
         ``TimeoutError``, which ``_is_non_retryable_media_op`` lets propagate to
         the outer retry loop.
+
+        Caveat since #232: floods absorbed inside Telethon by
+        ``absorb_media_floods`` (up to MEDIA_FLOOD_SLEEP_THRESHOLD seconds each)
+        sleep INSIDE this timeout and count toward it; only above-threshold
+        floods still raise before the timeout can cancel them. When raising
+        MEDIA_FLOOD_SLEEP_THRESHOLD on flood-heavy accounts, raise
+        DOWNLOAD_TIMEOUT_SECONDS along with it.
         """
         coro = self._fetch_media_bytes(message, tmp_path, file_size)
         if timeout_val is None:
@@ -2428,7 +2632,9 @@ class TelegramBackup:
                 except TimeoutError:
                     if attempt >= last:
                         logger.error(
-                            "Media download timed out after %ss on attempt %d/%d; giving up for this run",
+                            "Media download timed out after %ss on attempt %d/%d; giving up for this run "
+                            "(absorbed FloodWait sleeps count toward DOWNLOAD_TIMEOUT_SECONDS — "
+                            "consider raising it on flood-heavy accounts)",
                             timeout,
                             attempt + 1,
                             MEDIA_REFRESH_MAX_ATTEMPTS,
@@ -2440,6 +2646,18 @@ class TelegramBackup:
                         attempt + 1,
                         MEDIA_REFRESH_MAX_ATTEMPTS,
                     )
+                except ValueError:
+                    # Telethon raises a bare ValueError ("Request was unsuccessful
+                    # N time(s)") when one request exhausts its internal retry
+                    # budget — e.g. >= request_retries FloodWaits absorbed inside
+                    # a single chunk call, a failure mode that exists once
+                    # absorb_media_floods is active (#232).
+                    logger.warning(
+                        "Media download gave up after repeated in-request retries "
+                        "(likely sustained FloodWaits within one request); "
+                        "leaving it for a future backup run"
+                    )
+                    raise
             # Defensive: the loop returns on success or raises on the final attempt.
             raise FileReferenceExpiredError(request=None)
         except BaseException:
@@ -2655,21 +2873,25 @@ class TelegramBackup:
         the single-stream ``client.download_media``. A parallel attempt that
         reports itself unavailable transparently falls back to single-stream for
         that file; FloodWait and other real errors propagate unchanged so the
-        caller's single retry budget governs them.
+        caller's single retry budget governs them. Runs under
+        ``absorb_media_floods`` (#232): floods up to MEDIA_FLOOD_SLEEP_THRESHOLD
+        seconds are absorbed in place by Telethon so the transfer resumes at the
+        current offset; larger floods still propagate.
         """
-        if self._should_parallelize(message, file_size):
-            if self._parallel_downloader is None:
-                self._parallel_downloader = ParallelDownloader(
-                    self.client,
-                    connections=self.config.parallel_download_connections,
-                    part_size=self.config.get_parallel_download_part_size_bytes(),
-                    max_file_size=self.config.get_max_media_size_bytes(),
-                )
-            try:
-                return await self._parallel_downloader.download_media(message, tmp_path)
-            except ParallelDownloadUnavailable as exc:
-                logger.info("Parallel download not applicable (%s); falling back to single-stream", exc)
-        return await self.client.download_media(message, tmp_path)
+        async with absorb_media_floods(self.client, getattr(self.config, "media_flood_sleep_threshold", 0)):
+            if self._should_parallelize(message, file_size):
+                if self._parallel_downloader is None:
+                    self._parallel_downloader = ParallelDownloader(
+                        self.client,
+                        connections=self.config.parallel_download_connections,
+                        part_size=self.config.get_parallel_download_part_size_bytes(),
+                        max_file_size=self.config.get_max_media_size_bytes(),
+                    )
+                try:
+                    return await self._parallel_downloader.download_media(message, tmp_path)
+                except ParallelDownloadUnavailable as exc:
+                    logger.info("Parallel download not applicable (%s); falling back to single-stream", exc)
+            return await self.client.download_media(message, tmp_path)
 
     def _get_media_size(self, media) -> int:
         """Get estimated size of media object in bytes."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1419,3 +1419,66 @@ def _get_base_env(temp_dir: str) -> dict:
         "TELEGRAM_API_HASH": "abcdef",
         "TELEGRAM_PHONE": "+1234567890",
     }
+
+
+class TestMediaFloodSleepThreshold(unittest.TestCase):
+    """MEDIA_FLOOD_SLEEP_THRESHOLD (#232) parsing, and the #124 kwargs pin."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_default_is_60(self):
+        with patch.dict(os.environ, _get_base_env(self.temp_dir), clear=True):
+            config = Config()
+        self.assertEqual(config.media_flood_sleep_threshold, 60)
+
+    def test_env_override(self):
+        env = _get_base_env(self.temp_dir) | {"MEDIA_FLOOD_SLEEP_THRESHOLD": "300"}
+        with patch.dict(os.environ, env, clear=True):
+            config = Config()
+        self.assertEqual(config.media_flood_sleep_threshold, 300)
+
+    def test_env_zero_restores_raise_immediately(self):
+        env = _get_base_env(self.temp_dir) | {"MEDIA_FLOOD_SLEEP_THRESHOLD": "0"}
+        with patch.dict(os.environ, env, clear=True):
+            config = Config()
+        self.assertEqual(config.media_flood_sleep_threshold, 0)
+
+    def test_client_kwargs_keep_flood_sleep_threshold_zero(self):
+        """#124 pin: the media threshold must never leak into the client kwargs —
+        absorption is scoped to absorb_media_floods, not the whole client."""
+        env = _get_base_env(self.temp_dir) | {"MEDIA_FLOOD_SLEEP_THRESHOLD": "300"}
+        with patch.dict(os.environ, env, clear=True):
+            config = Config()
+            self.assertEqual(config.get_telegram_client_kwargs().get("flood_sleep_threshold"), 0)
+            self.assertEqual(build_telegram_client_kwargs().get("flood_sleep_threshold"), 0)
+
+
+class TestWhitelistResolveDialogLimit(unittest.TestCase):
+    """WHITELIST_RESOLVE_DIALOG_LIMIT (#234) parsing."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def test_default_is_1000(self):
+        with patch.dict(os.environ, _get_base_env(self.temp_dir), clear=True):
+            config = Config()
+        self.assertEqual(config.whitelist_resolve_dialog_limit, 1000)
+
+    def test_env_override(self):
+        env = _get_base_env(self.temp_dir) | {"WHITELIST_RESOLVE_DIALOG_LIMIT": "250"}
+        with patch.dict(os.environ, env, clear=True):
+            config = Config()
+        self.assertEqual(config.whitelist_resolve_dialog_limit, 250)
+
+    def test_env_zero_disables(self):
+        env = _get_base_env(self.temp_dir) | {"WHITELIST_RESOLVE_DIALOG_LIMIT": "0"}
+        with patch.dict(os.environ, env, clear=True):
+            config = Config()
+        self.assertEqual(config.whitelist_resolve_dialog_limit, 0)

--- a/tests/test_flood_wait_visibility.py
+++ b/tests/test_flood_wait_visibility.py
@@ -794,3 +794,63 @@ async def test_fetch_media_bytes_sets_flood_threshold_during_download(fake_db):
     assert result == "/tmp/media.part"
     assert observed == [60]
     assert client.flood_sleep_threshold == 0
+
+
+@pytest.mark.asyncio
+async def test_absorb_media_floods_restores_on_external_cancellation(fake_db):
+    """Cancellation mid-transfer (e.g. a wait_for timeout) still restores the threshold."""
+    import asyncio
+
+    from src.telegram_backup import absorb_media_floods
+
+    client = SimpleNamespace(flood_sleep_threshold=0)
+    entered = asyncio.Event()
+
+    async def _hold():
+        async with absorb_media_floods(client, 60):
+            entered.set()
+            await asyncio.sleep(30)
+
+    task = asyncio.create_task(_hold())
+    await entered.wait()
+    assert client.flood_sleep_threshold == 60
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert client.flood_sleep_threshold == 0
+    assert client._ta_media_flood_depth == 0
+
+
+def _make_media_backup():
+    """Minimal TelegramBackup for exercising _download_media_to_path directly."""
+    from src.telegram_backup import TelegramBackup
+
+    backup = TelegramBackup.__new__(TelegramBackup)
+    backup.config = MagicMock()  # non-int download_timeout_seconds → no wait_for bound
+    backup.db = AsyncMock()
+    backup.client = AsyncMock()
+    return backup
+
+
+@pytest.mark.asyncio
+async def test_download_media_valueerror_flood_exhaustion_logged(fake_db, caplog, tmp_path):
+    """Telethon's request-retries ValueError is surfaced as likely flood exhaustion (#232)."""
+    backup = _make_media_backup()
+    backup._fetch_media_bytes_bounded = AsyncMock(side_effect=ValueError("Request was unsuccessful 5 time(s)"))
+
+    with caplog.at_level(logging.WARNING, logger="src.telegram_backup"), pytest.raises(ValueError):
+        await backup._download_media_to_path(MagicMock(), str(tmp_path / "m.part"), 123, 42)
+
+    assert any("repeated in-request retries" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_download_media_foreign_valueerror_not_mislabeled(fake_db, caplog, tmp_path):
+    """A ValueError from anywhere else must not be labeled as flood exhaustion."""
+    backup = _make_media_backup()
+    backup._fetch_media_bytes_bounded = AsyncMock(side_effect=ValueError("unrelated parsing problem"))
+
+    with caplog.at_level(logging.WARNING, logger="src.telegram_backup"), pytest.raises(ValueError):
+        await backup._download_media_to_path(MagicMock(), str(tmp_path / "m.part"), 123, 42)
+
+    assert not any("repeated in-request retries" in r.getMessage() for r in caplog.records)

--- a/tests/test_flood_wait_visibility.py
+++ b/tests/test_flood_wait_visibility.py
@@ -690,3 +690,107 @@ async def test_call_with_flood_retry_gives_up_on_transient_error(fake_db):
         pytest.raises(OSError, match="disk failure"),
     ):
         await telegram_backup.call_with_flood_retry(broken_api, max_retries=3)
+
+
+# ---------------------------------------------------------------------------
+# Media flood absorption (#232): absorb_media_floods
+#
+# These pin OUR contract at the seam: the client-wide threshold is raised for
+# the duration of a media transfer and restored afterwards, while the global
+# client kwargs stay 0 (#124). The absorbed sleep itself happens inside
+# vendored Telethon and is not re-tested here.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_absorb_media_floods_sets_threshold_and_restores(fake_db):
+    from src.telegram_backup import absorb_media_floods
+
+    client = SimpleNamespace(flood_sleep_threshold=0)
+    async with absorb_media_floods(client, 60):
+        assert client.flood_sleep_threshold == 60
+    assert client.flood_sleep_threshold == 0
+
+
+@pytest.mark.asyncio
+async def test_absorb_media_floods_restores_on_exception(fake_db):
+    from src.telegram_backup import absorb_media_floods
+
+    client = SimpleNamespace(flood_sleep_threshold=0)
+    with pytest.raises(RuntimeError, match="boom"):
+        async with absorb_media_floods(client, 60):
+            raise RuntimeError("boom")
+    assert client.flood_sleep_threshold == 0
+
+
+@pytest.mark.asyncio
+async def test_absorb_media_floods_refcount_overlap(fake_db):
+    """Models a sweep download and a listener download overlapping on the
+    shared client: the threshold is only restored when the LAST one exits."""
+    from src.telegram_backup import absorb_media_floods
+
+    client = SimpleNamespace(flood_sleep_threshold=0)
+    cm_a = absorb_media_floods(client, 60)
+    cm_b = absorb_media_floods(client, 60)
+    await cm_a.__aenter__()
+    assert client.flood_sleep_threshold == 60
+    await cm_b.__aenter__()
+    assert client.flood_sleep_threshold == 60
+    await cm_a.__aexit__(None, None, None)
+    # B still holds the context — the threshold must NOT be restored yet.
+    assert client.flood_sleep_threshold == 60
+    await cm_b.__aexit__(None, None, None)
+    assert client.flood_sleep_threshold == 0
+
+
+@pytest.mark.asyncio
+async def test_absorb_media_floods_zero_threshold_noop(fake_db):
+    """Threshold 0 keeps the pre-#232 raise-immediately behavior untouched."""
+    from src.telegram_backup import absorb_media_floods
+
+    client = SimpleNamespace(flood_sleep_threshold=0)
+    async with absorb_media_floods(client, 0):
+        assert client.flood_sleep_threshold == 0
+    assert client.flood_sleep_threshold == 0
+    assert not hasattr(client, "_ta_media_flood_depth")
+    assert not hasattr(client, "_ta_media_flood_base")
+
+
+@pytest.mark.asyncio
+async def test_absorb_media_floods_non_int_threshold_noop(fake_db):
+    """A MagicMock threshold (auto-created config attr) must be inert."""
+    from src.telegram_backup import absorb_media_floods
+
+    client = SimpleNamespace(flood_sleep_threshold=0)
+    async with absorb_media_floods(client, MagicMock()):
+        assert client.flood_sleep_threshold == 0
+    assert client.flood_sleep_threshold == 0
+    assert not hasattr(client, "_ta_media_flood_depth")
+
+
+@pytest.mark.asyncio
+async def test_fetch_media_bytes_sets_flood_threshold_during_download(fake_db):
+    """_fetch_media_bytes raises the threshold for the download window only."""
+    from src.telegram_backup import TelegramBackup
+
+    backup = TelegramBackup.__new__(TelegramBackup)
+    config = MagicMock()
+    config.media_flood_sleep_threshold = 60
+    backup.config = config  # `is True` gate keeps MagicMock configs single-stream
+    backup.db = AsyncMock()
+
+    observed = []
+    client = SimpleNamespace(flood_sleep_threshold=0)
+
+    async def _download_media(message, tmp_path):
+        observed.append(client.flood_sleep_threshold)
+        return tmp_path
+
+    client.download_media = _download_media
+    backup.client = client
+
+    result = await backup._fetch_media_bytes(MagicMock(), "/tmp/media.part", 123)
+
+    assert result == "/tmp/media.part"
+    assert observed == [60]
+    assert client.flood_sleep_threshold == 0

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -711,6 +711,93 @@ class TestDownloadMedia:
         assert result is not None
         listener.client.download_media.assert_called_once()
 
+    @patch("os.path.exists", return_value=False)
+    @patch("os.makedirs")
+    @patch("os.path.lexists", return_value=False)
+    @patch("os.symlink")
+    @patch("os.path.relpath", return_value="../_shared/file.jpg")
+    async def test_download_media_absorbs_floods_dedup(
+        self, mock_relpath, mock_symlink, mock_lexists, mock_makedirs, mock_exists
+    ):
+        """#232: the dedup download closure runs under absorb_media_floods."""
+        from telethon.tl.types import MessageMediaPhoto
+
+        listener = self._make_listener(deduplicate_media=True, media_flood_sleep_threshold=60)
+        listener.client.flood_sleep_threshold = 0
+
+        msg = MagicMock()
+        media = MagicMock(spec=MessageMediaPhoto)
+        media.photo = MagicMock()
+        media.photo.id = 123
+        media.photo.sizes = []
+        msg.media = media
+        msg.id = 1
+
+        downloaded = {"done": False}
+        observed = []
+
+        async def fake_download(*args, **kwargs):
+            observed.append(listener.client.flood_sleep_threshold)
+            downloaded["done"] = True
+            return "/tmp/test_media/_shared/123.jpg"
+
+        listener.client.download_media = AsyncMock(side_effect=fake_download)
+
+        def exists(path):
+            if str(path).endswith("123.jpg") and "_shared" in str(path):
+                return downloaded["done"]
+            return False
+
+        mock_exists.side_effect = exists
+        with patch("src.message_utils.finalize_atomic_download", return_value="/tmp/test_media/_shared/123.jpg"):
+            result = await listener._download_media(msg, -100)
+        assert result is not None
+        # Threshold raised only for the download window, restored after.
+        assert observed == [60]
+        assert listener.client.flood_sleep_threshold == 0
+
+    @patch("os.path.exists", return_value=False)
+    @patch("os.makedirs")
+    async def test_download_media_absorbs_floods_no_dedup(self, mock_makedirs, mock_exists):
+        """#232: the direct (non-dedup) download runs under absorb_media_floods."""
+        from telethon.tl.types import MessageMediaPhoto
+
+        listener = self._make_listener(deduplicate_media=False, media_flood_sleep_threshold=60)
+        listener.client.flood_sleep_threshold = 0
+
+        msg = MagicMock()
+        media = MagicMock(spec=MessageMediaPhoto)
+        media.photo = MagicMock()
+        media.photo.id = 123
+        media.photo.sizes = []
+        msg.media = media
+        msg.id = 1
+
+        downloaded = {"done": False}
+        observed = []
+
+        async def fake_download(*args, **kwargs):
+            observed.append(listener.client.flood_sleep_threshold)
+            downloaded["done"] = True
+            return os.path.normpath("/tmp/test_media/-100/123.jpg")
+
+        listener.client.download_media = AsyncMock(side_effect=fake_download)
+
+        def exists(path):
+            if str(path).endswith("123.jpg") and "-100" in str(path):
+                return downloaded["done"]
+            return False
+
+        mock_exists.side_effect = exists
+        with patch(
+            "src.message_utils.finalize_atomic_download", return_value=os.path.normpath("/tmp/test_media/-100/123.jpg")
+        ):
+            result = await listener._download_media(msg, -100)
+        assert result is not None
+        # Threshold raised only for the download window, restored after.
+        assert observed == [60]
+        assert listener.client.flood_sleep_threshold == 0
+
     async def test_download_media_returns_none_on_exception(self):
         """Exception during download returns None instead of raising."""
         from telethon.tl.types import MessageMediaPhoto

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -9,6 +9,7 @@ import unittest.mock
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock
 
+from telethon.errors import FloodWaitError
 from telethon.tl.types import (
     Channel,
     Chat,
@@ -700,6 +701,8 @@ class TestWhitelistModeBackup(unittest.TestCase):
         self.backup.client.get_dialogs.assert_not_called()
         # get_entity SHOULD have been called for the whitelisted chat
         self.backup.client.get_entity.assert_awaited_once_with(-1002701160643)
+        # #234 fast path: everything resolved on the first pass → zero extra API calls
+        self.backup.client.iter_dialogs.assert_not_called()
 
     def test_whitelist_mode_handles_entity_fetch_failure(self):
         """If get_entity fails for a whitelisted chat, backup should continue without crashing."""
@@ -717,6 +720,218 @@ class TestWhitelistModeBackup(unittest.TestCase):
         self._run(self.backup.backup_all())
 
         self.backup.client.get_dialogs.assert_not_called()
+
+    # ------------------------------------------------------------------
+    # #234 fallback: bounded dialog scan for unresolvable whitelist ids
+    # ------------------------------------------------------------------
+
+    class _FakeDialogIter:
+        """Async iterator matching iter_dialogs' shape (sync call → async iterable).
+
+        A plain iterator object mirrors Telethon's RequestIter — no aclose() —
+        so an early ``break`` in the code under test leaves no suspended
+        async-generator frame behind (those warn at loop teardown).
+        """
+
+        def __init__(self, dialogs, *, error=None, delay=0.0, counter=None):
+            self._dialogs = list(dialogs)
+            self._error = error
+            self._delay = delay
+            self._counter = counter
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._delay:
+                await asyncio.sleep(self._delay)
+            if self._dialogs:
+                if self._counter is not None:
+                    self._counter["count"] += 1
+                return self._dialogs.pop(0)
+            if self._error is not None:
+                raise self._error
+            raise StopAsyncIteration
+
+    def _wire_backup_run(self, metadata=None):
+        """Mock wiring shared by the #234 fallback tests (mirrors the #95 tests)."""
+        self.backup.client.start = AsyncMock()
+        self.backup.client.get_me = AsyncMock(return_value=MagicMock(first_name="Test", id=123))
+        self.backup.db.get_metadata = AsyncMock(side_effect=lambda key: (metadata or {}).get(key))
+        self.backup.db.set_metadata = AsyncMock()
+        self.backup.db.get_last_message_id = AsyncMock(return_value=0)
+        self.backup.db.backfill_is_outgoing = AsyncMock()
+        self.backup.db.upsert_chat = AsyncMock()
+        self.backup.db.calculate_and_store_statistics = AsyncMock(
+            return_value={"chats": 1, "messages": 0, "media_files": 0, "total_size_mb": 0}
+        )
+        self.backup._backup_dialog = AsyncMock(return_value=0)
+        self.backup._backup_folders = AsyncMock()
+        self.backup._backup_forum_topics = AsyncMock()
+        self.config.follow_chat_migrations = False
+
+    def _backed_up_entities(self):
+        return [c.args[0].entity for c in self.backup._backup_dialog.await_args_list]
+
+    def test_whitelist_fallback_resolves_dm_after_dialog_sweep(self):
+        """An unresolvable DM id is recovered via the bounded dialog scan (#234)."""
+        self.config.chat_ids = {12345}
+        self.config.whitelist_resolve_dialog_limit = 1000
+        self._wire_backup_run()
+        self.backup.client.get_entity = AsyncMock(side_effect=Exception("Could not find the input entity"))
+        dm_entity = User(id=12345)
+        dialog = MagicMock(id=12345, entity=dm_entity)
+        self.backup.client.iter_dialogs = MagicMock(side_effect=lambda **kw: self._FakeDialogIter([dialog]))
+
+        self._run(self.backup.backup_all())
+
+        # Regression pin: no folder/archived kwarg — the scan must cover ALL folders.
+        self.backup.client.iter_dialogs.assert_called_once_with(limit=1000)
+        # The swept dialog already carries the entity — no second get_entity for it.
+        self.assertEqual(self.backup.client.get_entity.await_count, 1)
+        self.assertIn(dm_entity, self._backed_up_entities())
+
+    def test_whitelist_fallback_early_stops_when_all_resolved(self):
+        """The scan stops consuming dialogs once every pending id matched."""
+        self.config.chat_ids = {12345}
+        self.config.whitelist_resolve_dialog_limit = 1000
+        self._wire_backup_run()
+        self.backup.client.get_entity = AsyncMock(side_effect=Exception("unresolved"))
+        dialogs = [
+            MagicMock(id=12345, entity=User(id=12345)),
+            MagicMock(id=222, entity=User(id=222)),
+            MagicMock(id=333, entity=User(id=333)),
+        ]
+        consumed = {"count": 0}
+        self.backup.client.iter_dialogs = MagicMock(
+            side_effect=lambda **kw: self._FakeDialogIter(dialogs, counter=consumed)
+        )
+
+        self._run(self.backup.backup_all())
+
+        self.assertEqual(consumed["count"], 1)
+
+    def test_whitelist_fallback_disabled_when_limit_zero(self):
+        """WHITELIST_RESOLVE_DIALOG_LIMIT=0 disables the scan entirely."""
+        self.config.chat_ids = {12345}
+        self.config.whitelist_resolve_dialog_limit = 0
+        self._wire_backup_run()
+        self.backup.client.get_entity = AsyncMock(side_effect=Exception("unresolved"))
+        self.backup.client.iter_dialogs = MagicMock()
+
+        self._run(self.backup.backup_all())
+
+        self.backup.client.iter_dialogs.assert_not_called()
+        # First pass only — the retry pass is part of the disabled fallback.
+        self.assertEqual(self.backup.client.get_entity.await_count, 1)
+
+    def test_whitelist_fallback_floodwait_during_sweep_proceeds(self):
+        """A FloodWait mid-scan stops the sweep but never aborts the run."""
+        self.config.chat_ids = {12345}
+        self.config.whitelist_resolve_dialog_limit = 1000
+        self._wire_backup_run()
+        self.backup.client.get_entity = AsyncMock(side_effect=Exception("unresolved"))
+
+        self.backup.client.iter_dialogs = MagicMock(
+            side_effect=lambda **kw: self._FakeDialogIter(
+                [MagicMock(id=222, entity=User(id=222))],
+                error=FloodWaitError(request=None, capture=15),
+            )
+        )
+
+        with self.assertLogs("src.telegram_backup", level="INFO") as cm:
+            self._run(self.backup.backup_all())
+
+        messages = [r.getMessage() for r in cm.records]
+        self.assertTrue(any("hit a FloodWait" in m for m in messages))
+        self.assertTrue(any("remain unresolvable" in m for m in messages))
+
+    def test_whitelist_fallback_sweep_error_proceeds(self):
+        """Any other scan error is swallowed; the run completes."""
+        self.config.chat_ids = {12345}
+        self.config.whitelist_resolve_dialog_limit = 1000
+        self._wire_backup_run()
+        self.backup.client.get_entity = AsyncMock(side_effect=Exception("unresolved"))
+
+        self.backup.client.iter_dialogs = MagicMock(
+            side_effect=lambda **kw: self._FakeDialogIter([], error=RuntimeError("connection wedged"))
+        )
+
+        with self.assertLogs("src.telegram_backup", level="WARNING") as cm:
+            self._run(self.backup.backup_all())
+
+        self.assertTrue(any("dialog scan failed" in r.getMessage() for r in cm.records))
+
+    def test_whitelist_fallback_sweep_timeout_proceeds(self):
+        """The scan is wall-clock bounded; a hang cannot stall the run (#95)."""
+        self.config.chat_ids = {12345}
+        self.config.whitelist_resolve_dialog_limit = 1000
+        self._wire_backup_run()
+        self.backup.client.get_entity = AsyncMock(side_effect=Exception("unresolved"))
+
+        self.backup.client.iter_dialogs = MagicMock(
+            side_effect=lambda **kw: self._FakeDialogIter([MagicMock(id=12345, entity=User(id=12345))], delay=1.0)
+        )
+
+        with (
+            unittest.mock.patch("src.telegram_backup.WHITELIST_RESOLVE_SWEEP_TIMEOUT_SECONDS", 0.05),
+            self.assertLogs("src.telegram_backup", level="WARNING") as cm,
+        ):
+            self._run(self.backup.backup_all())
+
+        self.assertTrue(any("timed out" in r.getMessage() for r in cm.records))
+
+    def test_whitelist_fallback_still_unresolved_warns_without_ids(self):
+        """New #234 log lines carry counts only — never the configured ids."""
+        self.config.chat_ids = {987654321}
+        self.config.whitelist_resolve_dialog_limit = 500
+        self._wire_backup_run()
+        self.backup.client.get_entity = AsyncMock(side_effect=Exception("could not resolve"))
+        self.backup.client.iter_dialogs = MagicMock(
+            side_effect=lambda **kw: self._FakeDialogIter([MagicMock(id=111, entity=User(id=111))])
+        )
+
+        with self.assertLogs("src.telegram_backup", level="INFO") as cm:
+            self._run(self.backup.backup_all())
+
+        # Scope to the new fallback messages: the pre-existing per-entry
+        # "Could not fetch chat" line embeds Telethon's exception text and is exempt.
+        new_path_messages = [
+            r.getMessage() for r in cm.records if r.getMessage().startswith(("Whitelist:", "Whitelist resolve:"))
+        ]
+        self.assertTrue(any("remain unresolvable" in m for m in new_path_messages))
+        for message in new_path_messages:
+            self.assertNotIn("987654321", message)
+
+    def test_whitelist_fallback_sweep_suppressed_for_known_failed_ids(self):
+        """Ids that already failed a scan don't re-trigger one, but still get the cheap retry."""
+        self.config.chat_ids = {987654321}
+        self.config.whitelist_resolve_dialog_limit = 1000
+        self._wire_backup_run(metadata={"whitelist_unresolved_ids": "[987654321]"})
+        self.backup.client.get_entity = AsyncMock(side_effect=Exception("still failing"))
+        self.backup.client.iter_dialogs = MagicMock()
+
+        self._run(self.backup.backup_all())
+
+        self.backup.client.iter_dialogs.assert_not_called()
+        # First pass + cheap retry pass — the id must keep self-heal attempts.
+        self.assertEqual(self.backup.client.get_entity.await_count, 2)
+        self.backup.db.set_metadata.assert_any_call("whitelist_unresolved_ids", "[987654321]")
+
+    def test_whitelist_fallback_resolution_clears_known_failed(self):
+        """A known-failed id that resolves on the retry pass leaves the persisted set."""
+        self.config.chat_ids = {987654321}
+        self.config.whitelist_resolve_dialog_limit = 1000
+        self._wire_backup_run(metadata={"whitelist_unresolved_ids": "[987654321]"})
+        entity = User(id=987654321)
+        self.backup.client.get_entity = AsyncMock(side_effect=[Exception("cache cold"), entity])
+        self.backup.client.iter_dialogs = MagicMock()
+
+        self._run(self.backup.backup_all())
+
+        self.backup.client.iter_dialogs.assert_not_called()
+        self.backup.db.set_metadata.assert_any_call("whitelist_unresolved_ids", "[]")
+        self.assertIn(entity, self._backed_up_entities())
 
 
 class TestExtractTopicId(unittest.TestCase):

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -904,10 +904,10 @@ class TestWhitelistModeBackup(unittest.TestCase):
             self.assertNotIn("987654321", message)
 
     def test_whitelist_fallback_sweep_suppressed_for_known_failed_ids(self):
-        """Ids that already failed a scan don't re-trigger one, but still get the cheap retry."""
+        """Ids that already failed a scan at this bound don't re-trigger one, but still get the cheap retry."""
         self.config.chat_ids = {987654321}
         self.config.whitelist_resolve_dialog_limit = 1000
-        self._wire_backup_run(metadata={"whitelist_unresolved_ids": "[987654321]"})
+        self._wire_backup_run(metadata={"whitelist_unresolved_ids": '{"limit": 1000, "ids": [987654321]}'})
         self.backup.client.get_entity = AsyncMock(side_effect=Exception("still failing"))
         self.backup.client.iter_dialogs = MagicMock()
 
@@ -916,13 +916,14 @@ class TestWhitelistModeBackup(unittest.TestCase):
         self.backup.client.iter_dialogs.assert_not_called()
         # First pass + cheap retry pass — the id must keep self-heal attempts.
         self.assertEqual(self.backup.client.get_entity.await_count, 2)
-        self.backup.db.set_metadata.assert_any_call("whitelist_unresolved_ids", "[987654321]")
+        # Retained at its original proof bound (no scan ran this time).
+        self.backup.db.set_metadata.assert_any_call("whitelist_unresolved_ids", '{"limit": 1000, "ids": [987654321]}')
 
     def test_whitelist_fallback_resolution_clears_known_failed(self):
         """A known-failed id that resolves on the retry pass leaves the persisted set."""
         self.config.chat_ids = {987654321}
         self.config.whitelist_resolve_dialog_limit = 1000
-        self._wire_backup_run(metadata={"whitelist_unresolved_ids": "[987654321]"})
+        self._wire_backup_run(metadata={"whitelist_unresolved_ids": '{"limit": 1000, "ids": [987654321]}'})
         entity = User(id=987654321)
         self.backup.client.get_entity = AsyncMock(side_effect=[Exception("cache cold"), entity])
         self.backup.client.iter_dialogs = MagicMock()
@@ -930,8 +931,154 @@ class TestWhitelistModeBackup(unittest.TestCase):
         self._run(self.backup.backup_all())
 
         self.backup.client.iter_dialogs.assert_not_called()
-        self.backup.db.set_metadata.assert_any_call("whitelist_unresolved_ids", "[]")
+        self.backup.db.set_metadata.assert_any_call("whitelist_unresolved_ids", '{"limit": 1000, "ids": []}')
         self.assertIn(entity, self._backed_up_entities())
+
+    def test_whitelist_fallback_raised_limit_rearms_scan(self):
+        """Raising WHITELIST_RESOLVE_DIALOG_LIMIT re-arms the scan for suppressed ids.
+
+        The persisted proof bound records how far the absence was proven; a
+        higher configured limit invalidates it — this is what makes the
+        warning's own advice actually work (review finding on #234).
+        """
+        self.config.chat_ids = {987654321}
+        self.config.whitelist_resolve_dialog_limit = 2000
+        self._wire_backup_run(metadata={"whitelist_unresolved_ids": '{"limit": 1000, "ids": [987654321]}'})
+        self.backup.client.get_entity = AsyncMock(side_effect=Exception("cache cold"))
+        dm_entity = User(id=987654321)
+        self.backup.client.iter_dialogs = MagicMock(
+            side_effect=lambda **kw: self._FakeDialogIter([MagicMock(id=987654321, entity=dm_entity)])
+        )
+
+        self._run(self.backup.backup_all())
+
+        self.backup.client.iter_dialogs.assert_called_once_with(limit=2000)
+        self.assertIn(dm_entity, self._backed_up_entities())
+        self.backup.db.set_metadata.assert_any_call("whitelist_unresolved_ids", '{"limit": 2000, "ids": []}')
+
+    def test_whitelist_fallback_legacy_list_metadata_rearms_scan(self):
+        """A legacy plain-list metadata value has no proof bound — the scan re-runs once."""
+        self.config.chat_ids = {987654321}
+        self.config.whitelist_resolve_dialog_limit = 1000
+        self._wire_backup_run(metadata={"whitelist_unresolved_ids": "[987654321]"})
+        self.backup.client.get_entity = AsyncMock(side_effect=Exception("cache cold"))
+        self.backup.client.iter_dialogs = MagicMock(side_effect=lambda **kw: self._FakeDialogIter([]))
+
+        self._run(self.backup.backup_all())
+
+        self.backup.client.iter_dialogs.assert_called_once_with(limit=1000)
+        # Scan completed empty → absence now proven at the current bound.
+        self.backup.db.set_metadata.assert_any_call("whitelist_unresolved_ids", '{"limit": 1000, "ids": [987654321]}')
+
+    def test_whitelist_fallback_aborted_scan_does_not_suppress_new_ids(self):
+        """A flood-aborted scan proves nothing — unfound NEW ids must stay sweep-eligible.
+
+        One unlucky first run must not permanently disarm the #234 fallback
+        (confirmed high-severity review finding).
+        """
+        self.config.chat_ids = {987654321}
+        self.config.whitelist_resolve_dialog_limit = 1000
+        self._wire_backup_run()
+        self.backup.client.get_entity = AsyncMock(side_effect=Exception("cache cold"))
+        self.backup.client.iter_dialogs = MagicMock(
+            side_effect=lambda **kw: self._FakeDialogIter([], error=FloodWaitError(request=None, capture=15))
+        )
+
+        self._run(self.backup.backup_all())
+
+        # Nothing new persisted: next run's scan must retry this id.
+        self.backup.db.set_metadata.assert_any_call("whitelist_unresolved_ids", '{"limit": 0, "ids": []}')
+
+    def test_whitelist_fallback_completed_scan_suppresses_missing_ids(self):
+        """A scan that ran to completion proves absence — the id is persisted at the current bound."""
+        self.config.chat_ids = {987654321}
+        self.config.whitelist_resolve_dialog_limit = 1000
+        self._wire_backup_run()
+        self.backup.client.get_entity = AsyncMock(side_effect=Exception("cache cold"))
+        self.backup.client.iter_dialogs = MagicMock(
+            side_effect=lambda **kw: self._FakeDialogIter([MagicMock(id=111, entity=User(id=111))])
+        )
+
+        self._run(self.backup.backup_all())
+
+        self.backup.db.set_metadata.assert_any_call("whitelist_unresolved_ids", '{"limit": 1000, "ids": [987654321]}')
+
+    def test_whitelist_fallback_stale_suppressions_cleared_when_all_resolve(self):
+        """When every entry resolves directly, leftover suppressions are cleared.
+
+        Otherwise an id that goes cache-cold again later (session reset) would
+        be silently retry-only forever (review finding on #234).
+        """
+        self.config.chat_ids = {987654321}
+        self.config.whitelist_resolve_dialog_limit = 1000
+        self._wire_backup_run(metadata={"whitelist_unresolved_ids": '{"limit": 1000, "ids": [987654321]}'})
+        self.backup.client.get_entity = AsyncMock(return_value=User(id=987654321))
+        self.backup.client.iter_dialogs = MagicMock()
+
+        self._run(self.backup.backup_all())
+
+        self.backup.client.iter_dialogs.assert_not_called()
+        self.backup.db.set_metadata.assert_any_call("whitelist_unresolved_ids", '{"limit": 1000, "ids": []}')
+
+    def test_whitelist_fallback_known_failed_resolved_by_rider_scan_drops_out(self):
+        """A scan triggered by a NEW id also rescues known-failed ids — and un-suppresses them."""
+        self.config.chat_ids = {987654321, 12345}
+        self.config.whitelist_resolve_dialog_limit = 1000
+        self._wire_backup_run(metadata={"whitelist_unresolved_ids": '{"limit": 1000, "ids": [987654321]}'})
+        self.backup.client.get_entity = AsyncMock(side_effect=Exception("cache cold"))
+        old_dm = User(id=987654321)
+        new_dm = User(id=12345)
+        self.backup.client.iter_dialogs = MagicMock(
+            side_effect=lambda **kw: self._FakeDialogIter(
+                [MagicMock(id=987654321, entity=old_dm), MagicMock(id=12345, entity=new_dm)]
+            )
+        )
+
+        self._run(self.backup.backup_all())
+
+        entities = self._backed_up_entities()
+        self.assertIn(old_dm, entities)
+        self.assertIn(new_dm, entities)
+        self.backup.db.set_metadata.assert_any_call("whitelist_unresolved_ids", '{"limit": 1000, "ids": []}')
+
+    def test_whitelist_fallback_followed_ids_not_persisted(self):
+        """Unresolvable followed-migration ids are never written to the suppression key.
+
+        They are not CHAT_IDS entries — the warning's operator guidance does not
+        apply to them — so they stay eligible for the next run's scan instead.
+        """
+        self.config.chat_ids = {987654321}
+        self.config.whitelist_resolve_dialog_limit = 1000
+        self.config.global_exclude_ids = set()
+        self.config.groups_exclude_ids = set()
+        self.config.channels_exclude_ids = set()
+        self._wire_backup_run(metadata={"followed_migrations": "[-1002000000001]"})
+        self.config.follow_chat_migrations = True
+        self.backup.client.get_entity = AsyncMock(side_effect=Exception("cache cold"))
+        self.backup.client.iter_dialogs = MagicMock(side_effect=lambda **kw: self._FakeDialogIter([]))
+
+        self._run(self.backup.backup_all())
+
+        # Scan completed: the configured id is proven-absent and persisted; the
+        # followed id failed too but must NOT appear in the suppression set.
+        self.backup.db.set_metadata.assert_any_call("whitelist_unresolved_ids", '{"limit": 1000, "ids": [987654321]}')
+
+    def test_load_whitelist_unresolved_malformed_metadata_degrades(self):
+        """Malformed/legacy/absent metadata degrades to (0, ...) and never raises."""
+
+        async def _load_with(raw):
+            self.backup.db.get_metadata = AsyncMock(return_value=raw)
+            return await self.backup._load_whitelist_unresolved()
+
+        self.assertEqual(self._run(_load_with(None)), (0, set()))
+        self.assertEqual(self._run(_load_with("not json at all {{{")), (0, set()))
+        self.assertEqual(self._run(_load_with('{"ids": "nope", "limit": "x"}')), (0, set()))
+        self.assertEqual(self._run(_load_with('{"limit": -5, "ids": [1, "junk", 2]}')), (0, {1, 2}))
+        self.assertEqual(self._run(_load_with("[7, 8]")), (0, {7, 8}))
+        self.assertEqual(
+            self._run(_load_with('{"limit": 500, "ids": [7]}')),
+            (500, {7}),
+        )
 
 
 class TestExtractTopicId(unittest.TestCase):


### PR DESCRIPTION
Fixes #232, fixes #234 — two silent-data-loss bugs reported (with exemplary root-cause analysis and live A/B validation) by @Sasha50701.

## #232 — large media can never finish downloading

**Root cause (confirmed):** the client is deliberately built with `flood_sleep_threshold=0` (#124, so floods surface in app logs). Telethon floors `FloodWaitError.seconds` to ≥1 and *raises* whenever `seconds > threshold`, so any mid-transfer FloodWait aborts `download_media` entirely; the app-side retry then deletes the partial file and restarts from byte 0. Telegram paces sustained `upload.getFile` streams with short (1–2 s) waits once a burst allowance is consumed, so any file whose transfer outlives one flood-free window loops abort → restart → abort until the retry budget is spent — and each restart re-downloads the same leading bytes, draining the allowance faster (a feedback loop). Small files never see it.

**Fix — media-scoped absorption, global behavior unchanged:**
- New ref-counted async context manager `absorb_media_floods(client, threshold)`: inside a media transfer the client's `flood_sleep_threshold` is temporarily raised so Telethon absorbs floods ≤ threshold (sleeps and re-issues the *same chunk request* — the transfer resumes at the current offset, exactly what official clients do). Floods above the threshold still raise and follow the existing `call_with_flood_retry` path.
- Applied to all three media transports: sweep single-stream, sweep parallel downloader (chunks resume in place instead of cancelling siblings), and the real-time listener's downloads.
- **`MEDIA_FLOOD_SLEEP_THRESHOLD`** (default `60`, `0` = previous raise-immediately behavior).
- The global client kwargs keep `flood_sleep_threshold=0`: iteration and API calls preserve #124's visible-flood behavior. The manager is ref-counted because the sweep and listener share one client and their transfers overlap.
- Also widened flood handling to `FloodPremiumWaitError` (a *sibling* of `FloodWaitError` in Telethon — and the classic flood on large downloads), and surfaced Telethon's bare-`ValueError` request-retries exhaustion with an explanatory log instead of an anonymous failure.

## #234 — whitelisted DM user ids silently never archive

**Root cause (confirmed regression):** since 0316c41 (#96, the #95 hang fix) whitelist mode resolves each `CHAT_IDS` entry with a bare `get_entity(id)` and no longer runs the dialog sweep that used to warm the session entity cache. Telethon can probe channels with a zero access-hash and basic groups need none — but a bare **user** id resolves only from the cache, so a DM the session has never seen fails on every run, gets a warning, and the run still reports success.

**Fix — bounded, self-healing fallback (fast path untouched):**
- When (and only when) entries fail to resolve, one **bounded** `iter_dialogs` pass runs (default cap `1000` dialogs ≈ ≤10 requests, wall-clock-capped at 300 s, best-effort: floods/errors/timeouts log counts and never abort the run). Matching dialogs contribute their entity directly; iterating also persists every seen peer's `access_hash` into the session, so resolution is **permanent** after one pass.
- Entries written in unmarked form don't early-stop the scan but still resolve via the post-scan retry (the scan warmed the cache). Archived dialogs are included deliberately (no `folder` kwarg).
- Ids that remain unresolvable are remembered in DB metadata and don't re-trigger scans on every run (a cheap per-run `get_entity` retry remains, so the entry self-heals the moment the account sees the peer — e.g. an incoming message via the listener — and the memory self-clears). A counts-only actionable warning explains the escape hatches.
- **`WHITELIST_RESOLVE_DIALOG_LIMIT`** (default `1000`, `0` disables the fallback).
- `#95` stays fixed: the happy path issues zero dialog requests, and the fallback is count- *and* time-bounded.

## Notes
- No schema changes, no migration.
- New log lines are counts-only (no chat/user ids), per the project's logging rules.
- Docstrings that asserted the old "flood sleeps never run inside the download timeout" invariant were updated; absorbed pauses count toward `DOWNLOAD_TIMEOUT_SECONDS` (documented, default 3600 s dwarfs the 1–2 s pacing pauses).

## Tests
- 24 new tests (+1 extended): context-manager semantics (set/restore, exception, ref-count overlap, 0/non-int no-op), transport wiring (sweep + both listener paths), config parsing (defaults/overrides/`0`, and global kwargs still `flood_sleep_threshold=0`), whitelist fallback (resolve-after-scan, early-stop, cap `0`, flood/error/timeout best-effort, counts-only logging, known-failed suppression + self-clear, fast-path zero-extra-calls pin).
- Full suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `MEDIA_FLOOD_SLEEP_THRESHOLD` to absorb brief media FloodWaits so large downloads can resume without restarting.
  * Added `WHITELIST_RESOLVE_DIALOG_LIMIT` and bounded “warm cache” dialog sweeps to resolve previously unseen whitelisted chats.
* **Bug Fixes**
  * Improved retry behavior for both FloodWait and FloodPremiumWait during API calls and downloads.
  * Prevented repeated whitelist resolution attempts for known-unresolvable IDs and added sweep timeouts.
* **Documentation**
  * Documented the new environment variables and clarified media-download and chat-selection edge-case behavior.
* **Release**
  * Version updated to **7.27.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->