### PR TITLE
fix(viewer): floating date pill tracks the visible day (#249)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.29.1"
+version = "7.29.2"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.29.1"
+__version__ = "7.29.2"

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -2614,31 +2614,34 @@
                     const container = messagesContainer.value
                     if (!container) return
                     const containerTop = container.getBoundingClientRect().top
+                    // A separator sits directly ABOVE its own day's messages, so the day the
+                    // viewport is inside is the separator closest above the trip line.
+                    // One rect read per day (tens at most), never per message.
                     let best = null
                     let bestTop = -Infinity
-                    // Scan every separator, not just the ones the observer currently reports
-                    // as intersecting: a separator that has scrolled above the trip line is
-                    // exactly the one we want (it is the day the viewport is inside), but it
-                    // no longer intersects the thin observation band. One rect read per day
-                    // (tens at most), not per message.
+                    // Only reached when the viewport is above EVERY separator, i.e. at the
+                    // very start of history: then the day on screen is the one whose
+                    // separator is first BELOW the line (the oldest loaded day). Resolving
+                    // that case to "newest message" would show today's date while reading
+                    // the oldest day — the same wrong-date symptom, moved to the top edge.
+                    let firstBelow = null
+                    let firstBelowTop = Infinity
                     for (const marker of container.querySelectorAll('.date-separator')) {
                         const top = marker.getBoundingClientRect().top - containerTop
-                        if (top <= FLOATING_DATE_TRIP_PX && top > bestTop) {
-                            bestTop = top
-                            best = marker
+                        if (top <= FLOATING_DATE_TRIP_PX) {
+                            if (top > bestTop) {
+                                bestTop = top
+                                best = marker
+                            }
+                        } else if (top < firstBelowTop) {
+                            firstBelowTop = top
+                            firstBelow = marker
                         }
                     }
-                    // Before the first separator scrolls under the trip line (i.e. at the
-                    // newest end) fall back to the newest loaded message's own day.
+                    best = best || firstBelow
                     if (!best) {
-                        const newest = sortedMessages.value[0]
-                        if (!newest) {
-                            floatingDateLabel.value = ''
-                            floatingDateIso.value = null
-                            return
-                        }
-                        floatingDateLabel.value = formatDateFull(newest.date)
-                        floatingDateIso.value = newest.date
+                        floatingDateLabel.value = ''
+                        floatingDateIso.value = null
                         return
                     }
                     floatingDateLabel.value = best.dataset.dateLabel || ''

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -141,15 +141,39 @@
            reversed direction), so the day's pill pins to the top and is pushed
            up by the next-older day. pointer-events gate keeps only the pill
            itself clickable (jump-to-date), not the full-width strip. */
+        /* Inline per-day separator. Deliberately NOT position:sticky (#249): every
+           separator is a direct child of the one scroll container, so they all share
+           a single containing block and nothing ever evicts them — per CSS Position
+           L3 §3.4 "Multiple sticky positioned boxes in the same container are offset
+           independently, and therefore might overlap", which stacked N pinned pills
+           showing contradictory dates. The floating pill below is a single element
+           driven by an IntersectionObserver instead. */
         .date-separator {
             text-align: center;
             margin: 20px 0 10px 0;
-            position: sticky;
-            top: 6px;
-            z-index: 5;
+        }
+
+        /* Single floating day indicator, overlaid on the scroller (Telegram Android /
+           Signal Desktop model: a separate overlay reading the topmost visible day,
+           rather than making each separator sticky). Permanently visible while a chat
+           has messages — the official apps fade it after idle, but this archive viewer
+           optimises for orientation while reading, per the reporter's request. */
+        .floating-date-pill {
+            position: absolute;
+            top: 10px;
+            left: 0;
+            right: 0;
+            display: flex;
+            justify-content: center;
+            z-index: 6;
             pointer-events: none;
         }
 
+        .floating-date-pill button {
+            pointer-events: auto;
+        }
+
+        .floating-date-pill button,
         .date-separator button {
             background-color: rgba(30, 41, 59, 0.85);
             -webkit-backdrop-filter: blur(6px);
@@ -1386,8 +1410,11 @@
                                 </div>
                             </div>
 
-                            <!-- Date Separator - rendered AFTER message for flex-col-reverse (appears ABOVE visually) -->
-                            <div v-if="showDateSeparator(index) && !isHiddenAlbumMessage(msg, index)" class="date-separator">
+                            <!-- Date Separator - rendered AFTER message for flex-col-reverse (appears ABOVE visually).
+                                 data-date-* feed the floating day pill (#249): the pill observes these
+                                 markers and reads the day of whichever one is topmost in the viewport. -->
+                            <div v-if="showDateSeparator(index) && !isHiddenAlbumMessage(msg, index)" class="date-separator"
+                                :data-date-label="formatDateFull(msg.date)" :data-date-iso="msg.date">
                                 <button type="button" @click="openDatePicker(msg.date)"
                                     :aria-label="`Open date picker for ${formatDateFull(msg.date)}`">
                                     {{ formatDateFull(msg.date) }}
@@ -1408,6 +1435,19 @@
                         </div>
 
                         <div ref="scrollAnchor"></div>
+                    </div>
+
+                    <!-- Floating day indicator (#249). Sits OUTSIDE the scroll container so it
+                         is one element, never one-per-day; its label tracks the topmost visible
+                         day via updateFloatingDate. role=heading (not aria-live) so it is
+                         reachable by heading navigation without announcing on every scroll tick. -->
+                    <div v-if="floatingDateLabel && !showPinnedOnly && sortedMessages.length > 0"
+                        class="floating-date-pill">
+                        <button type="button" role="heading" aria-level="5"
+                            @click="floatingDateIso && openDatePicker(floatingDateIso)"
+                            :aria-label="`Currently viewing ${floatingDateLabel} — open date picker`">
+                            {{ floatingDateLabel }}
+                        </button>
                     </div>
 
                     <!-- Scroll to Bottom Button -->
@@ -1937,6 +1977,11 @@
                 let infiniteScrollObserver = null
                 let messagesScrollObserver = null  // Observer for loading older messages
                 let messagesNewerObserver = null  // Observer for detached-window newer pages
+                // Floating day indicator (#249): one pill reading the topmost visible day.
+                let floatingDateFramePending = false
+                const FLOATING_DATE_TRIP_PX = 60  // how far below the scrollport top still counts as "current"
+                const floatingDateLabel = ref('')
+                const floatingDateIso = ref(null)
                 // Two idioms share chatVersion: `++chatVersion` invalidates other in-flight
                 // work (view entries/jumps) so their post-await guards discard themselves,
                 // while a bare capture (`const myVersion = chatVersion`) is a passive read
@@ -2542,6 +2587,73 @@
                         if (loadNewerSentinel.value) {
                             messagesNewerObserver.observe(loadNewerSentinel.value)
                         }
+                    })
+
+                    nextTick(updateFloatingDate)
+                }
+
+                // --- Floating day indicator (#249) ---------------------------------
+                // One pill, not one sticky separator per day: sticky siblings sharing a
+                // single containing block all pin at once and overlap (CSS Position L3
+                // §3.4 "Multiple sticky positioned boxes in the same container are offset
+                // independently, and therefore might overlap"), which stacked N pills
+                // showing contradictory dates. Instead each `.date-separator` is a passive
+                // marker and the day is derived from geometry: the marker closest above
+                // the top of the scrollport is the day the viewport is currently inside.
+                //
+                // Recomputed from TWO triggers, because neither alone is sufficient:
+                //   * scroll (rAF-coalesced) — the common case;
+                //   * the sortedMessages watch — pagination in a flex-col-reverse list
+                //     changes content above the viewport WITHOUT firing a scroll event,
+                //     and jump windows replace the array outright.
+                // An IntersectionObserver "trip line" was tried and rejected: a fast or
+                // programmatic scroll can move a marker from below the band to above it
+                // with no change in intersection state, so no callback fires and the pill
+                // silently freezes. Reading rects is O(days) (tens at most), not O(messages).
+                const updateFloatingDate = () => {
+                    const container = messagesContainer.value
+                    if (!container) return
+                    const containerTop = container.getBoundingClientRect().top
+                    let best = null
+                    let bestTop = -Infinity
+                    // Scan every separator, not just the ones the observer currently reports
+                    // as intersecting: a separator that has scrolled above the trip line is
+                    // exactly the one we want (it is the day the viewport is inside), but it
+                    // no longer intersects the thin observation band. One rect read per day
+                    // (tens at most), not per message.
+                    for (const marker of container.querySelectorAll('.date-separator')) {
+                        const top = marker.getBoundingClientRect().top - containerTop
+                        if (top <= FLOATING_DATE_TRIP_PX && top > bestTop) {
+                            bestTop = top
+                            best = marker
+                        }
+                    }
+                    // Before the first separator scrolls under the trip line (i.e. at the
+                    // newest end) fall back to the newest loaded message's own day.
+                    if (!best) {
+                        const newest = sortedMessages.value[0]
+                        if (!newest) {
+                            floatingDateLabel.value = ''
+                            floatingDateIso.value = null
+                            return
+                        }
+                        floatingDateLabel.value = formatDateFull(newest.date)
+                        floatingDateIso.value = newest.date
+                        return
+                    }
+                    floatingDateLabel.value = best.dataset.dateLabel || ''
+                    floatingDateIso.value = best.dataset.dateIso || null
+                }
+
+                // Coalesce to one recompute per animation frame: `scroll` fires far more
+                // often than the answer can change, and this runs on the mobile-sized
+                // list the v7.27.1 work optimised.
+                const queueFloatingDateUpdate = () => {
+                    if (floatingDateFramePending) return
+                    floatingDateFramePending = true
+                    requestAnimationFrame(() => {
+                        floatingDateFramePending = false
+                        updateFloatingDate()
                     })
                 }
 
@@ -3626,6 +3738,18 @@
                 const currentPinnedIndex = ref(0)  // Which pinned message is currently shown in banner
                 const showPinnedOnly = ref(false)  // Whether we're in "pinned messages only" view
 
+                // Keep the floating day pill (#249) attached to the separators that actually
+                // exist. Pagination in a flex-col-reverse list changes content above the
+                // viewport WITHOUT firing a scroll event, and jump windows replace the array
+                // outright, so re-observing on list changes — not on scroll — is what keeps
+                // the pill from going stale.
+                // Placement note: this watch eagerly evaluates `sortedMessages`, which reads
+                // `showPinnedOnly`, so it must be declared after it (same
+                // state-before-watcher rule as the media gallery refs).
+                watch(sortedMessages, () => {
+                    nextTick(updateFloatingDate)
+                }, { flush: 'post' })
+
                 // Computed: current pinned message to display in banner
                 const pinnedMessage = computed(() => {
                     if (pinnedMessages.value.length === 0) return null
@@ -4049,6 +4173,9 @@
                     if (scrollTop > -STICK_TO_BOTTOM_PX) {
                         unseenMessageCount.value = 0
                     }
+
+                    // Keep the floating day pill in step with the viewport (#249).
+                    queueFloatingDateUpdate()
                 }
 
                 // Manual load more function (fallback for when infinite scroll doesn't trigger)
@@ -5289,6 +5416,9 @@
                     isRunEnd,
                     isSenderBreak,
                     showDateSeparator,
+                    // Floating day indicator (#249)
+                    floatingDateLabel,
+                    floatingDateIso,
                     // Album support
                     getAlbumForMessage,
                     isFirstInAlbum,

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -948,3 +948,81 @@ def test_date_jump_latest_intent_wins_and_cancellation_propagates_to_window_load
     assert "const isCurrentIntent = () =>" in window_body
     assert "!externalGuard || externalGuard()" in window_body
     assert window_body.count("if (!isCurrentIntent()) return") >= 6
+
+
+def test_date_separators_are_not_individually_sticky():
+    """Regression for #249.
+
+    Every ``.date-separator`` is a direct child of the one scroll container, so
+    making each one ``position: sticky`` pinned them all at the same offset —
+    CSS Position L3 §3.4: "Multiple sticky positioned boxes in the same
+    container are offset independently, and therefore might overlap". That
+    stacked several pills showing contradictory dates, and whichever painted
+    last looked "frozen". The day indicator must instead be a single element.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    separator_css_start = html.index(".date-separator {")
+    separator_css = html[separator_css_start : html.index("}", separator_css_start)]
+    assert "position: sticky" not in separator_css
+
+    # ...and no other rule may reintroduce per-day stickiness.
+    assert "position: sticky" not in html
+
+
+def test_floating_date_pill_is_a_single_element_outside_the_scroller():
+    """The pill must live outside the message list, so only one can ever exist."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert html.count('class="floating-date-pill"') == 1
+    # Rendered after the scroll container closes (the container ends with the scrollAnchor).
+    assert html.index('class="floating-date-pill"') > html.index('<div ref="scrollAnchor">')
+    # Accessible as a heading rather than a live region: it changes on every
+    # scroll, and announcing that would flood screen readers.
+    assert 'role="heading" aria-level="5"' in html
+    assert "aria-live" not in html.split('class="floating-date-pill"')[1][:400]
+
+
+def test_floating_date_pill_is_guarded_and_clickable():
+    """Empty lists and the pinned-only view must not render a day indicator."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    pill_start = html.index('v-if="floatingDateLabel')
+    pill_block = html[pill_start : html.index("</div>", pill_start)]
+    assert "!showPinnedOnly" in pill_block
+    assert "sortedMessages.length > 0" in pill_block
+    # Clicking still opens the date picker for the day being viewed.
+    assert "openDatePicker(floatingDateIso)" in pill_block
+
+
+def test_floating_date_recomputes_on_scroll_and_on_list_changes():
+    """#249: scroll alone is not enough.
+
+    Appending an older page to a ``flex-col-reverse`` list changes the content
+    above the viewport WITHOUT firing a scroll event, and jump windows replace
+    the array outright — so a scroll-only pill goes stale exactly after
+    pagination. Both triggers must stay wired.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    scroll_start = html.index("const handleScroll = (e) =>")
+    # End at the next sibling declaration (same indentation), not the first
+    # nested `const` inside the handler body.
+    scroll_body = html[scroll_start : html.index("\n                const ", scroll_start + 10)]
+    assert "queueFloatingDateUpdate()" in scroll_body
+
+    watch_start = html.index("watch(sortedMessages,")
+    watch_body = html[watch_start : html.index("})", watch_start)]
+    assert "updateFloatingDate" in watch_body
+
+    # The scroll path must be coalesced to one recompute per frame.
+    queue_start = html.index("const queueFloatingDateUpdate = () =>")
+    queue_body = html[queue_start : html.index("// Stats data", queue_start)]
+    assert "requestAnimationFrame" in queue_body
+    assert "floatingDateFramePending" in queue_body
+
+    # The day is derived from the separators (O(days)), never from every message row.
+    update_start = html.index("const updateFloatingDate = () =>")
+    update_body = html[update_start : html.index("const queueFloatingDateUpdate", update_start)]
+    assert "querySelectorAll('.date-separator')" in update_body
+    assert "[data-msg-id]" not in update_body

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -1026,3 +1026,24 @@ def test_floating_date_recomputes_on_scroll_and_on_list_changes():
     update_body = html[update_start : html.index("const queueFloatingDateUpdate", update_start)]
     assert "querySelectorAll('.date-separator')" in update_body
     assert "[data-msg-id]" not in update_body
+
+
+def test_floating_date_handles_the_top_of_history():
+    """#249: being above every separator is not the same as being at the newest end.
+
+    A separator sits above its own day's messages, so normally the current day is
+    the separator closest ABOVE the trip line. At the very start of history the
+    viewport is above every separator; resolving that to the newest message would
+    print today's date while the oldest day is on screen — the same wrong-date
+    symptom, moved to the top boundary. It must resolve to the first separator
+    BELOW the line instead.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    update_start = html.index("const updateFloatingDate = () =>")
+    update_body = html[update_start : html.index("const queueFloatingDateUpdate", update_start)]
+
+    assert "firstBelow" in update_body
+    assert "best = best || firstBelow" in update_body
+    # The newest loaded message must NOT be used to resolve that case.
+    assert "sortedMessages.value[0]" not in update_body


### PR DESCRIPTION
Fixes #249. Thanks @625801 — the screenshot of two contradictory pills stacked was the whole diagnosis.

## Root cause
Every per-day `.date-separator` was `position: sticky` **inside the single message scroll container**. Sticky siblings that share one containing block are offset independently — CSS Position L3 §3.4: *"Multiple sticky positioned boxes in the same container are offset independently, and therefore might overlap"* — and nothing ever evicts them, because there is no per-day containing block. So every separator pinned at the same offset simultaneously; whichever painted last is what you saw, which is why it looked frozen on a date unrelated to the messages on screen.

Reproduced at 420px on a seeded 5-day chat: **three pills (Jul 28 / Jul 27 / Jul 26) rendered at the identical position** while day-4 messages filled the viewport.

This is a regression from v7.27.1 (mine). Its verification checked that the pill *pinned* — never that its *text changed*. The new tests close exactly that hole.

## Fix
- `.date-separator` is a plain inline separator again (no sticky).
- **One** `.floating-date-pill`, rendered outside the scroll container, showing the day of the topmost visible message — so a second pill cannot exist by construction.
- **Permanently visible**, as you asked. Worth noting: every official client I checked fades it after idle (Telegram iOS ~0.3 s, Android 0.5 s, Web K 1.35 s, Signal Desktop 3 s). For a reading/archival viewer, constant orientation is the better trade, so this is a deliberate divergence.
- Recomputed from **two** triggers, because neither alone is correct: a rAF-coalesced scroll handler, and the `sortedMessages` watch. Appending an older page in a `flex-col-reverse` list changes content above the viewport **without firing a scroll event**, so a scroll-only pill would go stale immediately after pagination — precisely where you'd look.
- An IntersectionObserver "trip line" was tried and **rejected**: a fast or programmatic scroll can move a marker from below the band to above it with no change in intersection state, so no callback fires and the pill silently freezes. (Caught because the first spike passed only while the separators were still sticky.)
- Cost is O(days) rect reads (tens at most), never O(messages).
- `role="heading"` rather than `aria-live` — it changes on every scroll tick and announcing that would flood screen readers (none of the four official clients use a live region here). Guarded for empty chats and the pinned-only view; clicking still opens the date picker for the day shown.

## Verification (headless Chrome, 420×900, seeded 5-day chat)
| scroll | pills | sticky separators | pill | top message |
|---|---|---|---|---|
| initial / −700 / −1500 | 1 | 0 | July 29 | day 5 |
| −2400 | 1 | 0 | **July 28** | day 4 |
| −3300 | 1 | 0 | **July 27** | day 3 |
| −1000 (scrolling back) | 1 | 0 | July 29 | day 5 |
| **after older-page pagination, no further scroll** | 1 | 0 | **July 26** | day 2 |

Horizontal overflow still 0 (v7.27.1 mobile guarantee). 5 new regression tests; full suite **2447 passed**; ruff clean.

Version 7.29.2 (patch). #240 and #250 follow as separate PRs — they touch the same list and shipping them together would make any regression unbisectable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a single floating date indicator while scrolling through messages.
  * Made the floating date indicator clickable to open the date picker.
  * Improved date tracking during scrolling, loading, and range navigation.

* **Bug Fixes**
  * Replaced independently sticky date separators with a clearer, centralized date display.

* **Tests**
  * Added end-to-end regression coverage to ensure date UI stability and correct recomputation behavior.

* **Chores**
  * Updated the package version to 7.29.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->