### PR TITLE
feat: media URL encoding, service-message text, audio queue and download fixes (#257-#263)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.31.2"
+version = "7.32.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.31.2"
+__version__ = "7.32.0"

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from functools import wraps
 from typing import Any
 
-from sqlalchemy import and_, delete, exists, func, literal, or_, select, text, union_all, update
+from sqlalchemy import and_, case, delete, exists, func, literal, or_, select, text, union_all, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
@@ -1140,12 +1140,47 @@ class DatabaseAdapter:
                 "download_date": media_data.get("download_date"),
             }
 
-            if self._is_sqlite:
-                stmt = sqlite_insert(Media).values(**values)
-                stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=values)
-            else:
-                stmt = pg_insert(Media).values(**values)
-                stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=values)
+            stmt = sqlite_insert(Media).values(**values) if self._is_sqlite else pg_insert(Media).values(**values)
+
+            # On conflict, a writer that has NO value for a column must not blank out
+            # what an earlier writer already stored (#263). Both halves of the row
+            # are affected, so both are COALESCEd:
+            #   - the metadata columns, when an ingest path could not read the
+            #     attributes off the Telethon object;
+            #   - the file-identity columns, because ``_process_media`` returns a
+            #     value-less row for an over-size skip and for a download error —
+            #     that row used to null the file_path/file_name/content_hash/
+            #     download_date of a file that is still on disk.
+            # COALESCE only falls back on NULL, so a real value still overwrites a
+            # real value: a re-download to a new path DOES update file_path.
+            # The one deliberate clear path is ``mark_media_for_redownload`` — a
+            # separate UPDATE — so nothing needs insert_media to null these.
+            update_values = dict(values)
+            for column in (
+                "file_name",
+                "file_path",
+                "file_size",
+                "mime_type",
+                "width",
+                "height",
+                "duration",
+                "content_hash",
+                "download_date",
+            ):
+                update_values[column] = func.coalesce(getattr(stmt.excluded, column), getattr(Media, column))
+            # ``downloaded`` is a flag, not a value: 0 is a real value, so COALESCE
+            # cannot protect it. It is sticky instead — once a file is on disk (and
+            # the COALESCEs above keep its path), a later failed attempt must not
+            # report it as missing. Staying 1 hides nothing: a file that really is
+            # gone is re-found by verify_and_repair_media, which stats the disk for
+            # every ``downloaded=1 OR file_path IS NOT NULL`` row. The old null-out
+            # was what hid it — it dropped the row out of that scan, and for the
+            # over-size skip (whose file_size is a real, over-limit number) out of
+            # the pending-download retry too, leaving the file orphaned on disk.
+            # Written as a CASE because two-argument max()/GREATEST is not portable
+            # across SQLite and PostgreSQL (PostgreSQL's max() is an aggregate).
+            update_values["downloaded"] = case((stmt.excluded.downloaded == 1, 1), else_=Media.downloaded)
+            stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=update_values)
 
             await session.execute(stmt)
             await session.commit()
