### PR TITLE
fix(backup): skip retries for terminal peer errors

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [7.29.1] - 2026-07-28
+
+### Fixed
+- **Invalid or permanently unavailable peer identifiers no longer consume transient retry delays.** Terminal Telegram peer errors now fail immediately, allowing whitelist-based backup sweeps to skip stale entries and continue without repeated exponential waits.
+
 ## [7.29.0] - 2026-07-28
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.29.0"
+version = "7.29.1"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.29.0"
+__version__ = "7.29.1"

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -18,9 +18,11 @@ from telethon import TelegramClient
 from telethon.errors import (
     ChannelPrivateError,
     ChatForbiddenError,
+    ChatIdInvalidError,
     FileReferenceExpiredError,
     FloodPremiumWaitError,
     FloodWaitError,
+    PeerIdInvalidError,
     RPCError,
     UserBannedInChannelError,
 )
@@ -256,6 +258,8 @@ async def call_with_flood_retry(
                     FileReferenceExpiredError,
                     ChannelPrivateError,
                     ChatForbiddenError,
+                    ChatIdInvalidError,
+                    PeerIdInvalidError,
                     UserBannedInChannelError,
                 ),
             ):

--- a/tests/test_flood_wait_visibility.py
+++ b/tests/test_flood_wait_visibility.py
@@ -24,7 +24,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from telethon.errors import FloodWaitError
+from telethon.errors import ChatIdInvalidError, FloodWaitError, PeerIdInvalidError
 
 
 def _patch_db_module(monkeypatch):
@@ -690,6 +690,30 @@ async def test_call_with_flood_retry_gives_up_on_transient_error(fake_db):
         pytest.raises(OSError, match="disk failure"),
     ):
         await telegram_backup.call_with_flood_retry(broken_api, max_retries=3)
+
+
+@pytest.mark.parametrize("error_type", [ChatIdInvalidError, PeerIdInvalidError])
+@pytest.mark.asyncio
+async def test_call_with_flood_retry_rejects_terminal_peer_errors_immediately(fake_db, error_type):
+    """Permanent peer identifiers must not consume transient retry delays."""
+    from src import telegram_backup
+
+    attempts = 0
+
+    async def invalid_peer():
+        nonlocal attempts
+        attempts += 1
+        raise error_type(request=MagicMock())
+
+    sleep = AsyncMock()
+    with (
+        patch.object(telegram_backup.asyncio, "sleep", sleep),
+        pytest.raises(error_type),
+    ):
+        await telegram_backup.call_with_flood_retry(invalid_peer, max_retries=5)
+
+    assert attempts == 1
+    sleep.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -1195,7 +1195,7 @@ wheels = [
 
 [[package]]
 name = "telegram-archive"
-version = "7.29.0"
+version = "7.29.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary
- classify invalid chat and peer identifiers as terminal for an unchanged Telegram API call
- avoid repeated exponential sleeps while allowing whitelist sweeps to continue to later entries
- release as v7.29.1

## Testing
- [x] Full suite: 2,443 passed + 150 subtests
- [x] Parameterized terminal-error regression: one attempt, zero sleeps
- [x] Ruff check/format and diff checks pass
- [x] Independent code review approved with no medium-or-higher findings

## Database Changes
- [x] No database changes

## Deployment Notes
- Tag workflows publish the backup and viewer images.
- Private deployment automation updates both production image variants together after the release-age safety delay.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid or permanently unavailable Telegram peer identifiers now fail immediately instead of triggering retry delays.
  * Backup sweeps can skip stale entries and continue without unnecessary exponential backoff.

* **Release**
  * Updated the application version to 7.29.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->