### PR TITLE
fix(viewer): eliminate mobile horizontal scroll + app-like message bubbles

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.27.0"
+version = "7.27.1"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.27.0"
+__version__ = "7.27.1"

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -127,21 +127,34 @@
         }
 
 
-        /* Date Separator */
+        /* Date Separator — floats/sticks at the top of the scroll pane while
+           that day's messages are in view, like the native apps. Works in the
+           flex-col-reverse message list: `top` is physical (unaffected by the
+           reversed direction), so the day's pill pins to the top and is pushed
+           up by the next-older day. pointer-events gate keeps only the pill
+           itself clickable (jump-to-date), not the full-width strip. */
         .date-separator {
             text-align: center;
             margin: 20px 0 10px 0;
+            position: sticky;
+            top: 6px;
+            z-index: 5;
+            pointer-events: none;
         }
 
         .date-separator span {
-            background-color: #334155;
+            background-color: rgba(30, 41, 59, 0.85);
+            -webkit-backdrop-filter: blur(6px);
+            backdrop-filter: blur(6px);
             padding: 6px 16px;
             border-radius: 16px;
             font-size: 0.75rem;
-            color: #94a3b8;
+            color: #cbd5e1;
             cursor: pointer;
-            transition: all 0.2s;
+            transition: background-color 0.2s;
             display: inline-block;
+            pointer-events: auto;
+            box-shadow: 0 1px 4px rgba(0, 0, 0, 0.35);
         }
 
         .date-separator span:hover {
@@ -287,6 +300,15 @@
             /* Comfortable reading rhythm, closer to the native apps. */
             .message-text {
                 line-height: 1.45;
+            }
+            /* Guarantee a ~44px touch target on header icon buttons without
+               changing their visual (icon/padding) size. */
+            .tap-target {
+                min-width: 44px;
+                min-height: 44px;
+                display: inline-flex;
+                align-items: center;
+                justify-content: center;
             }
         }
     </style>
@@ -747,7 +769,7 @@
                         <div class="flex items-center gap-2 sm:gap-3 min-w-0 flex-1">
                             <!-- Back Button (mobile only) -->
                             <button @click="currentNav.type === 'chat' && currentNav.topicId ? navigateBack() : selectedChat = null"
-                                class="md:hidden p-2 -ml-2 text-gray-400 hover:text-white">
+                                class="tap-target md:hidden p-2 -ml-2 text-gray-400 hover:text-white">
                                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                         d="M15 19l-7-7 7-7"></path>
@@ -810,7 +832,7 @@
 
                             <!-- Media Gallery Button -->
                             <button @click="showMediaGallery = true"
-                                class="p-1.5 sm:p-2 text-gray-400 hover:text-white rounded-lg hover:bg-white/10 transition shrink-0"
+                                class="tap-target p-1.5 sm:p-2 text-gray-400 hover:text-white rounded-lg hover:bg-white/10 transition shrink-0"
                                 title="Shared Media Gallery">
                                 <svg class="w-4 h-4 sm:w-5 sm:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -820,7 +842,7 @@
 
                             <!-- Export Button - always visible -->
                             <button @click="exportChat"
-                                class="p-1.5 sm:p-2 text-gray-400 hover:text-white rounded-lg hover:bg-white/10 transition shrink-0"
+                                class="tap-target p-1.5 sm:p-2 text-gray-400 hover:text-white rounded-lg hover:bg-white/10 transition shrink-0"
                                 title="Export Chat to JSON">
                                 <svg class="w-4 h-4 sm:w-5 sm:h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
@@ -1052,7 +1074,7 @@
                                     </div>
                                 </div>
                                 <div class="message-bubble p-3 text-sm shadow-sm text-gray-100"
-                                    :class="isOwnMessage(msg) ? 'bubble-out' : 'bubble-in'"
+                                    :class="isRunEnd(index) ? (isOwnMessage(msg) ? 'bubble-out' : 'bubble-in') : ''"
                                     :style="getSenderStyle(msg)">
                                     <!-- Sender Name (if group and first in sequence) -->
                                     <div v-if="!isOwnMessage(msg) && isGroup && showSenderName(index)"
@@ -3900,6 +3922,18 @@
                     return olderMsg.sender_id !== currMsg.sender_id
                 }
 