@@ -1202,7 +1237,22 @@ class DatabaseAdapter:
         """
         Get paginated media records for a chat with cursor-based pagination.
 
-        Uses composite cursor (Message.date, Media.id) for deterministic ordering.
+        ``before_id`` stays an opaque ``Media.id`` token (the gallery round-trips the
+        composite ``{chat}_{msg}_{type}`` string), but it is resolved to the triple
+        (Message.date, Media.message_id, Media.id) before use. ``Media.id`` alone sorts
+        lexically, so rows sharing a timestamp came back as 9, 99, 98, ..., 8, 89 —
+        numerically meaningless; ``Media.message_id`` is an integer and orders correctly.
+
+        The ORDER BY and the cursor predicate MUST stay the same triple: that identity
+        is what guarantees a full walk yields every row exactly once (no skips, no
+        duplicates). Change one and you must change the other.
+
+        The cursor resolution is scoped to ``chat_id``. Unscoped, a caller could pass
+        ANOTHER chat's media id and have that row's timestamp shape this chat's result
+        window — a cross-chat existence/timestamp oracle for a chat the caller cannot
+        read. A token that does not belong to ``chat_id`` is indistinguishable from a
+        deleted one and returns an EMPTY page (never a full first page), so neither the
+        existence nor the date of a foreign row can be inferred from the response.
         """
         async with self.db_manager.async_session_factory() as session:
             stmt = (
@@ -1230,26 +1280,35 @@ class DatabaseAdapter:
 
             if before_id:
                 cursor_stmt = (
-                    select(Media.id, Message.date)
+                    select(Media.id, Media.message_id, Message.date)
                     .join(
                         Message,
                         and_(Media.message_id == Message.id, Media.chat_id == Message.chat_id),
                     )
-                    .where(Media.id == before_id)
+                    .where(and_(Media.id == before_id, Media.chat_id == chat_id))
                 )
                 cursor_result = await session.execute(cursor_stmt)
                 cursor_row = cursor_result.one_or_none()
                 if cursor_row is None:
                     return {"items": [], "has_more": False}
-                cursor_media_id, cursor_date = cursor_row
+                cursor_media_id, cursor_message_id, cursor_date = cursor_row
                 stmt = stmt.where(
                     or_(
                         Message.date < cursor_date,
-                        and_(Message.date == cursor_date, Media.id < cursor_media_id),
+                        and_(
+                            Message.date == cursor_date,
+                            or_(
+                                Media.message_id < cursor_message_id,
+                                and_(
+                                    Media.message_id == cursor_message_id,
+                                    Media.id < cursor_media_id,
+                                ),
+                            ),
+                        ),
                     )
                 )
 
-            stmt = stmt.order_by(Message.date.desc(), Media.id.desc())
+            stmt = stmt.order_by(Message.date.desc(), Media.message_id.desc(), Media.id.desc())
             stmt = stmt.limit(limit + 1)
             result = await session.execute(stmt)
             rows = result.all()

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from functools import wraps
 from typing import Any
 
-from sqlalchemy import and_, case, delete, exists, func, literal, or_, select, text, union_all, update
+from sqlalchemy import and_, delete, exists, func, literal, or_, select, text, union_all, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
@@ -1121,7 +1121,15 @@ class DatabaseAdapter:
 
     @retry_on_locked()
     async def insert_media(self, media_data: dict[str, Any]) -> None:
-        """Insert a media file record."""
+        """Insert (or upsert) a media file record.
+
+        Contract for the ``downloaded`` key: include it whenever the caller
+        actually observed the download outcome (True after a successful write,
+        False after a skip/failure it is willing to have retried), and OMIT it
+        when the caller cannot know whether a file is on disk. An omitted key
+        means "leave the stored flag alone" on conflict and 0 on a fresh insert —
+        see the comment on the conflict clause below.
+        """
         async with self.db_manager.async_session_factory() as session:
             values = {
                 "id": media_data["id"],
@@ -1153,8 +1161,8 @@ class DatabaseAdapter:
             #     download_date of a file that is still on disk.
             # COALESCE only falls back on NULL, so a real value still overwrites a
             # real value: a re-download to a new path DOES update file_path.
-            # The one deliberate clear path is ``mark_media_for_redownload`` — a
-            # separate UPDATE — so nothing needs insert_media to null these.
+            # (``mark_media_for_redownload`` is a separate UPDATE that clears these
+            # deliberately; it currently has no production caller, only tests.)
             update_values = dict(values)
             for column in (
                 "file_name",
@@ -1169,17 +1177,26 @@ class DatabaseAdapter:
             ):
                 update_values[column] = func.coalesce(getattr(stmt.excluded, column), getattr(Media, column))
             # ``downloaded`` is a flag, not a value: 0 is a real value, so COALESCE
-            # cannot protect it. It is sticky instead — once a file is on disk (and
-            # the COALESCEs above keep its path), a later failed attempt must not
-            # report it as missing. Staying 1 hides nothing: a file that really is
-            # gone is re-found by verify_and_repair_media, which stats the disk for
-            # every ``downloaded=1 OR file_path IS NOT NULL`` row. The old null-out
-            # was what hid it — it dropped the row out of that scan, and for the
-            # over-size skip (whose file_size is a real, over-limit number) out of
-            # the pending-download retry too, leaving the file orphaned on disk.
-            # Written as a CASE because two-argument max()/GREATEST is not portable
-            # across SQLite and PostgreSQL (PostgreSQL's max() is an aggregate).
-            update_values["downloaded"] = case((stmt.excluded.downloaded == 1, 1), else_=Media.downloaded)
+            # cannot express "this writer has no opinion" for it. The KEY'S PRESENCE
+            # in ``media_data`` does instead:
+            #   - present -> the writer observed the outcome, so write it. A failed
+            #     download therefore sets 0 again and the row returns to
+            #     ``get_pending_media_downloads``, which ``_retry_pending_media_downloads``
+            #     drains on EVERY backup cycle. That is the only always-on recovery
+            #     path: ``TelegramBackup._verify_and_redownload_media`` (the disk-stat
+            #     scan) runs only when VERIFY_MEDIA is on, and it defaults to false.
+            #     Pinning the flag at 1 stranded such a row forever, pointing at a
+            #     file that is gone.
+            #   - absent -> the writer knows nothing about what is on disk, so keep
+            #     the stored flag. ``_process_media``'s over-size skip is the one
+            #     such writer: the file may already be on disk from a run with a
+            #     higher MAX_MEDIA_SIZE, and flipping it to 0 would hide it from the
+            #     gallery (``get_media_paginated`` filters ``downloaded == 1``)
+            #     without ever retrying it (``get_pending_media_downloads`` excludes
+            #     its over-limit file_size).
+            # A fresh INSERT still lands 0 for an absent key — nothing is downloaded.
+            if "downloaded" not in media_data:
+                update_values["downloaded"] = Media.downloaded
             stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=update_values)
 
             await session.execute(stmt)

--- a/src/listener.py
+++ b/src/listener.py
@@ -41,6 +41,7 @@ from .message_utils import (
     build_media_filename,
     compute_file_hash,
     download_and_shard_media,
+    extract_media_attributes,
     extract_reactions,
     extract_topic_id,
     fallback_media_filename,
@@ -1101,33 +1102,39 @@ class TelegramListener:
                                 media_path, media_file_name, content_hash = download_result
                                 # Create media record (FK to messages now satisfied)
                                 media_id = f"{chat_id}_{message.id}_{media_type}"
-                                await self.db.insert_media(
-                                    {
-                                        "id": media_id,
-                                        "message_id": message.id,
-                                        "chat_id": chat_id,
-                                        "type": media_type,
-                                        "file_path": media_path,
-                                        "file_name": media_file_name,
-                                        "content_hash": content_hash,
-                                        "downloaded": True,
-                                        "download_date": utcnow_naive(),
-                                    }
-                                )
+                                # Same metadata the scheduled sweep records (#263) — without it
+                                # live-captured voice notes had a NULL duration and rendered
+                                # without it while sweep-captured ones showed it.
+                                media_attributes = extract_media_attributes(message.media)
+                                try:
+                                    media_attributes["file_size"] = os.path.getsize(media_path)
+                                except OSError:
+                                    pass  # Keep Telegram's reported size when the path isn't stat-able
+                                media_row = {
+                                    "id": media_id,
+                                    "message_id": message.id,
+                                    "chat_id": chat_id,
+                                    "type": media_type,
+                                    "file_path": media_path,
+                                    "file_name": media_file_name,
+                                    "content_hash": content_hash,
+                                    "downloaded": True,
+                                    "download_date": utcnow_naive(),
+                                    **media_attributes,
+                                }
+                                await self.db.insert_media(media_row)
                                 logger.debug("📎 Downloaded media")
-                                # Mirror the DB row: insert_media leaves file_size/mime_type/width/
-                                # height/duration as None in this path (not passed above), so the
-                                # WS row matches what the next poll will return.
+                                # Mirror the DB row so the WS row matches what the next poll returns.
                                 ws_media = {
                                     "id": media_id,
                                     "type": media_type,
                                     "file_path": media_path,
                                     "file_name": media_file_name,
-                                    "file_size": None,
-                                    "mime_type": None,
-                                    "width": None,
-                                    "height": None,
-                                    "duration": None,
+                                    "file_size": media_row["file_size"],
+                                    "mime_type": media_row["mime_type"],
+                                    "width": media_row["width"],
+                                    "height": media_row["height"],
+                                    "duration": media_row["duration"],
                                 }
                         except Exception as e:
                             logger.warning(f"Failed to download media for message {message.id}: {e}")

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -458,6 +458,16 @@ def extract_media_attributes(media: object) -> dict[str, Any]:
     are what produced the bug: live-captured voice notes rendered without their
     duration while the same note captured by the sweep showed it.
 
+    THE RETURNED KEY SET IS A CONTRACT: exactly ``file_size``, ``mime_type``,
+    ``width``, ``height``, ``duration`` — every key always present, value ``None``
+    when unknown. Both callers spread it into a ``media`` row and then OVERRIDE
+    ``file_size`` with the on-disk byte count (the sweep re-assigns it after the
+    spread, the listener mutates the dict before spreading); the other four are
+    taken as returned. Adding or renaming a key here silently changes what those
+    rows write, so ``TestExtractMediaAttributes`` pins the key set — extend both
+    callers and that test together. ``file_size`` is Telegram's DECLARED size and
+    is the value that survives only when no file was written.
+
     ``mime_type`` is read off ``media.document`` (the ``MessageMediaDocument``
     wrapper itself has no ``mime_type``; the sweep's old ``getattr(media, ...)``
     read therefore always yielded ``None``). Photo dimensions and ``file_size``
@@ -516,7 +526,7 @@ def extract_media_attributes(media: object) -> dict[str, Any]:
 _MEDIA_STORAGE_PREFIX_RE = re.compile(r"^(?:import_-?[0-9]+_[0-9]+_|[0-9]+_)")
 
 
-def media_display_filename(stored_name: str, media_id: str | None = None) -> str:
+def media_display_filename(stored_name: str) -> str:
     """Turn a stored media basename back into the name the user recognises.
 
     Media is stored under a uniqueness-prefixed name (``<file_id>_holiday.jpg``),
@@ -525,13 +535,14 @@ def media_display_filename(stored_name: str, media_id: str | None = None) -> str
     the prefix (``getMediaDisplayName`` in index.html); this is the server-side
     twin so a forced download saves ``holiday.jpg`` rather than the storage name.
 
-    Produces the same name the viewer shows, in the same two steps: strip
-    ``<media_id>_`` when the caller knows the media id, then strip one leading run
-    of digits followed by ``_``. The extra ``import_<chat>_<msg>_`` alternation
-    stands in for the media id when the caller has none — the viewer always holds
-    ``media.id`` and removes that prefix with it, while ``serve_media`` only has a
-    URL path, so without the alternation an imported file would save as
-    ``import_-1001_5_report.pdf`` while the gallery labels it ``report.pdf``.
+    Takes only the basename, because the only caller (``serve_media``) only has a
+    URL path — it never holds ``Media.id``. That is why the pattern carries an
+    explicit ``import_<chat>_<msg>_`` alternation: the viewer strips that prefix
+    using the media id it already has, and without the alternation an imported
+    file would save as ``import_-1001_5_report.pdf`` while the gallery labels it
+    ``report.pdf``. Every prefix any ingest path actually writes is covered —
+    ``build_media_filename`` emits ``<file_id>_`` and the importer emits
+    ``import_<chat>_<msg>_``.
 
     At most one prefix is removed, so ``77_2026_report.pdf`` keeps the second one
     and yields ``2026_report.pdf``. A name whose ORIGINAL first component is
@@ -541,12 +552,7 @@ def media_display_filename(stored_name: str, media_id: str | None = None) -> str
     is the point of this function. Returns ``stored_name`` unchanged when nothing
     matches or stripping would leave an empty name.
     """
-    name = stored_name
-    if media_id:
-        prefix = f"{media_id}_"
-        if name.startswith(prefix):
-            name = name[len(prefix) :]
-    name = _MEDIA_STORAGE_PREFIX_RE.sub("", name, count=1)
+    name = _MEDIA_STORAGE_PREFIX_RE.sub("", stored_name, count=1)
     return name or stored_name
 
 

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -9,6 +9,7 @@ import os
 import re
 import stat
 from datetime import UTC, datetime
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -424,6 +425,129 @@ async def download_and_shard_media(
             shutil.move(shared_file_path, file_path)
 
     return shared_file_path, content_hash
+
+
+def _photo_size_bytes(size: object) -> int:
+    """Byte count of a Telethon ``PhotoSize`` variant, 0 when it carries none.
+
+    ``PhotoSize`` exposes a scalar ``size``; ``PhotoSizeProgressive`` exposes NO
+    ``size`` at all, only ``sizes`` — the list of progressive byte offsets whose
+    last/largest entry is the full rendition. Scoring the progressive variant as 0
+    made it lose every comparison, so the largest rendition (the one Telegram
+    actually delivers for big photos) was never selected and its ``w``/``h`` were
+    read off a smaller thumbnail instead.
+    """
+    value = getattr(size, "size", None)
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value
+    progressive = getattr(size, "sizes", None)
+    if isinstance(progressive, (list, tuple)):
+        candidates = [v for v in progressive if isinstance(v, int) and not isinstance(v, bool)]
+        if candidates:
+            return max(candidates)
+    return 0
+
+
+def extract_media_attributes(media: object) -> dict[str, Any]:
+    """Extract size/mime/dimension/duration metadata from a Telegram media object.
+
+    THE single extractor for these five columns: both the scheduled sweep
+    (``TelegramBackup._process_media``) and the realtime listener call it, so a
+    sweep that re-upserts a message the listener already stored writes back the
+    SAME values instead of nulling them (#263). Two divergent copies of this logic
+    are what produced the bug: live-captured voice notes rendered without their
+    duration while the same note captured by the sweep showed it.
+
+    ``mime_type`` is read off ``media.document`` (the ``MessageMediaDocument``
+    wrapper itself has no ``mime_type``; the sweep's old ``getattr(media, ...)``
+    read therefore always yielded ``None``). Photo dimensions and ``file_size``
+    come from the largest ``PhotoSize`` (the ``Photo`` object itself carries no
+    ``w``/``h``), sized via ``_photo_size_bytes`` so progressive renditions count.
+
+    ``duration`` is coerced to ``int``: Telethon reports video durations as a
+    float while the ``media.duration`` column is INTEGER. Rounding (not
+    truncation) is used because that is what PostgreSQL's implicit float->int
+    assignment cast did to the raw floats the sweep has always passed, so newly
+    written rows stay consistent with the historical ones.
+    """
+    attributes: dict[str, Any] = {
+        "file_size": None,
+        "mime_type": None,
+        "width": None,
+        "height": None,
+        "duration": None,
+    }
+
+    document = getattr(media, "document", None)
+    photo = getattr(media, "photo", None)
+
+    if document is not None:
+        attributes["file_size"] = getattr(document, "size", None)
+        attributes["mime_type"] = getattr(document, "mime_type", None)
+        for attr in getattr(document, "attributes", None) or ():
+            if hasattr(attr, "w") and hasattr(attr, "h"):
+                attributes["width"] = attr.w
+                attributes["height"] = attr.h
+            if hasattr(attr, "duration"):
+                attributes["duration"] = attr.duration
+    elif photo is not None:
+        sizes = getattr(photo, "sizes", None) or ()
+        largest = max(sizes, key=_photo_size_bytes, default=None)
+        if largest is not None:
+            attributes["file_size"] = _photo_size_bytes(largest) or None
+            attributes["width"] = getattr(largest, "w", None)
+            attributes["height"] = getattr(largest, "h", None)
+
+    duration = attributes["duration"]
+    if isinstance(duration, float):
+        attributes["duration"] = round(duration)
+
+    return attributes
+
+
+# Storage-name prefixes added by the ingest paths, stripped back off for display
+# and for the download filename. ``<file_id>_`` comes from ``build_media_filename``
+# (Telegram download) and ``import_<chat>_<msg>_`` from the Telegram Desktop
+# importer's media id. Anchored and applied at most once, so only the FIRST
+# component can ever be lost: ``77_2026_report.pdf`` -> ``2026_report.pdf``.
+# ``[0-9]`` rather than ``\d``: Python's ``\d`` also matches non-ASCII decimal
+# digits, which the viewer's ``/^[0-9]+_/`` does not — and this function exists to
+# produce exactly the name the viewer shows.
+_MEDIA_STORAGE_PREFIX_RE = re.compile(r"^(?:import_-?[0-9]+_[0-9]+_|[0-9]+_)")
+
+
+def media_display_filename(stored_name: str, media_id: str | None = None) -> str:
+    """Turn a stored media basename back into the name the user recognises.
+
+    Media is stored under a uniqueness-prefixed name (``<file_id>_holiday.jpg``),
+    which is what ``Media.file_name`` holds too — it is the basename of
+    ``Media.file_path``, not the original document name. The viewer already hides
+    the prefix (``getMediaDisplayName`` in index.html); this is the server-side
+    twin so a forced download saves ``holiday.jpg`` rather than the storage name.
+
+    Produces the same name the viewer shows, in the same two steps: strip
+    ``<media_id>_`` when the caller knows the media id, then strip one leading run
+    of digits followed by ``_``. The extra ``import_<chat>_<msg>_`` alternation
+    stands in for the media id when the caller has none — the viewer always holds
+    ``media.id`` and removes that prefix with it, while ``serve_media`` only has a
+    URL path, so without the alternation an imported file would save as
+    ``import_-1001_5_report.pdf`` while the gallery labels it ``report.pdf``.
+
+    At most one prefix is removed, so ``77_2026_report.pdf`` keeps the second one
+    and yields ``2026_report.pdf``. A name whose ORIGINAL first component is
+    digits (``2026_report.pdf``) is indistinguishable from a prefixed one and does
+    lose it (-> ``report.pdf``); the viewer's unconditional
+    ``name.replace(/^[0-9]+_/, '')`` does the same, and matching the visible label
+    is the point of this function. Returns ``stored_name`` unchanged when nothing
+    matches or stripping would leave an empty name.
+    """
+    name = stored_name
+    if media_id:
+        prefix = f"{media_id}_"
+        if name.startswith(prefix):
+            name = name[len(prefix) :]
+    name = _MEDIA_STORAGE_PREFIX_RE.sub("", name, count=1)
+    return name or stored_name
 
 
 def extract_topic_id(message: object) -> int | None:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -2788,13 +2788,20 @@ class TelegramBackup:
 
         if file_size > max_size:
             logger.debug(f"Skipping large media file: {file_size / 1024 / 1024:.2f} MB")
+            # No ``downloaded`` key on purpose: nothing was attempted, so this row
+            # knows nothing about what is on disk. Per insert_media's contract an
+            # omitted key means "keep the stored flag" (0 on a fresh insert), which
+            # stops a lowered MAX_MEDIA_SIZE from marking an already-downloaded file
+            # as missing — it would vanish from the gallery and never be retried,
+            # since the over-limit file_size below excludes it from
+            # get_pending_media_downloads. Callers that test the outcome use
+            # ``.get("downloaded")``, so an absent key still reads as "not downloaded".
             return {
                 "id": media_id,
                 "type": media_type,
                 "message_id": message.id,
                 "chat_id": chat_id,
                 "file_size": file_size,
-                "downloaded": False,
             }
 
         # Download media (with optional global deduplication)

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -54,6 +54,7 @@ from .message_utils import (
     build_media_filename,
     compute_file_hash,
     download_and_shard_media,
+    extract_media_attributes,
     extract_reactions,
     extract_topic_id,
     fallback_media_filename,
@@ -2859,7 +2860,11 @@ class TelegramBackup:
                     file_size = os.path.getsize(file_path)
                     content_hash = compute_file_hash(file_path)
 
-            # Extract media metadata
+            # Extract media metadata via the SHARED extractor (#263). The listener
+            # writes the same columns from the same helper, so this sweep's upsert
+            # re-writes identical values instead of nulling what live capture stored.
+            # ``file_size`` is overridden afterwards because only the sweep knows the
+            # real on-disk size (the helper reports Telegram's declared size).
             media_data = {
                 "id": media_id,
                 "type": media_type,
@@ -2867,26 +2872,12 @@ class TelegramBackup:
                 "chat_id": chat_id,
                 "file_name": file_name,
                 "file_path": file_path,
-                "file_size": file_size,
-                "mime_type": getattr(media, "mime_type", None),
                 "content_hash": content_hash,
                 "downloaded": True,
                 "download_date": utcnow_naive(),
+                **extract_media_attributes(media),
+                "file_size": file_size,
             }
-
-            # Add type-specific metadata
-            if hasattr(media, "photo"):
-                photo = media.photo
-                media_data["width"] = getattr(photo, "w", None)
-                media_data["height"] = getattr(photo, "h", None)
-            elif hasattr(media, "document"):
-                doc = media.document
-                for attr in doc.attributes:
-                    if hasattr(attr, "w") and hasattr(attr, "h"):
-                        media_data["width"] = attr.w
-                        media_data["height"] = attr.h
-                    if hasattr(attr, "duration"):
-                        media_data["duration"] = attr.duration
 
             # Pre-generate thumbnail for instant gallery loading
             try:

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1453,6 +1453,18 @@ def _encode_media_path(path: str) -> str:
     request never reaches /media/{path:path} (#258). Encoding per segment (rather
     than the whole string) keeps the folder/filename structure routable; Starlette
     decodes the path before the traversal guard in serve_media sees it.
+
+    Applied to avatar paths too, even though ``_find_avatar_path`` builds them
+    from ``{chat_id}_{photo_id}.jpg`` and cannot itself produce a reserved
+    character: the name is whatever the glob found on disk, so encoding keeps a
+    single rule for everything served under /media/ rather than two.
+
+    The viewer builds the same URLs client-side with ``encodeURIComponent`` per
+    segment. The two agree on every character that matters here (both encode
+    "#", "?", "/" and space) and differ only on ``!*'()``, which ``quote`` escapes
+    and ``encodeURIComponent`` leaves literal — both spellings decode to the same
+    path server-side, so they resolve to the same file and differ only as cache
+    keys.
     """
     return "/".join(quote(segment, safe="") for segment in path.split("/"))
 
@@ -1763,10 +1775,13 @@ async def get_chat_media(
 
             parts = file_path.split("/", 1)
             if len(parts) == 2:
-                folder, filename = parts
+                # The split only gates on "has a folder component" and reads the
+                # extension; the URL below re-uses ``file_path`` itself, which is
+                # exactly ``folder/filename``.
+                filename = parts[1]
                 ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
                 if ext in THUMBNAIL_EXTENSIONS:
-                    item["thumb_url"] = f"/media/thumb/200/{_encode_media_path(f'{folder}/{filename}')}"
+                    item["thumb_url"] = f"/media/thumb/200/{_encode_media_path(file_path)}"
                 else:
                     item["thumb_url"] = None
             else:

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -31,6 +31,7 @@ from sqlalchemy.exc import DBAPIError, OperationalError
 
 from ..config import Config
 from ..db import DatabaseAdapter, close_database, get_db_manager, init_database
+from ..message_utils import media_display_filename
 from ..realtime import RealtimeListener
 from .media_utils import THUMBNAIL_EXTENSIONS, legacy_folder_alternates, legacy_marked_chat_ids
 
@@ -1045,7 +1046,23 @@ async def serve_media(path: str, download: int = Query(0), user: UserContext = D
     # the FileResponse(resolved) call is unchanged; the containment check above
     # (reject ../absolute, resolve strict, is_relative_to media root) is the
     # actual path-traversal protection.
-    response = FileResponse(resolved)
+    # ?download=1 forces a save instead of inline rendering. The saved name is the
+    # DISPLAY name, not the storage name: on disk every file carries a uniqueness
+    # prefix (``<file_id>_holiday.jpg``), and Media.file_name holds that same
+    # prefixed basename, so a download otherwise landed as ``12345678_holiday.jpg``
+    # while the gallery labelled it ``holiday.jpg``. media_display_filename is the
+    # server-side twin of the viewer's getMediaDisplayName, so the saved name and
+    # the gallery label agree. The viewer's download anchor also carries a
+    # ``download="<display name>"`` attribute, but per the HTML download algorithm a
+    # Content-Disposition: attachment filename takes precedence over it, so THIS
+    # name is the one the browser writes.
+    # The filename is attacker-influenced (it is the Telegram document name), but
+    # Starlette percent-quotes it and falls back to RFC 5987 whenever quoting
+    # changes the string — every header-dangerous byte (CR, LF, ", ;, space) is
+    # escaped by that quote(), so only unreserved chars and "/" survive verbatim.
+    # Default (no download param) stays inline: <img>/<video> use the same URL.
+    download_name = media_display_filename(path.rsplit("/", 1)[-1]) if download else None
+    response = FileResponse(resolved, filename=download_name or None)
     if path.startswith("avatars/"):
         response.headers["Cache-Control"] = "public, max-age=86400"
     return response
@@ -1415,6 +1432,18 @@ _avatar_member_cache_time: datetime | None = None
 AVATAR_MEMBER_CACHE_TTL_SECONDS = 300  # 5 minutes
 
 
+def _encode_media_path(path: str) -> str:
+    """Percent-encode each segment of a media path, keeping "/" separators intact.
+
+    Media filenames come from Telegram document names, so they can contain "#"
+    or "?" — unencoded, those truncate the URL into a fragment/query and the
+    request never reaches /media/{path:path} (#258). Encoding per segment (rather
+    than the whole string) keeps the folder/filename structure routable; Starlette
+    decodes the path before the traversal guard in serve_media sees it.
+    """
+    return "/".join(quote(segment, safe="") for segment in path.split("/"))
+
+
 def _get_cached_avatar_path(chat_id: int, chat_type: str) -> str | None:
     """Get avatar path with caching."""
     global _avatar_cache, _avatar_cache_time
@@ -1454,7 +1483,7 @@ def _sender_avatar_url(sender_id: int | None) -> str | None:
     if not sender_id or sender_id <= 0:
         return None
     avatar_path = _get_cached_avatar_path(sender_id, "private")
-    return f"/media/{avatar_path}" if avatar_path else None
+    return f"/media/{_encode_media_path(avatar_path)}" if avatar_path else None
 
 
 async def _avatar_user_visible_member(path: str, user: UserContext) -> bool:
@@ -1548,7 +1577,7 @@ async def get_chats(
             try:
                 avatar_path = _get_cached_avatar_path(chat["id"], chat.get("type", "private"))
                 if avatar_path:
-                    chat["avatar_url"] = f"/media/{avatar_path}"
+                    chat["avatar_url"] = f"/media/{_encode_media_path(avatar_path)}"
                 else:
                     chat["avatar_url"] = None
             except Exception as e:
@@ -1724,7 +1753,7 @@ async def get_chat_media(
                 folder, filename = parts
                 ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
                 if ext in THUMBNAIL_EXTENSIONS:
-                    item["thumb_url"] = f"/media/thumb/200/{folder}/{filename}"
+                    item["thumb_url"] = f"/media/thumb/200/{_encode_media_path(f'{folder}/{filename}')}"
                 else:
                     item["thumb_url"] = None
             else:
@@ -1733,7 +1762,7 @@ async def get_chat_media(
             if user.no_download:
                 item.pop("file_path", None)
             else:
-                item["media_url"] = f"/media/{file_path}"
+                item["media_url"] = f"/media/{_encode_media_path(file_path)}"
 
         return result
     except Exception as e:

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1056,13 +1056,26 @@ async def serve_media(path: str, download: int = Query(0), user: UserContext = D
     # ``download="<display name>"`` attribute, but per the HTML download algorithm a
     # Content-Disposition: attachment filename takes precedence over it, so THIS
     # name is the one the browser writes.
-    # The filename is attacker-influenced (it is the Telegram document name), but
-    # Starlette percent-quotes it and falls back to RFC 5987 whenever quoting
-    # changes the string — every header-dangerous byte (CR, LF, ", ;, space) is
-    # escaped by that quote(), so only unreserved chars and "/" survive verbatim.
+    # The filename is attacker-influenced (it is the Telegram document name), so it
+    # is percent-quoted and falls back to RFC 5987 whenever quoting changes the
+    # string — every header-dangerous byte (CR, LF, ", ;, space) is escaped by that
+    # quote(), so only unreserved characters survive verbatim. This mirrors
+    # Starlette's own FileResponse header construction; it is written out here
+    # rather than passed as filename= so the FileResponse call keeps the plain
+    # FileResponse(resolved) shape. Passing a user-derived filename= makes CodeQL
+    # model the call as a filesystem sink and raise py/path-injection on
+    # `resolved`, which is a false positive: containment is already enforced above
+    # (reject ../absolute, resolve(strict=True), is_relative_to(_media_root)).
     # Default (no download param) stays inline: <img>/<video> use the same URL.
-    download_name = media_display_filename(path.rsplit("/", 1)[-1]) if download else None
-    response = FileResponse(resolved, filename=download_name or None)
+    response = FileResponse(resolved)
+    if download:
+        download_name = media_display_filename(path.rsplit("/", 1)[-1])
+        quoted = quote(download_name)
+        response.headers["Content-Disposition"] = (
+            f"attachment; filename*=utf-8''{quoted}"
+            if quoted != download_name
+            else f'attachment; filename="{download_name}"'
+        )
     if path.startswith("avatars/"):
         response.headers["Cache-Control"] = "public, max-age=86400"
     return response

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -6441,10 +6441,6 @@
                     linkifyText,
                     // Global audio player (#250)
                     audioTrack,
-                    // The queue itself is exposed so the #257 hole guard is OBSERVABLE
-                    // from outside: adopting a paged walk replaces it, refusing one
-                    // leaves the seeded window untouched. No debug-only hook.
-                    audioQueue,
                     audioIsPlaying,
                     audioCurrentTime,
                     audioDuration,

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1199,13 +1199,29 @@
                         <template v-for="(msg, index) in sortedMessages" :key="msg.id">
                             <!-- Service Message (chat actions like photo changed, user joined, etc) -->
                             <!-- v6.0.0: Service type moved to raw_data.service_type -->
+                            <!-- #259: msg.text is empty on rows captured before 7.28.0, so the
+                                 wording is rebuilt from raw_data at render time.
+                                 #260: rendered from structured parts (actor + tail) so the
+                                 actor can be a real button — never by parsing the sentence. -->
                             <div v-if="msg.raw_data?.service_type === 'service'" :data-msg-id="msg.id" class="flex justify-center my-2">
-                                <div class="service-message px-4 py-1.5 rounded-full text-xs text-center max-w-[80%]"
-                                    style="background: rgba(0,0,0,0.3); color: rgba(255,255,255,0.8);">
-                                    {{ msg.text }}
-                                </div>
+                                <template v-for="view in [serviceMessageView(msg)]" :key="msg.id">
+                                    <div v-if="view.tail || view.actor"
+                                        class="service-message px-4 py-1.5 rounded-full text-xs text-center max-w-[80%]"
+                                        style="background: rgba(0,0,0,0.3); color: rgba(255,255,255,0.8);">
+                                        <button v-if="view.clickable" type="button"
+                                            @click="openSenderInfo(msg, $event)"
+                                            :aria-label="`Show sender details for ${view.actor}`"
+                                            class="font-semibold hover:underline hover:text-white focus:outline-none focus:ring-2 focus:ring-blue-400 rounded">{{ view.actor }}</button><span v-else-if="view.actor" class="font-semibold">{{ view.actor }}</span>{{ view.tail }}
+                                    </div>
+                                </template>
                             </div>
-                            <!-- Regular Message (hide duplicate album messages - only show first in group) -->
+                            <!-- Regular Message. Album duplicates are the ONLY rows this branch
+                                 drops; every other non-service row renders, even when it carries
+                                 no text and no media. That is the DEFAULT shape of a caption-less
+                                 voice note or sticker (LISTEN_NEW_MESSAGES_MEDIA /
+                                 DOWNLOAD_MEDIA off), and hiding it would lose the row and its
+                                 :data-msg-id anchor. Emptiness is a SERVICE-ONLY concern and is
+                                 decided by the service branch above; see isRenderedMessageRow. -->
                             <div v-else-if="!isHiddenAlbumMessage(msg, index)" :data-msg-id="msg.id"
                                 class="flex items-end gap-2"
                                 :class="[isOwnMessage(msg) ? 'justify-end' : 'justify-start', isSenderBreak(index) ? 'message-run-break' : 'message-run-continue']">
@@ -1372,6 +1388,23 @@
                                                         <span v-else-if="noDownload">Playback disabled</span>
                                                     </div>
                                                 </div>
+                                                <!-- #261: per-message download. Deliberately here on the
+                                                     bubble and NOT inside the playbar's sm-only speed
+                                                     group, which is hidden below the sm breakpoint —
+                                                     i.e. on mobile, where it matters most. ?download=1
+                                                     makes the server send Content-Disposition with the
+                                                     clean original filename. -->
+                                                <a v-if="!noDownload && getMediaUrl(msg)"
+                                                    :href="getMediaUrl(msg) + '?download=1'"
+                                                    :download="getDocumentDisplayName(msg)"
+                                                    @click.stop
+                                                    :aria-label="'Download ' + getDocumentDisplayName(msg)"
+                                                    class="w-9 h-9 shrink-0 rounded-full flex items-center justify-center text-gray-300 hover:text-white hover:bg-white/10 transition focus:outline-none focus:ring-2 focus:ring-blue-400">
+                                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                            d="M12 4v12m0 0l-4-4m4 4l4-4M4 20h16"></path>
+                                                    </svg>
+                                                </a>
                                             </div>
                                         </div>
 
@@ -1488,7 +1521,7 @@
                             <!-- Date Separator - rendered AFTER message for flex-col-reverse (appears ABOVE visually).
                                  data-date-* feed the floating day pill (#249): the pill observes these
                                  markers and reads the day of whichever one is topmost in the viewport. -->
-                            <div v-if="showDateSeparator(index) && !isHiddenAlbumMessage(msg, index)" class="date-separator"
+                            <div v-if="showDateSeparator(index)" class="date-separator"
                                 :data-date-label="formatDateFull(msg.date)" :data-date-iso="msg.date">
                                 <button type="button" @click="openDatePicker(msg.date)"
                                     :aria-label="`Open date picker for ${formatDateFull(msg.date)}`">
@@ -1981,7 +2014,7 @@
                         class="block w-full text-left truncate rounded px-1 hover:bg-white/10 transition focus:outline-none focus:ring-2 focus:ring-blue-400">
                         <span class="text-sm text-white">{{ audioTrack.sender }}</span>
                         <span class="text-[11px] text-tg-muted ml-2">
-                            {{ audioTrack.chatName }}<template v-if="audioTrack.date"> · {{ formatTime(audioTrack.date) }}</template>
+                            {{ audioTrack.chatName }}<template v-if="audioTrack.date"> · {{ formatShortDate(audioTrack.date) }} {{ formatTime(audioTrack.date) }}</template>
                         </span>
                     </button>
                     <div class="flex items-center gap-2 mt-0.5">
@@ -4445,6 +4478,135 @@
                     return !!msg.sender_name && !!currentName && currentName !== msg.sender_name
                 }
 
+                // ---------------------------------------------------------------
+                // Service message wording (#259)
+                //
+                // Rows captured before 7.28.0 stored service events with text='' and
+                // only raw_data.action_type, so the pill rendered as an EMPTY capsule.
+                // This is a render-time fallback (no migration): the wording mirrors
+                // message_utils.service_message_text exactly.
+                //
+                // The mapping is deliberately SPLIT IN TWO. For the actions below the
+                // row's sender IS the subject of the sentence, so naming them is
+                // correct and the name may be made clickable.
+                // ---------------------------------------------------------------
+                const SERVICE_PREDICATES = {
+                    chat_joined_by_link: 'joined the group via invite link',
+                    chat_joined_by_request: 'joined the group',
+                    chat_edit_photo: 'changed the group photo',
+                    chat_delete_photo: 'removed the group photo',
+                }
+
+                // Same group, but the predicate quotes raw_data.new_title.
+                const SERVICE_TITLE_PREDICATES = {
+                    chat_edit_title: 'changed the group name to',
+                    chat_create: 'created the group',
+                    channel_create: 'created the channel',
+                }
+
+                // For these two the subject is the AFFECTED user (added / removed), NOT
+                // the sender — the sender is the admin who performed the action. The
+                // affected user is never persisted (only service_type/action_type are),
+                // so naming the sender here would assert something false about who
+                // joined or left. Render the backend's own unknown-actor form instead;
+                // added-vs-joined and removed-vs-left are not stored either, so the
+                // default flags are the only honest choice.
+                const SERVICE_UNKNOWN_SUBJECT = {
+                    chat_add_user: 'Someone was added to the group',
+                    chat_delete_user: 'Someone was removed from the group',
+                }
+
+                const serviceRawData = (msg) => {
+                    // adapter.py substitutes {} for unparseable raw_data, but a string or
+                    // null must never throw during render either.
+                    const raw = msg?.raw_data
+                    return raw && typeof raw === 'object' ? raw : null
+                }
+
+                const serviceActionType = (msg) => {
+                    const type = serviceRawData(msg)?.action_type
+                    return typeof type === 'string' ? type : ''
+                }
+
+                // Object.hasOwn, never a bare lookup: an action_type of "constructor"
+                // would otherwise resolve against Object.prototype and render garbage.
+                const serviceActorIsSender = (msg) => {
+                    const action = serviceActionType(msg)
+                    return Object.hasOwn(SERVICE_PREDICATES, action)
+                        || Object.hasOwn(SERVICE_TITLE_PREDICATES, action)
+                }
+
+                const serviceMessagePredicate = (msg) => {
+                    const action = serviceActionType(msg)
+                    if (Object.hasOwn(SERVICE_UNKNOWN_SUBJECT, action)) return SERVICE_UNKNOWN_SUBJECT[action]
+                    if (Object.hasOwn(SERVICE_PREDICATES, action)) return SERVICE_PREDICATES[action]
+                    if (Object.hasOwn(SERVICE_TITLE_PREDICATES, action)) {
+                        const title = serviceRawData(msg)?.new_title
+                        return `${SERVICE_TITLE_PREDICATES[action]} "${typeof title === 'string' ? title : ''}"`
+                    }
+                    // Unmapped action: the backend returns None for these, so show nothing.
+                    return ''
+                }
+
+                // #260: the pill is rendered from STRUCTURED PARTS — an actor and a tail —
+                // so the actor can be a real <button>. A rendered sentence is never parsed
+                // for the name: a display name can contain the words around it.
+                const serviceMessageView = (msg) => {
+                    const stored = typeof msg?.text === 'string' ? msg.text.trim() : ''
+                    const clickable = serviceActorIsSender(msg) && msg?.sender_id != null
+                    if (stored) {
+                        // Materialised wording (post-7.28.0) wins: it was built at capture
+                        // time from facts the row no longer carries. Split the actor off
+                        // only on a literal PREFIX match — a prefix test, not a parser.
+                        const name = clickable ? getSenderName(msg) : ''
+                        if (name && stored.startsWith(name)) {
+                            return { actor: name, tail: stored.slice(name.length), clickable: true }
+                        }
+                        return { actor: '', tail: stored, clickable: false }
+                    }
+                    const predicate = serviceMessagePredicate(msg)
+                    if (!predicate) return { actor: '', tail: '', clickable: false }
+                    if (!serviceActorIsSender(msg)) return { actor: '', tail: predicate, clickable: false }
+                    // A channel service row carries no sender; the backend renders
+                    // "Someone" for a missing actor, so match it instead of inventing a
+                    // "Deleted Account" subject. It is not clickable — the popup would be
+                    // empty.
+                    const actor = msg?.sender_id != null ? getSenderName(msg) : 'Someone'
+                    return { actor, tail: ` ${predicate}`, clickable }
+                }
+
+                // Does this index paint anything at all? The two row branches and the
+                // day divider must agree on this, or a divider ends up heading a row
+                // that was never drawn.
+                //
+                // #259 DATA-HIDING GUARD: ONLY a service-shaped row can ever come out
+                // unpainted. A regular row that merely LOOKS empty is NOT empty data.
+                // media is null on perfectly good rows by DEFAULT configuration:
+                // LISTEN_NEW_MESSAGES_MEDIA is false (live rows carry "media": null)
+                // and DOWNLOAD_MEDIA / skip_media_chat_ids do the same, permanently,
+                // for the sweep. A caption-less voice note, sticker or photo therefore
+                // arrives with falsy text and null media all the time. Hiding it would
+                // drop the row AND its :data-msg-id anchor — findMessageElement,
+                // scrollToMessage, jumpToReply and focusAudioTrackMessage all resolve
+                // through that anchor — while unseenMessageCount still counted it, i.e.
+                // an unread badge for a message that renders nowhere.
+                const isRenderedMessageRow = (msg, index) => {
+                    if (!msg) return false
+                    if (serviceRawData(msg)?.service_type === 'service') {
+                        // Ask the SERVICE BRANCH'S OWN condition, never a proxy for it.
+                        // That branch paints on `view.tail || view.actor` and renders
+                        // NOTHING else — no media, no reply quote, no forward header, no
+                        // reactions, no poll. A service row carrying any of those but no
+                        // mapped wording still draws an empty pill, so none of them may
+                        // count as painted or the divider hangs on an invisible row.
+                        // (The container, and its :data-msg-id anchor, survive either way.)
+                        const view = serviceMessageView(msg)
+                        return !!(view.actor || view.tail)
+                    }
+                    // Album duplicates are the ONLY regular rows the template drops.
+                    return !isHiddenAlbumMessage(msg, index)
+                }
+
                 const handleSenderInfoKeydown = (event) => {
                     if (!senderInfoMessage.value) return
                     if (event.key === 'Escape') {
@@ -4592,16 +4754,24 @@
                     // With flex-col-reverse: separator rendered AFTER message appears ABOVE it visually
                     // Show separator when this is the last message of a day (next message is different day)
                     const currMsg = sortedMessages.value[index]
-                    const nextMsg = sortedMessages.value[index + 1]
+                    // Both neighbours are resolved through isRenderedMessageRow so the
+                    // divider always lands on the oldest row that is actually PAINTED.
+                    // Hanging it on a suppressed row leaves it orphaned with nothing
+                    // under it; simply dropping it there would delete the day header
+                    // for every remaining row of that day.
+                    if (!isRenderedMessageRow(currMsg, index)) return false
 
                     // Parse as UTC and convert to viewer timezone for correct date boundaries
                     const currDate = moment.utc(currMsg.date).tz(viewerTimezone.value).format('YYYY-MM-DD')
 
-                    // Last message (oldest) always gets a separator above it
-                    if (!nextMsg) return true
-
-                    const nextDate = moment.utc(nextMsg.date).tz(viewerTimezone.value).format('YYYY-MM-DD')
-                    return currDate !== nextDate
+                    for (let older = index + 1; older < sortedMessages.value.length; older++) {
+                        const olderMsg = sortedMessages.value[older]
+                        if (!isRenderedMessageRow(olderMsg, older)) continue
+                        const olderDate = moment.utc(olderMsg.date).tz(viewerTimezone.value).format('YYYY-MM-DD')
+                        return currDate !== olderDate
+                    }
+                    // Oldest painted message: it always gets a separator above it
+                    return true
                 }
 
                 const getChatName = (chat) => {
@@ -4727,6 +4897,15 @@
                 const formatTime = (dateStr) => {
                     // Parse as UTC (DB stores UTC) then convert to viewer timezone
                     return moment.utc(dateStr).tz(viewerTimezone.value).format('HH:mm')
+                }
+
+                const formatShortDate = (dateStr) => {
+                    if (!dateStr) return ''
+                    // #262: SAME reading as formatTime — moment.utc(...).tz(...). The
+                    // stored timestamp is naive UTC, and the native parsers read a naive
+                    // string as LOCAL time, which shows the wrong calendar day for
+                    // anything near midnight. 'll' is locale-aware (no US-only mm/dd/yy).
+                    return moment.utc(dateStr).tz(viewerTimezone.value).format('ll')
                 }
 
                 const formatMetadataTimestampTitle = (label, dateStr) => {
@@ -4918,7 +5097,11 @@
                     const parts = msg.media?.file_path.split(/[/\\]/)
                     const filename = parts.pop()
                     const folder = parts.pop()  // Get the folder from the path, not from chat_id
-                    return `/media/${folder}/${filename}`
+                    // #258: encode each SEGMENT on its own. A filename containing '#' or
+                    // '?' is otherwise cut by the browser (fragment / query) before the
+                    // request is even sent. Encoding the assembled path instead would
+                    // escape the '/' separators, so it must stay per-segment.
+                    return `/media/${encodeURIComponent(folder)}/${encodeURIComponent(filename)}`
                 }
 
                 const getMediaDisplayName = (media) => {
@@ -5244,8 +5427,11 @@
                     // be planted in defaultPlaybackRate BEFORE load() and re-applied on
                     // loadedmetadata — otherwise each new track silently drops to 1x.
                     audioEngine.defaultPlaybackRate = rate
+                    // #257: assigning src ALREADY invokes the media load algorithm
+                    // (preload='metadata'), so an explicit load() here aborts the fetch
+                    // it just started and re-invokes it — every track cost 2-3 requests
+                    // for the same file. The rate handling above/below is unchanged.
                     audioEngine.src = track.url
-                    audioEngine.load()
                     updateAudioMediaSessionMetadata()
                     startAudioPlayback()
                 }
@@ -5399,16 +5585,45 @@
                     const collected = []
                     let cursor = null
                     let hasOlder = false
+                    let foundPlaying = false
                     try {
                         for (let page = 0; page < AUDIO_QUEUE_MAX_PAGES; page++) {
                             const data = await fetchAudioQueuePage(track.chatId, track.kind, cursor)
                             const items = Array.isArray(data?.items) ? data.items : []
-                            if (!items.length) break
+                            if (!items.length) {
+                                // An empty page is NOT self-evidently "exhausted": it has
+                                // two causes and hasOlder must survive them differently.
+                                //
+                                // 1. FIRST page (cursor is still null, so no before_id was
+                                //    sent): the chat simply has no audio of this kind.
+                                //    Genuinely exhausted — nothing older to hole through.
+                                //    hasOlder is still its initial false, which is exactly
+                                //    what the guard below needs to adopt the walk.
+                                // 2. MID-WALK: control only reaches a second fetch because
+                                //    the PREVIOUS page reported has_more, so an empty page
+                                //    CONTRADICTS it. get_media_paginated also answers
+                                //    {items: [], has_more: false} for a before_id it cannot
+                                //    resolve (a foreign or since-deleted cursor row), so an
+                                //    empty page here is no proof the walk reached the end.
+                                //    hasOlder therefore stays true and the #257 guard below
+                                //    refuses a walk that may be non-contiguous, instead of
+                                //    adopting or truncating it.
+                                //
+                                // So hasOlder already holds the right answer in both cases
+                                // and must NOT be overwritten. What matters is that this
+                                // still BREAKS unconditionally: the loop terminates on every
+                                // path, so the infinite-walk risk stays closed.
+                                break
+                            }
                             collected.push(...items)
                             cursor = items[items.length - 1].id
                             hasOlder = !!data.has_more
                             // Found the playing track, or there is nothing older left.
-                            if (items.some(item => item.message_id === track.id) || !hasOlder) break
+                            if (items.some(item => item.message_id === track.id)) {
+                                foundPlaying = true
+                                break
+                            }
+                            if (!hasOlder) break
                         }
                     } catch (e) {
                         // A queue page that fails to load is NOT a playback failure: it
@@ -5422,6 +5637,27 @@
                     // these pages were in flight; those results belong to nobody now.
                     if (requestId !== audioQueueRequestId || !audioQueueBelongsToTrack(track)) return
                     if (!collected.length) return
+                    // #257: the walk is capped at AUDIO_QUEUE_MAX_PAGES. When more audio
+                    // is NEWER than the playing track than that cap allows, the loop ends
+                    // without ever reaching it, and `collected` (the newest block) plus
+                    // the seed window (around the playing track) are two DISJOINT blocks
+                    // with a chronological HOLE between them. Merging and date-sorting
+                    // them made "next" walk to the seed edge and then teleport days
+                    // ahead into the newest block. Only adopt the paged result when the
+                    // playing track was actually found, or when the walk exhausted the
+                    // chat (hasOlder false — then there is nothing to hole through).
+                    // Otherwise abandon THIS extension and leave the seeded window
+                    // queue exactly as it is, so the queue simply ENDS at the seed
+                    // edge: wrong-but-honest beats wrong-and-silent.
+                    //
+                    // Deliberately does NOT latch audioQueueHasOlder = false. That
+                    // disabled head-of-queue paging for the rest of the session even
+                    // though a later, correctly seeded walk could succeed. The
+                    // cursor / has-older pair keeps whatever the last CONTIGUOUS
+                    // result left (null / false for a freshly seeded queue, which
+                    // already ends it at the seed edge), and playAudioMessage and
+                    // closeAudioPlayer reset both on the next track or chat.
+                    if (!foundPlaying && hasOlder) return
                     audioQueueCursor = cursor
                     audioQueueHasOlder = hasOlder
                     audioQueue.value = mergeAudioQueue(audioTracksFromMediaItems(collected, track))
@@ -5581,6 +5817,15 @@
                         const chat = chats.value.find(c => c.id === track.chatId)
                         if (!chat) return
                         await selectChat(chat)
+                    }
+                    await nextTick()
+                    // #257: the queue reaches far past the loaded message window, so the
+                    // track's row is usually NOT in the DOM — scrollToMessage alone just
+                    // logged "Message not loaded yet" and did nothing. Mirror jumpToReply:
+                    // fetch the window around the message first, which scrolls to it.
+                    if (!findMessageElement(track.id)) {
+                        await loadMessagesAroundId(track.id)
+                        return
                     }
                     scrollToMessage(track.id)
                 }
@@ -6161,7 +6406,10 @@
                     formatDate,
                     formatDateFull,
                     formatTime,
+                    formatShortDate,
                     formatMetadataTimestampTitle,
+                    // Service messages (#259 / #260)
+                    serviceMessageView,
                     getMessageVersions,
                     isMessageVersionsLoading,
                     getMessageVersionsError,
@@ -6193,6 +6441,10 @@
                     linkifyText,
                     // Global audio player (#250)
                     audioTrack,
+                    // The queue itself is exposed so the #257 hole guard is OBSERVABLE
+                    // from outside: adopting a paged walk replaces it, refusing one
+                    // leaves the seeded window untouched. No debug-only hook.
+                    audioQueue,
                     audioIsPlaying,
                     audioCurrentTime,
                     audioDuration,

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -1,6 +1,8 @@
 """Regression tests for frontend boot-time failures."""
 
+import inspect
 import json
+import re
 import shutil
 import subprocess
 import tempfile
@@ -8,9 +10,16 @@ import unittest
 from pathlib import Path
 from typing import Any
 
+from src.message_utils import service_action_type, service_message_text
+
 INDEX_HTML = Path(__file__).resolve().parents[1] / "src" / "web" / "templates" / "index.html"
 
 NODE = shutil.which("node")
+
+try:  # Telethon is archived; keep the cross-check optional rather than a hard dep.
+    from telethon.tl import types as telethon_types
+except Exception:  # pragma: no cover - exercised only where telethon is absent
+    telethon_types = None
 
 
 def _setup_slice(html: str, declaration: str) -> str:
@@ -1777,12 +1786,19 @@ const scenario = async (pages) => {
         self.assertIsNone(out["badCursor"]["cursor"])
         self.assertFalse(out["badCursor"]["hasOlder"])
 
-    def test_the_queue_itself_is_observable_from_the_setup_object(self) -> None:
-        """String assertions cannot prove the guard works — a harness must be
-        able to watch the queue. ``audioQueue`` is an existing reactive ref, so
-        it is exported instead of adding any debug-only hook."""
-        self.assertIn("\n                    audioQueue,\n", self.html)
+    def test_the_guard_is_verified_without_shipping_any_observation_hook(self) -> None:
+        """The queue is watched by EXECUTING the real helpers, not by exporting it.
+
+        ``test_walk_outcomes_executed_against_both_kinds_of_empty_page`` lifts
+        the declarations verbatim and supplies its own ``audioQueue`` ref, so the
+        shipped template needs no debug hook AND no ``setup()`` export: nothing
+        in the markup consumes ``audioQueue``, and an entry in the returned
+        object that no template expression reads is dead surface that reads as
+        if the UI depended on it. If a template expression ever does need it,
+        export it and drop the second assertion.
+        """
         self.assertNotIn("window.__dbg", self.html)
+        self.assertNotIn("\n                    audioQueue,\n", self.html)
 
     def test_track_change_does_not_double_request_the_file(self) -> None:
         """Assigning ``src`` already invokes the media load algorithm.
@@ -2140,6 +2156,179 @@ class TestServiceMessageSenderTrigger(unittest.TestCase):
         self.assertNotIn(".replace(", body)
 
 
+def _stub_action(class_name: str) -> Any:
+    """An object whose CLASS NAME is ``class_name``.
+
+    ``service_message_text`` and ``service_action_type`` branch on
+    ``type(action).__name__`` and read only ``.title``, so a bare stub drives
+    the real backend wording without pinning Telethon constructor signatures.
+    ``test_every_mapped_action_names_a_real_telethon_action`` is what proves the
+    names are not invented.
+    """
+    return type(class_name, (), {})()
+
+
+# The backend's curated wording set, read out of the function itself: every
+# ``if name == "MessageAction..."`` branch in ``service_message_text``. Parsed
+# rather than hand-listed so ADDING a branch server-side without mirroring it in
+# index.html fails this file instead of silently drifting.
+_SERVER_ACTION_CLASSES = tuple(
+    dict.fromkeys(re.findall(r'name == "(MessageAction[A-Za-z]+)"', inspect.getsource(service_message_text)))
+)
+_SERVER_ACTION_TYPES = {service_action_type(_stub_action(name)): name for name in _SERVER_ACTION_CLASSES}
+
+_SERVICE_WORDING_DECLARATIONS = (
+    "const SERVICE_PREDICATES = {",
+    "const SERVICE_TITLE_PREDICATES = {",
+    "const SERVICE_UNKNOWN_SUBJECT = {",
+    "const getSenderName = (msg) =>",
+    "const getCurrentSenderName = (msg) =>",
+    "const serviceRawData = (msg) =>",
+    "const serviceActionType = (msg) =>",
+    "const serviceActorIsSender = (msg) =>",
+    "const serviceMessagePredicate = (msg) =>",
+    "const serviceMessageView = (msg) =>",
+)
+
+# Distinctive on purpose: a sentence-shaped actor name would hide a wording bug
+# where one side happens to read the same as the other.
+_ACTOR_NAME = "Ada Lovelace"
+_NEW_TITLE = "Analytical Engine"
+
+
+class TestServiceMessageWordingParity(unittest.TestCase):
+    """#259 DRIFT GUARD: the client's wording IS the backend's wording.
+
+    #259 happened because the same sentences existed in two places with nothing
+    tying them together. The render-time fallback in index.html re-states them a
+    THIRD time (as literal JS strings), so this test executes the real client
+    helpers and compares every rendered sentence against
+    ``message_utils.service_message_text`` — the two copies cannot drift without
+    a red test.
+
+    THE ONE DELIBERATE DIVERGENCE is asserted here too rather than excluded:
+    ``chat_add_user`` / ``chat_delete_user`` render "Someone ..." client-side.
+    The subject of those two sentences is the AFFECTED user, and only
+    ``service_type`` / ``action_type`` are persisted — the affected user is not,
+    so the sender (the admin who acted) must never be named as the joiner or
+    leaver. That is exactly the backend's own unknown-actor form, so parity here
+    means "matches ``service_message_text(action, actor_name=None)``" while the
+    rest mean "matches it with the row's sender".
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+
+    def _render_client(self, action_types: tuple[str, ...]) -> dict[str, Any]:
+        """EXECUTE the template's own service-pill helpers under node."""
+        rows = [
+            {
+                "id": index + 1,
+                "text": "",  # pre-7.28.0 rows: no materialised wording
+                "sender_id": 7,
+                "sender_name": _ACTOR_NAME,
+                "raw_data": {
+                    "service_type": "service",
+                    "action_type": action_type,
+                    "new_title": _NEW_TITLE,
+                },
+            }
+            for index, action_type in enumerate(action_types)
+        ]
+        epilogue = f"""
+const rows = {json.dumps(rows)}
+const rendered = {{}}
+const clickable = {{}}
+for (const row of rows) {{
+    const view = serviceMessageView(row)
+    rendered[row.raw_data.action_type] = view.actor + view.tail
+    clickable[row.raw_data.action_type] = view.clickable
+}}
+console.log(JSON.stringify({{
+    rendered,
+    clickable,
+    named: Object.keys(SERVICE_PREDICATES),
+    titled: Object.keys(SERVICE_TITLE_PREDICATES),
+    unknown: Object.keys(SERVICE_UNKNOWN_SUBJECT),
+}}))
+"""
+        return _run_setup_program(self.html, _SERVICE_WORDING_DECLARATIONS, "", epilogue)
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_client_covers_exactly_the_backend_wording_set(self) -> None:
+        """Neither side may gain (or lose) an action without the other."""
+        result = self._render_client(())
+        client_types = set(result["named"]) | set(result["titled"]) | set(result["unknown"])
+        self.assertEqual(client_types, set(_SERVER_ACTION_TYPES))
+        # The three client maps are disjoint: an action rendered both with and
+        # without its actor would resolve by lookup order, not by intent.
+        self.assertEqual(
+            len(result["named"]) + len(result["titled"]) + len(result["unknown"]),
+            len(client_types),
+        )
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_every_rendered_sentence_matches_the_backend_verbatim(self) -> None:
+        result = self._render_client(tuple(_SERVER_ACTION_TYPES))
+        unknown_subject = set(result["unknown"])
+
+        for action_type, class_name in _SERVER_ACTION_TYPES.items():
+            with self.subTest(action_type=action_type):
+                action = _stub_action(class_name)
+                action.title = _NEW_TITLE
+                if action_type in unknown_subject:
+                    # DELIBERATE DIVERGENCE (see the class docstring): the
+                    # affected user is not persisted, so the client renders the
+                    # backend's unknown-actor form with the default flags.
+                    expected = service_message_text(action, actor_name=None)
+                else:
+                    expected = service_message_text(action, actor_name=_ACTOR_NAME)
+                self.assertEqual(result["rendered"][action_type], expected)
+                # Only a sentence whose subject IS the sender may open the
+                # sender popup.
+                self.assertEqual(result["clickable"][action_type], action_type not in unknown_subject)
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_unknown_subject_actions_never_render_the_stored_variant_wording(self) -> None:
+        """``affected_left`` / ``affected_joined_self`` are NOT persisted.
+
+        The backend reads them off the live Telethon event; a stored row keeps
+        neither, so "left"/"joined" can never be reconstructed at render time.
+        The default (``was removed`` / ``was added``) is the only honest choice,
+        and this pins that the client did not pick the variant wording instead.
+        """
+        result = self._render_client(("chat_add_user", "chat_delete_user"))
+        added = _stub_action("MessageActionChatAddUser")
+        removed = _stub_action("MessageActionChatDeleteUser")
+
+        self.assertEqual(
+            result["rendered"]["chat_add_user"],
+            service_message_text(added, actor_name=None, affected_joined_self=False),
+        )
+        self.assertNotEqual(
+            result["rendered"]["chat_add_user"],
+            service_message_text(added, actor_name=None, affected_joined_self=True),
+        )
+        self.assertEqual(
+            result["rendered"]["chat_delete_user"],
+            service_message_text(removed, actor_name=None, affected_left=False),
+        )
+        self.assertNotEqual(
+            result["rendered"]["chat_delete_user"],
+            service_message_text(removed, actor_name=None, affected_left=True),
+        )
+        # And the sender is never named in either sentence.
+        for action_type in ("chat_add_user", "chat_delete_user"):
+            self.assertNotIn(_ACTOR_NAME, result["rendered"][action_type])
+
+    @unittest.skipUnless(telethon_types, "telethon is required for the class-name cross-check")
+    def test_every_mapped_action_names_a_real_telethon_action(self) -> None:
+        """The tags are derived from Telethon class names, so they must exist."""
+        for class_name in _SERVER_ACTION_CLASSES:
+            self.assertTrue(hasattr(telethon_types, class_name), class_name)
+
+
 class TestPlaybarDate(unittest.TestCase):
     """#262: the playbar showed a time with no date."""
 
@@ -2181,6 +2370,49 @@ class TestAudioBubbleDownload(unittest.TestCase):
         self.assertIn('v-if="!noDownload && getMediaUrl(msg)"', bubble)
         self.assertIn(":href=\"getMediaUrl(msg) + '?download=1'\"", bubble)
         self.assertIn(':download="getDocumentDisplayName(msg)"', bubble)
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_the_url_term_of_the_guard_is_load_bearing(self) -> None:
+        """``getMediaUrl(msg)`` in the ``v-if`` is NOT a dead term.
+
+        The bubble renders on ``isAudioFile(msg)``, which is satisfied by
+        ``media.type`` alone — and a media row exists with ``type`` set but NO
+        ``file_path`` whenever the file was never written: an oversized voice
+        note (``_process_media`` returns ``downloaded: False`` with no path once
+        it exceeds ``MAX_MEDIA_SIZE``) or a row still queued for the pending
+        -media retry loop (``downloaded=0``, ``file_path`` NULL). The adapter
+        emits ``msg.media`` for every row whose ``media_type`` is set, so those
+        rows reach the client verbatim and ``getMediaUrl`` returns ``''``.
+
+        Without the term the anchor would render ``href="?download=1"`` — a link
+        to the viewer page itself, offered as if the audio were downloadable.
+        """
+        rows = [
+            # Oversized voice note: typed, never written.
+            {"id": 1, "media": {"id": "7_1_voice", "type": "voice", "file_path": None}},
+            # Pending download of an audio document, name known, file not there.
+            {"id": 2, "media": {"id": "7_2_audio", "type": "audio", "file_name": "note.ogg", "file_path": None}},
+            # Downloaded: both terms true, anchor renders.
+            {"id": 3, "media": {"id": "7_3_voice", "type": "voice", "file_path": "/data/media/7/7_3_voice.ogg"}},
+        ]
+        verdicts = _run_setup_helpers(
+            self.html,
+            (
+                "const getMediaUrl = (msg) =>",
+                "const getMediaDisplayName = (media) =>",
+                "const getDocumentDisplayName = (msg) =>",
+                "const isAudioFile = (msg) =>",
+            ),
+            f"{json.dumps(rows)}.map(m => [isAudioFile(m), getMediaUrl(m)])",
+        )
+        self.assertEqual(
+            verdicts,
+            [
+                [True, ""],
+                [True, ""],
+                [True, "/media/7/7_3_voice.ogg"],
+            ],
+        )
 
     def test_download_is_not_inside_the_sm_only_playbar_group(self) -> None:
         """The playbar speed group is ``hidden sm:flex``.

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -2255,6 +2255,36 @@ console.log(JSON.stringify({{
 """
         return _run_setup_program(self.html, _SERVICE_WORDING_DECLARATIONS, "", epilogue)
 
+    def _render_client_titles(self, cases: tuple[tuple[str, dict[str, Any]], ...]) -> dict[str, Any]:
+        """Like ``_render_client``, but each row's ``raw_data`` is built from a
+        caller-supplied override instead of the fixed ``_NEW_TITLE`` — needed to
+        exercise a missing/null ``new_title`` per action_type, which
+        ``_render_client`` cannot express (it keys its result dict by
+        action_type, so two rows sharing one action_type would collide)."""
+        rows = [
+            {
+                "id": index + 1,
+                "text": "",
+                "sender_id": 7,
+                "sender_name": _ACTOR_NAME,
+                "raw_data": {
+                    "service_type": "service",
+                    "action_type": action_type,
+                    **raw_data_override,
+                },
+            }
+            for index, (action_type, raw_data_override) in enumerate(cases)
+        ]
+        epilogue = f"""
+const rows = {json.dumps(rows)}
+const rendered = rows.map(row => {{
+    const view = serviceMessageView(row)
+    return view.actor + view.tail
+}})
+console.log(JSON.stringify({{ rendered }}))
+"""
+        return _run_setup_program(self.html, _SERVICE_WORDING_DECLARATIONS, "", epilogue)
+
     @unittest.skipUnless(NODE, "node is required to execute the helper")
     def test_client_covers_exactly_the_backend_wording_set(self) -> None:
         """Neither side may gain (or lose) an action without the other."""
@@ -2288,6 +2318,64 @@ console.log(JSON.stringify({{
                 # Only a sentence whose subject IS the sender may open the
                 # sender popup.
                 self.assertEqual(result["clickable"][action_type], action_type not in unknown_subject)
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_title_bearing_actions_render_empty_quotes_when_new_title_is_missing(self) -> None:
+        """The ONE place client and backend are DELIBERATELY allowed to differ.
+
+        Client (``serviceMessagePredicate``, index.html): reads
+        ``raw_data.new_title`` and falls back to ``''`` whenever it is absent
+        or not a string — ``created the group ""``.
+
+        Backend (``service_message_text``, message_utils.py): does
+        ``title = getattr(action, "title", None)`` with no guard against
+        ``None`` before interpolating it into the f-string, so a title-less
+        action would render the literal Python stringification ``"None"``
+        inside the quotes — ``created the group "None"``.
+
+        Verified against the real telethon types (see
+        ``test_every_mapped_action_names_a_real_telethon_action``):
+        ``MessageActionChatEditTitle`` / ``MessageActionChatCreate`` /
+        ``MessageActionChannelCreate`` all declare ``title`` as a REQUIRED
+        constructor field, so the backend's ``None``-title branch can never
+        actually fire from a live Telethon event — it is unreachable in
+        production. The client's branch IS reachable: ``new_title`` is read
+        out of the persisted ``raw_data`` JSON blob, and a historical or
+        otherwise incomplete row can simply lack that key. The client's
+        empty-quotes rendering is therefore the correct behaviour, not a gap
+        — a future "fix" that fetches ``"None"``/``"null"``/``"undefined"``
+        into the sentence to chase parity would be a regression.
+        """
+        title_bearing = tuple(self._render_client(())["titled"])
+        self.assertTrue(title_bearing)  # sanity: SERVICE_TITLE_PREDICATES must not be empty
+
+        cases: list[tuple[str, dict[str, Any]]] = []
+        for action_type in title_bearing:
+            cases.append((action_type, {}))  # new_title key absent entirely
+            cases.append((action_type, {"new_title": None}))  # new_title explicitly null
+        rendered = self._render_client_titles(tuple(cases))["rendered"]
+
+        for (action_type, override), sentence in zip(cases, rendered, strict=True):
+            variant = "new_title absent" if not override else "new_title: null"
+            with self.subTest(action_type=action_type, variant=variant):
+                class_name = _SERVER_ACTION_TYPES[action_type]
+
+                # The client's actual fallback is an empty string, and an empty
+                # string IS a str, so the backend's own type-check leaves it
+                # untouched too — the two sides genuinely agree here.
+                action = _stub_action(class_name)
+                action.title = ""
+                self.assertEqual(sentence, service_message_text(action, actor_name=_ACTOR_NAME))
+
+                # The forbidden variant: the backend's OWN behaviour when title
+                # is actually None (unreachable in production, per the
+                # docstring above, but that's exactly what must never leak
+                # into the client's rendering).
+                action.title = None
+                self.assertNotEqual(sentence, service_message_text(action, actor_name=_ACTOR_NAME))
+                self.assertNotIn('"None"', sentence)
+                self.assertNotIn('"null"', sentence)
+                self.assertNotIn('"undefined"', sentence)
 
     @unittest.skipUnless(NODE, "node is required to execute the helper")
     def test_unknown_subject_actions_never_render_the_stored_variant_wording(self) -> None:

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -6,13 +6,25 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from typing import Any
 
 INDEX_HTML = Path(__file__).resolve().parents[1] / "src" / "web" / "templates" / "index.html"
 
 NODE = shutil.which("node")
 
 
-def _run_setup_program(html: str, declarations: tuple[str, ...], prelude: str, epilogue: str):
+def _setup_slice(html: str, declaration: str) -> str:
+    """Return one top-level ``const`` body from the root Vue ``setup()``.
+
+    Setup-scope declarations are indented 16 spaces, so the next such line is
+    the end of the current one; nested declarations are indented deeper and do
+    not terminate the slice.
+    """
+    start = html.index(declaration)
+    return html[start : html.index("\n                const ", start + len(declaration))]
+
+
+def _run_setup_program(html: str, declarations: tuple[str, ...], prelude: str, epilogue: str) -> Any:
     """EXECUTE real setup-scope declarations under a stubbed environment.
 
     String assertions cannot tell a working helper from a broken one, and this
@@ -23,8 +35,7 @@ def _run_setup_program(html: str, declarations: tuple[str, ...], prelude: str, e
     """
     parts = [prelude]
     for declaration in declarations:
-        start = html.index(declaration)
-        parts.append(html[start : html.index("\n                const ", start + len(declaration))])
+        parts.append(_setup_slice(html, declaration))
     program = "\n".join(parts) + "\n" + epilogue + "\n"
     with tempfile.TemporaryDirectory() as tmp:
         script = Path(tmp) / "helpers.js"
@@ -34,7 +45,7 @@ def _run_setup_program(html: str, declarations: tuple[str, ...], prelude: str, e
     return json.loads(result.stdout)
 
 
-def _run_setup_helpers(html: str, declarations: tuple[str, ...], expression: str, prelude: str = ""):
+def _run_setup_helpers(html: str, declarations: tuple[str, ...], expression: str, prelude: str = "") -> Any:
     """EXECUTE a few setup-scope helpers and return the JSON value of ``expression``."""
     return _run_setup_program(html, declarations, prelude, f"console.log(JSON.stringify({expression}))")
 
@@ -1161,17 +1172,6 @@ def test_chat_header_avatar_button_is_not_a_tap_target():
 # --- Global audio player (#250) -------------------------------------------------
 
 
-def _setup_slice(html: str, declaration: str) -> str:
-    """Return one top-level ``const`` body from the root Vue ``setup()``.
-
-    Setup-scope declarations are indented 16 spaces, so the next such line is
-    the end of the current one; nested declarations are indented deeper and do
-    not terminate the slice.
-    """
-    start = html.index(declaration)
-    return html[start : html.index("\n                const ", start + len(declaration))]
-
-
 def _code_only(body: str) -> str:
     """Drop whole-line ``//`` comments: some assertions are about code, not prose."""
     return "\n".join(line for line in body.splitlines() if not line.strip().startswith("//"))
@@ -1715,6 +1715,10 @@ const mediaItem = (n) => ({
     id: `m${n}`, message_id: n, chat_id: 7,
     media_url: `/media/${n}.ogg`, message_date: `2026-07-0${n}T00:00:00`,
 })
+// NOTE: audioQueueCursor and audioQueueHasOlder are NOT declared here on
+// purpose. Both are real module-scope `let`s in the template and arrive with
+// the sliced declarations below; declaring them again is a duplicate-binding
+// SyntaxError, so the epilogue's assignments are not implicit globals.
 """
         epilogue = """
 const scenario = async (pages) => {

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -1,9 +1,42 @@
 """Regression tests for frontend boot-time failures."""
 
+import json
+import shutil
+import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
 INDEX_HTML = Path(__file__).resolve().parents[1] / "src" / "web" / "templates" / "index.html"
+
+NODE = shutil.which("node")
+
+
+def _run_setup_program(html: str, declarations: tuple[str, ...], prelude: str, epilogue: str):
+    """EXECUTE real setup-scope declarations under a stubbed environment.
+
+    String assertions cannot tell a working helper from a broken one, and this
+    repo has shipped green-CI regressions on exactly that. The declarations are
+    lifted VERBATIM out of the template — no DOM, no Vue, no browser — with
+    ``prelude`` supplying whatever they close over (refs, module-level
+    counters, fetch) and ``epilogue`` driving them and printing one JSON line.
+    """
+    parts = [prelude]
+    for declaration in declarations:
+        start = html.index(declaration)
+        parts.append(html[start : html.index("\n                const ", start + len(declaration))])
+    program = "\n".join(parts) + "\n" + epilogue + "\n"
+    with tempfile.TemporaryDirectory() as tmp:
+        script = Path(tmp) / "helpers.js"
+        script.write_text(program, encoding="utf-8")
+        result = subprocess.run([NODE, str(script)], capture_output=True, text=True, timeout=60)
+    assert result.returncode == 0, result.stderr + "\n----\n" + program
+    return json.loads(result.stdout)
+
+
+def _run_setup_helpers(html: str, declarations: tuple[str, ...], expression: str, prelude: str = ""):
+    """EXECUTE a few setup-scope helpers and return the JSON value of ``expression``."""
+    return _run_setup_program(html, declarations, prelude, f"console.log(JSON.stringify({expression}))")
 
 
 def test_media_gallery_refs_are_initialized_before_watcher():
@@ -1193,15 +1226,14 @@ def test_audio_engine_and_playbar_live_outside_the_message_loop():
 def test_audio_playback_rate_survives_a_track_change():
     """#250: the media load algorithm resets ``playbackRate`` on every ``src`` change.
 
-    Without planting the rate in ``defaultPlaybackRate`` before ``load()`` AND
-    re-applying it once metadata arrives, every new track silently falls back to
-    1x while the UI still shows the chosen speed.
+    Without planting the rate in ``defaultPlaybackRate`` before the ``src``
+    assignment AND re-applying it once metadata arrives, every new track
+    silently falls back to 1x while the UI still shows the chosen speed.
     """
     html = INDEX_HTML.read_text(encoding="utf-8")
 
     load_body = _setup_slice(html, "const loadAudioTrack = (track) =>")
     assert load_body.index("audioEngine.defaultPlaybackRate = rate") < load_body.index("audioEngine.src = track.url")
-    assert load_body.index("audioEngine.src = track.url") < load_body.index("audioEngine.load()")
 
     meta_start = html.index("audioEngine.addEventListener('loadedmetadata'")
     meta_body = html[meta_start : html.index("audioEngine.addEventListener('timeupdate'", meta_start)]
@@ -1357,8 +1389,10 @@ def test_audio_queue_pages_the_media_endpoint_with_a_capped_cursor_walk():
     assert "await fetchAudioQueuePage(track.chatId, track.kind, cursor)" in extend_body
     assert "cursor = items[items.length - 1].id" in extend_body
     # Stop as soon as the playing track is in hand, or nothing older is left.
-    assert "items.some(item => item.message_id === track.id) || !hasOlder" in extend_body
-    # Hitting the cap keeps whatever was fetched instead of failing.
+    assert "items.some(item => item.message_id === track.id)" in extend_body
+    assert "if (!hasOlder) break" in extend_body
+    # Hitting the cap keeps whatever was fetched instead of failing — but only
+    # when the walk actually reached the playing track (see #257 hole guard).
     assert "audioQueue.value = mergeAudioQueue(audioTracksFromMediaItems(collected, track))" in extend_body
 
     # "Previous" at the head of the queue pages one more time from the same cursor.
@@ -1568,3 +1602,596 @@ class TestAudioQueuePagingOutcomes(unittest.TestCase):
     def test_teardown_aborts_the_in_flight_page(self) -> None:
         close_body = self._slice("const closeAudioPlayer = () =>")
         self.assertIn("audioQueueAbort?.abort()", close_body)
+
+
+class TestAudioQueueHoleGuard(unittest.TestCase):
+    """#257: a capped backward walk must not splice two disjoint time blocks."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+
+    def test_paged_result_is_adopted_only_when_the_playing_track_was_found(self) -> None:
+        """The walk stops at AUDIO_QUEUE_PAGE_SIZE * AUDIO_QUEUE_MAX_PAGES items.
+
+        With more audio newer than the playing track than that cap allows, the
+        loop ends without ever reaching it, and the newest block plus the seed
+        window are two blocks with a chronological HOLE between them. The old
+        code merged and date-sorted them unconditionally, so "next" walked to
+        the seed edge and then jumped days ahead.
+        """
+        body = _setup_slice(self.html, "const extendAudioQueueFromMedia = async (track) =>")
+
+        # The loop records whether the playing track actually showed up.
+        self.assertIn("let foundPlaying = false", body)
+        self.assertIn("foundPlaying = true", body)
+
+        # The guard runs BEFORE the merge, and bails out of it.
+        self.assertIn("if (!foundPlaying && hasOlder) return", body)
+        guard = body.index("if (!foundPlaying && hasOlder) return")
+        merge = body.index("audioQueue.value = mergeAudioQueue(")
+        self.assertLess(guard, merge)
+
+        # Not found -> keep the seed queue exactly as it is.
+        bail = body[guard:merge]
+        self.assertNotIn("audioQueue.value =", bail)
+
+    def test_hole_guard_does_not_latch_paging_off_for_the_session(self) -> None:
+        """The guard must abandon ONE extension, not disable 'previous' forever.
+
+        Setting ``audioQueueHasOlder = false`` on the not-found path permanently
+        killed head-of-queue paging past the seed window for the rest of the
+        session, even though a later, correctly seeded walk could succeed. Only
+        a CONTIGUOUS result may write the cursor / has-older pair, and the reset
+        on the next track or chat is what re-enables paging.
+        """
+        body = _code_only(_setup_slice(self.html, "const extendAudioQueueFromMedia = async (track) =>"))
+        guard = body.index("if (!foundPlaying && hasOlder) return")
+        # The guard is a bare early return: it writes NOTHING back. The only
+        # assignment to the session flag in this whole helper is the contiguous
+        # one, so the not-found path cannot latch paging off.
+        self.assertNotIn("audioQueueHasOlder = false", body)
+        self.assertEqual(body.count("audioQueueHasOlder"), 1)
+        # The pair is still written on the contiguous path, after the guard.
+        self.assertLess(guard, body.index("audioQueueCursor = cursor"))
+        self.assertLess(guard, body.index("audioQueueHasOlder = hasOlder"))
+        # ...and reset on the next track / on close, which is the re-enable point.
+        self.assertIn("audioQueueHasOlder = false", _setup_slice(self.html, "const playAudioMessage = (msg) =>"))
+        self.assertIn("audioQueueHasOlder = false", _setup_slice(self.html, "const closeAudioPlayer = () =>"))
+
+    def test_an_empty_page_never_forces_exhaustion_and_always_terminates(self) -> None:
+        """An empty page is not proof the walk reached the end of the chat.
+
+        ``get_media_paginated`` also answers ``{items: [], has_more: False}``
+        for a ``before_id`` it cannot resolve (a foreign or since-deleted cursor
+        row). Forcing ``hasOlder = false`` there made an unresolvable cursor
+        look exactly like exhaustion, so the #257 guard adopted or truncated a
+        walk that never reached the end.
+
+        ``hasOlder`` already carries the right answer on both paths — its
+        initial ``false`` on the first page, the previous page's ``has_more``
+        mid-walk — so the branch must write NOTHING. What it must still do is
+        ``break``, which is what keeps the walk finite.
+        """
+        body = _code_only(_setup_slice(self.html, "const extendAudioQueueFromMedia = async (track) =>"))
+        # The initial value is what makes an empty FIRST page read as exhausted.
+        self.assertIn("let hasOlder = false", body)
+        empty = body.index("if (!items.length) {")
+        branch = body[empty : body.index("collected.push(...items)")]
+        self.assertNotIn("hasOlder", branch)
+        # ...but the loop still ends here, so F4's infinite-walk risk stays closed.
+        self.assertIn("break", branch)
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_walk_outcomes_executed_against_both_kinds_of_empty_page(self) -> None:
+        """The EXECUTED counterpart: two walks that differ only in has_more.
+
+        Both end on a page the loop cannot continue from, and the string test
+        above cannot tell them apart:
+
+        * ``endOfChat`` — the last page carries items and ``has_more: false``.
+          The chat really is exhausted, so the paged result is adopted even
+          though the playing track was never reached.
+        * ``badCursor`` — the first page promises ``has_more: true`` and the
+          second comes back empty, which is what an unresolvable ``before_id``
+          returns. That walk may have a hole in it, so it must be abandoned and
+          the seeded queue left exactly as it was.
+        """
+        prelude = """
+const noDownload = { value: false }
+const audioQueue = { value: [] }
+const audioTrack = { value: { chatId: 7, kind: 'voice' } }
+const audioTrackFromMediaItem = (item, kind, chatName) => ({
+    id: item.message_id, chatId: item.chat_id, kind, chatName,
+    date: item.message_date, url: item.media_url,
+})
+let PAGES = []
+const REQUESTED = []
+const fetchAudioQueuePage = async (chatId, kind, beforeId) => {
+    REQUESTED.push(beforeId ?? null)
+    return PAGES.shift() ?? { items: [], has_more: false }
+}
+const mediaItem = (n) => ({
+    id: `m${n}`, message_id: n, chat_id: 7,
+    media_url: `/media/${n}.ogg`, message_date: `2026-07-0${n}T00:00:00`,
+})
+"""
+        epilogue = """
+const scenario = async (pages) => {
+    PAGES = pages.slice()
+    REQUESTED.length = 0
+    audioQueueCursor = null
+    audioQueueHasOlder = false
+    // The seeded window queue around the playing track, which the guard
+    // protects when the walk cannot be trusted.
+    audioQueue.value = [{ id: 999, chatId: 7, kind: 'voice', date: '2026-07-09T00:00:00' }]
+    await extendAudioQueueFromMedia({ chatId: 7, kind: 'voice', id: 999, chatName: 'c' })
+    return {
+        cursor: audioQueueCursor,
+        hasOlder: audioQueueHasOlder,
+        ids: audioQueue.value.map(t => t.id),
+        requested: REQUESTED.slice(),
+    }
+};
+(async () => {
+    const endOfChat = await scenario([
+        { items: [mediaItem(3)], has_more: true },
+        { items: [mediaItem(2)], has_more: false },
+    ]);
+    const badCursor = await scenario([
+        { items: [mediaItem(3)], has_more: true },
+        { items: [], has_more: false },
+    ]);
+    console.log(JSON.stringify({ endOfChat, badCursor }));
+})();
+"""
+        out = _run_setup_program(
+            self.html,
+            (
+                "const AUDIO_QUEUE_MAX_PAGES = ",
+                "const audioTracksFromMediaItems = (items, track) =>",
+                "const audioTrackTime = (track) =>",
+                "const mergeAudioQueue = (tracks) =>",
+                "const audioQueueBelongsToTrack = (track) =>",
+                "const extendAudioQueueFromMedia = async (track) =>",
+            ),
+            prelude,
+            epilogue,
+        )
+
+        # Genuine end of chat: both pages were walked, the result is contiguous,
+        # and it is merged into the seeded queue in date order.
+        self.assertEqual(out["endOfChat"]["requested"], [None, "m3"])
+        self.assertFalse(out["endOfChat"]["hasOlder"])
+        self.assertEqual(out["endOfChat"]["cursor"], "m2")
+        self.assertEqual(out["endOfChat"]["ids"], [2, 3, 999])
+
+        # Unresolvable cursor: the same two fetches, the same "no more items",
+        # but the walk is NOT trustworthy, so nothing is adopted.
+        self.assertEqual(out["badCursor"]["requested"], [None, "m3"])
+        self.assertEqual(out["badCursor"]["ids"], [999])
+        self.assertIsNone(out["badCursor"]["cursor"])
+        self.assertFalse(out["badCursor"]["hasOlder"])
+
+    def test_the_queue_itself_is_observable_from_the_setup_object(self) -> None:
+        """String assertions cannot prove the guard works — a harness must be
+        able to watch the queue. ``audioQueue`` is an existing reactive ref, so
+        it is exported instead of adding any debug-only hook."""
+        self.assertIn("\n                    audioQueue,\n", self.html)
+        self.assertNotIn("window.__dbg", self.html)
+
+    def test_track_change_does_not_double_request_the_file(self) -> None:
+        """Assigning ``src`` already invokes the media load algorithm.
+
+        The extra ``load()`` aborted that fetch and re-invoked it, so the same
+        .ogg was requested 2-3 times per track.
+        """
+        body = _setup_slice(self.html, "const loadAudioTrack = (track) =>")
+        self.assertNotIn("audioEngine.load()", body)
+        # The playbackRate trap stays fixed: rate before src, re-applied on metadata.
+        self.assertLess(
+            body.index("audioEngine.defaultPlaybackRate = rate"),
+            body.index("audioEngine.src = track.url"),
+        )
+        meta_start = self.html.index("audioEngine.addEventListener('loadedmetadata'")
+        meta_body = self.html[meta_start : self.html.index("audioEngine.addEventListener('timeupdate'", meta_start)]
+        self.assertIn("audioEngine.playbackRate = audioTrack.value", meta_body)
+
+    def test_playbar_jump_loads_the_window_when_the_row_is_absent(self) -> None:
+        """The queue reaches far past the loaded window, so the row is usually absent."""
+        body = _setup_slice(self.html, "const focusAudioTrackMessage = async () =>")
+        self.assertIn("if (!findMessageElement(track.id)) {", body)
+        self.assertIn("await loadMessagesAroundId(track.id)", body)
+        self.assertLess(
+            body.index("findMessageElement(track.id)"),
+            body.index("scrollToMessage(track.id)"),
+        )
+
+
+class TestMediaUrlEncoding(unittest.TestCase):
+    """#258: '#' or '?' in a filename truncated the URL inside the browser."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+
+    def test_get_media_url_encodes_each_segment(self) -> None:
+        body = _setup_slice(self.html, "const getMediaUrl = (msg) =>")
+        self.assertIn("encodeURIComponent(folder)", body)
+        self.assertIn("encodeURIComponent(filename)", body)
+        # Per-segment only: encoding the assembled path would escape the '/'.
+        self.assertNotIn("encodeURIComponent(`/media/", body)
+        self.assertNotIn("encodeURI(`/media/", body)
+
+    def test_server_provided_urls_are_not_encoded_again(self) -> None:
+        """media_url / thumb_url / avatar_url arrive already encoded server-side."""
+        self.assertNotIn("encodeURIComponent(item.media_url", self.html)
+        self.assertNotIn("encodeURIComponent(msg.sender_avatar_url", self.html)
+
+
+class TestServiceMessageFallback(unittest.TestCase):
+    """#259: pre-7.28.0 service rows have text='' and rendered as empty pills."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+
+    def test_service_branch_falls_back_to_raw_data(self) -> None:
+        self.assertIn("const serviceMessagePredicate = (msg) =>", self.html)
+        self.assertIn("const serviceMessageView = (msg) =>", self.html)
+        # The pill renders the resolved view, not the bare (possibly empty) text.
+        self.assertIn("serviceMessageView(msg)", self.html)
+        self.assertNotIn(
+            '<div class="service-message px-4 py-1.5 rounded-full text-xs text-center max-w-[80%]"',
+            self.html,
+        )
+
+    def test_malformed_raw_data_cannot_throw(self) -> None:
+        """adapter.py substitutes {} for unparseable raw_data — guard anyway."""
+        body = _setup_slice(self.html, "const serviceRawData = (msg) =>")
+        self.assertIn("typeof raw === 'object'", body)
+        action_body = _setup_slice(self.html, "const serviceActionType = (msg) =>")
+        self.assertIn("typeof type === 'string' ? type : ''", action_body)
+
+    def test_add_and_delete_user_never_name_the_sender(self) -> None:
+        """REGRESSION GUARD for the correctness trap.
+
+        For chat_add_user / chat_delete_user the subject of the sentence is the
+        AFFECTED user, which is never persisted — only service_type and
+        action_type are. The row's sender is the ADMIN, so naming them would
+        claim the wrong person joined or left. The backend's unknown-actor form
+        ("Someone", with the default flags) is the only honest rendering.
+        """
+        unknown = _setup_slice(self.html, "const SERVICE_UNKNOWN_SUBJECT = {")
+        self.assertIn("chat_add_user: 'Someone was added to the group'", unknown)
+        self.assertIn("chat_delete_user: 'Someone was removed from the group'", unknown)
+
+        # ...and EXACTLY those two: no other action may use the unknown form,
+        # and neither may appear in a sender-named mapping.
+        self.assertEqual(unknown.count("Someone"), 2)
+        named = _setup_slice(self.html, "const SERVICE_PREDICATES = {")
+        titled = _setup_slice(self.html, "const SERVICE_TITLE_PREDICATES = {")
+        for action in ("chat_add_user", "chat_delete_user"):
+            self.assertNotIn(action, named)
+            self.assertNotIn(action, titled)
+
+        # The sender-is-subject group reproduces the backend wording verbatim.
+        self.assertIn("chat_joined_by_link: 'joined the group via invite link'", named)
+        self.assertIn("chat_joined_by_request: 'joined the group'", named)
+        self.assertIn("chat_edit_photo: 'changed the group photo'", named)
+        self.assertIn("chat_delete_photo: 'removed the group photo'", named)
+        self.assertIn("chat_edit_title: 'changed the group name to'", titled)
+        self.assertIn("chat_create: 'created the group'", titled)
+        self.assertIn("channel_create: 'created the channel'", titled)
+
+    def test_unmapped_actions_and_blank_rows_render_nothing(self) -> None:
+        predicate = _setup_slice(self.html, "const serviceMessagePredicate = (msg) =>")
+        # Object.hasOwn, never a bare lookup: action_type 'constructor' would
+        # otherwise resolve against Object.prototype.
+        self.assertIn("Object.hasOwn(SERVICE_UNKNOWN_SUBJECT, action)", predicate)
+        self.assertIn("Object.hasOwn(SERVICE_PREDICATES, action)", predicate)
+        self.assertIn("Object.hasOwn(SERVICE_TITLE_PREDICATES, action)", predicate)
+        # Falls through to the empty string, matching the backend's None: the
+        # LAST statement of the helper is a bare `return ''`, not a fabricated
+        # sentence. Asserted on the code, never on the comment above it.
+        self.assertTrue(_code_only(predicate).rstrip().rstrip("}").rstrip().endswith("return ''"), predicate)
+
+        # A service row with nothing to show paints an empty pill, and the day
+        # divider is resolved through the same condition the pill renders on.
+        self.assertIn("const isRenderedMessageRow = (msg, index) =>", self.html)
+        self.assertIn('<div v-if="view.tail || view.actor"', self.html)
+
+    def test_a_non_service_row_is_never_suppressed(self) -> None:
+        """DATA-HIDING GUARD.
+
+        ``media`` is null on perfectly good rows under DEFAULT configuration:
+        ``LISTEN_NEW_MESSAGES_MEDIA`` is false (so the live WS payload carries
+        ``"media": None``) and ``DOWNLOAD_MEDIA`` / ``skip_media_chat_ids`` do
+        the same, permanently, for the sweep. A caption-less voice note,
+        sticker or photo therefore has falsy text AND null media, and
+        suppressing it would render the message NOWHERE while the unread badge
+        still counted it — and would drop its ``:data-msg-id`` anchor, which
+        findMessageElement / scrollToMessage / jumpToReply /
+        focusAudioTrackMessage all resolve through.
+
+        So the regular-message branch has exactly ONE reason to drop a row —
+        an album duplicate, which is drawn by the album grid instead. There is
+        no emptiness term in it: a term that could only ever be false still
+        reads as "this branch may hide messages", which is the regression this
+        guard exists to prevent.
+        """
+        self.assertIn('v-else-if="!isHiddenAlbumMessage(msg, index)"', self.html)
+        # The two branches split on the same service condition, so a regular row
+        # can never reach the service arm of the predicate either.
+        self.assertIn("v-if=\"msg.raw_data?.service_type === 'service'\"", self.html)
+        rendered = _code_only(_setup_slice(self.html, "const isRenderedMessageRow = (msg, index) =>"))
+        statements = [line.strip() for line in rendered.splitlines() if line.strip()]
+        # The non-service arm is the LAST statement, and album duplication is
+        # the only thing it tests.
+        self.assertEqual(statements[-2], "return !isHiddenAlbumMessage(msg, index)")
+        # The dead emptiness predicate is gone from the whole template.
+        self.assertNotIn("isBlankMessageRow", self.html)
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_rendered_row_predicate_executed_against_real_row_shapes(self) -> None:
+        """The EXECUTED counterpart of the guard above.
+
+        Row 0 is the failure the string test cannot see: a caption-less voice
+        note under default config (``LISTEN_NEW_MESSAGES_MEDIA`` false) —
+        ``{text: '', media: null, raw_data: {}}``. It MUST render.
+
+        Rows 7-9 are #T3: a service row whose only content is media, a reply, a
+        forward, a reaction or a poll. The service branch renders NONE of those
+        — it paints ``view.actor`` and ``view.tail`` and nothing else — so an
+        unmapped action_type leaves an empty pill however much other data the
+        row carries.
+        """
+        service = {"service_type": "service", "action_type": "nope"}
+        rows = [
+            # Not service-shaped: renders, whatever it looks like.
+            {"id": 1, "text": "", "media": None, "raw_data": {}},
+            {"id": 2, "text": None, "media": None, "raw_data": None},
+            {"id": 3, "text": "", "media": None, "raw_data": "unparseable"},
+            {"id": 4, "text": "", "media": None, "raw_data": {"grouped_id": None}},
+            # Service-shaped with no renderable wording: paints nothing.
+            {"id": 5, "text": "", "media": None, "raw_data": service},
+            # Service-shaped WITH wording: painted.
+            {
+                "id": 6,
+                "text": "",
+                "media": None,
+                "raw_data": {"service_type": "service", "action_type": "chat_edit_photo"},
+            },
+            {"id": 7, "text": "hi", "media": None, "raw_data": service},
+            # Service-shaped, no wording, but carrying data the service branch
+            # does not render: still paints NOTHING.
+            {"id": 8, "text": "", "media": {"type": "photo"}, "raw_data": service},
+            {"id": 9, "text": "", "media": None, "reactions": [{"emoji": "x"}], "raw_data": service},
+            {
+                "id": 10,
+                "text": "",
+                "media": None,
+                "reply_to_msg_id": 5,
+                "forward_from_id": 42,
+                "raw_data": {**service, "poll": {"question": "?"}},
+            },
+        ]
+        verdicts = _run_setup_helpers(
+            self.html,
+            (
+                "const SERVICE_PREDICATES = {",
+                "const SERVICE_TITLE_PREDICATES = {",
+                "const SERVICE_UNKNOWN_SUBJECT = {",
+                "const getSenderName = (msg) =>",
+                "const getCurrentSenderName = (msg) =>",
+                "const serviceRawData = (msg) =>",
+                "const serviceActionType = (msg) =>",
+                "const serviceActorIsSender = (msg) =>",
+                "const serviceMessagePredicate = (msg) =>",
+                "const serviceMessageView = (msg) =>",
+                "const getGroupedId = (msg) =>",
+                "const isFirstInAlbum = (msg, index) =>",
+                "const isHiddenAlbumMessage = (msg, index) =>",
+                "const isRenderedMessageRow = (msg, index) =>",
+            ),
+            f"{json.dumps(rows)}.map(isRenderedMessageRow)",
+            prelude="const sortedMessages = { value: [] }\n",
+        )
+        self.assertEqual(
+            verdicts,
+            [True, True, True, True, False, True, True, False, False, False],
+        )
+
+    def test_the_day_divider_lands_on_a_row_that_is_actually_painted(self) -> None:
+        """A divider must never head a suppressed row.
+
+        Under ``flex-col-reverse`` the divider emitted at ``index`` appears
+        ABOVE that row, so it heads the whole day. Emitting it on a suppressed
+        row leaves it orphaned with nothing under it; dropping it there instead
+        would delete the day header for every remaining row of that day. Both
+        neighbours are therefore resolved through the same predicate the row
+        branches use, and the search walks past suppressed rows to the next
+        painted one.
+        """
+        self.assertIn('<div v-if="showDateSeparator(index)" class="date-separator"', self.html)
+        body = _code_only(_setup_slice(self.html, "const showDateSeparator = (index) =>"))
+        self.assertIn("if (!isRenderedMessageRow(currMsg, index)) return false", body)
+        self.assertIn("if (!isRenderedMessageRow(olderMsg, older)) continue", body)
+        # The bail-out precedes any date comparison, and the walk replaced the
+        # bare index + 1 neighbour lookup.
+        self.assertLess(body.index("isRenderedMessageRow(currMsg, index)"), body.index("moment.utc(currMsg.date)"))
+        self.assertNotIn("sortedMessages.value[index + 1]", body)
+
+        rendered = _code_only(_setup_slice(self.html, "const isRenderedMessageRow = (msg, index) =>"))
+        self.assertIn("!isHiddenAlbumMessage(msg, index)", rendered)
+        # A service row paints its container (and keeps its :data-msg-id anchor)
+        # whatever the pill inside resolves to.
+        self.assertIn("serviceRawData(msg)?.service_type === 'service'", rendered)
+        # #T3: the service arm asks the SERVICE BRANCH'S OWN condition rather
+        # than a proxy for it. The branch paints on `view.tail || view.actor`,
+        # so the predicate must build that same view.
+        self.assertIn("const view = serviceMessageView(msg)", rendered)
+        self.assertIn("return !!(view.actor || view.tail)", rendered)
+        self.assertIn('<div v-if="view.tail || view.actor"', self.html)
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_a_service_row_with_reactions_but_no_wording_does_not_orphan_a_divider(self) -> None:
+        """#T3 EXECUTED, end to end through the real ``showDateSeparator``.
+
+        The old predicate answered "painted" for any service row carrying media,
+        a reply, a forward, reactions or a poll — none of which the service
+        branch renders. Such a row is the OLDEST of its day here, so the divider
+        was emitted on it and then had nothing under it: an orphaned "July 29"
+        header above an invisible row.
+
+        Row order is newest-first, matching ``sortedMessages`` under
+        ``flex-col-reverse``: the divider emitted at ``index`` appears ABOVE
+        that row.
+        """
+        rows = [
+            {"id": 3, "date": "2026-07-30 09:00:00", "text": "later", "raw_data": {}},
+            # Reactions only, unmapped action_type -> empty pill, paints nothing.
+            {
+                "id": 2,
+                "date": "2026-07-29 12:00:00",
+                "text": "",
+                "reactions": [{"emoji": "x", "count": 1}],
+                "raw_data": {"service_type": "service", "action_type": "nope"},
+            },
+            {"id": 1, "date": "2026-07-28 08:00:00", "text": "hi", "raw_data": {}},
+        ]
+        prelude = f"""
+const sortedMessages = {{ value: {json.dumps(rows)} }}
+const viewerTimezone = {{ value: 'UTC' }}
+// The rows are naive UTC and the zone is UTC, so the real
+// moment.utc(s).tz(z).format('YYYY-MM-DD') is exactly the date prefix.
+const moment = {{ utc: (s) => ({{ tz: () => ({{ format: () => String(s).slice(0, 10) }}) }}) }}
+"""
+        verdicts = _run_setup_helpers(
+            self.html,
+            (
+                "const SERVICE_PREDICATES = {",
+                "const SERVICE_TITLE_PREDICATES = {",
+                "const SERVICE_UNKNOWN_SUBJECT = {",
+                "const getSenderName = (msg) =>",
+                "const getCurrentSenderName = (msg) =>",
+                "const serviceRawData = (msg) =>",
+                "const serviceActionType = (msg) =>",
+                "const serviceActorIsSender = (msg) =>",
+                "const serviceMessagePredicate = (msg) =>",
+                "const serviceMessageView = (msg) =>",
+                "const getGroupedId = (msg) =>",
+                "const isFirstInAlbum = (msg, index) =>",
+                "const isHiddenAlbumMessage = (msg, index) =>",
+                "const isRenderedMessageRow = (msg, index) =>",
+                "const showDateSeparator = (index) =>",
+            ),
+            "[showDateSeparator(0), showDateSeparator(1), showDateSeparator(2)]",
+            prelude=prelude,
+        )
+        # index 1 is the empty pill: no divider may hang on it. The July 30 row
+        # still heads its own day (the walk skips past the empty pill to July 28),
+        # and the oldest row always gets one.
+        self.assertEqual(verdicts, [True, False, True])
+
+    def test_quoted_title_is_reproduced_for_title_bearing_actions(self) -> None:
+        predicate = _setup_slice(self.html, "const serviceMessagePredicate = (msg) =>")
+        self.assertIn("const title = serviceRawData(msg)?.new_title", predicate)
+        # Backend wording quotes the title: 'X changed the group name to "Y"'.
+        self.assertIn(
+            "`${SERVICE_TITLE_PREDICATES[action]} \"${typeof title === 'string' ? title : ''}\"`",
+            predicate,
+        )
+
+
+class TestServiceMessageSenderTrigger(unittest.TestCase):
+    """#260: the actor name in a service pill opens the sender popup."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+
+    def test_actor_is_a_button_wired_to_the_existing_popup(self) -> None:
+        # The ORIGINAL message-row avatar trigger must stay exactly as it was.
+        self.assertEqual(self.html.count('@click="openSenderInfo(msg, $event)"'), 2)
+        # A real $event is required: the popup stores event.currentTarget and
+        # restores focus to it on close.
+        self.assertIn(':aria-label="`Show sender details for ${view.actor}`"', self.html)
+        self.assertIn('<button v-if="view.clickable" type="button"', self.html)
+
+    def test_trigger_is_gated_on_sender_id_and_on_the_sender_being_the_subject(self) -> None:
+        body = _setup_slice(self.html, "const serviceMessageView = (msg) =>")
+        self.assertIn("serviceActorIsSender(msg) && msg?.sender_id != null", body)
+        # Channel service rows have a NULL sender_id: named, but not clickable.
+        self.assertIn("msg?.sender_id != null ? getSenderName(msg) : 'Someone'", body)
+
+    def test_prose_is_never_parsed_for_the_name(self) -> None:
+        """Only a literal PREFIX match may be split — a display name can contain
+        the words around it, so a substring search would mangle the sentence."""
+        body = _setup_slice(self.html, "const serviceMessageView = (msg) =>")
+        self.assertIn("stored.startsWith(name)", body)
+        self.assertIn("stored.slice(name.length)", body)
+        self.assertNotIn(".indexOf(", body)
+        self.assertNotIn(".split(", body)
+        self.assertNotIn(".replace(", body)
+
+
+class TestPlaybarDate(unittest.TestCase):
+    """#262: the playbar showed a time with no date."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+
+    def test_compact_date_helper_reads_the_timestamp_as_utc(self) -> None:
+        """The stored timestamp is naive UTC.
+
+        ``Date.parse`` / ``new Date`` read a naive string as LOCAL time, which
+        renders the wrong calendar day for anything near midnight, so this must
+        use the same moment.utc(...).tz(...) form as ``formatTime``.
+        """
+        body = _setup_slice(self.html, "const formatShortDate = (dateStr) =>")
+        self.assertIn("moment.utc(dateStr).tz(viewerTimezone.value)", body)
+        self.assertNotIn("Date.parse", body)
+        self.assertNotIn("new Date(", body)
+        self.assertNotIn("toLocaleDateString", body)
+
+    def test_helper_is_registered_and_used_in_the_playbar(self) -> None:
+        self.assertIn("\n                    formatShortDate,\n", self.html)
+        self.assertIn("{{ formatShortDate(audioTrack.date) }} {{ formatTime(audioTrack.date) }}", self.html)
+
+
+class TestAudioBubbleDownload(unittest.TestCase):
+    """#261: per-message download control on audio / voice bubbles."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+
+    def _audio_bubble(self) -> str:
+        start = self.html.index('<div v-else-if="isAudioFile(msg)"')
+        return self.html[start : self.html.index("<!-- GIFs / Animations", start)]
+
+    def test_download_is_a_real_anchor_gated_on_no_download(self) -> None:
+        bubble = self._audio_bubble()
+        self.assertIn('v-if="!noDownload && getMediaUrl(msg)"', bubble)
+        self.assertIn(":href=\"getMediaUrl(msg) + '?download=1'\"", bubble)
+        self.assertIn(':download="getDocumentDisplayName(msg)"', bubble)
+
+    def test_download_is_not_inside_the_sm_only_playbar_group(self) -> None:
+        """The playbar speed group is ``hidden sm:flex``.
+
+        A download button placed in there vanishes below the sm breakpoint —
+        i.e. on mobile, where a per-message download matters most.
+        """
+        bubble = self._audio_bubble()
+        self.assertNotIn("hidden sm:flex", bubble)
+
+        speed_start = self.html.index('role="group" aria-label="Playback speed"')
+        speed_body = self.html[speed_start : self.html.index("</div>", self.html.index("</button>", speed_start))]
+        self.assertNotIn("download", speed_body)
+
+    def test_duration_is_rendered_once(self) -> None:
+        """#263: duration already exists on the bubble — no duplicate element."""
+        bubble = self._audio_bubble()
+        self.assertEqual(bubble.count("formatAudioTime(msg.media.duration)"), 1)

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -1619,19 +1619,12 @@ class TestOnNewMessageAdvanced:
         assert ws_message["username"] == "testuser"
         assert ws_message["sender_name"] == "Test User"
 
-        # Nested media dict mirrors the insert_media call exactly (same id/type/file_path/
-        # file_name; the unset fields insert_media defaults to None via .get() also stay None)
+        # Nested media dict mirrors the insert_media call exactly, including the
+        # attributes extracted from the media object (#263).
         media_data = db.insert_media.call_args[0][0]
         assert ws_message["media"] == {
-            "id": media_data["id"],
-            "type": media_data["type"],
-            "file_path": media_data["file_path"],
-            "file_name": media_data["file_name"],
-            "file_size": None,
-            "mime_type": None,
-            "width": None,
-            "height": None,
-            "duration": None,
+            key: media_data[key]
+            for key in ("id", "type", "file_path", "file_name", "file_size", "mime_type", "width", "height", "duration")
         }
 
         # message_data passed to db.insert_message is untouched -- DB path unchanged
@@ -2319,3 +2312,134 @@ class TestListenerMainEntryPoint:
             pytest.raises(RuntimeError, match="fatal"),
         ):
             await main()
+
+
+# ===========================================================================
+# #263 -- realtime listener must record the same media attributes as the sweep
+# ===========================================================================
+
+
+def _voice_media(duration: int = 7, size: int = 4321):
+    """A MessageMediaDocument mock shaped like a Telegram voice note."""
+    from types import SimpleNamespace
+
+    from telethon.tl.types import DocumentAttributeAudio, MessageMediaDocument
+
+    media = MagicMock(spec=MessageMediaDocument)
+    media.document = SimpleNamespace(
+        id=987654321,
+        size=size,
+        mime_type="audio/ogg",
+        attributes=[DocumentAttributeAudio(duration=duration, voice=True)],
+    )
+    return media
+
+
+def _video_media(width: int = 640, height: int = 480, duration: int = 12, size: int = 90000):
+    """A MessageMediaDocument mock shaped like a Telegram video."""
+    from types import SimpleNamespace
+
+    from telethon.tl.types import DocumentAttributeVideo, MessageMediaDocument
+
+    media = MagicMock(spec=MessageMediaDocument)
+    media.document = SimpleNamespace(
+        id=123456789,
+        size=size,
+        mime_type="video/mp4",
+        attributes=[DocumentAttributeVideo(duration=duration, w=width, h=height)],
+    )
+    return media
+
+
+def _media_event(media, message_id: int = 4242):
+    """NewMessage event carrying the given media object."""
+    event = MagicMock()
+    event.chat_id = -1001234567890
+    msg = MagicMock()
+    msg.reply_to = None
+    msg.id = message_id
+    msg.sender_id = 111
+    msg.date = datetime(2026, 1, 1)
+    msg.text = ""
+    msg.reply_to_msg_id = None
+    msg.edit_date = None
+    msg.out = False
+    msg.grouped_id = None
+    msg.media = media
+    msg.sender = None
+    event.message = msg
+    event.get_chat = AsyncMock(return_value=MagicMock())
+    return event
+
+
+class TestRealtimeMediaAttributes:
+    """#263: live capture left duration/file_size/mime_type/width/height NULL."""
+
+    async def test_voice_note_attributes_reach_the_db_row(self):
+        listener, handlers, db, config = _make_listener_with_handlers(listen_new_messages_media=True)
+        handler = handlers[events.NewMessage]
+        listener._download_media = AsyncMock(return_value=("/tmp/media/-100/voice.ogg", "voice.ogg", "hash123"))
+
+        await handler(_media_event(_voice_media(duration=7, size=4321)))
+
+        media_data = db.insert_media.call_args[0][0]
+        assert media_data["type"] == "voice"
+        assert media_data["duration"] == 7
+        assert media_data["file_size"] == 4321
+        assert media_data["mime_type"] == "audio/ogg"
+
+    async def test_video_dimensions_and_duration_reach_the_db_row(self):
+        listener, handlers, db, config = _make_listener_with_handlers(listen_new_messages_media=True)
+        handler = handlers[events.NewMessage]
+        listener._download_media = AsyncMock(return_value=("/tmp/media/-100/clip.mp4", "clip.mp4", "hash456"))
+
+        await handler(_media_event(_video_media(width=640, height=480, duration=12, size=90000)))
+
+        media_data = db.insert_media.call_args[0][0]
+        assert media_data["type"] == "video"
+        assert media_data["width"] == 640
+        assert media_data["height"] == 480
+        assert media_data["duration"] == 12
+        assert media_data["file_size"] == 90000
+        assert media_data["mime_type"] == "video/mp4"
+
+    async def test_ws_media_mirrors_the_inserted_row(self):
+        from src.realtime import NotificationType
+
+        listener, handlers, db, config = _make_listener_with_handlers(listen_new_messages_media=True)
+        handler = handlers[events.NewMessage]
+        notifier = AsyncMock()
+        listener._notifier = notifier
+        listener._download_media = AsyncMock(return_value=("/tmp/media/-100/voice.ogg", "voice.ogg", "hash123"))
+
+        await handler(_media_event(_voice_media(duration=9, size=555)))
+
+        media_data = db.insert_media.call_args[0][0]
+        assert notifier.notify.call_args[0][0] == NotificationType.NEW_MESSAGE
+        ws_media = notifier.notify.call_args[0][2]["message"]["media"]
+        assert ws_media == {
+            "id": media_data["id"],
+            "type": media_data["type"],
+            "file_path": media_data["file_path"],
+            "file_name": media_data["file_name"],
+            "file_size": media_data["file_size"],
+            "mime_type": media_data["mime_type"],
+            "width": media_data["width"],
+            "height": media_data["height"],
+            "duration": media_data["duration"],
+        }
+        assert ws_media["duration"] == 9
+        assert ws_media["file_size"] == 555
+
+    async def test_on_disk_size_wins_over_telegram_reported_size(self, tmp_path):
+        listener, handlers, db, config = _make_listener_with_handlers(listen_new_messages_media=True)
+        handler = handlers[events.NewMessage]
+        on_disk = tmp_path / "voice.ogg"
+        on_disk.write_bytes(b"x" * 17)
+        listener._download_media = AsyncMock(return_value=(str(on_disk), "voice.ogg", "hash123"))
+
+        await handler(_media_event(_voice_media(duration=3, size=999999)))
+
+        media_data = db.insert_media.call_args[0][0]
+        assert media_data["file_size"] == 17
+        assert media_data["duration"] == 3

--- a/tests/test_media_adapter.py
+++ b/tests/test_media_adapter.py
@@ -261,3 +261,164 @@ class TestGetMediaCounts:
     async def test_empty_chat_returns_empty_dict(self, adapter):
         counts = await adapter.get_media_counts(-9999)
         assert counts == {}
+
+
+# ===========================================================================
+# #257 -- ordering / tiebreak of get_media_paginated
+#
+# The pre-existing pagination tests above only assert "no duplicates" and every
+# fixture message has a unique date, so the tiebreak branch was never exercised.
+# These fixtures use PRODUCTION-format composite ids (f"{chat_id}_{msg_id}_{type}")
+# because the defect was Media.id sorting LEXICALLY.
+# ===========================================================================
+
+
+async def _build_adapter(seed) -> DatabaseAdapter:
+    """In-memory SQLite adapter, seeded by the given ``seed(session, chat_id)``."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db_manager = DatabaseManager.__new__(DatabaseManager)
+    db_manager.engine = engine
+    db_manager.database_url = "sqlite+aiosqlite://"
+    db_manager._is_sqlite = True
+    db_manager.async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with db_manager.async_session_factory() as session:
+        await seed(session)
+        await session.commit()
+
+    return DatabaseAdapter(db_manager)
+
+
+async def _walk_all(adapter: DatabaseAdapter, chat_id: int, limit: int) -> list[dict]:
+    """Page through every media row using before_id cursors until exhaustion."""
+    collected: list[dict] = []
+    before_id = None
+    for _ in range(1000):  # guard: a broken cursor must fail the test, not hang it
+        page = await adapter.get_media_paginated(chat_id, limit=limit, before_id=before_id)
+        collected.extend(page["items"])
+        if not page["has_more"]:
+            return collected
+        assert page["items"], "has_more=True with an empty page would loop forever"
+        before_id = page["items"][-1]["id"]
+    raise AssertionError("pagination did not terminate")
+
+
+MULTI_DATE_CHAT = -100257
+MULTI_DATE_TOTAL = 120
+SAME_DATE_CHAT = -100258
+SAME_DATE_MESSAGE_IDS = [7, 8, 9, 80, 89, 99, 120, 1000]
+
+
+@pytest_asyncio.fixture
+async def multi_date_adapter():
+    """120 media rows spread over 4 timestamps (30 rows share each timestamp)."""
+
+    async def seed(session) -> None:
+        session.add(Chat(id=MULTI_DATE_CHAT, type="channel", title="Bulk"))
+        for index in range(MULTI_DATE_TOTAL):
+            message_id = index + 1
+            day = 1 + index // 30
+            session.add(
+                Message(
+                    id=message_id,
+                    chat_id=MULTI_DATE_CHAT,
+                    sender_id=None,
+                    date=datetime(2026, 3, day, 12),
+                    text="",
+                )
+            )
+            session.add(
+                Media(
+                    id=f"{MULTI_DATE_CHAT}_{message_id}_voice",
+                    message_id=message_id,
+                    chat_id=MULTI_DATE_CHAT,
+                    type="voice",
+                    file_path=f"{MULTI_DATE_CHAT}/voice_{message_id}.ogg",
+                    file_name=f"voice_{message_id}.ogg",
+                    downloaded=1,
+                )
+            )
+
+    return await _build_adapter(seed)
+
+
+@pytest_asyncio.fixture
+async def same_date_adapter():
+    """Every media row shares ONE timestamp; message_ids differ in digit length."""
+
+    async def seed(session) -> None:
+        session.add(Chat(id=SAME_DATE_CHAT, type="channel", title="Tiebreak"))
+        shared_date = datetime(2026, 4, 1, 9, 30)
+        for message_id in SAME_DATE_MESSAGE_IDS:
+            session.add(
+                Message(
+                    id=message_id,
+                    chat_id=SAME_DATE_CHAT,
+                    sender_id=None,
+                    date=shared_date,
+                    text="",
+                )
+            )
+            session.add(
+                Media(
+                    id=f"{SAME_DATE_CHAT}_{message_id}_voice",
+                    message_id=message_id,
+                    chat_id=SAME_DATE_CHAT,
+                    type="voice",
+                    file_path=f"{SAME_DATE_CHAT}/voice_{message_id}.ogg",
+                    file_name=f"voice_{message_id}.ogg",
+                    downloaded=1,
+                )
+            )
+
+    return await _build_adapter(seed)
+
+
+class TestMediaPaginationOrdering:
+    """#257: full-walk integrity plus numeric (not lexical) tiebreak ordering."""
+
+    async def test_full_walk_returns_every_row_exactly_once(self, multi_date_adapter) -> None:
+        items = await _walk_all(multi_date_adapter, MULTI_DATE_CHAT, limit=7)
+        ids = [item["id"] for item in items]
+
+        assert len(ids) == MULTI_DATE_TOTAL
+        assert len(set(ids)) == MULTI_DATE_TOTAL, "duplicate rows across the walk"
+        expected = {f"{MULTI_DATE_CHAT}_{n}_voice" for n in range(1, MULTI_DATE_TOTAL + 1)}
+        assert set(ids) == expected, "the walk skipped rows"
+
+    async def test_full_walk_dates_are_non_increasing(self, multi_date_adapter) -> None:
+        items = await _walk_all(multi_date_adapter, MULTI_DATE_CHAT, limit=7)
+        dates = [item["message_date"] for item in items]
+
+        assert all(dates[i] >= dates[i + 1] for i in range(len(dates) - 1)), "message_date is not descending"
+
+    async def test_full_walk_is_numerically_descending_within_each_date(self, multi_date_adapter) -> None:
+        items = await _walk_all(multi_date_adapter, MULTI_DATE_CHAT, limit=7)
+        message_ids = [item["message_id"] for item in items]
+
+        assert message_ids == sorted(message_ids, reverse=True)
+
+    async def test_identical_dates_tiebreak_numerically_not_lexically(self, same_date_adapter) -> None:
+        items = await _walk_all(same_date_adapter, SAME_DATE_CHAT, limit=3)
+        message_ids = [item["message_id"] for item in items]
+
+        assert message_ids == sorted(SAME_DATE_MESSAGE_IDS, reverse=True)
+
+        # A lexical sort on the composite Media.id puts 9 before 89 before 8 -- the
+        # exact symptom of #257. Assert we are NOT producing that order.
+        lexical = sorted(SAME_DATE_MESSAGE_IDS, key=lambda n: f"{SAME_DATE_CHAT}_{n}_voice", reverse=True)
+        assert message_ids != lexical
+
+    async def test_identical_dates_walk_has_no_duplicates_or_gaps(self, same_date_adapter) -> None:
+        items = await _walk_all(same_date_adapter, SAME_DATE_CHAT, limit=3)
+        ids = [item["id"] for item in items]
+
+        assert len(ids) == len(set(ids))
+        assert set(ids) == {f"{SAME_DATE_CHAT}_{n}_voice" for n in SAME_DATE_MESSAGE_IDS}

--- a/tests/test_media_download_disposition.py
+++ b/tests/test_media_download_disposition.py
@@ -1,0 +1,281 @@
+"""Tests for #261 (?download=1 forces attachment) and #258 (URL percent-encoding).
+
+Both defects made a media file unreachable or unsaveable from the viewer:
+- serve_media accepted a ``download`` query param and ignored it, so the gallery's
+  download button just opened/played the file inline.
+- Server-built media URLs were plain f-strings, so a Telegram filename containing
+  "#" or "?" produced a URL that truncated into a fragment/query.
+"""
+
+import importlib
+import os
+import tempfile
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+# Self-contained bootstrap (same pattern as tests/test_database_viewer.py): importing
+# src.web.main builds a Config, which creates BACKUP_PATH — defaulting to the
+# read-only "/data" and failing this whole module when it runs on its own.
+os.environ.setdefault("BACKUP_PATH", tempfile.mkdtemp(prefix="ta_test_backup_"))
+
+pytest.importorskip("fastapi")
+
+from fastapi.testclient import TestClient
+
+ANON_ENV = {
+    "VIEWER_USERNAME": "",
+    "VIEWER_PASSWORD": "",
+    "ALLOW_ANONYMOUS_VIEWER": "true",
+}
+
+
+def _reload_main(media_root=None):
+    """Reload src.web.main under anonymous auth and return (client, module)."""
+    import src.web.main as main_mod
+
+    importlib.reload(main_mod)
+    main_mod.db = AsyncMock()
+    if media_root is not None:
+        main_mod._media_root = main_mod.Path(media_root).resolve()
+    return TestClient(main_mod.app, raise_server_exceptions=False), main_mod
+
+
+class TestDownloadDisposition:
+    """#261: ?download=1 must emit Content-Disposition: attachment."""
+
+    def _serve(self, filename: str, query: str = ""):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            chat_dir = os.path.join(tmpdir, "-1001")
+            os.makedirs(chat_dir)
+            with open(os.path.join(chat_dir, filename), "wb") as handle:
+                handle.write(b"bytes")
+            with patch.dict(os.environ, ANON_ENV):
+                client, _ = _reload_main(media_root=tmpdir)
+                from urllib.parse import quote
+
+                return client.get(f"/media/-1001/{quote(filename, safe='')}{query}")
+
+    def test_download_flag_sets_attachment_disposition(self) -> None:
+        resp = self._serve("clip.mp4", "?download=1")
+        assert resp.status_code == 200
+        assert resp.headers["content-disposition"].startswith("attachment")
+        assert "clip.mp4" in resp.headers["content-disposition"]
+
+    def test_inline_by_default(self) -> None:
+        """<img>/<video> use the same URL without the flag — must stay inline."""
+        resp = self._serve("photo.jpg")
+        assert resp.status_code == 200
+        assert "attachment" not in resp.headers.get("content-disposition", "")
+
+    def test_download_zero_stays_inline(self) -> None:
+        resp = self._serve("photo.jpg", "?download=0")
+        assert resp.status_code == 200
+        assert "attachment" not in resp.headers.get("content-disposition", "")
+
+    def test_download_keeps_media_type(self) -> None:
+        """Forcing a download must not mislabel the bytes."""
+        resp = self._serve("photo.jpg", "?download=1")
+        assert resp.status_code == 200
+        assert resp.headers["content-type"].startswith("image/jpeg")
+
+    def test_quote_injecting_filename_is_escaped(self) -> None:
+        """The filename is attacker-influenced (it is the Telegram document name)."""
+        resp = self._serve('a"b;q=1.txt', "?download=1")
+        assert resp.status_code == 200
+        disposition = resp.headers["content-disposition"]
+        # Starlette falls back to RFC 5987 whenever quoting changed the string, so
+        # the raw quote never reaches the header value and cannot close it early.
+        assert disposition.startswith("attachment; filename*=utf-8''")
+        assert '"' not in disposition
+
+    def test_download_name_is_the_display_name_not_the_storage_name(self) -> None:
+        """On disk every file carries a uniqueness prefix; the save dialog must not."""
+        resp = self._serve("123456789_holiday.jpg", "?download=1")
+        assert resp.status_code == 200
+        disposition = resp.headers["content-disposition"]
+        assert disposition == 'attachment; filename="holiday.jpg"'
+        assert "123456789" not in disposition
+
+    def test_imported_media_storage_prefix_is_stripped_too(self) -> None:
+        resp = self._serve("import_-1001_5_report.pdf", "?download=1")
+        assert resp.status_code == 200
+        assert resp.headers["content-disposition"] == 'attachment; filename="report.pdf"'
+
+    def test_a_digit_first_component_is_stripped_like_the_gallery_label(self) -> None:
+        """A leading digit run is indistinguishable from a storage prefix — both go.
+
+        The saved name must equal the label the gallery shows for the same file,
+        and the viewer's getMediaDisplayName strips ``^[0-9]+_`` unconditionally.
+        """
+        resp = self._serve("2026_report.pdf", "?download=1")
+        assert resp.status_code == 200
+        assert resp.headers["content-disposition"] == 'attachment; filename="report.pdf"'
+
+    def test_name_without_any_prefix_is_saved_verbatim(self) -> None:
+        """Only a leading prefix is removed — nothing else is rewritten."""
+        resp = self._serve("holiday.jpg", "?download=1")
+        assert resp.status_code == 200
+        assert resp.headers["content-disposition"] == 'attachment; filename="holiday.jpg"'
+
+    def test_only_the_first_prefix_is_stripped(self) -> None:
+        resp = self._serve("77_2026_report.pdf", "?download=1")
+        assert resp.status_code == 200
+        assert resp.headers["content-disposition"] == 'attachment; filename="2026_report.pdf"'
+
+    def test_escaping_still_applies_after_the_prefix_is_stripped(self) -> None:
+        """Stripping must not smuggle a dangerous byte past Starlette's quoting."""
+        resp = self._serve('123_a"b;q=1.txt', "?download=1")
+        assert resp.status_code == 200
+        disposition = resp.headers["content-disposition"]
+        assert disposition.startswith("attachment; filename*=utf-8''")
+        assert '"' not in disposition
+        assert "123_" not in disposition
+
+    def test_crlf_filename_cannot_inject_a_header(self) -> None:
+        """CRLF is escaped by Starlette's own quoting before it reaches the header.
+
+        Driven at the FileResponse level: an ASGI client normalises %0D%0A out of
+        the request path, so the router can never carry such a name.
+        """
+        from starlette.responses import FileResponse
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = os.path.join(tmpdir, "ok.txt")
+            with open(target, "wb") as handle:
+                handle.write(b"bytes")
+            response = FileResponse(target, filename='a"b\r\nX-Injected: 1.txt')
+
+        disposition = response.headers["content-disposition"]
+        assert "\r" not in disposition and "\n" not in disposition
+        assert "x-injected" not in {key.lower() for key in response.headers}
+        assert disposition.startswith("attachment; filename*=utf-8''")
+
+    def test_no_download_account_still_blocked(self) -> None:
+        """The 403 guard must fire before any disposition handling."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            chat_dir = os.path.join(tmpdir, "-1001")
+            os.makedirs(chat_dir)
+            with open(os.path.join(chat_dir, "photo.jpg"), "wb") as handle:
+                handle.write(b"bytes")
+            with patch.dict(
+                os.environ,
+                {"VIEWER_USERNAME": "admin", "VIEWER_PASSWORD": "testpass123", "SECURE_COOKIES": "false"},
+            ):
+                client, main_mod = _reload_main(media_root=tmpdir)
+                main_mod.AUTH_ENABLED = True
+                token = "no-download-token"
+                main_mod._sessions[token] = main_mod.SessionData(username="viewer1", role="viewer", no_download=True)
+                resp = client.get("/media/-1001/photo.jpg?download=1", cookies={"viewer_auth": token})
+                assert resp.status_code == 403
+
+
+class TestMediaUrlEncoding:
+    """#258: server-built media URLs must percent-encode each path segment."""
+
+    def test_encode_helper_escapes_reserved_chars_per_segment(self) -> None:
+        with patch.dict(os.environ, ANON_ENV):
+            _, main_mod = _reload_main()
+        encoded = main_mod._encode_media_path("-1001/we#1 who are? .jpg")
+        assert encoded == "-1001/we%231%20who%20are%3F%20.jpg"
+        assert encoded.count("/") == 1, "path separators must survive"
+
+    def test_gallery_urls_encode_hash_and_question_mark(self) -> None:
+        with patch.dict(os.environ, ANON_ENV):
+            client, main_mod = _reload_main()
+            main_mod.db.get_media_paginated = AsyncMock(
+                return_value={
+                    "items": [
+                        {
+                            "id": "-1001_5_photo",
+                            "message_id": 5,
+                            "chat_id": -1001,
+                            "type": "photo",
+                            "file_path": "-1001/we#1 who? are.jpg",
+                            "file_name": "we#1 who? are.jpg",
+                        }
+                    ],
+                    "has_more": False,
+                }
+            )
+            resp = client.get("/api/chats/-1001/media")
+
+        assert resp.status_code == 200
+        item = resp.json()["items"][0]
+        assert item["media_url"] == "/media/-1001/we%231%20who%3F%20are.jpg"
+        assert item["thumb_url"] == "/media/thumb/200/-1001/we%231%20who%3F%20are.jpg"
+
+    def test_plain_filenames_are_unchanged(self) -> None:
+        """Existing URLs must not shift — the gallery and tests round-trip them."""
+        with patch.dict(os.environ, ANON_ENV):
+            client, main_mod = _reload_main()
+            main_mod.db.get_media_paginated = AsyncMock(
+                return_value={
+                    "items": [
+                        {
+                            "id": "-1001_5_photo",
+                            "message_id": 5,
+                            "chat_id": -1001,
+                            "type": "photo",
+                            "file_path": "-1001/photo_123.jpg",
+                            "file_name": "photo_123.jpg",
+                        }
+                    ],
+                    "has_more": False,
+                }
+            )
+            resp = client.get("/api/chats/-1001/media")
+
+        item = resp.json()["items"][0]
+        assert item["media_url"] == "/media/-1001/photo_123.jpg"
+        assert item["thumb_url"] == "/media/thumb/200/-1001/photo_123.jpg"
+
+    def test_chat_avatar_url_is_encoded(self) -> None:
+        with patch.dict(os.environ, ANON_ENV):
+            client, main_mod = _reload_main()
+            main_mod.db.get_all_chats = AsyncMock(return_value=[{"id": -1001, "title": "Chat A", "type": "channel"}])
+            main_mod.db.get_chat_count = AsyncMock(return_value=1)
+            main_mod.db.get_archived_chat_count = AsyncMock(return_value=0)
+            with patch.object(main_mod, "_get_cached_avatar_path", return_value="avatars/chats/-1001_a#b.jpg"):
+                resp = client.get("/api/chats")
+
+        assert resp.status_code == 200
+        assert resp.json()["chats"][0]["avatar_url"] == "/media/avatars/chats/-1001_a%23b.jpg"
+
+    def test_sender_avatar_url_is_encoded(self) -> None:
+        with patch.dict(os.environ, ANON_ENV):
+            _, main_mod = _reload_main()
+        with patch.object(main_mod, "_get_cached_avatar_path", return_value="avatars/users/42_a?b.jpg"):
+            assert main_mod._sender_avatar_url(42) == "/media/avatars/users/42_a%3Fb.jpg"
+
+    def test_encoded_thumb_url_routes_with_decoded_segments(self) -> None:
+        """The encoded thumb URL must still match /media/thumb/{size}/{folder:path}/{filename}."""
+        ensure = AsyncMock(return_value=None)
+        with (
+            tempfile.TemporaryDirectory() as tmpdir,
+            patch.dict(os.environ, ANON_ENV),
+            patch("src.web.thumbnails.ensure_thumbnail", ensure),
+        ):
+            client, main_mod = _reload_main(media_root=tmpdir)
+            encoded = main_mod._encode_media_path("-1001/we#1 who? are.jpg")
+            resp = client.get(f"/media/thumb/200/{encoded}")
+
+        assert resp.status_code == 404, "route matched but no thumbnail exists — 404 is the expected miss"
+        assert ensure.await_count == 1
+        _, size, folder, filename = ensure.await_args[0]
+        assert (size, folder, filename) == (200, "-1001", "we#1 who? are.jpg")
+
+    def test_encoded_url_round_trips_through_serve_media(self) -> None:
+        """The encoded URL must resolve back to the same file on disk."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            chat_dir = os.path.join(tmpdir, "-1001")
+            os.makedirs(chat_dir)
+            with open(os.path.join(chat_dir, "we#1 who? are.jpg"), "wb") as handle:
+                handle.write(b"jpegbytes")
+            with patch.dict(os.environ, ANON_ENV):
+                client, main_mod = _reload_main(media_root=tmpdir)
+                encoded = main_mod._encode_media_path("-1001/we#1 who? are.jpg")
+                resp = client.get(f"/media/{encoded}")
+
+        assert resp.status_code == 200
+        assert resp.content == b"jpegbytes"

--- a/tests/test_media_download_disposition.py
+++ b/tests/test_media_download_disposition.py
@@ -160,7 +160,7 @@ class TestDownloadDisposition:
                 handle.write(b"bytes")
             with patch.dict(
                 os.environ,
-                {"VIEWER_USERNAME": "admin", "VIEWER_PASSWORD": "testpass123", "SECURE_COOKIES": "false"},
+                {"VIEWER_USERNAME": "admin", "VIEWER_PASSWORD": "test@value/here", "SECURE_COOKIES": "false"},
             ):
                 client, main_mod = _reload_main(media_root=tmpdir)
                 main_mod.AUTH_ENABLED = True

--- a/tests/test_media_metadata_persistence.py
+++ b/tests/test_media_metadata_persistence.py
@@ -68,6 +68,12 @@ def _photo_media(*sizes):
     return media
 
 
+def _plain_size(width=320, height=240, size=8000):
+    from telethon.tl.types import PhotoSize
+
+    return PhotoSize(type="m", w=width, h=height, size=size)
+
+
 def _message(msg_id, media):
     msg = MagicMock()
     msg.id = msg_id
@@ -200,6 +206,21 @@ class TestExtractMediaAttributes(unittest.TestCase):
             {"file_size": None, "mime_type": None, "width": None, "height": None, "duration": None},
         )
 
+    def test_returned_key_set_is_the_pinned_contract(self):
+        """Both callers spread this dict into a media row, so the key set is a contract.
+
+        Adding/renaming a key silently changes what the sweep and the listener
+        write (and which one of them then overrides ``file_size``). Pin it for
+        every media shape, not just the empty one.
+        """
+        expected = {"file_size", "mime_type", "width", "height", "duration"}
+        for media in (_video_media(), _photo_media(), _photo_media(_plain_size())):
+            self.assertEqual(set(extract_media_attributes(media)), expected)
+
+    def test_file_size_is_telegrams_declared_size_not_a_disk_size(self):
+        """The collision both callers resolve: this value is overridden on-disk."""
+        self.assertEqual(extract_media_attributes(_video_media(size=90000))["file_size"], 90000)
+
 
 class TestMediaDisplayFilename(unittest.TestCase):
     """Server-side twin of the viewer's getMediaDisplayName."""
@@ -209,9 +230,6 @@ class TestMediaDisplayFilename(unittest.TestCase):
 
     def test_strips_the_import_media_id_prefix(self):
         self.assertEqual(media_display_filename("import_-1001_5_report.pdf"), "report.pdf")
-
-    def test_strips_an_explicit_media_id_prefix(self):
-        self.assertEqual(media_display_filename("-1001_5_photo_shot.jpg", media_id="-1001_5_photo"), "shot.jpg")
 
     def test_strips_at_most_one_prefix(self):
         """Only the FIRST component can be lost — the second digit run survives."""
@@ -337,11 +355,42 @@ class TestSweepPreservesLiveCapturedMetadata:
         assert stored.file_size == 90000
         assert stored.content_hash == "hash123"
         assert stored.download_date is not None
-        # A failed attempt must not un-download a file whose path we just kept.
-        assert stored.downloaded == 1
+
+    async def test_failed_download_leaves_the_row_retryable(self, adapter):
+        """A row whose file is gone must return to the pending-download queue.
+
+        The except branch of ``_process_media`` reports ``downloaded: False``, and
+        that is the ONLY always-on recovery signal: ``_retry_pending_media_downloads``
+        drains ``get_pending_media_downloads`` every cycle, while the disk-stat
+        scan ``_verify_and_redownload_media`` is gated on VERIFY_MEDIA (default
+        false). Pinning the flag at 1 stranded the row pointing at a missing file.
+        """
+        media_id = f"{CHAT_ID}_7_video"
+        await adapter.insert_media(self._listener_row(media_id, _video_media()))
+
+        await adapter.insert_media(
+            {
+                "id": media_id,
+                "message_id": 7,
+                "chat_id": CHAT_ID,
+                "type": "video",
+                "downloaded": False,
+            }
+        )
+
+        stored = await _media_row(adapter, media_id)
+        assert stored.downloaded == 0
+        pending = await adapter.get_pending_media_downloads(100 * 1024 * 1024, 5)
+        assert [row["id"] for row in pending] == [media_id]
 
     async def test_oversize_skip_row_does_not_strand_an_already_downloaded_file(self, adapter):
-        """Lowering MAX_MEDIA_SIZE makes the sweep emit a not-downloaded row for a stored file."""
+        """Lowering MAX_MEDIA_SIZE must not un-download a file that is already stored.
+
+        The skip row never attempted a download, so it states no ``downloaded``
+        outcome at all and the stored flag is kept. Flipping it to 0 would hide the
+        file from the gallery (``get_media_paginated`` filters ``downloaded == 1``)
+        while the retry queue skips it for being over the limit — orphaned on disk.
+        """
         media_id = f"{CHAT_ID}_7_video"
         listener_row = self._listener_row(media_id, _video_media())
         await adapter.insert_media(listener_row)
@@ -349,7 +398,7 @@ class TestSweepPreservesLiveCapturedMetadata:
         backup = _make_backup(self.media_root)
         backup.config.get_max_media_size_bytes = MagicMock(return_value=1)
         skip_row = await backup._process_media(_message(7, _video_media()), CHAT_ID)
-        assert skip_row["downloaded"] is False
+        assert "downloaded" not in skip_row
         await adapter.insert_media(skip_row)
 
         stored = await _media_row(adapter, media_id)
@@ -357,6 +406,22 @@ class TestSweepPreservesLiveCapturedMetadata:
         assert stored.file_path == listener_row["file_path"]
         # The one thing the skip row DOES know is the real size — a value overwrites.
         assert stored.file_size == skip_row["file_size"]
+
+    async def test_oversize_skip_row_is_never_retried(self, adapter):
+        """Even as a first sighting (flag 0), its over-limit size keeps it out of the queue."""
+        backup = _make_backup(self.media_root)
+        backup.config.get_max_media_size_bytes = MagicMock(return_value=1)
+        skip_row = await backup._process_media(_message(7, _video_media(size=90000)), CHAT_ID)
+        await adapter.insert_media(skip_row)
+
+        stored = await _media_row(adapter, skip_row["id"])
+        assert stored.downloaded == 0
+        assert stored.file_size == 90000
+        assert await adapter.get_pending_media_downloads(1, 5) == []
+        # Positive control: raise the limit and the very same row IS retryable.
+        assert [row["id"] for row in await adapter.get_pending_media_downloads(100 * 1024 * 1024, 5)] == [
+            skip_row["id"]
+        ]
 
     async def test_redownload_to_a_new_path_still_updates_the_row(self, adapter):
         """Positive control: COALESCE only falls back on NULL, it never pins a value."""
@@ -399,10 +464,10 @@ class TestSweepPreservesLiveCapturedMetadata:
         assert stored.download_date is None
 
     async def test_upsert_compiles_on_both_dialects(self):
-        """Two-argument ``max(a, b)`` is SQLite-only — the sticky flag must compile on psycopg2 too."""
+        """The conflict clause must compile identically on SQLite and psycopg2."""
         from sqlalchemy.dialects import postgresql, sqlite
 
-        for dialect in (sqlite.dialect(), postgresql.psycopg2.dialect()):
+        async def _compiled(media_data, dialect):
             db_manager = MagicMock()
             db_manager._is_sqlite = dialect.name == "sqlite"
 
@@ -412,12 +477,18 @@ class TestSweepPreservesLiveCapturedMetadata:
             async_ctx.__aexit__ = AsyncMock(return_value=False)
             db_manager.async_session_factory.return_value = async_ctx
 
-            await DatabaseAdapter(db_manager).insert_media({"id": "m1", "type": "photo", "downloaded": False})
+            await DatabaseAdapter(db_manager).insert_media(media_data)
+            return str(session.execute.await_args[0][0].compile(dialect=dialect))
 
-            sql = str(session.execute.await_args[0][0].compile(dialect=dialect))
-            assert "coalesce(excluded.file_path, media.file_path)" in sql
-            assert "CASE WHEN (excluded.downloaded" in sql
-            assert "max(" not in sql
+        for dialect in (sqlite.dialect(), postgresql.psycopg2.dialect()):
+            stated = await _compiled({"id": "m1", "type": "photo", "downloaded": False}, dialect)
+            assert "coalesce(excluded.file_path, media.file_path)" in stated
+            # A stated outcome is written, not preserved.
+            assert "downloaded = media.downloaded" not in stated
+
+            unstated = await _compiled({"id": "m1", "type": "photo"}, dialect)
+            assert "coalesce(excluded.file_path, media.file_path)" in unstated
+            assert "downloaded = media.downloaded" in unstated
 
     async def test_upsert_still_overwrites_a_real_value_with_a_real_value(self, adapter):
         media_id = f"{CHAT_ID}_7_video"

--- a/tests/test_media_metadata_persistence.py
+++ b/tests/test_media_metadata_persistence.py
@@ -96,6 +96,11 @@ def _make_backup(media_root):
         return path
 
     backup.client.download_media = AsyncMock(side_effect=fake_download)
+    # config is a MagicMock, so an unset predicate returns a truthy mock. Pin the
+    # skip predicates to False: a future test routing through _process_message or
+    # _backup_dialog with this fixture would otherwise silently skip every message
+    # and pass vacuously.
+    backup.config.should_skip_topic.return_value = False
     return backup
 
 

--- a/tests/test_media_metadata_persistence.py
+++ b/tests/test_media_metadata_persistence.py
@@ -1,0 +1,497 @@
+"""#263 follow-ups: the media metadata written by live capture must SURVIVE.
+
+Three defects, one theme — a value that reached the ``media`` table got lost again:
+
+- The scheduled sweep re-extracted mime_type/width/height/duration with its own
+  (weaker) code and upserted the row, blanking what the listener had stored. Both
+  paths now share ``extract_media_attributes``, and the upsert COALESCEs the
+  metadata columns so an ingest path with nothing to say cannot null them.
+- ``duration`` arrives from Telethon as a float for video, but the column is
+  INTEGER.
+- ``PhotoSizeProgressive`` scored 0 in the "largest size" pick, so dimensions were
+  read off a thumbnail.
+
+Plus the cross-chat cursor oracle in ``get_media_paginated``.
+"""
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Base, Chat, Media, Message
+from src.message_utils import extract_media_attributes, media_display_filename, utcnow_naive
+from src.telegram_backup import TelegramBackup
+
+CHAT_ID = -1001
+OTHER_CHAT_ID = -2002
+
+
+# ---------------------------------------------------------------------------
+# Telethon-shaped fixtures
+# ---------------------------------------------------------------------------
+
+
+def _video_media(width=640, height=480, duration=12, size=90000):
+    """A MessageMediaDocument shaped like a Telegram video."""
+    from telethon.tl.types import DocumentAttributeVideo, MessageMediaDocument
+
+    media = MagicMock(spec=MessageMediaDocument)
+    media.document = SimpleNamespace(
+        id=123456789,
+        size=size,
+        mime_type="video/mp4",
+        attributes=[DocumentAttributeVideo(duration=duration, w=width, h=height)],
+    )
+    return media
+
+
+def _photo_media(*sizes):
+    """A MessageMediaPhoto whose ``photo.sizes`` are the given size objects."""
+    from telethon.tl.types import MessageMediaPhoto
+
+    media = MagicMock(spec=MessageMediaPhoto)
+    media.photo = SimpleNamespace(id=99, sizes=list(sizes))
+    return media
+
+
+def _message(msg_id, media):
+    msg = MagicMock()
+    msg.id = msg_id
+    msg.media = media
+    msg.date = datetime(2026, 1, 1, 10)
+    msg.reply_to = None
+    msg.action = None
+    return msg
+
+
+def _make_backup(media_root):
+    """TelegramBackup wired for a real, dedup-free download into ``media_root``."""
+    backup = TelegramBackup.__new__(TelegramBackup)
+    backup.config = MagicMock()
+    backup.config.media_path = media_root
+    backup.config.deduplicate_media = False
+    backup.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
+    backup.db = AsyncMock()
+    backup.client = AsyncMock()
+    backup._owns_client = True
+    backup._cleaned_media_chats = set()
+
+    async def fake_download(_message, path):
+        with open(path, "wb") as handle:
+            handle.write(b"mediabytes")
+        return path
+
+    backup.client.download_media = AsyncMock(side_effect=fake_download)
+    return backup
+
+
+# ---------------------------------------------------------------------------
+# Database fixture (real in-memory SQLite, so the upsert SQL actually runs)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def adapter():
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db_manager = DatabaseManager.__new__(DatabaseManager)
+    db_manager.engine = engine
+    db_manager.database_url = "sqlite+aiosqlite://"
+    db_manager._is_sqlite = True
+    db_manager.async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with db_manager.async_session_factory() as session:
+        session.add(Chat(id=CHAT_ID, type="channel", title="Chat A"))
+        session.add(Chat(id=OTHER_CHAT_ID, type="channel", title="Chat B"))
+        session.add(Message(id=7, chat_id=CHAT_ID, sender_id=None, date=datetime(2026, 1, 1, 10), text=""))
+        # The other chat's media is NEWER, so an unscoped cursor would have left
+        # this chat's whole (older) page visible instead of an empty one.
+        session.add(Message(id=8, chat_id=OTHER_CHAT_ID, sender_id=None, date=datetime(2026, 6, 1, 10), text=""))
+        await session.commit()
+
+    return DatabaseAdapter(db_manager)
+
+
+async def _media_row(adapter_, media_id):
+    async with adapter_.db_manager.async_session_factory() as session:
+        result = await session.execute(select(Media).where(Media.id == media_id))
+        return result.scalar_one()
+
+
+# ---------------------------------------------------------------------------
+# extract_media_attributes
+# ---------------------------------------------------------------------------
+
+
+class TestExtractMediaAttributes(unittest.TestCase):
+    """Pure-extraction behaviour shared by the sweep and the listener."""
+
+    def test_float_video_duration_is_coerced_to_int(self):
+        """The ``duration`` column is INTEGER; Telethon reports video seconds as float."""
+        attributes = extract_media_attributes(_video_media(duration=12.4))
+        self.assertEqual(attributes["duration"], 12)
+        self.assertIsInstance(attributes["duration"], int)
+        self.assertNotIsInstance(attributes["duration"], float)
+
+    def test_float_duration_rounds_like_the_integer_column_cast(self):
+        self.assertEqual(extract_media_attributes(_video_media(duration=12.6))["duration"], 13)
+
+    def test_int_duration_is_left_alone(self):
+        attributes = extract_media_attributes(_video_media(duration=12))
+        self.assertEqual(attributes["duration"], 12)
+        self.assertIsInstance(attributes["duration"], int)
+
+    def test_progressive_photo_size_wins_over_smaller_plain_sizes(self):
+        """PhotoSizeProgressive has no ``size`` — scoring it 0 picked a thumbnail."""
+        from telethon.tl.types import PhotoSize, PhotoSizeProgressive
+
+        thumbnail = PhotoSize(type="m", w=320, h=240, size=8000)
+        full = PhotoSizeProgressive(type="y", w=1280, h=960, sizes=[1000, 20000, 90000])
+
+        attributes = extract_media_attributes(_photo_media(thumbnail, full))
+
+        self.assertEqual((attributes["width"], attributes["height"]), (1280, 960))
+        self.assertEqual(attributes["file_size"], 90000)
+
+    def test_plain_photo_size_still_wins_when_it_is_the_largest(self):
+        from telethon.tl.types import PhotoSize, PhotoSizeProgressive
+
+        small_progressive = PhotoSizeProgressive(type="x", w=200, h=150, sizes=[100, 900])
+        big_plain = PhotoSize(type="y", w=1600, h=1200, size=500000)
+
+        attributes = extract_media_attributes(_photo_media(small_progressive, big_plain))
+
+        self.assertEqual((attributes["width"], attributes["height"]), (1600, 1200))
+        self.assertEqual(attributes["file_size"], 500000)
+
+    def test_document_mime_type_comes_from_the_document(self):
+        """The MessageMediaDocument wrapper has no mime_type; the document does."""
+        self.assertEqual(extract_media_attributes(_video_media())["mime_type"], "video/mp4")
+
+    def test_photo_without_sizes_yields_all_none(self):
+        attributes = extract_media_attributes(_photo_media())
+        self.assertEqual(
+            attributes,
+            {"file_size": None, "mime_type": None, "width": None, "height": None, "duration": None},
+        )
+
+
+class TestMediaDisplayFilename(unittest.TestCase):
+    """Server-side twin of the viewer's getMediaDisplayName."""
+
+    def test_strips_the_file_id_prefix(self):
+        self.assertEqual(media_display_filename("123456789_holiday.jpg"), "holiday.jpg")
+
+    def test_strips_the_import_media_id_prefix(self):
+        self.assertEqual(media_display_filename("import_-1001_5_report.pdf"), "report.pdf")
+
+    def test_strips_an_explicit_media_id_prefix(self):
+        self.assertEqual(media_display_filename("-1001_5_photo_shot.jpg", media_id="-1001_5_photo"), "shot.jpg")
+
+    def test_strips_at_most_one_prefix(self):
+        """Only the FIRST component can be lost — the second digit run survives."""
+        self.assertEqual(media_display_filename("77_2026_report.pdf"), "2026_report.pdf")
+
+    def test_a_digit_first_component_is_stripped_like_the_viewer(self):
+        """Documented wart: an original name starting with digits loses them.
+
+        A storage prefix and a genuine leading digit run are indistinguishable, and
+        the viewer's getMediaDisplayName strips ``^[0-9]+_`` unconditionally — the
+        download name must match the label the gallery shows, so it strips too.
+        """
+        self.assertEqual(media_display_filename("2026_report.pdf"), "report.pdf")
+
+    def test_non_ascii_digits_are_not_treated_as_a_prefix(self):
+        """``[0-9]``, not ``\\d`` — the viewer's regex never matches these."""
+        self.assertEqual(media_display_filename("١٢٣_report.pdf"), "١٢٣_report.pdf")
+
+    def test_unprefixed_name_is_unchanged(self):
+        self.assertEqual(media_display_filename("clip.mp4"), "clip.mp4")
+
+    def test_never_returns_an_empty_name(self):
+        self.assertEqual(media_display_filename("12345_"), "12345_")
+
+
+# ---------------------------------------------------------------------------
+# The sweep must not undo the listener's capture
+# ---------------------------------------------------------------------------
+
+
+class TestSweepPreservesLiveCapturedMetadata:
+    """A scheduled sweep re-upserting a live-captured message keeps its metadata."""
+
+    def setup_method(self):
+        self.media_root = tempfile.mkdtemp()
+
+    def teardown_method(self):
+        shutil.rmtree(self.media_root, ignore_errors=True)
+
+    def _listener_row(self, media_id, media):
+        """The row the listener writes (listener.py builds it from the same helper)."""
+        return {
+            "id": media_id,
+            "message_id": 7,
+            "chat_id": CHAT_ID,
+            "type": "video",
+            "file_path": os.path.join(self.media_root, str(CHAT_ID), "clip.mp4"),
+            "file_name": "clip.mp4",
+            "content_hash": "hash123",
+            "downloaded": True,
+            "download_date": utcnow_naive(),
+            **extract_media_attributes(media),
+        }
+
+    async def test_sweep_after_listener_capture_keeps_the_metadata(self, adapter):
+        media = _video_media(width=640, height=480, duration=12, size=90000)
+        message = _message(7, media)
+        media_id = f"{CHAT_ID}_7_video"
+
+        await adapter.insert_media(self._listener_row(media_id, media))
+        before = await _media_row(adapter, media_id)
+        assert (before.mime_type, before.width, before.height, before.duration) == ("video/mp4", 640, 480, 12)
+
+        backup = _make_backup(self.media_root)
+        sweep_row = await backup._process_media(message, CHAT_ID)
+        assert sweep_row is not None
+        await adapter.insert_media(sweep_row)
+
+        after = await _media_row(adapter, media_id)
+        assert (after.mime_type, after.width, after.height, after.duration) == ("video/mp4", 640, 480, 12)
+
+    async def test_sweep_extraction_matches_the_listener_extraction(self, adapter):
+        """Same media object in, same five columns out — one shared extractor."""
+        media = _video_media(width=1280, height=720, duration=30.2, size=4242)
+        message = _message(7, media)
+
+        backup = _make_backup(self.media_root)
+        sweep_row = await backup._process_media(message, CHAT_ID)
+
+        listener_attributes = extract_media_attributes(media)
+        for column in ("mime_type", "width", "height", "duration"):
+            assert sweep_row[column] == listener_attributes[column]
+        # file_size is the ONE deliberate difference: the sweep measures the file
+        # it just wrote instead of trusting Telegram's declared size.
+        assert sweep_row["file_size"] == len(b"mediabytes")
+
+    async def test_sweep_writes_an_int_duration_into_the_integer_column(self, adapter):
+        media = _video_media(duration=12.4)
+        backup = _make_backup(self.media_root)
+        sweep_row = await backup._process_media(_message(7, media), CHAT_ID)
+
+        await adapter.insert_media(sweep_row)
+
+        stored = await _media_row(adapter, f"{CHAT_ID}_7_video")
+        assert stored.duration == 12
+        assert isinstance(stored.duration, int)
+
+    async def test_upsert_without_metadata_cannot_null_stored_values(self, adapter):
+        """Any writer with nothing to say (e.g. the not-downloaded row) must not blank it.
+
+        The failed re-attempt row is exactly what ``_process_media`` returns from its
+        except branch: id/type/message_id/chat_id and ``downloaded: False``. It used
+        to erase the file record of a file that is still on disk.
+        """
+        media_id = f"{CHAT_ID}_7_video"
+        listener_row = self._listener_row(media_id, _video_media())
+        await adapter.insert_media(listener_row)
+
+        await adapter.insert_media(
+            {
+                "id": media_id,
+                "message_id": 7,
+                "chat_id": CHAT_ID,
+                "type": "video",
+                "downloaded": False,
+            }
+        )
+
+        stored = await _media_row(adapter, media_id)
+        assert (stored.mime_type, stored.width, stored.height, stored.duration) == ("video/mp4", 640, 480, 12)
+        assert stored.file_path == listener_row["file_path"]
+        assert stored.file_name == "clip.mp4"
+        assert stored.file_size == 90000
+        assert stored.content_hash == "hash123"
+        assert stored.download_date is not None
+        # A failed attempt must not un-download a file whose path we just kept.
+        assert stored.downloaded == 1
+
+    async def test_oversize_skip_row_does_not_strand_an_already_downloaded_file(self, adapter):
+        """Lowering MAX_MEDIA_SIZE makes the sweep emit a not-downloaded row for a stored file."""
+        media_id = f"{CHAT_ID}_7_video"
+        listener_row = self._listener_row(media_id, _video_media())
+        await adapter.insert_media(listener_row)
+
+        backup = _make_backup(self.media_root)
+        backup.config.get_max_media_size_bytes = MagicMock(return_value=1)
+        skip_row = await backup._process_media(_message(7, _video_media()), CHAT_ID)
+        assert skip_row["downloaded"] is False
+        await adapter.insert_media(skip_row)
+
+        stored = await _media_row(adapter, media_id)
+        assert stored.downloaded == 1
+        assert stored.file_path == listener_row["file_path"]
+        # The one thing the skip row DOES know is the real size — a value overwrites.
+        assert stored.file_size == skip_row["file_size"]
+
+    async def test_redownload_to_a_new_path_still_updates_the_row(self, adapter):
+        """Positive control: COALESCE only falls back on NULL, it never pins a value."""
+        media_id = f"{CHAT_ID}_7_video"
+        await adapter.insert_media(self._listener_row(media_id, _video_media()))
+
+        new_path = os.path.join(self.media_root, "_shared", "ab", "moved.mp4")
+        await adapter.insert_media(
+            {
+                "id": media_id,
+                "message_id": 7,
+                "chat_id": CHAT_ID,
+                "type": "video",
+                **extract_media_attributes(_video_media()),
+                "file_path": new_path,
+                "file_name": "moved.mp4",
+                "file_size": 4242,
+                "content_hash": "hash456",
+                "downloaded": True,
+                "download_date": utcnow_naive(),
+            }
+        )
+
+        stored = await _media_row(adapter, media_id)
+        assert stored.file_path == new_path
+        assert stored.file_name == "moved.mp4"
+        assert stored.file_size == 4242
+        assert stored.content_hash == "hash456"
+
+    async def test_deliberate_clear_path_still_clears(self, adapter):
+        """mark_media_for_redownload is the ONE writer allowed to null the file record."""
+        media_id = f"{CHAT_ID}_7_video"
+        await adapter.insert_media(self._listener_row(media_id, _video_media()))
+
+        await adapter.mark_media_for_redownload(media_id)
+
+        stored = await _media_row(adapter, media_id)
+        assert stored.downloaded == 0
+        assert stored.file_path is None
+        assert stored.download_date is None
+
+    async def test_upsert_compiles_on_both_dialects(self):
+        """Two-argument ``max(a, b)`` is SQLite-only — the sticky flag must compile on psycopg2 too."""
+        from sqlalchemy.dialects import postgresql, sqlite
+
+        for dialect in (sqlite.dialect(), postgresql.psycopg2.dialect()):
+            db_manager = MagicMock()
+            db_manager._is_sqlite = dialect.name == "sqlite"
+
+            session = AsyncMock()
+            async_ctx = AsyncMock()
+            async_ctx.__aenter__ = AsyncMock(return_value=session)
+            async_ctx.__aexit__ = AsyncMock(return_value=False)
+            db_manager.async_session_factory.return_value = async_ctx
+
+            await DatabaseAdapter(db_manager).insert_media({"id": "m1", "type": "photo", "downloaded": False})
+
+            sql = str(session.execute.await_args[0][0].compile(dialect=dialect))
+            assert "coalesce(excluded.file_path, media.file_path)" in sql
+            assert "CASE WHEN (excluded.downloaded" in sql
+            assert "max(" not in sql
+
+    async def test_upsert_still_overwrites_a_real_value_with_a_real_value(self, adapter):
+        media_id = f"{CHAT_ID}_7_video"
+        await adapter.insert_media(self._listener_row(media_id, _video_media()))
+
+        await adapter.insert_media(
+            {
+                "id": media_id,
+                "message_id": 7,
+                "chat_id": CHAT_ID,
+                "type": "video",
+                "mime_type": "video/webm",
+                "width": 1920,
+                "height": 1080,
+                "duration": 99,
+                "downloaded": True,
+            }
+        )
+
+        stored = await _media_row(adapter, media_id)
+        assert (stored.mime_type, stored.width, stored.height, stored.duration) == ("video/webm", 1920, 1080, 99)
+
+
+# ---------------------------------------------------------------------------
+# Cursor scoping
+# ---------------------------------------------------------------------------
+
+
+class TestMediaCursorIsChatScoped:
+    """A media id from another chat must not steer this chat's page."""
+
+    async def _seed(self, adapter):
+        async with adapter.db_manager.async_session_factory() as session:
+            session.add(
+                Media(
+                    id="mine_1",
+                    message_id=7,
+                    chat_id=CHAT_ID,
+                    type="photo",
+                    file_path=f"{CHAT_ID}/mine.jpg",
+                    file_name="mine.jpg",
+                    downloaded=1,
+                )
+            )
+            session.add(
+                Media(
+                    id="theirs_1",
+                    message_id=8,
+                    chat_id=OTHER_CHAT_ID,
+                    type="photo",
+                    file_path=f"{OTHER_CHAT_ID}/theirs.jpg",
+                    file_name="theirs.jpg",
+                    downloaded=1,
+                )
+            )
+            await session.commit()
+
+    async def test_foreign_cursor_returns_an_empty_page(self, adapter):
+        """Unscoped, this leaked that 'theirs_1' exists and is NEWER than our rows."""
+        await self._seed(adapter)
+
+        result = await adapter.get_media_paginated(CHAT_ID, before_id="theirs_1")
+
+        assert result == {"items": [], "has_more": False}
+
+    async def test_foreign_cursor_is_indistinguishable_from_an_unknown_one(self, adapter):
+        await self._seed(adapter)
+
+        foreign = await adapter.get_media_paginated(CHAT_ID, before_id="theirs_1")
+        unknown = await adapter.get_media_paginated(CHAT_ID, before_id="no_such_media_id")
+
+        assert foreign == unknown
+
+    async def test_own_cursor_still_paginates(self, adapter):
+        """Positive control: scoping must not break the real cursor."""
+        await self._seed(adapter)
+
+        first = await adapter.get_media_paginated(CHAT_ID)
+        assert [item["id"] for item in first["items"]] == ["mine_1"]
+
+        after = await adapter.get_media_paginated(CHAT_ID, before_id="mine_1")
+        assert after["items"] == []

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -1927,7 +1927,13 @@ class TestProcessMedia(unittest.TestCase):
         self.assertIsNone(result)
 
     def test_oversized_media_returns_not_downloaded(self):
-        """Media exceeding max size returns downloaded=False."""
+        """Media exceeding max size states no download outcome at all.
+
+        Nothing was attempted, so the row must not claim the file is missing —
+        insert_media keeps whatever flag is stored for a key it isn't given. The
+        outcome checks in _retry_pending_media_downloads / _verify_and_redownload_media
+        use ``.get("downloaded")``, so an absent key still reads as falsy there.
+        """
         msg = _make_message(3)
         msg.media = MagicMock()
         self.backup._get_media_type = MagicMock(return_value="video")
@@ -1936,7 +1942,9 @@ class TestProcessMedia(unittest.TestCase):
 
         result = _run(self.backup._process_media(msg, 100))
 
-        self.assertFalse(result["downloaded"])
+        self.assertNotIn("downloaded", result)
+        self.assertFalse(result.get("downloaded"))
+        self.assertEqual(result["file_size"], 999999999)
 
     def test_download_exception_returns_not_downloaded(self):
         """Exception during download returns downloaded=False."""


### PR DESCRIPTION
Addresses seven issues reported by @625801 against v7.31.1. Thanks Igor — these were detailed reports and three of them pointed at behaviour that turned out to have a different cause than the symptom suggested, which is exactly the kind of thing that is hard to see from the outside.

## What was actually wrong

Three of the seven had a different root cause than reported, so the fixes are not what the issue text proposed:

**#257** — the report attributed the out-of-order playback to `/api/chats/{id}/media` paging by file name. That endpoint is correct: its cursor predicate and `ORDER BY` are the same expression, and a 300-row walk at `limit=7` returns 300 unique rows with no skips or duplicates. The real defect was in the viewer: the audio queue pages backward with a 500-item ceiling, and when the playing track was further back than that, the loop gave up but merged the collected block anyway — leaving a chronological hole that `next` jumped across. Reproduced at +14 days.

Two secondary causes were folded in: rows sharing a timestamp ordered lexically because the media id is a composite string (`9, 99, 8, 89, 80, 7` instead of `1000, 120, 99, 89, 80, 9, 8, 7`), and the duplicate `.ogg` requests came from an explicit `load()` after assigning `src`, which re-invokes the media load algorithm.

**#261** — `serve_media` accepted a `download` parameter and never referenced it, so the existing media-gallery download button was already a no-op. Fixed server-side first, which repairs that button too.

**#263** — duration has rendered on audio bubbles since v7.31.0. The gap was capture: the realtime listener hardcoded `duration: None` (its own comment said so), so live-captured voice notes had no duration while swept ones did.

## A correctness trap worth recording

For #259/#260 the obvious implementation is wrong. `service_message_text`'s contract is that the subject of the sentence is the **affected** user for `chat_add_user`/`chat_delete_user` — explicitly not the admin who acted — and the affected user is never persisted. Synthesizing from the sender would have rendered "Alice was added to the group" about the person who added Bob, and clicking that name would have opened a third person's card. Those two actions therefore render "Someone was added/removed" and carry no clickable name; the other seven actions, where sender and subject coincide, get both.

## Verification

Full suite green (2552 passed), ruff clean. Because this repo's frontend tests are string assertions on the template — which have shipped a broken feature with green CI before — the viewer changes were also verified in headless Chrome against a seeded database:

- blank-looking rows still render (regression guard, see below)
- service pills render correct wording; the malformed-`raw_data` row does not throw
- no pill names anyone for add/delete user
- the `#`/`?` filename loads (200, correct content-length) instead of 404
- playbar date agrees with the bubble under `Pacific/Honolulu` in a `Europe/Madrid` browser, catching the off-by-one
- audio queue walk is monotonic across days, forward and backward
- **1 network request per file, 13 files, zero duplicates** (reported as 2-3)
- download returns `Content-Disposition: attachment` with the clean filename; without the flag it stays inline

## Review notes

Adversarial review caught a high-severity regression in the first cut: a blank-row suppression added for #259 also hid real messages. `LISTEN_NEW_MESSAGES_MEDIA` defaults to false, so caption-less voice notes and stickers arrive with `media: null` and would have been permanently invisible while still incrementing the unread badge. Suppression is now restricted to service-shaped rows, and the guard is proven by an executed test plus two independent browser checks.

One consequence is deliberate: a pre-7.28.0 service row whose `raw_data` fails to parse is collapsed to `{}` by the adapter, which erases the only signal that it was a service row. It is then indistinguishable from a legitimate caption-less message, so it renders an ordinary bubble with just sender and timestamp. Hiding it is not possible from the client — the distinguishing information never reaches the browser. A stray near-empty bubble is the right trade against invisible messages; removing it would need the adapter to preserve `service_type`, which is outside this batch.

Closes #257, #258, #259, #260, #261, #262, #263

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added richer media metadata, filenames, file sizes, and durations across downloads and live updates.
  - Added per-message audio downloads, improved audio queue handling, and localized playbar dates.
  - Improved service-message rendering, sender links, and media URL handling for special characters.

- **Bug Fixes**
  - Preserved valid media metadata during updates and redownloads.
  - Improved deterministic, chat-scoped media pagination.
  - Corrected download naming, media display behavior, and metadata consistency.

- **Chores**
  - Updated the project version to 7.32.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->