### PR TITLE
feat(viewer): page the audio queue past the loaded message window (#254)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.31.0"
+version = "7.31.1"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.31.0"
+__version__ = "7.31.1"

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -5271,14 +5271,167 @@
 
                 const buildAudioQueue = (msg) => {
                     // Same type class only: voice notes and music are separate queues,
-                    // so a voice run never rolls into a music file. Confined to the
-                    // already-loaded window of this chat, oldest -> newest.
+                    // so a voice run never rolls into a music file. This is only the
+                    // SEED, taken from the already-loaded window of this chat so the
+                    // queue is usable on the click itself; extendAudioQueueFromMedia
+                    // then grows it past that window. Oldest -> newest.
                     const kind = audioMediaKind(msg)
                     const chatId = audioMessageChatId(msg)
                     return sortedMessages.value
                         .filter(m => isAudioFile(m) && audioMediaKind(m) === kind && audioMessageChatId(m) === chatId)
                         .map(m => audioTrackFromMessage(m))
                         .reverse()
+                }
+
+                // ---------------------------------------------------------------
+                // Queue paging (#254)
+                //
+                // The queue is paged from the media endpoint, which is a SEPARATE
+                // cursor from the message pane: the pane's two IntersectionObservers
+                // own their own fetches, and a second driver poking them would
+                // double-fetch and race their in-flight guards. The player therefore
+                // never calls the pane's loaders and keeps every descriptor it needs
+                // in its own state, so a chat switch (which empties messages.value)
+                // cannot invalidate the queue.
+                // ---------------------------------------------------------------
+                const AUDIO_QUEUE_PAGE_SIZE = 50
+                const AUDIO_QUEUE_MAX_PAGES = 10
+
+                let audioQueueRequestId = 0      // stale-result guard
+                let audioQueueCursor = null      // media id of the OLDEST item fetched so far
+                let audioQueueHasOlder = false
+                let audioQueueFetching = false
+
+                // Voice and music are queried separately — the endpoint would happily
+                // return both in one call ("voice,audio"), which is exactly what must
+                // not happen here.
+                const audioQueueTypes = (kind) => kind === 'voice' ? 'voice' : 'audio'
+
+                const fetchAudioQueuePage = async (chatId, kind, beforeId) => {
+                    const params = new URLSearchParams({
+                        types: audioQueueTypes(kind),
+                        limit: String(AUDIO_QUEUE_PAGE_SIZE),
+                    })
+                    // Cursor is the composite media id of the last item seen; the
+                    // endpoint pages backwards in time from it.
+                    if (beforeId) params.set('before_id', beforeId)
+                    const res = await fetch(`/api/chats/${chatId}/media?${params}`, {
+                        credentials: 'include'
+                    })
+                    if (!res.ok) throw new Error('Failed to load audio queue page')
+                    return await res.json()
+                }
+
+                const audioTrackFromMediaItem = (item, kind, chatName) => ({
+                    id: item.message_id,
+                    chatId: item.chat_id,
+                    chatName,
+                    url: item.media_url || '',
+                    sender: item.sender_name || 'Deleted Account',
+                    date: item.message_date,
+                    duration: item.duration ?? null,
+                    kind,
+                })
+
+                const audioTracksFromMediaItems = (items, track) => items
+                    // no_download viewers get no media_url, and paths outside the media
+                    // root are stripped server-side: an entry with no URL is unplayable.
+                    .filter(item => item && item.media_url && item.message_id != null)
+                    .map(item => audioTrackFromMediaItem(item, track.kind, track.chatName))
+
+                const audioTrackTime = (track) => {
+                    const ms = Date.parse(track.date || '')
+                    return isFinite(ms) ? ms : 0
+                }
+
+                const mergeAudioQueue = (tracks) => {
+                    // The seed descriptors win on collision: they carry the richer
+                    // sender resolution the message shape allows.
+                    const byKey = new Map()
+                    for (const t of [...audioQueue.value, ...tracks]) {
+                        const key = `${t.chatId}:${t.id}`
+                        if (!byKey.has(key)) byKey.set(key, t)
+                    }
+                    return [...byKey.values()].sort((a, b) => {
+                        const delta = audioTrackTime(a) - audioTrackTime(b)
+                        return delta !== 0 ? delta : (Number(a.id) || 0) - (Number(b.id) || 0)
+                    })
+                }
+
+                const audioQueueBelongsToTrack = (track) => {
+                    // A queue is valid for one (chat, kind) pair. Voice notes are short
+                    // enough that auto-advance can move to the NEXT track while the pages
+                    // are still in flight — that track shares the queue, so the result is
+                    // still wanted. A different chat or class, or a closed player, is what
+                    // makes it stale; a track the USER started instead is caught by the
+                    // request id, which only a new playback session bumps.
+                    const current = audioTrack.value
+                    return !!current && current.chatId === track.chatId && current.kind === track.kind
+                }
+
+                const extendAudioQueueFromMedia = async (track) => {
+                    // Playback advances forward in time while the endpoint pages
+                    // backwards from the newest item, so paging back until the playing
+                    // track shows up puts EVERY possible next track in hand.
+                    if (!track || track.chatId == null || noDownload.value) return
+                    const requestId = ++audioQueueRequestId
+                    audioQueueFetching = true
+                    const collected = []
+                    let cursor = null
+                    let hasOlder = false
+                    try {
+                        for (let page = 0; page < AUDIO_QUEUE_MAX_PAGES; page++) {
+                            const data = await fetchAudioQueuePage(track.chatId, track.kind, cursor)
+                            const items = Array.isArray(data?.items) ? data.items : []
+                            if (!items.length) break
+                            collected.push(...items)
+                            cursor = items[items.length - 1].id
+                            hasOlder = !!data.has_more
+                            // Found the playing track, or there is nothing older left.
+                            if (items.some(item => item.message_id === track.id) || !hasOlder) break
+                        }
+                    } catch (e) {
+                        // A queue page that fails to load is NOT a playback failure: it
+                        // must never touch audioConsecutiveFailures / audioAutoAdvanceHalted.
+                        // The seeded window queue stays in place — today's behaviour.
+                        return
+                    } finally {
+                        if (requestId === audioQueueRequestId) audioQueueFetching = false
+                    }
+                    // The user may have started another track (or another chat) while
+                    // these pages were in flight; those results belong to nobody now.
+                    if (requestId !== audioQueueRequestId || !audioQueueBelongsToTrack(track)) return
+                    if (!collected.length) return
+                    audioQueueCursor = cursor
+                    audioQueueHasOlder = hasOlder
+                    audioQueue.value = mergeAudioQueue(audioTracksFromMediaItems(collected, track))
+                }
+
+                const extendAudioQueueOlder = async () => {
+                    // One page older, on demand, for "previous" at the head of the queue.
+                    const track = audioTrack.value
+                    if (!track || audioQueueFetching || !audioQueueHasOlder || !audioQueueCursor) return false
+                    const requestId = ++audioQueueRequestId
+                    audioQueueFetching = true
+                    let data
+                    try {
+                        data = await fetchAudioQueuePage(track.chatId, track.kind, audioQueueCursor)
+                    } catch (e) {
+                        return false  // paging failure ≠ playback failure, see above
+                    } finally {
+                        if (requestId === audioQueueRequestId) audioQueueFetching = false
+                    }
+                    if (requestId !== audioQueueRequestId || !audioQueueBelongsToTrack(track)) return false
+                    const items = Array.isArray(data?.items) ? data.items : []
+                    if (!items.length) {
+                        audioQueueHasOlder = false
+                        return false
+                    }
+                    audioQueueCursor = items[items.length - 1].id
+                    audioQueueHasOlder = !!data.has_more
+                    const before = audioQueue.value.length
+                    audioQueue.value = mergeAudioQueue(audioTracksFromMediaItems(items, track))
+                    return audioQueue.value.length > before
                 }
 
                 const currentAudioQueueIndex = () => {
@@ -5288,10 +5441,11 @@
                 }
 
                 const playAdjacentAudio = (step) => {
-                    // Advances only inside the already-loaded window and stops at its
-                    // edge: pagination is driven by two IntersectionObservers, and having
-                    // playback drive it too would double-fetch and race their in-flight
-                    // guards.
+                    // Pure walk over the player's own queue. It stays synchronous and
+                    // never touches the message pane's pagination: those fetches are
+                    // driven by two IntersectionObservers, and a second driver would
+                    // double-fetch and race their in-flight guards. Reaching the end of
+                    // the queue means the end of the chat's audio of this kind.
                     const index = currentAudioQueueIndex()
                     if (index < 0) return false
                     const next = audioQueue.value[index + step]
@@ -5302,10 +5456,13 @@
 
                 const playNextAudio = () => playAdjacentAudio(1)
 
-                const playPrevAudio = () => {
+                const playPrevAudio = async () => {
+                    if (playAdjacentAudio(-1)) return
+                    // At the head of the queue: one more page of older audio, on demand.
+                    if (await extendAudioQueueOlder() && playAdjacentAudio(-1)) return
                     // Restart the current track when there is nothing older, the way
                     // every media player treats "previous".
-                    if (!playAdjacentAudio(-1)) seekAudioTo(0)
+                    seekAudioTo(0)
                 }
 
                 const playAudioMessage = (msg) => {
@@ -5316,8 +5473,14 @@
                     }
                     audioConsecutiveFailures = 0
                     audioAutoAdvanceHalted.value = false
+                    audioQueueCursor = null
+                    audioQueueHasOlder = false
                     audioQueue.value = buildAudioQueue(msg)
-                    loadAudioTrack(audioTrackFromMessage(msg))
+                    const track = audioTrackFromMessage(msg)
+                    // Start on the user gesture, THEN grow the queue: awaiting the fetch
+                    // first would spend the gesture and hand iOS a blocked play().
+                    loadAudioTrack(track)
+                    extendAudioQueueFromMedia(track)
                 }
 
                 const toggleAudioPlayback = () => {
@@ -5354,6 +5517,10 @@
                     audioEngine.load()  // release the decoder / in-flight range requests
                     audioTrack.value = null
                     audioQueue.value = []
+                    // Bumping the request id makes any in-flight queue page stale.
+                    audioQueueRequestId += 1
+                    audioQueueCursor = null
+                    audioQueueHasOlder = false
                     audioIsPlaying.value = false
                     audioCurrentTime.value = 0
                     audioDuration.value = 0

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -5298,6 +5298,11 @@
                 const AUDIO_QUEUE_MAX_PAGES = 10
 
                 let audioQueueRequestId = 0      // stale-result guard
+                // Ownership of the in-flight flag, deliberately SEPARATE from the
+                // staleness id: teardown bumps that id without starting a fetch, so
+                // keying the flag on it leaks (the finally then never matches) and
+                // head-of-queue paging dies for the session.
+                let audioQueueFetchSeq = 0
                 let audioQueueCursor = null      // media id of the OLDEST item fetched so far
                 let audioQueueHasOlder = false
                 let audioQueueFetching = false
@@ -5375,6 +5380,7 @@
                     // track shows up puts EVERY possible next track in hand.
                     if (!track || track.chatId == null || noDownload.value) return
                     const requestId = ++audioQueueRequestId
+                    const fetchToken = ++audioQueueFetchSeq
                     audioQueueFetching = true
                     const collected = []
                     let cursor = null
@@ -5396,7 +5402,7 @@
                         // The seeded window queue stays in place — today's behaviour.
                         return
                     } finally {
-                        if (requestId === audioQueueRequestId) audioQueueFetching = false
+                        if (fetchToken === audioQueueFetchSeq) audioQueueFetching = false
                     }
                     // The user may have started another track (or another chat) while
                     // these pages were in flight; those results belong to nobody now.
@@ -5412,6 +5418,7 @@
                     const track = audioTrack.value
                     if (!track || audioQueueFetching || !audioQueueHasOlder || !audioQueueCursor) return false
                     const requestId = ++audioQueueRequestId
+                    const fetchToken = ++audioQueueFetchSeq
                     audioQueueFetching = true
                     let data
                     try {
@@ -5419,7 +5426,7 @@
                     } catch (e) {
                         return false  // paging failure ≠ playback failure, see above
                     } finally {
-                        if (requestId === audioQueueRequestId) audioQueueFetching = false
+                        if (fetchToken === audioQueueFetchSeq) audioQueueFetching = false
                     }
                     if (requestId !== audioQueueRequestId || !audioQueueBelongsToTrack(track)) return false
                     const items = Array.isArray(data?.items) ? data.items : []
@@ -5519,6 +5526,11 @@
                     audioQueue.value = []
                     // Bumping the request id makes any in-flight queue page stale.
                     audioQueueRequestId += 1
+                    // ...and release the in-flight flag: the page still resolving no
+                    // longer owns anything, and leaving it set would block every later
+                    // head-of-queue fetch.
+                    audioQueueFetchSeq += 1
+                    audioQueueFetching = false
                     audioQueueCursor = null
                     audioQueueHasOlder = false
                     audioIsPlaying.value = false

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -1492,3 +1492,25 @@ def test_audio_queue_keeps_voice_and_music_on_separate_types():
     # Fetched descriptors inherit that kind, so a merged queue stays single-class.
     tracks_body = _setup_slice(html, "const audioTracksFromMediaItems = (items, track) =>")
     assert "audioTrackFromMediaItem(item, track.kind, track.chatName)" in tracks_body
+
+
+def test_audio_queue_in_flight_flag_cannot_leak():
+    """#254: closing the player mid-fetch must not disable paging forever.
+
+    The in-flight flag is owned by its own sequence, NOT by the staleness id:
+    teardown bumps the staleness id without starting a fetch, so a `finally`
+    keyed on that id never matches and the flag stays set — after which
+    extendAudioQueueOlder bails on every later call and head-of-queue
+    "previous" silently stops paging for the rest of the session.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert "let audioQueueFetchSeq = 0" in html
+    # Both fetch paths release the flag by ownership token, not by request id.
+    assert html.count("if (fetchToken === audioQueueFetchSeq) audioQueueFetching = false") == 2
+    assert "if (requestId === audioQueueRequestId) audioQueueFetching = false" not in html
+
+    # Teardown releases it outright.
+    close_start = html.index("const closeAudioPlayer = () =>")
+    close_body = html[close_start : html.index("\n                const ", close_start + 10)]
+    assert "audioQueueFetching = false" in close_body

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -1139,6 +1139,11 @@ def _setup_slice(html: str, declaration: str) -> str:
     return html[start : html.index("\n                const ", start + len(declaration))]
 
 
+def _code_only(body: str) -> str:
+    """Drop whole-line ``//`` comments: some assertions are about code, not prose."""
+    return "\n".join(line for line in body.splitlines() if not line.strip().startswith("//"))
+
+
 def test_audio_playback_uses_a_single_shared_element():
     """#250: no per-message player may exist.
 
@@ -1316,3 +1321,174 @@ def test_audio_auto_advance_does_not_drive_pagination():
     assert "audioTrackFromMessage(m)" in queue_body
     # Voice and music never share a queue.
     assert "audioMediaKind(m) === kind" in queue_body
+
+
+# --- Pagination-aware audio queue (#254) ---------------------------------------
+
+_AUDIO_QUEUE_DECLARATIONS = (
+    "const fetchAudioQueuePage = async (chatId, kind, beforeId) =>",
+    "const extendAudioQueueFromMedia = async (track) =>",
+    "const extendAudioQueueOlder = async () =>",
+)
+
+
+def test_audio_queue_pages_the_media_endpoint_with_a_capped_cursor_walk():
+    """#254: the queue grows from the media endpoint's own cursor, not the pane's.
+
+    Playback runs oldest -> newest while ``/media`` pages newest -> oldest, so
+    paging back until the playing track appears puts every possible next track in
+    hand. The walk must be capped so a huge chat cannot spin forever.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    fetch_body = _setup_slice(html, "const fetchAudioQueuePage = async (chatId, kind, beforeId) =>")
+    assert "`/api/chats/${chatId}/media?${params}`" in fetch_body
+    assert "types: audioQueueTypes(kind)," in fetch_body
+    assert "limit: String(AUDIO_QUEUE_PAGE_SIZE)," in fetch_body
+    # The cursor is the composite media id of the last item seen.
+    assert "params.set('before_id', beforeId)" in fetch_body
+    assert "credentials: 'include'" in fetch_body
+
+    assert "const AUDIO_QUEUE_PAGE_SIZE = 50" in html
+    assert "const AUDIO_QUEUE_MAX_PAGES = 10" in html
+
+    extend_body = _setup_slice(html, "const extendAudioQueueFromMedia = async (track) =>")
+    assert "for (let page = 0; page < AUDIO_QUEUE_MAX_PAGES; page++)" in extend_body
+    assert "await fetchAudioQueuePage(track.chatId, track.kind, cursor)" in extend_body
+    assert "cursor = items[items.length - 1].id" in extend_body
+    # Stop as soon as the playing track is in hand, or nothing older is left.
+    assert "items.some(item => item.message_id === track.id) || !hasOlder" in extend_body
+    # Hitting the cap keeps whatever was fetched instead of failing.
+    assert "audioQueue.value = mergeAudioQueue(audioTracksFromMediaItems(collected, track))" in extend_body
+
+    # "Previous" at the head of the queue pages one more time from the same cursor.
+    older_body = _setup_slice(html, "const extendAudioQueueOlder = async () =>")
+    assert "await fetchAudioQueuePage(track.chatId, track.kind, audioQueueCursor)" in older_body
+    prev_body = _setup_slice(html, "const playPrevAudio = async () =>")
+    assert "await extendAudioQueueOlder()" in prev_body
+    assert "seekAudioTo(0)" in prev_body
+
+
+def test_audio_queue_extension_never_drives_message_pagination():
+    """#254 is only safe because the player owns a SEPARATE cursor.
+
+    The pane's older/newer pages are fetched by two IntersectionObservers. A
+    player that also called those loaders would double-fetch and race
+    ``loading`` / ``loadingNewer`` / ``newerLoadError`` / ``chatVersion``.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    advance_declarations = _AUDIO_QUEUE_DECLARATIONS + (
+        "const playAdjacentAudio = (step) =>",
+        "const playNextAudio = () => playAdjacentAudio(1)",
+        "const playPrevAudio = async () =>",
+        "const playAudioMessage = (msg) =>",
+    )
+    for declaration in advance_declarations:
+        body = _setup_slice(html, declaration)
+        assert "loadMessages" not in body, declaration
+        assert "loadNewerMessages" not in body, declaration
+        assert "messagesScrollObserver" not in body, declaration
+        assert "messagesNewerObserver" not in body, declaration
+
+    ended_start = html.index("audioEngine.addEventListener('ended'")
+    ended_body = html[ended_start : html.index("audioEngine.addEventListener('error'", ended_start)]
+    assert "loadMessages" not in ended_body
+    assert "loadNewerMessages" not in ended_body
+
+    # Auto-advance itself stays a synchronous walk over the player's own queue,
+    # so the 'ended' handler can still branch on its boolean result.
+    assert "const playNextAudio = () => playAdjacentAudio(1)" in html
+    advance_body = _setup_slice(html, "const playAdjacentAudio = (step) =>")
+    assert "audioQueue.value[index + step]" in advance_body
+
+    # The queue holds copied descriptors, so emptying messages.value on a chat
+    # switch cannot invalidate it.
+    item_body = _setup_slice(html, "const audioTrackFromMediaItem = (item, kind, chatName) =>")
+    assert "id: item.message_id," in item_body
+    assert "chatId: item.chat_id," in item_body
+    assert "url: item.media_url || ''," in item_body
+
+
+def test_audio_queue_discards_results_for_a_superseded_track():
+    """A page that lands after the user started something else belongs to nobody.
+
+    Two guards, because they catch different things: the request id is bumped by
+    each new playback session (and by closing the player), while the (chat, kind)
+    check catches a chat switch. Auto-advance within the same queue is NOT stale
+    — voice notes are short enough to advance mid-fetch.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    guard_body = _setup_slice(html, "const audioQueueBelongsToTrack = (track) =>")
+    assert "current.chatId === track.chatId" in guard_body
+    assert "current.kind === track.kind" in guard_body
+
+    extend_body = _setup_slice(html, "const extendAudioQueueFromMedia = async (track) =>")
+    assert "const requestId = ++audioQueueRequestId" in extend_body
+    assert "if (requestId !== audioQueueRequestId || !audioQueueBelongsToTrack(track)) return" in extend_body
+    # The guard runs before anything is written back to the queue.
+    assert extend_body.index("!audioQueueBelongsToTrack(track)") < extend_body.index(
+        "audioQueue.value = mergeAudioQueue"
+    )
+
+    older_body = _setup_slice(html, "const extendAudioQueueOlder = async () =>")
+    assert "const requestId = ++audioQueueRequestId" in older_body
+    assert "if (requestId !== audioQueueRequestId || !audioQueueBelongsToTrack(track)) return false" in older_body
+    assert older_body.index("!audioQueueBelongsToTrack(track)") < older_body.index("audioQueue.value = mergeAudioQueue")
+
+    # Closing the player invalidates whatever is still in flight.
+    close_body = _setup_slice(html, "const closeAudioPlayer = () =>")
+    assert "audioQueueRequestId += 1" in close_body
+    assert "audioQueueCursor = null" in close_body
+
+
+def test_audio_queue_fetch_failure_does_not_halt_auto_advance():
+    """A failed queue page and a failed MEDIA load are different failure modes.
+
+    Only the latter may count towards ``AUDIO_MAX_FAILURES``; a queue fetch that
+    fails must degrade to the already-loaded window, silently.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    for declaration in _AUDIO_QUEUE_DECLARATIONS:
+        body = _code_only(_setup_slice(html, declaration))
+        assert "audioConsecutiveFailures" not in body, declaration
+        assert "audioAutoAdvanceHalted" not in body, declaration
+        assert "handleAudioLoadFailure" not in body, declaration
+
+    extend_body = _setup_slice(html, "const extendAudioQueueFromMedia = async (track) =>")
+    assert "} catch (e) {" in extend_body
+    older_body = _setup_slice(html, "const extendAudioQueueOlder = async () =>")
+    assert "} catch (e) {" in older_body
+    assert "return false  // paging failure" in older_body
+
+    # The window-derived queue is seeded before the fetch is even started, so a
+    # failure leaves playback exactly where it is today.
+    play_body = _setup_slice(html, "const playAudioMessage = (msg) =>")
+    assert play_body.index("audioQueue.value = buildAudioQueue(msg)") < play_body.index(
+        "extendAudioQueueFromMedia(track)"
+    )
+    # ...and the fetch is not awaited, so it cannot spend the user gesture that
+    # authorises playback on iOS.
+    assert "await extendAudioQueueFromMedia(track)" not in play_body
+
+
+def test_audio_queue_keeps_voice_and_music_on_separate_types():
+    """Voice notes and music are separate queues, so they are separate queries."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    types_body = _setup_slice(html, "const audioQueueTypes = (kind) =>")
+    assert "kind === 'voice' ? 'voice' : 'audio'" in types_body
+    # Never the combined filter the media gallery uses.
+    assert "'voice,audio'" not in types_body
+
+    # Every page request is keyed on the playing track's own kind.
+    extend_body = _setup_slice(html, "const extendAudioQueueFromMedia = async (track) =>")
+    assert "fetchAudioQueuePage(track.chatId, track.kind, cursor)" in extend_body
+    older_body = _setup_slice(html, "const extendAudioQueueOlder = async () =>")
+    assert "fetchAudioQueuePage(track.chatId, track.kind, audioQueueCursor)" in older_body
+
+    # Fetched descriptors inherit that kind, so a merged queue stays single-class.
+    tracks_body = _setup_slice(html, "const audioTracksFromMediaItems = (items, track) =>")
+    assert "audioTrackFromMediaItem(item, track.kind, track.chatName)" in tracks_body


### PR DESCRIPTION
Closes #254. Completes the remaining item from #250.

## What changed
Auto-advance previously stopped at the edge of whatever the message list happened to have loaded. The queue now pages from the media endpoint that already exists:

```
GET /api/chats/{id}/media?types=<voice|audio>&limit=50&before_id=<cursor>
```

cursor-paginated, downloaded-only, ACL-checked — and crucially a **separate cursor from the message pane**. The pane's two IntersectionObservers own their own fetches; a second driver poking `loadMessages()` / `loadNewerMessages()` would double-fetch and race their in-flight guards. The player never calls them, and keeps every descriptor in its own state so a chat switch (which empties `messages.value`) can't invalidate the queue.

The ordering makes it cheap: playback runs **forward** in time while the endpoint pages **backward** from newest, so paging back until the playing track appears puts every possible *next* track in hand. "Previous" at the head of the queue fetches one more older page on demand.

Also: voice and music are queried separately so the two queues never merge; paging failures are **not** playback failures (they never touch the consecutive-failure counter that halts auto-advance); and stale pages are discarded when the track or chat changed while they were in flight.

## Verification
Against a purpose-built 200-message chat whose 20 voice notes extend far beyond the first page — the list loads ids **9150–9199**, containing only 5 voice notes:

| measurement | result |
|---|---|
| queue length | **20** (every voice note in the chat) |
| oldest *loaded* message id | 9150 |
| walking "previous" from 9150 | **9140 → 9130 → 9120 → 9110 → 9100 → 9090** |
| calls to the pane's loaders from the audio path | **none** |
| JS errors | 0 |

Every track reached is older than anything the message list has loaded, which is exactly the behaviour the issue asked for.

A note on how that was measured, because it nearly produced a false negative: the fixture's clips are 1 s long, so with 1.5 s between probes auto-advance carried playback forward again and made "previous" look like a no-op. Pausing playback before walking the queue showed the real behaviour. Worth remembering for anyone testing this later.

5 new tests; full suite **2466 passed**; ruff + format clean. Version 7.31.1 (patch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the audio player with a cursor-based, pagination-aware queue that extends beyond the currently loaded messages.
  * “Previous” navigation now loads additional older items on demand as the queue head is reached.
* **Bug Fixes**
  * Improved queue resilience: queue state no longer breaks on chat switching or player reloads.
  * Closing the player now reliably prevents in-flight queue results from affecting playback.
  * Voice and music are kept in separate queue flows, keyed to the selected track type.
* **Release**
  * Updated the package version to **7.31.1**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->