+                const isRunEnd = (index) => {
+                    // flex-col-reverse: index 0 = newest (visual bottom). A run's
+                    // last (newest) bubble is the one whose NEWER neighbour
+                    // (index - 1, visually below) is a different sender — that's
+                    // where the native-app tail belongs. Stacked bubbles above it
+                    // stay fully rounded (no tail).
+                    const currMsg = sortedMessages.value[index]
+                    const newerMsg = sortedMessages.value[index - 1]
+                    if (!newerMsg) return true
+                    return newerMsg.sender_id !== currMsg.sender_id
+                }
+
                 const showDateSeparator = (index) => {
                     // With flex-col-reverse: separator rendered AFTER message appears ABOVE it visually
                     // Show separator when this is the last message of a day (next message is different day)
@@ -4720,6 +4754,7 @@
                     getSenderName,
                     getForwardName,
                     showSenderName,
+                    isRunEnd,
                     showDateSeparator,
                     // Album support
                     getAlbumForMessage,

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -31,6 +31,10 @@
 
         html {
             background-color: #0f172a;
+            /* Stop iOS from auto-inflating text on rotate / in landscape,
+               which also silently widens content and can force h-scroll. */
+            -webkit-text-size-adjust: 100%;
+            text-size-adjust: 100%;
         }
 
         body {
@@ -60,34 +64,56 @@
             background: #64748b;
         }
 
-        /* Message Bubbles */
+        /* Message Bubbles.
+           max-width is a PERCENTAGE of the message row (the flex container),
+           NOT of the viewport: the row already holds the avatar gutter + gap,
+           so a viewport-relative cap (the old calc(100vw - 32px)) let the
+           bubble sit AFTER the avatar and run off the right edge — clipping
+           the timestamp and any long content. A row-relative cap keeps
+           avatar + bubble inside the row on every width, and lets the bubble
+           shrink to fit an unbreakable token (min-width:0). */
         .message-bubble {
             display: inline-block;
-            max-width: calc(100vw - 32px);
-            /* 32px = padding lateral del contenedor */
+            max-width: 85%;
+            min-width: 0;
             width: auto;
             word-wrap: break-word;
             overflow-wrap: anywhere;
-            border-radius: 12px;
+            border-radius: 14px;
         }
 
         @media (min-width: 768px) {
             .message-bubble {
-                max-width: 600px;
+                /* Roomier reading column on desktop, still content-sized. */
+                max-width: min(72%, 600px);
             }
         }
 
+        /* Asymmetric corner pointing toward the sender — the native-app "tail"
+           cue: incoming bubbles tuck their bottom-left, outgoing their
+           bottom-right. */
+        .message-bubble.bubble-in {
+            border-bottom-left-radius: 4px;
+        }
+        .message-bubble.bubble-out {
+            border-bottom-right-radius: 4px;
+        }
 
+
+        html,
         body,
         #app {
-            max-width: 100vw;
+            max-width: 100%;
             overflow-x: hidden;
         }
 
-        /* Messages scroll container - fix mobile touch scrolling */
+        /* Messages scroll container - fix mobile touch scrolling.
+           overflow-x:hidden is defence-in-depth: content is already sized to
+           fit, but this guarantees the pane can only ever scroll vertically. */
         .messages-scroll {
             -webkit-overflow-scrolling: touch;
             overscroll-behavior-y: contain;
+            overflow-x: hidden;
         }
 
         .message-bubble img,
@@ -243,6 +269,25 @@
         /* 3-item album: make first item span 2 rows */
         .album-grid .grid-cols-2:has(.album-item:nth-child(3):last-child) .album-item:first-child {
             grid-row: span 2;
+        }
+        /* Album never wider than its bubble on narrow screens. */
+        .album-grid {
+            width: 100%;
+        }
+
+        /* Message text: break even unbreakable tokens (long URLs, hashes) so
+           they wrap instead of forcing the bubble wider than its cap. */
+        .message-text {
+            overflow-wrap: anywhere;
+            word-break: break-word;
+        }
+
+        /* ---- Mobile polish (app-like feel) ---- */
+        @media (max-width: 767px) {
+            /* Comfortable reading rhythm, closer to the native apps. */
+            .message-text {
+                line-height: 1.45;
+            }
         }
     </style>
     <script>
