### PR TITLE
feat(viewer): larger avatar in sender details, openable from 1:1 headers (#240)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.29.2"
+version = "7.30.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.29.2"
+__version__ = "7.30.0"

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -852,7 +852,35 @@
                                         d="M15 19l-7-7 7-7"></path>
                                 </svg>
                             </button>
-                            <div
+                            <!-- Header avatar (#240). In a 1:1 chat the photo IS the
+                                 counterpart, so it opens the same "Sender details"
+                                 dialog the group message avatars use. Groups/channels
+                                 keep the plain non-interactive circle: there the photo
+                                 is the GROUP picture, and the dialog would show the
+                                 group title and a -100… id, which is not a sender.
+                                 No .tap-target here — its 44px mobile minimum would
+                                 stretch this fixed 40px aspect-square into an ellipse. -->
+                            <button v-if="selectedChat?.type === 'private'" type="button"
+                                @click="openSenderInfoFromChat(selectedChat, $event)"
+                                :aria-label="`Show details for ${getChatName(selectedChat)}`"
+                                class="w-10 h-10 min-w-[2.5rem] aspect-square rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center font-bold text-white overflow-hidden shrink-0 focus:outline-none focus:ring-2 focus:ring-blue-400">
+                                <img v-if="selectedChat?.avatar_url" :src="selectedChat.avatar_url"
+                                    class="w-full h-full object-cover rounded-full" @error="selectedChat.avatar_url = null"
+                                    :alt="getChatName(selectedChat)">
+                                <template v-else-if="isDeletedChat(selectedChat)">
+                                    <svg class="w-6 h-6 opacity-80" fill="none" stroke="currentColor"
+                                        viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                            d="M12 14c2.21 0 4-1.343 4-3s-1.79-3-4-3-4 1.343-4 3 1.79 3 4 3z" />
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                            d="M5 21a7 7 0 0114 0" />
+                                    </svg>
+                                </template>
+                                <template v-else>
+                                    {{ getInitials(selectedChat) }}
+                                </template>
+                            </button>
+                            <div v-else
                                 class="w-10 h-10 min-w-[2.5rem] aspect-square rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center font-bold text-white overflow-hidden shrink-0">
                                 <img v-if="selectedChat?.avatar_url" :src="selectedChat.avatar_url"
                                     class="w-full h-full object-cover rounded-full" @error="selectedChat.avatar_url = null"
@@ -1527,6 +1555,20 @@
                         <i class="fa-solid fa-xmark text-lg"></i>
                     </button>
                 </header>
+                <!-- Larger version of the photo the row avatar already resolved (#240).
+                     Decorative on purpose: not a button/link, so it stays out of the
+                     Tab trap and never opens a modal-over-modal lightbox. alt is empty
+                     because the name it would announce is already the next thing read
+                     out of the <dl> below — a non-empty alt would just duplicate it. -->
+                <div class="mt-4 flex justify-center">
+                    <div class="w-20 h-20 rounded-full overflow-hidden flex items-center justify-center text-2xl font-bold text-white select-none"
+                        :style="{ background: getAvatarFill(senderInfoMessage) }">
+                        <img v-if="senderInfoMessage.sender_avatar_url" :src="senderInfoMessage.sender_avatar_url"
+                            class="w-full h-full object-cover"
+                            @error="senderInfoMessage.sender_avatar_url = null" alt="">
+                        <template v-else>{{ getSenderInitials(senderInfoMessage) }}</template>
+                    </div>
+                </div>
                 <dl class="mt-4 space-y-3 text-sm">
                     <div>
                         <dt class="text-xs uppercase tracking-wide text-tg-muted">
@@ -4331,6 +4373,27 @@
                     nextTick(() => trigger?.focus())
                 }
 
+                // Adapter for the 1:1 header avatar (#240). A chat is NOT message-shaped:
+                // it carries `id` and `avatar_url`, while the dialog reads `sender_id` and
+                // `sender_avatar_url` — passing the raw chat straight through would render
+                // "Telegram ID: Unknown" and a blank avatar. In a private chat `chat.id` IS
+                // the counterpart's Telegram user id and its photo resolves to the same file
+                // a message's sender avatar would. `sender_name` is null on purpose: it is a
+                // per-message archival snapshot chats never have, so the dialog falls back to
+                // the current name and correctly hides the "Latest known name" duplicate row.
+                const openSenderInfoFromChat = (chat, event) => {
+                    if (!chat) return
+                    openSenderInfo({
+                        sender_id: chat.id,
+                        sender_name: null,
+                        first_name: chat.first_name,
+                        last_name: chat.last_name,
+                        username: chat.username,
+                        sender_avatar_url: chat.avatar_url,
+                        raw_data: null,
+                    }, event)
+                }
+
                 // Get name for forwarded message source
                 const getForwardName = (msg) => {
                     // First check raw_data for the resolved name
@@ -5412,6 +5475,7 @@
                     getSenderInfoName,
                     hasDifferentCurrentSenderName,
                     openSenderInfo,
+                    openSenderInfoFromChat,
                     closeSenderInfo,
                     getForwardName,
                     getSenderRunKey,

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -1047,3 +1047,79 @@ def test_floating_date_handles_the_top_of_history():
     assert "best = best || firstBelow" in update_body
     # The newest loaded message must NOT be used to resolve that case.
     assert "sortedMessages.value[0]" not in update_body
+
+
+def test_sender_details_dialog_shows_a_large_avatar():
+    """#240: the popup renders the already-resolved photo at a readable size."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    start = html.index('<section ref="senderInfoDialog"')
+    body = html[start : html.index("</section>", start)]
+
+    # Big circle, above the definition list.
+    assert "w-20 h-20 rounded-full" in body
+    assert body.index("w-20 h-20 rounded-full") < body.index('<dl class="mt-4 space-y-3 text-sm">')
+
+    # Same photo the message row resolved, with a fallback on load failure.
+    assert 'v-if="senderInfoMessage.sender_avatar_url"' in body
+    assert '@error="senderInfoMessage.sender_avatar_url = null"' in body
+
+    # Fallback reuses the existing initials + deterministic gradient helpers.
+    assert "getSenderInitials(senderInfoMessage)" in body
+    assert "getAvatarFill(senderInfoMessage)" in body
+
+    # Decorative only: it must not become a focusable child of the dialog's Tab trap.
+    avatar = body[body.index("w-20 h-20 rounded-full") : body.index('<dl class="mt-4 space-y-3 text-sm">')]
+    assert "<button" not in avatar
+    assert "<a " not in avatar
+
+
+def test_private_chat_header_avatar_opens_sender_details():
+    """#240: the 1:1 header photo is the counterpart, so it opens the same popup."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    start = html.index('<button v-if="selectedChat?.type === \'private\'" type="button"')
+    body = html[start : html.index("</button>", start)]
+
+    # Real <button> => native Enter/Space activation.
+    assert body.startswith('<button v-if="selectedChat?.type === \'private\'" type="button"')
+    # $event must be forwarded or openSenderInfo cannot restore focus on close.
+    assert '@click="openSenderInfoFromChat(selectedChat, $event)"' in body
+    assert ":aria-label=" in body
+    assert "getChatName(selectedChat)" in body
+    assert "focus:ring-2 focus:ring-blue-400" in body
+
+    # Groups/channels keep the non-interactive circle (that photo is the group, not a sender).
+    assert "<div v-else" in html[html.index("</button>", start) :][:400]
+
+    # The original message-row call site stays an independent second trigger.
+    assert '@click="openSenderInfo(msg, $event)"' in html
+
+
+def test_chat_header_sender_trigger_maps_chat_fields_to_message_shape():
+    """#240: chats carry id/avatar_url, the dialog reads sender_id/sender_avatar_url."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    start = html.index("const openSenderInfoFromChat = (chat, event) =>")
+    body = html[start : html.index("}, event)", start)]
+
+    assert "sender_id: chat.id" in body
+    assert "sender_avatar_url: chat.avatar_url" in body
+    assert "sender_name: null" in body
+    assert "first_name: chat.first_name" in body
+    assert "last_name: chat.last_name" in body
+    assert "username: chat.username" in body
+
+    # Must be exposed to the template.
+    assert "openSenderInfoFromChat," in html
+
+
+def test_chat_header_avatar_button_is_not_a_tap_target():
+    """.tap-target forces 44px minimums on mobile and would deform the 40px circle."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    start = html.index('<button v-if="selectedChat?.type === \'private\'" type="button"')
+    body = html[start : html.index("</button>", start)]
+
+    assert "tap-target" not in body
+    assert "aspect-square" in body


### PR DESCRIPTION
Closes #240. Thanks @625801 — both of these reuse data that was already there, exactly as you said.

## What shipped

**1. Larger avatar in the Sender details dialog.** The photo the viewer already resolves (`sender_avatar_url`), shown at 80px with the same initials-on-deterministic-gradient fallback used in the message list. It is decorative markup rather than a control, so it deliberately stays out of the dialog's focus trap — and it is intentionally not clickable, since opening a lightbox from inside a modal would stack two Escape handlers.

**2. The 1:1 chat header avatar opens the same dialog.** Gated to private chats: in a group the header photo is the *group's*, so a "Sender details" dialog there would show the group name against a `-100…` id.

The wiring detail worth naming: `openSenderInfoFromChat` adapts the chat object to the message shape the dialog expects — `chat.id → sender_id`, `chat.avatar_url → sender_avatar_url`, `sender_name: null`. Passing the chat straight through would have silently produced **"Telegram ID: Unknown"** and a blank avatar, since chats carry `id`/`avatar_url` and the dialog reads `sender_id`/`sender_avatar_url`. `sender_name: null` is correct rather than lossy: there is no per-chat archived-name snapshot, so the dialog falls back to the current name and correctly hides the "Latest known name" row.

No backend change — a 1:1 chat's id *is* the counterpart's user id, and the media ACL already grants 1:1 contact avatars directly.

## Verification (headless Chrome, 390×844)
| check | result |
|---|---|
| 1:1 header opens the dialog | ✓ |
| Telegram ID renders the real id (777001), not "Unknown" | ✓ |
| Avatar renders large and loaded | ✓ 80×80 |
| Escape closes, focus returns to the header avatar | ✓ |
| Group chat header exposes no trigger | ✓ (0 buttons) |
| Avatar stays circular on mobile | ✓ 40×40 (no `.tap-target` — it would force a 44×40 ellipse) |
| Horizontal overflow | ✓ 0 |

4 new tests; full suite **2452 passed**; ruff + format clean. Version 7.30.0 (minor).