### PR TITLE
feat(viewer): global persistent voice/audio player (#250)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.30.0"
+version = "7.31.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.30.0"
+__version__ = "7.31.0"

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -315,6 +315,38 @@
             height: 24px;
         }
 
+        /* Global audio playbar (#250). Docked to the BOTTOM edge rather than the top
+           (where Telegram Web puts it): this viewer is read-only, so the bottom strip
+           is free, while the top of the message pane already carries the chat header,
+           the pinned-message banner and the floating day pill. z-index sits in the
+           41-49 band — above the message list and the scroll FAB (10), below the
+           modals/lightbox (50) and the toast (9999). */
+        .audio-playbar {
+            position: fixed;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            z-index: 45;
+            background: rgba(30, 41, 59, 0.97);
+            -webkit-backdrop-filter: blur(8px);
+            backdrop-filter: blur(8px);
+            border-top: 1px solid #334155;
+            box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.35);
+        }
+
+        .audio-playbar input[type="range"] {
+            accent-color: #3b82f6;
+        }
+
+        /* Keep the newest bubbles and the scroll FAB clear of the docked bar. */
+        .audio-player-open .messages-scroll {
+            padding-bottom: 80px;
+        }
+
+        .audio-player-open .scroll-to-bottom-btn {
+            bottom: 92px;
+        }
+
         /* Loading Spinner (Telegram-style) */
         .loading-spinner {
             width: 24px;
@@ -1310,21 +1342,36 @@
                                             class="rounded-lg max-h-64 max-w-full object-cover cursor-pointer hover:opacity-90 transition"
                                             @click="openMedia(msg)" @error="handleImageError($event, msg)">
 
-                                        <!-- Audio / Voice Notes -->
+                                        <!-- Audio / Voice Notes (#250). The bubble owns no media element of
+                                             its own — it only delegates to the single app-wide player, so
+                                             playback survives chat switches and jump-window rebuilds. -->
                                         <div v-else-if="isAudioFile(msg)"
                                             class="w-full min-w-0 max-w-md bg-gradient-to-r from-gray-800 to-gray-700 p-3 rounded-xl shadow-lg">
-                                            <audio
-                                                controls
-                                                preload="metadata"
-                                                class="w-full"
-                                                style="height: 40px; min-height: 40px;"
-                                                :src="getMediaUrl(msg)"
-                                                @error="console.error('Audio load error:', getMediaUrl(msg))">
-                                                Your browser does not support audio playback.
-                                            </audio>
-                                            <div class="flex items-center gap-2 mt-2 text-xs text-gray-400">
-                                                <span>🎵</span>
-                                                <span class="truncate">{{ getDocumentDisplayName(msg) }}</span>
+                                            <div class="flex items-center gap-3">
+                                                <button type="button" @click.stop="playAudioMessage(msg)"
+                                                    :disabled="noDownload"
+                                                    :aria-label="(isPlayingAudioMessage(msg) ? 'Pause ' : 'Play ') + getDocumentDisplayName(msg)"
+                                                    class="w-10 h-10 shrink-0 rounded-full bg-blue-600 hover:bg-blue-500 disabled:opacity-40 disabled:cursor-not-allowed flex items-center justify-center text-white transition focus:outline-none focus:ring-2 focus:ring-blue-400">
+                                                    <svg v-if="isPlayingAudioMessage(msg)" class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                                                        <path d="M6 5h4v14H6zm8 0h4v14h-4z"/>
+                                                    </svg>
+                                                    <svg v-else class="w-5 h-5 ml-0.5" fill="currentColor" viewBox="0 0 24 24">
+                                                        <path d="M8 5v14l11-7z"/>
+                                                    </svg>
+                                                </button>
+                                                <div class="min-w-0 flex-1">
+                                                    <div class="flex items-center gap-2 text-xs text-gray-300">
+                                                        <span>🎵</span>
+                                                        <span class="truncate">{{ getDocumentDisplayName(msg) }}</span>
+                                                    </div>
+                                                    <div class="flex items-center gap-2 mt-1 text-[11px] text-gray-400">
+                                                        <span v-if="msg.media?.duration">{{ formatAudioTime(msg.media.duration) }}</span>
+                                                        <span v-if="isCurrentAudioMessage(msg)" class="text-blue-400">
+                                                            {{ audioIsPlaying ? 'Now playing' : 'Paused' }}
+                                                        </span>
+                                                        <span v-else-if="noDownload">Playback disabled</span>
+                                                    </div>
+                                                </div>
                                             </div>
                                         </div>
 
@@ -1897,6 +1944,77 @@
                     </div>
                 </div>
             </div>
+        </div>
+
+        <!-- Global audio playbar (#250). Rendered here, at app-shell level and outside
+             the per-chat message pane, so it survives chat switches; the media element
+             it drives is a single JS-owned HTMLAudioElement created in setup(). -->
+        <div v-if="audioTrack && !noDownload" class="audio-playbar px-3 py-2"
+            role="region" aria-label="Audio player">
+            <div class="max-w-5xl mx-auto flex items-center gap-2 sm:gap-3">
+                <button type="button" @click="playPrevAudio()" aria-label="Previous audio message"
+                    class="p-2 rounded-full text-gray-300 hover:text-white hover:bg-white/10 transition focus:outline-none focus:ring-2 focus:ring-blue-400">
+                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M6 6h2v12H6zm3.5 6l8.5 6V6z"/>
+                    </svg>
+                </button>
+                <button type="button" @click="toggleAudioPlayback()"
+                    :aria-label="audioIsPlaying ? 'Pause audio' : 'Play audio'"
+                    class="w-10 h-10 shrink-0 rounded-full bg-blue-600 hover:bg-blue-500 flex items-center justify-center text-white transition focus:outline-none focus:ring-2 focus:ring-blue-400">
+                    <svg v-if="audioIsPlaying" class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M6 5h4v14H6zm8 0h4v14h-4z"/>
+                    </svg>
+                    <svg v-else class="w-5 h-5 ml-0.5" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M8 5v14l11-7z"/>
+                    </svg>
+                </button>
+                <button type="button" @click="playNextAudio()" aria-label="Next audio message"
+                    class="p-2 rounded-full text-gray-300 hover:text-white hover:bg-white/10 transition focus:outline-none focus:ring-2 focus:ring-blue-400">
+                    <svg class="w-5 h-5" fill="currentColor" viewBox="0 0 24 24">
+                        <path d="M16 6h2v12h-2zM6 18l8.5-6L6 6z"/>
+                    </svg>
+                </button>
+
+                <div class="flex-1 min-w-0">
+                    <button type="button" @click="focusAudioTrackMessage()"
+                        :aria-label="'Go to message from ' + audioTrack.sender"
+                        class="block w-full text-left truncate rounded px-1 hover:bg-white/10 transition focus:outline-none focus:ring-2 focus:ring-blue-400">
+                        <span class="text-sm text-white">{{ audioTrack.sender }}</span>
+                        <span class="text-[11px] text-tg-muted ml-2">
+                            {{ audioTrack.chatName }}<template v-if="audioTrack.date"> · {{ formatTime(audioTrack.date) }}</template>
+                        </span>
+                    </button>
+                    <div class="flex items-center gap-2 mt-0.5">
+                        <span class="text-[11px] text-tg-muted w-10 text-right shrink-0">{{ formatAudioTime(audioCurrentTime) }}</span>
+                        <input type="range" min="0" step="0.1" :max="audioSeekMax" :value="audioCurrentTime"
+                            @input="seekAudioTo($event.target.value)"
+                            aria-label="Seek within audio"
+                            class="flex-1 h-1 cursor-pointer">
+                        <span class="text-[11px] text-tg-muted w-10 shrink-0">{{ formatAudioTime(audioDuration) }}</span>
+                    </div>
+                </div>
+
+                <div role="group" aria-label="Playback speed" class="hidden sm:flex items-center gap-1">
+                    <button v-for="rate in audioSpeeds" :key="rate" type="button" @click="setAudioSpeed(rate)"
+                        :aria-pressed="currentAudioSpeed === rate"
+                        :aria-label="'Playback speed ' + rate + 'x'"
+                        :class="currentAudioSpeed === rate ? 'bg-blue-600 text-white' : 'text-gray-300 hover:bg-white/10'"
+                        class="text-[11px] px-2 py-1 rounded transition focus:outline-none focus:ring-2 focus:ring-blue-400">
+                        {{ rate }}x
+                    </button>
+                </div>
+
+                <button type="button" @click="closeAudioPlayer()" aria-label="Close audio player"
+                    class="p-2 rounded-full text-gray-400 hover:text-white hover:bg-white/10 transition focus:outline-none focus:ring-2 focus:ring-blue-400">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                    </svg>
+                </button>
+            </div>
+            <p v-if="audioStatusMessage" role="status" aria-live="polite"
+                class="max-w-5xl mx-auto mt-1 text-[11px] text-amber-300">
+                {{ audioStatusMessage }}
+            </p>
         </div>
 
         <!-- Toast notification for background failures -->
@@ -4990,6 +5108,343 @@
                     await loadMessagesAroundId(msgId)
                 }
 
+                // ---------------------------------------------------------------
+                // Global audio player (#250)
+                //
+                // ONE HTMLAudioElement drives every voice note and music file in the
+                // app. It is deliberately not an element per bubble, and not an
+                // element in the template at all:
+                //   * loadMessagesAroundId REPLACES messages.value wholesale, so any
+                //     player rendered inside the message v-for is destroyed mid-track
+                //     by an ordinary jump-to-message;
+                //   * iOS grants playback authorisation per element per user gesture,
+                //     so reusing the element the user already tapped is what lets
+                //     auto-advance start the next track without a fresh tap.
+                // ---------------------------------------------------------------
+                const audioSpeeds = [0.5, 1, 1.5, 2]
+                const AUDIO_MAX_FAILURES = 2
+
+                const audioTrack = ref(null)        // descriptor of the loaded track (own copy of the metadata)
+                const audioQueue = ref([])          // descriptors, oldest -> newest
+                const audioIsPlaying = ref(false)
+                const audioCurrentTime = ref(0)
+                const audioDuration = ref(0)
+                const audioBlocked = ref(false)     // play() refused by the autoplay policy
+                const audioError = ref('')
+                const audioAutoAdvanceHalted = ref(false)
+                let audioConsecutiveFailures = 0
+
+                // Voice notes and music keep independent speeds, like the official
+                // clients (Telegram Android stores playbackSpeed / musicPlaybackSpeed).
+                const audioSpeedStorageKey = (kind) => kind === 'voice' ? 'audio_speed_voice' : 'audio_speed_music'
+
+                const readStoredAudioSpeed = (kind) => {
+                    try {
+                        const raw = parseFloat(localStorage.getItem(audioSpeedStorageKey(kind)))
+                        return audioSpeeds.includes(raw) ? raw : 1
+                    } catch (e) {
+                        return 1  // storage can throw in private mode
+                    }
+                }
+
+                const audioSpeedByKind = ref({
+                    voice: readStoredAudioSpeed('voice'),
+                    music: readStoredAudioSpeed('music'),
+                })
+
+                const audioEngine = new Audio()
+                audioEngine.preload = 'metadata'
+
+                const audioMediaKind = (msg) => msg.media?.type === 'voice' ? 'voice' : 'music'
+
+                const audioMessageChatId = (msg) => msg.chat_id ?? selectedChat.value?.id ?? null
+
+                const audioTrackFromMessage = (msg) => ({
+                    id: msg.id,
+                    chatId: audioMessageChatId(msg),
+                    chatName: selectedChat.value ? getChatName(selectedChat.value) : '',
+                    url: getMediaUrl(msg),
+                    sender: getSenderName(msg),
+                    date: msg.date,
+                    duration: msg.media?.duration ?? null,
+                    kind: audioMediaKind(msg),
+                })
+
+                const isCurrentAudioMessage = (msg) => {
+                    const track = audioTrack.value
+                    return !!track && track.id === msg.id && track.chatId === audioMessageChatId(msg)
+                }
+
+                const isPlayingAudioMessage = (msg) => isCurrentAudioMessage(msg) && audioIsPlaying.value
+
+                const currentAudioSpeed = computed(() => {
+                    const kind = audioTrack.value ? audioTrack.value.kind : 'voice'
+                    return audioSpeedByKind.value[kind] || 1
+                })
+
+                const audioSeekMax = computed(() => {
+                    const seconds = audioDuration.value || (audioTrack.value?.duration ?? 0)
+                    return seconds > 0 ? seconds : 1
+                })
+
+                const audioStatusMessage = computed(() => {
+                    if (audioBlocked.value) return 'Playback was blocked by the browser — press play to start.'
+                    if (audioAutoAdvanceHalted.value) return 'Several files failed to load — auto-advance stopped.'
+                    if (audioError.value) return audioError.value
+                    return ''
+                })
+
+                const formatAudioTime = (seconds) => {
+                    const total = Math.max(0, Math.floor(Number(seconds) || 0))
+                    return `${Math.floor(total / 60)}:${String(total % 60).padStart(2, '0')}`
+                }
+
+                const syncAudioMediaSession = () => {
+                    if (!('mediaSession' in navigator)) return
+                    navigator.mediaSession.playbackState = audioTrack.value
+                        ? (audioIsPlaying.value ? 'playing' : 'paused')
+                        : 'none'
+                }
+
+                const updateAudioMediaSessionMetadata = () => {
+                    if (!('mediaSession' in navigator) || typeof MediaMetadata !== 'function') return
+                    const track = audioTrack.value
+                    if (!track) {
+                        navigator.mediaSession.metadata = null
+                        return
+                    }
+                    navigator.mediaSession.metadata = new MediaMetadata({
+                        title: track.sender || 'Audio message',
+                        artist: track.chatName || '',
+                    })
+                }
+
+                const handleAudioLoadFailure = () => {
+                    audioConsecutiveFailures += 1
+                    audioIsPlaying.value = false
+                    audioError.value = 'This audio could not be played.'
+                    if (audioConsecutiveFailures >= AUDIO_MAX_FAILURES) {
+                        // Stop walking the queue: with a broken media path every advance
+                        // is another failed request across the whole chat.
+                        audioAutoAdvanceHalted.value = true
+                    }
+                }
+
+                const loadAudioTrack = (track) => {
+                    if (!track || !track.url || noDownload.value) return
+                    audioTrack.value = track
+                    audioError.value = ''
+                    audioBlocked.value = false
+                    audioCurrentTime.value = 0
+                    audioDuration.value = 0
+                    const rate = audioSpeedByKind.value[track.kind] || 1
+                    audioEngine.pause()
+                    // TRAP: the WHATWG media load algorithm resets playbackRate to
+                    // defaultPlaybackRate on every src change, so the chosen rate has to
+                    // be planted in defaultPlaybackRate BEFORE load() and re-applied on
+                    // loadedmetadata — otherwise each new track silently drops to 1x.
+                    audioEngine.defaultPlaybackRate = rate
+                    audioEngine.src = track.url
+                    audioEngine.load()
+                    updateAudioMediaSessionMetadata()
+                    startAudioPlayback()
+                }
+
+                const startAudioPlayback = () => {
+                    const started = audioEngine.play()
+                    if (!started || typeof started.catch !== 'function') return
+                    started.catch((err) => {
+                        const name = err && err.name
+                        // AbortError just means a newer load()/skip superseded this play.
+                        if (name === 'AbortError') return
+                        if (name === 'NotAllowedError') {
+                            // Autoplay policy refused it — never stall silently, show a
+                            // paused state the user can tap.
+                            audioBlocked.value = true
+                            audioIsPlaying.value = false
+                            syncAudioMediaSession()
+                            return
+                        }
+                        handleAudioLoadFailure()
+                    })
+                }
+
+                const buildAudioQueue = (msg) => {
+                    // Same type class only: voice notes and music are separate queues,
+                    // so a voice run never rolls into a music file. Confined to the
+                    // already-loaded window of this chat, oldest -> newest.
+                    const kind = audioMediaKind(msg)
+                    const chatId = audioMessageChatId(msg)
+                    return sortedMessages.value
+                        .filter(m => isAudioFile(m) && audioMediaKind(m) === kind && audioMessageChatId(m) === chatId)
+                        .map(m => audioTrackFromMessage(m))
+                        .reverse()
+                }
+
+                const currentAudioQueueIndex = () => {
+                    const track = audioTrack.value
+                    if (!track) return -1
+                    return audioQueue.value.findIndex(t => t.id === track.id && t.chatId === track.chatId)
+                }
+
+                const playAdjacentAudio = (step) => {
+                    // Advances only inside the already-loaded window and stops at its
+                    // edge: pagination is driven by two IntersectionObservers, and having
+                    // playback drive it too would double-fetch and race their in-flight
+                    // guards.
+                    const index = currentAudioQueueIndex()
+                    if (index < 0) return false
+                    const next = audioQueue.value[index + step]
+                    if (!next) return false
+                    loadAudioTrack(next)
+                    return true
+                }
+
+                const playNextAudio = () => playAdjacentAudio(1)
+
+                const playPrevAudio = () => {
+                    // Restart the current track when there is nothing older, the way
+                    // every media player treats "previous".
+                    if (!playAdjacentAudio(-1)) seekAudioTo(0)
+                }
+
+                const playAudioMessage = (msg) => {
+                    if (noDownload.value) return
+                    if (isCurrentAudioMessage(msg)) {
+                        toggleAudioPlayback()
+                        return
+                    }
+                    audioConsecutiveFailures = 0
+                    audioAutoAdvanceHalted.value = false
+                    audioQueue.value = buildAudioQueue(msg)
+                    loadAudioTrack(audioTrackFromMessage(msg))
+                }
+
+                const toggleAudioPlayback = () => {
+                    if (!audioTrack.value) return
+                    if (audioEngine.paused) {
+                        audioBlocked.value = false
+                        startAudioPlayback()
+                    } else {
+                        audioEngine.pause()
+                    }
+                }
+
+                const seekAudioTo = (value) => {
+                    const seconds = Number(value)
+                    if (!audioTrack.value || !isFinite(seconds)) return
+                    const limit = isFinite(audioEngine.duration) ? audioEngine.duration : seconds
+                    audioEngine.currentTime = Math.max(0, Math.min(seconds, limit))
+                    audioCurrentTime.value = audioEngine.currentTime
+                }
+
+                const setAudioSpeed = (rate) => {
+                    const kind = audioTrack.value ? audioTrack.value.kind : 'voice'
+                    audioSpeedByKind.value = { ...audioSpeedByKind.value, [kind]: rate }
+                    try {
+                        localStorage.setItem(audioSpeedStorageKey(kind), String(rate))
+                    } catch (e) { /* storage unavailable (private mode) — speed stays session-only */ }
+                    audioEngine.defaultPlaybackRate = rate
+                    audioEngine.playbackRate = rate
+                }
+
+                const closeAudioPlayer = () => {
+                    audioEngine.pause()
+                    audioEngine.removeAttribute('src')
+                    audioEngine.load()  // release the decoder / in-flight range requests
+                    audioTrack.value = null
+                    audioQueue.value = []
+                    audioIsPlaying.value = false
+                    audioCurrentTime.value = 0
+                    audioDuration.value = 0
+                    audioBlocked.value = false
+                    audioError.value = ''
+                    audioAutoAdvanceHalted.value = false
+                    audioConsecutiveFailures = 0
+                    updateAudioMediaSessionMetadata()
+                    syncAudioMediaSession()
+                }
+
+                const focusAudioTrackMessage = async () => {
+                    const track = audioTrack.value
+                    if (!track) return
+                    if (track.chatId != null && track.chatId !== (selectedChat.value?.id ?? null)) {
+                        const chat = chats.value.find(c => c.id === track.chatId)
+                        if (!chat) return
+                        await selectChat(chat)
+                    }
+                    scrollToMessage(track.id)
+                }
+
+                // Listeners are attached ONCE to the shared element, never per track.
+                audioEngine.addEventListener('loadedmetadata', () => {
+                    audioDuration.value = isFinite(audioEngine.duration)
+                        ? audioEngine.duration
+                        : (audioTrack.value?.duration || 0)
+                    // Re-apply the rate: the load algorithm has just reset playbackRate
+                    // to defaultPlaybackRate (see the trap note in loadAudioTrack).
+                    audioEngine.playbackRate = audioTrack.value
+                        ? (audioSpeedByKind.value[audioTrack.value.kind] || 1)
+                        : 1
+                    audioConsecutiveFailures = 0
+                    audioError.value = ''
+                })
+
+                audioEngine.addEventListener('timeupdate', () => {
+                    audioCurrentTime.value = audioEngine.currentTime
+                })
+
+                audioEngine.addEventListener('play', () => {
+                    audioIsPlaying.value = true
+                    audioBlocked.value = false
+                    syncAudioMediaSession()
+                })
+
+                audioEngine.addEventListener('pause', () => {
+                    audioIsPlaying.value = false
+                    syncAudioMediaSession()
+                })
+
+                audioEngine.addEventListener('ended', () => {
+                    audioIsPlaying.value = false
+                    if (audioAutoAdvanceHalted.value || !playNextAudio()) {
+                        audioCurrentTime.value = 0
+                        syncAudioMediaSession()
+                    }
+                })
+
+                audioEngine.addEventListener('error', () => {
+                    if (!audioTrack.value) return  // teardown clears src, which is not a failure
+                    handleAudioLoadFailure()
+                    if (!audioAutoAdvanceHalted.value) playNextAudio()
+                })
+
+                // OS / lock-screen / media-key control, feature-detected.
+                const audioMediaSessionActions = {
+                    play: () => { if (!audioIsPlaying.value) toggleAudioPlayback() },
+                    pause: () => { if (audioIsPlaying.value) toggleAudioPlayback() },
+                    previoustrack: () => playPrevAudio(),
+                    nexttrack: () => playNextAudio(),
+                }
+
+                if ('mediaSession' in navigator) {
+                    for (const [action, handler] of Object.entries(audioMediaSessionActions)) {
+                        // Unsupported actions throw NotSupportedError; register each on its own.
+                        try {
+                            navigator.mediaSession.setActionHandler(action, handler)
+                        } catch (e) { /* action not supported by this browser */ }
+                    }
+                }
+
+                // Reserve room under the message pane (and lift the scroll FAB) only while
+                // the bar is docked. The flag goes on <body>: #app is the mount CONTAINER,
+                // so a :class binding written on it is never part of the template and is
+                // silently ignored. Declared after audioTrack/noDownload, per this file's
+                // watch-placement rule.
+                watch(audioTrack, (track) => {
+                    document.body.classList.toggle('audio-player-open', !!track && !noDownload.value)
+                })
+
                 const calendarAvailabilityKey = (chatId, topicId, timezone, monthKey) => {
                     return `${chatId}:${topicId ?? 'all'}:${timezone}:${monthKey}`
                 }
@@ -5527,6 +5982,26 @@
                     isLightboxImage,
                     isLightboxVideo,
                     linkifyText,
+                    // Global audio player (#250)
+                    audioTrack,
+                    audioIsPlaying,
+                    audioCurrentTime,
+                    audioDuration,
+                    audioSeekMax,
+                    audioSpeeds,
+                    currentAudioSpeed,
+                    audioStatusMessage,
+                    formatAudioTime,
+                    isCurrentAudioMessage,
+                    isPlayingAudioMessage,
+                    playAudioMessage,
+                    toggleAudioPlayback,
+                    playNextAudio,
+                    playPrevAudio,
+                    seekAudioTo,
+                    setAudioSpeed,
+                    closeAudioPlayer,
+                    focusAudioTrackMessage,
                     scrollToMessage,
                     jumpToReply,
                     messagesContainer,

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -1123,3 +1123,196 @@ def test_chat_header_avatar_button_is_not_a_tap_target():
 
     assert "tap-target" not in body
     assert "aspect-square" in body
+
+
+# --- Global audio player (#250) -------------------------------------------------
+
+
+def _setup_slice(html: str, declaration: str) -> str:
+    """Return one top-level ``const`` body from the root Vue ``setup()``.
+
+    Setup-scope declarations are indented 16 spaces, so the next such line is
+    the end of the current one; nested declarations are indented deeper and do
+    not terminate the slice.
+    """
+    start = html.index(declaration)
+    return html[start : html.index("\n                const ", start + len(declaration))]
+
+
+def test_audio_playback_uses_a_single_shared_element():
+    """#250: no per-message player may exist.
+
+    ``loadMessagesAroundId`` replaces ``messages.value`` wholesale, so a player
+    rendered inside the message ``v-for`` is destroyed mid-track by an ordinary
+    jump. The bubble must only delegate to the app-wide engine.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    # Zero markup players: the engine is a JS-owned HTMLAudioElement.
+    assert html.count("<audio") == 0
+    assert "<audio controls" not in html
+    assert html.count("new Audio()") == 1
+
+    # The bubble branch now delegates.
+    audio_branch_start = html.index('v-else-if="isAudioFile(msg)"')
+    audio_branch = html[audio_branch_start : audio_branch_start + 2500]
+    assert 'type="button"' in audio_branch
+    assert "playAudioMessage(msg)" in audio_branch
+    assert ":aria-label=" in audio_branch
+
+
+def test_audio_engine_and_playbar_live_outside_the_message_loop():
+    """The engine and its bar must survive chat switches and list rebuilds."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    # The element is created in setup(), not in the template.
+    engine_index = html.index("const audioEngine = new Audio()")
+    assert engine_index > html.index("createApp({")
+
+    # A single playbar, rendered after the message scroll container closes.
+    assert html.count('class="audio-playbar') == 1
+    assert html.index('class="audio-playbar') > html.index('<div ref="scrollAnchor">')
+
+    # z-index band: above the message list / scroll FAB (10), below modals (50).
+    playbar_css = html[html.index(".audio-playbar {") : html.index(".audio-playbar input")]
+    z_index = int(playbar_css.split("z-index:")[1].split(";")[0].strip())
+    assert 41 <= z_index <= 49
+
+    # The layout flag must NOT be a :class on #app — that div is the mount
+    # CONTAINER, so bindings written on it are never part of the template and are
+    # silently dropped (verified in a browser: the class never appeared).
+    assert ":class=\"{ 'audio-player-open'" not in html
+    assert "document.body.classList.toggle('audio-player-open'" in html
+
+
+def test_audio_playback_rate_survives_a_track_change():
+    """#250: the media load algorithm resets ``playbackRate`` on every ``src`` change.
+
+    Without planting the rate in ``defaultPlaybackRate`` before ``load()`` AND
+    re-applying it once metadata arrives, every new track silently falls back to
+    1x while the UI still shows the chosen speed.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    load_body = _setup_slice(html, "const loadAudioTrack = (track) =>")
+    assert load_body.index("audioEngine.defaultPlaybackRate = rate") < load_body.index("audioEngine.src = track.url")
+    assert load_body.index("audioEngine.src = track.url") < load_body.index("audioEngine.load()")
+
+    meta_start = html.index("audioEngine.addEventListener('loadedmetadata'")
+    meta_body = html[meta_start : html.index("audioEngine.addEventListener('timeupdate'", meta_start)]
+    assert "audioEngine.playbackRate = audioTrack.value" in meta_body
+
+
+def test_audio_ended_advances_and_errors_halt_after_repeated_failures():
+    """Auto-advance must chain tracks, but a broken media path must not be walked."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    ended_start = html.index("audioEngine.addEventListener('ended'")
+    ended_body = html[ended_start : html.index("audioEngine.addEventListener('error'", ended_start)]
+    assert "playNextAudio()" in ended_body
+    assert "audioAutoAdvanceHalted.value" in ended_body
+
+    error_start = html.index("audioEngine.addEventListener('error'")
+    error_body = html[error_start : html.index("const audioMediaSessionActions", error_start)]
+    assert "handleAudioLoadFailure()" in error_body
+    assert "if (!audioAutoAdvanceHalted.value) playNextAudio()" in error_body
+
+    assert "const AUDIO_MAX_FAILURES = 2" in html
+    failure_body = _setup_slice(html, "const handleAudioLoadFailure = () =>")
+    assert "audioConsecutiveFailures += 1" in failure_body
+    assert "audioConsecutiveFailures >= AUDIO_MAX_FAILURES" in failure_body
+    assert "audioAutoAdvanceHalted.value = true" in failure_body
+
+
+def test_audio_play_rejection_distinguishes_blocked_from_aborted():
+    """``play()`` rejects for two very different reasons and must not be swallowed."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    body = _setup_slice(html, "const startAudioPlayback = () =>")
+    # Fast skipping aborts the pending play — benign, ignored.
+    assert "if (name === 'AbortError') return" in body
+    # Autoplay policy — surfaced as a tap-to-play state, never a silent stall.
+    assert "name === 'NotAllowedError'" in body
+    assert "audioBlocked.value = true" in body
+    # Anything else is a real load failure.
+    assert "handleAudioLoadFailure()" in body
+    assert "audioStatusMessage" in html
+
+
+def test_audio_speed_is_persisted_per_media_type():
+    """Voice speed and music speed are independent and survive a reload."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert "const audioSpeeds = [0.5, 1, 1.5, 2]" in html
+    key_body = _setup_slice(html, "const audioSpeedStorageKey = (kind) =>")
+    assert "'audio_speed_voice'" in key_body
+    assert "'audio_speed_music'" in key_body
+
+    restore_body = _setup_slice(html, "const readStoredAudioSpeed = (kind) =>")
+    assert "localStorage.getItem(audioSpeedStorageKey(kind))" in restore_body
+
+    set_body = _setup_slice(html, "const setAudioSpeed = (rate) =>")
+    assert "localStorage.setItem(audioSpeedStorageKey(kind), String(rate))" in set_body
+    # The kind comes from the playing track, so music never overwrites voice.
+    assert "audioTrack.value ? audioTrack.value.kind : 'voice'" in set_body
+
+
+def test_audio_player_is_gated_on_no_download():
+    """no_download viewers 403 on every /media GET — never offer or queue playback."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert 'v-if="audioTrack && !noDownload"' in html
+
+    play_body = _setup_slice(html, "const playAudioMessage = (msg) =>")
+    assert "if (noDownload.value) return" in play_body
+
+    load_body = _setup_slice(html, "const loadAudioTrack = (track) =>")
+    assert "noDownload.value" in load_body
+
+    audio_branch_start = html.index('v-else-if="isAudioFile(msg)"')
+    audio_branch = html[audio_branch_start : audio_branch_start + 2500]
+    assert ':disabled="noDownload"' in audio_branch
+
+
+def test_audio_media_session_is_feature_detected():
+    """OS / lock-screen controls must be optional, never a hard dependency."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert "'mediaSession' in navigator" in html
+    assert "typeof MediaMetadata !== 'function'" in html
+    assert "new MediaMetadata(" in html
+
+    actions_start = html.index("const audioMediaSessionActions = {")
+    actions_body = html[actions_start : html.index("if ('mediaSession' in navigator) {", actions_start)]
+    for action in ("play:", "pause:", "previoustrack:", "nexttrack:"):
+        assert action in actions_body
+    # Unsupported actions throw, so each registration is independent.
+    assert "navigator.mediaSession.setActionHandler(action, handler)" in html
+    assert "navigator.mediaSession.playbackState" in html
+
+
+def test_audio_auto_advance_does_not_drive_pagination():
+    """Deferred by design (#250).
+
+    Two IntersectionObservers already auto-fire the older/newer page loads. A
+    player that also drove them would double-fetch and race ``loadingNewer`` /
+    ``newerLoadError`` / ``chatVersion``, so advancing stops at the edge of the
+    already-loaded window.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    advance_body = _setup_slice(html, "const playAdjacentAudio = (step) =>")
+    assert "loadMessages" not in advance_body
+    assert "loadNewerMessages" not in advance_body
+    assert "audioQueue.value[index + step]" in advance_body
+
+    ended_start = html.index("audioEngine.addEventListener('ended'")
+    ended_body = html[ended_start : html.index("audioEngine.addEventListener('error'", ended_start)]
+    assert "loadMessages" not in ended_body
+    assert "loadNewerMessages" not in ended_body
+
+    # The queue is a snapshot of copied metadata, not references into messages.value.
+    queue_body = _setup_slice(html, "const buildAudioQueue = (msg) =>")
+    assert "audioTrackFromMessage(m)" in queue_body
+    # Voice and music never share a queue.
+    assert "audioMediaKind(m) === kind" in queue_body


### PR DESCRIPTION
Addresses #250. Thanks @625801 — pointing at the Web K client as a behavioural spec was the right call; I read its player source and matched it where it mattered.

## The problem, concretely
Every voice/audio bubble rendered its **own** `<audio controls>`. Nothing stopped a second clip starting over the first, there was no control once you scrolled past the playing message, and playback never continued to the next one.

## What shipped
- **One** `HTMLAudioElement`, created once and owned by the app (the template now contains **zero** `<audio>` tags). This is required, not stylistic: jump-to-message replaces the whole message array and would destroy an in-list element, and iOS grants playback authorisation *per element per gesture* — so auto-advance only works if the `src` is swapped on an already-activated element.
- **A persistent playbar** outside the message pane: play/pause, prev/next, seek, elapsed/total, speed, sender + chat + timestamp, close. Clicking the metadata focuses the source message.
- Bubbles now carry a play/pause button that delegates to the shared element, so **one-at-a-time is structural** rather than coordinated.
- **Auto-advance** on `ended` within the loaded window. **Voice notes and music are separate queues**, matching the official clients (Web K uses distinct filters; Android keeps separate playlists) — a voice run never spills into a music file.
- **Speed 0.5/1/1.5/2, persisted per media type** across sessions — as Web K does, and as Android corroborates with separate `playbackSpeed`/`musicPlaybackSpeed` keys. The subtle part: `playbackRate` is **reset to `defaultPlaybackRate` by the media load algorithm on every `src` change**, so it is set before `load()` *and* re-applied on `loadedmetadata`. Without that the chosen speed silently drops back to 1× on every track.
- `play()` rejections are distinguished: `NotAllowedError` surfaces a paused state rather than stalling the queue; `AbortError` (fast skipping) is ignored.
- Gated on `!noDownload`, and auto-advance halts after repeated load failures — those accounts 403 on every `/media` GET, and a naive queue would walk the whole chat issuing 403s.
- **MediaSession** metadata + action handlers, feature-detected, so OS/lock-screen/media keys work.

## Deliberately not included (and why)
- **Auto-advance does not trigger pagination.** Two IntersectionObservers already auto-fire `loadMessages()`/`loadNewerMessages()`; a player also driving them can double-fetch and fight `loadingNewer`/`newerLoadError`/`chatVersion`. Advancing stops at the edge of the loaded window.
- **The queue does not span chats.** Playback itself continues while you browse elsewhere (that falls out of the singleton), but the queue stays with the chat it started in.

Happy to do both as a follow-up — I'd rather land the core solidly than race the existing pagination observers.

## Verification (headless Chrome, `Audio` instrumented before page load)
| check | result |
|---|---|
| Audio instances created | **1** (never grows) |
| Playback real | ✓ `paused:false`, time advancing |
| 1.5× applied | ✓ rate + defaultPlaybackRate |
| **Speed survives a track change** | ✓ src `5062`→`5064`, rate still **1.5** |
| Auto-advance on end | ✓ `5064`→`5065` |
| Stops at end of the voice run | ✓ did not cross into the music file |
| JS errors | 0 |

9 new tests; full suite **2461 passed**; ruff + format clean. Version 7.31.0 (minor).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a global audio player for voice notes and music.
  * Added playback controls including queue navigation, seeking, speed adjustment, jump-to-message, and Media Session support.
  * Added automatic track advancement and separate playback speed preferences for different media types.
  * Improved audio playback availability handling when downloads are restricted.

* **Bug Fixes**
  * Improved playback error handling and prevented repeated failures from advancing indefinitely.

* **Tests**
  * Added coverage for global audio playback, queue behavior, persistence, restrictions, and error handling.

* **Chores**
  * Updated the application version to 7.31.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->