@@ -1007,6 +1052,7 @@
                                     </div>
                                 </div>
                                 <div class="message-bubble p-3 text-sm shadow-sm text-gray-100"
+                                    :class="isOwnMessage(msg) ? 'bubble-out' : 'bubble-in'"
                                     :style="getSenderStyle(msg)">
                                     <!-- Sender Name (if group and first in sequence) -->
                                     <div v-if="!isOwnMessage(msg) && isGroup && showSenderName(index)"

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1187,7 +1187,7 @@
 
                                         <!-- Audio / Voice Notes -->
                                         <div v-else-if="isAudioFile(msg)"
-                                            class="w-full min-w-[250px] max-w-md bg-gradient-to-r from-gray-800 to-gray-700 p-3 rounded-xl shadow-lg">
+                                            class="w-full min-w-0 max-w-md bg-gradient-to-r from-gray-800 to-gray-700 p-3 rounded-xl shadow-lg">
                                             <audio
                                                 controls
                                                 preload="metadata"


### PR DESCRIPTION
## Problem
On mobile the chat view scrolled horizontally / clipped content: **every message timestamp was cut off** at the right edge, and long URLs, hashes and code ran off-screen. The user's ask: nothing should exceed the viewport (vertical-only scrolling), and the UI should feel closer to the official Telegram iOS/Android apps.

## Root cause
`.message-bubble` was capped at `max-width: calc(100vw - 32px)` — the full viewport minus container padding. In group chats the bubble sits **after** a ~40px avatar gutter inside a `flex` row, so *avatar + bubble* exceeded the viewport and overflowed right. `body/#app { overflow-x: hidden }` only **clipped** it (hiding the timestamps), and on some mobile browsers an ancestor scrolled horizontally instead. There was also only a single `min-width:768px` media query — essentially no mobile-specific layout.

## Fix (CSS + one class binding; no JS/behavior change)
- Bubble `max-width` is now **row-relative** — `85%` on mobile, `min(72%, 600px)` on desktop — with `min-width: 0`, so avatar + bubble always fit and the bubble shrinks to **wrap** unbreakable tokens instead of forcing width.
- `messages-scroll` is `overflow-x: hidden`; `html/body/#app` use `max-width: 100%` (not `100vw`, which includes the scrollbar) as defence-in-depth.
- `-webkit-text-size-adjust: 100%` stops iOS text inflation silently widening content.
- `.message-text` breaks long tokens; album media capped to its bubble.
- **App-like polish:** asymmetric bubble **tail** toward the sender (incoming tucks bottom-left, outgoing bottom-right); comfortable mobile line-height.

## Verification (headless Chrome @ 390×844, iPhone emulation)
- Horizontal overflow: **0** (was **6** off-screen elements on the messages view); `documentElement.scrollWidth == clientWidth == 390` on both the chat list and the messages screen.
- All timestamps now visible; long URL / hash / code block / 160-char token all wrap inside their bubbles with right-edge breathing room.
- Full suite **2379 passed**; ruff + ruff format clean.

Version bumped to 7.27.1 (patch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile chat rendering, including safer text scaling and stronger message text wrapping for long tokens.
  * Refined message bubble geometry (sizing, corner tails) for more accurate in/out bubble styling.
  * Prevented horizontal overflow and improved scroll-container behavior on narrow screens.
  * Enhanced mobile UI touch targets (including chat header actions) and improved album grid fit.

* **Chores**
  * Updated the application version to **7.27.1**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

### Update — app-like polish added (verified)
Per request, three deeper native-app touches were added and verified in headless Chrome @390px:
- **Run-end bubble tails** — the asymmetric "tail" corner now appears **only on the last message of a consecutive same-sender run** (Telegram-exact), not on every bubble. New `isRunEnd(index)` helper, `flex-col-reverse` aware. Verified: a 3-message burst tails only the 3rd (bottom-left 4px); the two above stay 14px all-round.
- **Sticky date headers** — the date separator is now `position: sticky` with a blur/shadow pill, so the current day floats at the top of the scroll pane while its messages are in view. Verified pinning on scroll in the reversed list.
- **Tap targets** — the chat-header icon buttons (back, media gallery, export) get a guaranteed 44px touch target on mobile (`.tap-target`), no visual change.

Full suite still **2379 passed**; horizontal overflow still **0**.