### PR TITLE
fix(viewer): tell audio queue paging errors apart from end-of-queue (#254)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.31.1"
+version = "7.31.2"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.31.1"
+__version__ = "7.31.2"

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -5430,7 +5430,13 @@
                 const extendAudioQueueOlder = async () => {
                     // One page older, on demand, for "previous" at the head of the queue.
                     const track = audioTrack.value
-                    if (!track || audioQueueFetching || !audioQueueHasOlder || !audioQueueCursor) return 'exhausted'
+                    // Three DIFFERENT states; collapsing them is the very bug this
+                    // path exists to avoid. A page already on its way is not the end
+                    // of the queue, and reporting it as such makes a second
+                    // "previous" press restart the track before that page lands.
+                    if (!track) return 'aborted'
+                    if (audioQueueFetching) return 'pending'
+                    if (!audioQueueHasOlder || !audioQueueCursor) return 'exhausted'
                     const requestId = ++audioQueueRequestId
                     const fetchToken = ++audioQueueFetchSeq
                     audioQueueFetching = true

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -5312,6 +5312,10 @@
                 // not happen here.
                 const audioQueueTypes = (kind) => kind === 'voice' ? 'voice' : 'audio'
 
+                // In-flight queue request, so teardown can abort it instead of leaving
+                // a response to land on a player the user has already closed.
+                let audioQueueAbort = null
+
                 const fetchAudioQueuePage = async (chatId, kind, beforeId) => {
                     const params = new URLSearchParams({
                         types: audioQueueTypes(kind),
@@ -5320,10 +5324,20 @@
                     // Cursor is the composite media id of the last item seen; the
                     // endpoint pages backwards in time from it.
                     if (beforeId) params.set('before_id', beforeId)
+                    audioQueueAbort?.abort()
+                    const controller = new AbortController()
+                    audioQueueAbort = controller
                     const res = await fetch(`/api/chats/${chatId}/media?${params}`, {
-                        credentials: 'include'
+                        credentials: 'include',
+                        signal: controller.signal
                     })
-                    if (!res.ok) throw new Error('Failed to load audio queue page')
+                    if (!res.ok) {
+                        // Carry the status: 401/403/429/5xx must not be mistaken for
+                        // "no older media", which is what an empty item list means.
+                        const error = new Error(`Audio queue page failed (${res.status})`)
+                        error.status = res.status
+                        throw error
+                    }
                     return await res.json()
                 }
 
@@ -5416,7 +5430,7 @@
                 const extendAudioQueueOlder = async () => {
                     // One page older, on demand, for "previous" at the head of the queue.
                     const track = audioTrack.value
-                    if (!track || audioQueueFetching || !audioQueueHasOlder || !audioQueueCursor) return false
+                    if (!track || audioQueueFetching || !audioQueueHasOlder || !audioQueueCursor) return 'exhausted'
                     const requestId = ++audioQueueRequestId
                     const fetchToken = ++audioQueueFetchSeq
                     audioQueueFetching = true
@@ -5424,21 +5438,28 @@
                     try {
                         data = await fetchAudioQueuePage(track.chatId, track.kind, audioQueueCursor)
                     } catch (e) {
-                        return false  // paging failure ≠ playback failure, see above
+                        // A transport failure is NOT the end of the queue. Collapsing the
+                        // two makes "previous" restart the track on a 401/403/429 as if
+                        // the user had reached the oldest message. Keep audioQueueHasOlder
+                        // set so a later press retries, and surface it — while never
+                        // touching the playback failure counter (paging ≠ playback).
+                        if (e?.name === 'AbortError') return 'aborted'
+                        audioError.value = 'Could not load older audio. Try again.'
+                        return 'error'
                     } finally {
                         if (fetchToken === audioQueueFetchSeq) audioQueueFetching = false
                     }
-                    if (requestId !== audioQueueRequestId || !audioQueueBelongsToTrack(track)) return false
+                    if (requestId !== audioQueueRequestId || !audioQueueBelongsToTrack(track)) return 'aborted'
                     const items = Array.isArray(data?.items) ? data.items : []
                     if (!items.length) {
-                        audioQueueHasOlder = false
-                        return false
+                        audioQueueHasOlder = false   // genuinely nothing older
+                        return 'exhausted'
                     }
                     audioQueueCursor = items[items.length - 1].id
                     audioQueueHasOlder = !!data.has_more
                     const before = audioQueue.value.length
                     audioQueue.value = mergeAudioQueue(audioTracksFromMediaItems(items, track))
-                    return audioQueue.value.length > before
+                    return audioQueue.value.length > before ? 'extended' : 'exhausted'
                 }
 
                 const currentAudioQueueIndex = () => {
@@ -5466,10 +5487,11 @@
                 const playPrevAudio = async () => {
                     if (playAdjacentAudio(-1)) return
                     // At the head of the queue: one more page of older audio, on demand.
-                    if (await extendAudioQueueOlder() && playAdjacentAudio(-1)) return
-                    // Restart the current track when there is nothing older, the way
-                    // every media player treats "previous".
-                    seekAudioTo(0)
+                    const outcome = await extendAudioQueueOlder()
+                    if (outcome === 'extended' && playAdjacentAudio(-1)) return
+                    // Only restart when we actually know there is nothing older. A failed
+                    // or aborted page must not masquerade as the start of the queue.
+                    if (outcome === 'exhausted') seekAudioTo(0)
                 }
 
                 const playAudioMessage = (msg) => {
@@ -5531,6 +5553,8 @@
                     // head-of-queue fetch.
                     audioQueueFetchSeq += 1
                     audioQueueFetching = false
+                    audioQueueAbort?.abort()
+                    audioQueueAbort = null
                     audioQueueCursor = null
                     audioQueueHasOlder = false
                     audioIsPlaying.value = false

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -1518,39 +1518,53 @@ def test_audio_queue_in_flight_flag_cannot_leak():
     assert "audioQueueFetching = false" in close_body
 
 
-def test_audio_queue_paging_errors_are_not_end_of_queue():
-    """#254 follow-up: a failed page must not look like "no older audio".
+class TestAudioQueuePagingOutcomes(unittest.TestCase):
+    """#254 follow-up: paging outcomes must stay distinguishable."""
 
-    fetchAudioQueuePage only checked res.ok, so 401/403/429/5xx collapsed into
-    the same falsy result as an exhausted cursor — and "previous" then restarted
-    the current track as though the user had reached the oldest message, with no
-    indication anything had failed.
-    """
-    html = INDEX_HTML.read_text(encoding="utf-8")
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
 
-    fetch_start = html.index("const fetchAudioQueuePage = async (chatId, kind, beforeId) =>")
-    fetch_body = html[fetch_start : html.index("\n                const ", fetch_start + 10)]
-    # The HTTP status is carried on the error so callers can tell transport
-    # failure from an empty page.
-    assert "error.status = res.status" in fetch_body
-    # Stale pages are aborted rather than left to land on a closed player.
-    assert "new AbortController()" in fetch_body
-    assert "signal: controller.signal" in fetch_body
+    def _slice(self, declaration: str) -> str:
+        start = self.html.index(declaration)
+        return self.html[start : self.html.index("\n                const ", start + 10)]
 
-    older_start = html.index("const extendAudioQueueOlder = async () =>")
-    older_body = html[older_start : html.index("\n                const ", older_start + 10)]
-    assert "return 'error'" in older_body  # transport failure
-    assert "return 'exhausted'" in older_body  # genuinely nothing older
-    assert "return 'extended'" in older_body or "'extended' : 'exhausted'" in older_body
-    assert "if (e?.name === 'AbortError') return 'aborted'" in older_body
-    # A paging failure must still never halt playback.
-    assert "audioConsecutiveFailures" not in older_body
+    def test_transport_failure_is_not_end_of_queue(self) -> None:
+        """401/403/429/5xx must not read as "no older audio".
 
-    prev_start = html.index("const playPrevAudio = async () =>")
-    prev_body = html[prev_start : html.index("\n                const ", prev_start + 10)]
-    # Restart only on a known-exhausted queue, never on error/abort.
-    assert "if (outcome === 'exhausted') seekAudioTo(0)" in prev_body
+        fetchAudioQueuePage only checked res.ok, so any error collapsed into the
+        same falsy result as an exhausted cursor and "previous" restarted the
+        current track as though the oldest message had been reached.
+        """
+        fetch_body = self._slice("const fetchAudioQueuePage = async (chatId, kind, beforeId) =>")
+        self.assertIn("error.status = res.status", fetch_body)
+        # Stale pages are aborted rather than landing on a closed player.
+        self.assertIn("new AbortController()", fetch_body)
+        self.assertIn("signal: controller.signal", fetch_body)
 
-    close_start = html.index("const closeAudioPlayer = () =>")
-    close_body = html[close_start : html.index("\n                const ", close_start + 10)]
-    assert "audioQueueAbort?.abort()" in close_body
+        older_body = self._slice("const extendAudioQueueOlder = async () =>")
+        self.assertIn("return 'error'", older_body)
+        self.assertIn("return 'exhausted'", older_body)
+        self.assertIn("if (e?.name === 'AbortError') return 'aborted'", older_body)
+        # Paging failure must never halt playback.
+        self.assertNotIn("audioConsecutiveFailures", older_body)
+
+    def test_in_flight_page_is_not_reported_as_exhausted(self) -> None:
+        """A page already on its way is not the end of the queue.
+
+        Returning 'exhausted' while a fetch is in flight makes a second
+        "previous" press restart the track before that page lands.
+        """
+        older_body = self._slice("const extendAudioQueueOlder = async () =>")
+        self.assertIn("if (audioQueueFetching) return 'pending'", older_body)
+        # The three guard states stay separate rather than collapsing into one.
+        self.assertIn("if (!track) return 'aborted'", older_body)
+        self.assertIn("if (!audioQueueHasOlder || !audioQueueCursor) return 'exhausted'", older_body)
+
+        prev_body = self._slice("const playPrevAudio = async () =>")
+        # Restart only on a known-exhausted queue — never on error, abort or pending.
+        self.assertIn("if (outcome === 'exhausted') seekAudioTo(0)", prev_body)
+
+    def test_teardown_aborts_the_in_flight_page(self) -> None:
+        close_body = self._slice("const closeAudioPlayer = () =>")
+        self.assertIn("audioQueueAbort?.abort()", close_body)

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -1539,8 +1539,8 @@ def test_audio_queue_paging_errors_are_not_end_of_queue():
 
     older_start = html.index("const extendAudioQueueOlder = async () =>")
     older_body = html[older_start : html.index("\n                const ", older_start + 10)]
-    assert "return 'error'" in older_body          # transport failure
-    assert "return 'exhausted'" in older_body      # genuinely nothing older
+    assert "return 'error'" in older_body  # transport failure
+    assert "return 'exhausted'" in older_body  # genuinely nothing older
     assert "return 'extended'" in older_body or "'extended' : 'exhausted'" in older_body
     assert "if (e?.name === 'AbortError') return 'aborted'" in older_body
     # A paging failure must still never halt playback.

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -1434,7 +1434,9 @@ def test_audio_queue_discards_results_for_a_superseded_track():
 
     older_body = _setup_slice(html, "const extendAudioQueueOlder = async () =>")
     assert "const requestId = ++audioQueueRequestId" in older_body
-    assert "if (requestId !== audioQueueRequestId || !audioQueueBelongsToTrack(track)) return false" in older_body
+    # Tri-state outcome since the follow-up: the stale guard yields 'aborted',
+    # which playPrevAudio must not treat as "reached the oldest message".
+    assert "if (requestId !== audioQueueRequestId || !audioQueueBelongsToTrack(track)) return 'aborted'" in older_body
     assert older_body.index("!audioQueueBelongsToTrack(track)") < older_body.index("audioQueue.value = mergeAudioQueue")
 
     # Closing the player invalidates whatever is still in flight.
@@ -1461,7 +1463,7 @@ def test_audio_queue_fetch_failure_does_not_halt_auto_advance():
     assert "} catch (e) {" in extend_body
     older_body = _setup_slice(html, "const extendAudioQueueOlder = async () =>")
     assert "} catch (e) {" in older_body
-    assert "return false  // paging failure" in older_body
+    assert "return 'error'" in older_body  # paging failure, explicitly not end-of-queue
 
     # The window-derived queue is seeded before the fetch is even started, so a
     # failure leaves playback exactly where it is today.
@@ -1514,3 +1516,41 @@ def test_audio_queue_in_flight_flag_cannot_leak():
     close_start = html.index("const closeAudioPlayer = () =>")
     close_body = html[close_start : html.index("\n                const ", close_start + 10)]
     assert "audioQueueFetching = false" in close_body
+
+
+def test_audio_queue_paging_errors_are_not_end_of_queue():
+    """#254 follow-up: a failed page must not look like "no older audio".
+
+    fetchAudioQueuePage only checked res.ok, so 401/403/429/5xx collapsed into
+    the same falsy result as an exhausted cursor — and "previous" then restarted
+    the current track as though the user had reached the oldest message, with no
+    indication anything had failed.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    fetch_start = html.index("const fetchAudioQueuePage = async (chatId, kind, beforeId) =>")
+    fetch_body = html[fetch_start : html.index("\n                const ", fetch_start + 10)]
+    # The HTTP status is carried on the error so callers can tell transport
+    # failure from an empty page.
+    assert "error.status = res.status" in fetch_body
+    # Stale pages are aborted rather than left to land on a closed player.
+    assert "new AbortController()" in fetch_body
+    assert "signal: controller.signal" in fetch_body
+
+    older_start = html.index("const extendAudioQueueOlder = async () =>")
+    older_body = html[older_start : html.index("\n                const ", older_start + 10)]
+    assert "return 'error'" in older_body          # transport failure
+    assert "return 'exhausted'" in older_body      # genuinely nothing older
+    assert "return 'extended'" in older_body or "'extended' : 'exhausted'" in older_body
+    assert "if (e?.name === 'AbortError') return 'aborted'" in older_body
+    # A paging failure must still never halt playback.
+    assert "audioConsecutiveFailures" not in older_body
+
+    prev_start = html.index("const playPrevAudio = async () =>")
+    prev_body = html[prev_start : html.index("\n                const ", prev_start + 10)]
+    # Restart only on a known-exhausted queue, never on error/abort.
+    assert "if (outcome === 'exhausted') seekAudioTo(0)" in prev_body
+
+    close_start = html.index("const closeAudioPlayer = () =>")
+    close_body = html[close_start : html.index("\n                const ", close_start + 10)]
+    assert "audioQueueAbort?.abort()" in close_body


### PR DESCRIPTION
Addresses the outstanding CodeRabbit finding on #255, which I merged past — my mistake: the CodeRabbit *check* was green and the PR was `CLEAN`, but it posts findings as review comments while the check still passes, and a third review landed after my fix commit.

## The problem
`fetchAudioQueuePage` only checked `res.ok`, so **401 / 403 / 429 / 5xx collapsed into the same falsy result as an exhausted cursor**. "Previous" at the head of the queue then restarted the current track exactly as though the user had reached the oldest message — no error, no retry, no indication anything had gone wrong.

## Fix
- The HTTP status is carried on the thrown error, so a transport failure is distinguishable from an empty page.
- `extendAudioQueueOlder` returns an outcome — `'extended' | 'exhausted' | 'error' | 'aborted'` — instead of a boolean. A failure **keeps `audioQueueHasOlder` set** so a later press retries, and surfaces a message, while still never touching the playback failure counter (paging is not playback).
- `playPrevAudio` restarts the track **only** on `'exhausted'`, never on error or abort.
- Queue fetches now carry an `AbortController`, and teardown aborts the in-flight page rather than leaving a response to land on a player the user already closed (the second half of the finding).

## Tests
Two #254 tests asserted the old boolean literals (`return false`); I retargeted them to the outcome values rather than deleting them — their intent (stale results discarded, paging failure never halts playback) is unchanged and still asserted.

Re-verified in headless Chrome against the 200-message deep-voice fixture: "previous" from the oldest **loaded** message (9150) still walks 9140 → 9130 → 9120 → 9110 → 9100 → 9090, all beyond the loaded window.

1 new test; full suite **2468 passed**; ruff + format clean. Version 7.31.2 (patch).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio queue pagination when loading older items.
  * Prevented playback from incorrectly restarting when requests are canceled, pending, or fail.
  * Ensured closing the audio player cancels in-progress queue requests.

* **Tests**
  * Added coverage for failed, canceled, pending, and exhausted queue-loading scenarios.

* **Chores**
  * Updated the package version to 7.31.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->