### PR TITLE
feat: forward audio paging, reply sender, reconnect on disconnect (#265-#268)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.32.0"
+version = "7.33.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.32.0"
+__version__ = "7.33.0"

--- a/src/connection.py
+++ b/src/connection.py
@@ -127,6 +127,12 @@ class TelegramConnection:
         self._client: TelegramClient | None = None
         self._connected = False
         self._me = None
+        # One healer at a time. The scheduler drives the listener watchdog and
+        # the scheduled backup job on the SAME event loop, so either can reach
+        # ensure_connected() while the other is suspended at an await. Without
+        # this lock two coroutines could run the session-file backup/restore and
+        # Telethon's connect() concurrently against a single session database.
+        self._connect_lock = asyncio.Lock()
 
     @property
     def client(self) -> TelegramClient | None:
@@ -175,12 +181,38 @@ class TelegramConnection:
         On auth failure we restore from the golden backup first (known-good state),
         falling back to the pre-connect snapshot.
 
+        Serialised by ``_connect_lock`` so two coroutines (a scheduled backup and
+        the listener watchdog) can never run this session-file dance at once.
+
         Returns:
             The connected TelegramClient instance
 
         Raises:
             RuntimeError: If session is not authorized
         """
+        async with self._connect_lock:
+            return await self._connect_locked()
+
+    async def _discard_client(self) -> None:
+        """Tear the current client down so the next connect builds a fresh one.
+
+        Only for the cases where reviving in place is *wrong*: Telethon reads the
+        session's ``auth_key`` once, when the session object is constructed, so a
+        client that already exists keeps using the old key no matter what we
+        write to the session file. Restoring a backup file therefore only takes
+        effect on a freshly constructed client.
+        """
+        client, self._client = self._client, None
+        self._connected = False
+        if client is None:
+            return
+        try:
+            await client.disconnect()
+        except Exception as e:
+            logger.debug(f"Discarding client: {e}")
+
+    async def _connect_locked(self) -> TelegramClient:
+        """``connect()`` body. Caller must hold ``_connect_lock``."""
         if self._connected and self._client:
             logger.debug("Already connected to Telegram")
             return self._client
@@ -197,18 +229,35 @@ class TelegramConnection:
         if os.path.isfile(golden_file) and not self._session_has_auth(session_file):
             if self._session_has_auth(golden_file):
                 logger.warning("Session file has no auth — restoring from authenticated backup")
+                # The restored auth_key only reaches Telethon through a NEW
+                # session object, and the existing client still holds the file
+                # open. Drop it before overwriting the file underneath it.
+                await self._discard_client()
                 shutil.copy2(golden_file, session_file)
 
         # Tier 2: snapshot the current state before TelegramClient can modify it.
         if self._session_has_auth(session_file):
             shutil.copy2(session_file, snapshot_file)
 
-        self._client = TelegramClient(
-            self.config.session_path,
-            self.config.api_id,
-            self.config.api_hash,
-            **self.config.get_telegram_client_kwargs(),
-        )
+        # Revive the SAME client object whenever we still have one. Callers hold
+        # `connection.client` across long awaits — a backup keeps the client it
+        # was handed for the whole run, and the listener keeps one for the life
+        # of its task — so swapping the object out from under them would strand
+        # them on a disconnected client while the healthy one lives elsewhere,
+        # and would put two TelegramClients on one session file. Telethon allows
+        # connect() after disconnect() on the same instance (only log_out()
+        # invalidates it), so healing in place is both safe for concurrent
+        # holders and sufficient for #265, whose failure is a sender that gave up
+        # and that only a fresh connect() call can revive.
+        if self._client is None:
+            self._client = TelegramClient(
+                self.config.session_path,
+                self.config.api_id,
+                self.config.api_hash,
+                **self.config.get_telegram_client_kwargs(),
+            )
+        else:
+            logger.info("Reviving the existing Telegram client in place")
 
         # Enable WAL mode for session DB to handle concurrent access
         self._enable_wal_mode()
@@ -218,7 +267,9 @@ class TelegramConnection:
 
         # Check authorization
         if not await self._client.is_user_authorized():
-            await self._client.disconnect()
+            # Drop the client too: the restore below rewrites the session file,
+            # and only a client built afterwards can pick the restored key up.
+            await self._discard_client()
             # Restore from the best available backup.
             # Golden backup is preferred (known-good); snapshot is the fallback.
             restored = False
@@ -272,7 +323,16 @@ class TelegramConnection:
         tasks (_send_loop, _recv_loop) aren't properly cancelled on disconnect,
         causing "Task was destroyed but it is pending" warnings. These are harmless
         and don't affect functionality.
+
+        Takes the connect lock: a scheduled backup job can still be in
+        ensure_connected() while the process is tearing down, and tearing the
+        client down mid-connect is the interleaving this lock exists to prevent.
         """
+        async with self._connect_lock:
+            await self._disconnect_locked()
+
+    async def _disconnect_locked(self) -> None:
+        """``disconnect()`` body. Caller must hold ``_connect_lock``."""
         if self._client and self._connected:
             try:
                 await self._client.disconnect()
@@ -289,30 +349,40 @@ class TelegramConnection:
         """
         Ensure the client is connected, reconnecting if necessary.
 
+        Concurrency contract (both halves matter — see ``_connect_locked``):
+
+        - Healing happens IN PLACE. The object returned is the one this
+          connection already owned, so a backup suspended mid-call keeps a
+          reference that heals with it instead of going stale.
+        - Healing is SERIALISED by ``_connect_lock``. The listener watchdog and
+          a scheduled backup share an event loop; without the lock both could be
+          inside connect() at once, on one session database.
+
         Returns:
             The connected TelegramClient instance
         """
-        if not self.is_connected:
-            return await self.connect()
+        async with self._connect_lock:
+            if not self.is_connected:
+                return await self._connect_locked()
 
-        # Check if connection is still alive
-        try:
-            if not self._client.is_connected():
-                logger.warning("Connection lost, reconnecting...")
-                await self._client.connect()
-                self._me = await _call_with_flood_retry(self._client.get_me)
-                logger.info(f"Reconnected as {self._me.first_name}")
-        except Exception as e:
-            logger.warning(f"Connection check failed: {e}, reconnecting...")
-            self._connected = False
-            if self._client:
-                try:
-                    await self._client.disconnect()
-                except Exception:
-                    pass
-            await self.connect()
+            # Check if connection is still alive
+            try:
+                if not self._client.is_connected():
+                    logger.warning("Connection lost, reconnecting...")
+                    await self._client.connect()
+                    self._me = await _call_with_flood_retry(self._client.get_me)
+                    logger.info(f"Reconnected as {self._me.first_name}")
+            except Exception as e:
+                logger.warning(f"Connection check failed: {e}, reconnecting...")
+                self._connected = False
+                if self._client:
+                    try:
+                        await self._client.disconnect()
+                    except Exception:
+                        pass
+                await self._connect_locked()
 
-        return self._client
+            return self._client
 
     async def __aenter__(self) -> TelegramConnection:
         """Async context manager entry."""

--- a/src/connection.py
+++ b/src/connection.py
@@ -300,7 +300,10 @@ class TelegramConnection:
             pass
         shutil.copy2(session_file, golden_file)
 
-        logger.info(f"Connected as {self._me.first_name} ({self._me.phone})")
+        # Deliberately anonymous: the account's name and phone are PII and must
+        # not reach the logs (the same rule that keeps chat ids and message text
+        # out). Which account authenticated is already confirmed at setup time.
+        logger.info("Connected")
 
         return self._client
 
@@ -371,7 +374,7 @@ class TelegramConnection:
                     logger.warning("Connection lost, reconnecting...")
                     await self._client.connect()
                     self._me = await _call_with_flood_retry(self._client.get_me)
-                    logger.info(f"Reconnected as {self._me.first_name}")
+                    logger.info("Reconnected")
             except Exception as e:
                 logger.warning(f"Connection check failed: {e}, reconnecting...")
                 self._connected = False

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -22,7 +22,7 @@ from sqlalchemy import and_, delete, exists, func, literal, or_, select, text, u
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
-from ..message_utils import compute_directory_size, utcnow_naive
+from ..message_utils import compute_directory_size, resolve_sender_display_name, utcnow_naive
 from .base import DatabaseManager
 from .models import (
     AppSettings,
@@ -1250,27 +1250,50 @@ class DatabaseAdapter:
         media_types: list[str] | None = None,
         limit: int = 50,
         before_id: str | None = None,
+        after_id: str | None = None,
     ) -> dict[str, Any]:
         """
         Get paginated media records for a chat with cursor-based pagination.
 
-        ``before_id`` stays an opaque ``Media.id`` token (the gallery round-trips the
-        composite ``{chat}_{msg}_{type}`` string), but it is resolved to the triple
-        (Message.date, Media.message_id, Media.id) before use. ``Media.id`` alone sorts
-        lexically, so rows sharing a timestamp came back as 9, 99, 98, ..., 8, 89 —
-        numerically meaningless; ``Media.message_id`` is an integer and orders correctly.
+        ``before_id``/``after_id`` are opaque ``Media.id`` tokens (the gallery
+        round-trips the composite ``{chat}_{msg}_{type}`` string), but each is resolved
+        to the triple (Message.date, Media.message_id, Media.id) before use.
+        ``Media.id`` alone sorts lexically, so rows sharing a timestamp came back as
+        9, 99, 98, ..., 8, 89 — numerically meaningless; ``Media.message_id`` is an
+        integer and orders correctly.
 
-        The ORDER BY and the cursor predicate MUST stay the same triple: that identity
-        is what guarantees a full walk yields every row exactly once (no skips, no
-        duplicates). Change one and you must change the other.
+        Two directions, one cursor shape:
 
-        The cursor resolution is scoped to ``chat_id``. Unscoped, a caller could pass
-        ANOTHER chat's media id and have that row's timestamp shape this chat's result
-        window — a cross-chat existence/timestamp oracle for a chat the caller cannot
-        read. A token that does not belong to ``chat_id`` is indistinguishable from a
-        deleted one and returns an EMPTY page (never a full first page), so neither the
-        existence nor the date of a foreign row can be inferred from the response.
+        - ``before_id`` walks BACKWARD (older): predicate ``<`` on the triple, ordered
+          DESC, page returned newest-first. ``has_more`` means "more OLDER rows exist".
+        - ``after_id`` walks FORWARD (newer): predicate ``>`` on the triple, ordered
+          ASC, page returned oldest-first. ``has_more`` means "more NEWER rows exist".
+          The audio queue uses this to extend forward on demand instead of
+          pre-collecting every item newer than the playing track (#266).
+
+        The two are MUTUALLY EXCLUSIVE: supplying both is a caller bug (there is no
+        coherent page "before X and after Y" in this API) and raises ``ValueError``.
+
+        The ORDER BY and the cursor predicate MUST stay the same triple, in the same
+        direction: that identity is what guarantees a full walk yields every row
+        exactly once (no skips, no duplicates). Change one and you must change the
+        other — in both directions.
+
+        The cursor resolution is scoped to ``chat_id``, forward as well as backward.
+        Unscoped, a caller could pass ANOTHER chat's media id and have that row's
+        timestamp shape this chat's result window — a cross-chat existence/timestamp
+        oracle for a chat the caller cannot read. A token that does not belong to
+        ``chat_id`` is indistinguishable from a deleted one and returns an EMPTY page
+        (never a full first page) in either direction, so neither the existence nor the
+        date of a foreign row can be inferred from the response, and a client can treat
+        both directions alike.
         """
+        if before_id and after_id:
+            raise ValueError("before_id and after_id are mutually exclusive")
+
+        forward = bool(after_id)
+        cursor_token = after_id if forward else before_id
+
         async with self.db_manager.async_session_factory() as session:
             stmt = (
                 select(
@@ -1295,37 +1318,57 @@ class DatabaseAdapter:
             if media_types:
                 stmt = stmt.where(Media.type.in_(media_types))
 
-            if before_id:
+            if cursor_token:
                 cursor_stmt = (
                     select(Media.id, Media.message_id, Message.date)
                     .join(
                         Message,
                         and_(Media.message_id == Message.id, Media.chat_id == Message.chat_id),
                     )
-                    .where(and_(Media.id == before_id, Media.chat_id == chat_id))
+                    .where(and_(Media.id == cursor_token, Media.chat_id == chat_id))
                 )
                 cursor_result = await session.execute(cursor_stmt)
                 cursor_row = cursor_result.one_or_none()
                 if cursor_row is None:
                     return {"items": [], "has_more": False}
                 cursor_media_id, cursor_message_id, cursor_date = cursor_row
-                stmt = stmt.where(
-                    or_(
-                        Message.date < cursor_date,
-                        and_(
-                            Message.date == cursor_date,
-                            or_(
-                                Media.message_id < cursor_message_id,
-                                and_(
-                                    Media.message_id == cursor_message_id,
-                                    Media.id < cursor_media_id,
+                if forward:
+                    stmt = stmt.where(
+                        or_(
+                            Message.date > cursor_date,
+                            and_(
+                                Message.date == cursor_date,
+                                or_(
+                                    Media.message_id > cursor_message_id,
+                                    and_(
+                                        Media.message_id == cursor_message_id,
+                                        Media.id > cursor_media_id,
+                                    ),
                                 ),
                             ),
-                        ),
+                        )
                     )
-                )
+                else:
+                    stmt = stmt.where(
+                        or_(
+                            Message.date < cursor_date,
+                            and_(
+                                Message.date == cursor_date,
+                                or_(
+                                    Media.message_id < cursor_message_id,
+                                    and_(
+                                        Media.message_id == cursor_message_id,
+                                        Media.id < cursor_media_id,
+                                    ),
+                                ),
+                            ),
+                        )
+                    )
 
-            stmt = stmt.order_by(Message.date.desc(), Media.message_id.desc(), Media.id.desc())
+            if forward:
+                stmt = stmt.order_by(Message.date.asc(), Media.message_id.asc(), Media.id.asc())
+            else:
+                stmt = stmt.order_by(Message.date.desc(), Media.message_id.desc(), Media.id.desc())
             stmt = stmt.limit(limit + 1)
             result = await session.execute(stmt)
             rows = result.all()
@@ -1345,7 +1388,7 @@ class DatabaseAdapter:
                     "height": media.height,
                     "duration": media.duration,
                     "message_date": msg_date.isoformat() if msg_date else None,
-                    "sender_name": (sender_name or f"{first_name or ''} {last_name or ''}".strip() or username or None),
+                    "sender_name": resolve_sender_display_name(sender_name, first_name, last_name, username),
                 }
                 for media, msg_date, sender_name, first_name, last_name, username in rows[:limit]
             ]
@@ -1971,6 +2014,74 @@ class DatabaseAdapter:
 
     # ========== Web Viewer Operations ==========
 
+    async def _attach_reply_metadata(self, session, chat_id: int, messages: list[dict[str, Any]]) -> None:
+        """Resolve the reply targets of a whole page in ONE query (#268).
+
+        THE single rule for what a reply quote block shows. Every read path that
+        returns rendered messages calls this — the normal list, the pinned list
+        and the by-date lookup — so the same message can never render one way in
+        one list and another way in the next (#259 was exactly that drift).
+
+        Null contract: a message that IS a reply always carries both
+        ``reply_to_sender_name`` and ``reply_to_media_type``. They are None when
+        the target is not in the archive (never captured, hard-deleted, or in
+        another chat) or when the target's sender cannot be named at all — the
+        viewer renders its own fallback. A soft-deleted target is still archived
+        history and resolves normally. A message that is not a reply carries
+        neither key. ``reply_to_text`` is only backfilled when the row did not
+        capture one.
+
+        Cost: one statement per page regardless of how many replies it holds.
+        The media kind rides along as a correlated scalar subquery (first media
+        row per message) rather than a join, which would multiply rows for
+        albums, and never as a per-row lookup.
+        """
+        reply_ids_needed = {msg["reply_to_msg_id"] for msg in messages if msg.get("reply_to_msg_id")}
+        if not reply_ids_needed:
+            return
+
+        reply_media_type = (
+            select(Media.type)
+            .where(and_(Media.chat_id == chat_id, Media.message_id == Message.id))
+            .order_by(Media.id)
+            .limit(1)
+            .scalar_subquery()
+            .label("reply_media_type")
+        )
+        reply_stmt = (
+            select(
+                Message.id,
+                Message.text,
+                Message.sender_name,
+                User.first_name,
+                User.last_name,
+                User.username,
+                reply_media_type,
+            )
+            .outerjoin(User, Message.sender_id == User.id)
+            .where(and_(Message.chat_id == chat_id, Message.id.in_(reply_ids_needed)))
+        )
+        reply_result = await session.execute(reply_stmt)
+        reply_rows: dict[int, dict[str, Any]] = {
+            row.id: {
+                "text": row.text,
+                "sender_name": resolve_sender_display_name(
+                    row.sender_name, row.first_name, row.last_name, row.username
+                ),
+                "media_type": row.reply_media_type,
+            }
+            for row in reply_result
+        }
+
+        for msg in messages:
+            if not msg.get("reply_to_msg_id"):
+                continue
+            reply_row = reply_rows.get(msg["reply_to_msg_id"])
+            msg["reply_to_sender_name"] = reply_row["sender_name"] if reply_row else None
+            msg["reply_to_media_type"] = reply_row["media_type"] if reply_row else None
+            if reply_row and not msg.get("reply_to_text") and reply_row["text"]:
+                msg["reply_to_text"] = reply_row["text"][:100]
+
     async def get_messages_paginated(
         self,
         chat_id: int,
@@ -2006,7 +2117,9 @@ class DatabaseAdapter:
             topic_id: Optional forum topic ID to filter messages by thread
 
         Returns:
-            List of message dictionaries with user and media info
+            List of message dictionaries with user and media info. A row that is a
+            reply also carries ``reply_to_sender_name`` and ``reply_to_media_type``
+            (both nullable) so the viewer can render "Reply to <name>" (#268).
         """
         async with self.db_manager.async_session_factory() as session:
             # Build query with joins - v6.0.0: join on composite key
@@ -2130,20 +2243,7 @@ class DatabaseAdapter:
                 count_result = await session.execute(count_stmt)
                 version_counts.update({row.message_id: int(row.version_count or 0) for row in count_result})
 
-            # Batch reply-text backfill: one query for the whole page instead of one
-            # SELECT per reply row (previously up to `limit` round-trips per page).
-            reply_ids_needed = {
-                msg["reply_to_msg_id"]
-                for msg in messages
-                if msg.get("reply_to_msg_id") and not msg.get("reply_to_text")
-            }
-            reply_texts: dict[int, str] = {}
-            if reply_ids_needed:
-                reply_stmt = select(Message.id, Message.text).where(
-                    and_(Message.chat_id == chat_id, Message.id.in_(reply_ids_needed))
-                )
-                reply_result = await session.execute(reply_stmt)
-                reply_texts = {row.id: row.text for row in reply_result if row.text}
+            await self._attach_reply_metadata(session, chat_id, messages)
 
             # Batch reactions: one query for the whole page instead of one
             # get_reactions() call per message. Ties within the same emoji are
@@ -2171,11 +2271,6 @@ class DatabaseAdapter:
 
             for msg in messages:
                 msg["version_count"] = version_counts.get(msg["id"], 0)
-
-                if msg.get("reply_to_msg_id") and not msg.get("reply_to_text"):
-                    reply_text = reply_texts.get(msg["reply_to_msg_id"])
-                    if reply_text:
-                        msg["reply_to_text"] = reply_text[:100]
 
                 reactions_by_emoji = {}
                 for reaction in reactions_by_message.get(msg["id"], []):
@@ -2310,14 +2405,10 @@ class DatabaseAdapter:
                     logger.debug("Malformed raw_data JSON for a message row; substituting empty dict")
                     msg["raw_data"] = {}
 
-            # Get reply text
-            if msg.get("reply_to_msg_id") and not msg.get("reply_to_text"):
-                reply_result = await session.execute(
-                    select(Message.text).where(and_(Message.chat_id == chat_id, Message.id == msg["reply_to_msg_id"]))
-                )
-                reply_text = reply_result.scalar_one_or_none()
-                if reply_text:
-                    msg["reply_to_text"] = reply_text[:100]
+            # Reply quote metadata — same helper, same rule as every other read
+            # path. It replaces a text-only lookup that resolved less than the
+            # message list did for the very same message.
+            await self._attach_reply_metadata(session, chat_id, [msg])
 
             # Get reactions
             reactions = await self.get_reactions(msg["id"], chat_id)
@@ -2358,6 +2449,11 @@ class DatabaseAdapter:
         """Get all pinned messages for a chat, ordered by date descending (newest first).
 
         v6.0.0: Media is now returned as a nested object from the media table.
+
+        The pinned-only view swaps this list into the SAME message renderer the
+        normal list uses, so a pinned reply must arrive with the same reply
+        metadata (#268) — otherwise one message renders "Reply to <name>" in the
+        list and a bare "Reply to / Message" in the pinned view.
         """
         async with self.db_manager.async_session_factory() as session:
             stmt = (
@@ -2418,6 +2514,9 @@ class DatabaseAdapter:
                         msg["raw_data"] = {}
 
                 messages.append(msg)
+
+            # One query for the whole pinned list, not one per pinned reply.
+            await self._attach_reply_metadata(session, chat_id, messages)
 
             return messages
 
@@ -2544,9 +2643,9 @@ class DatabaseAdapter:
                     "id": row.id,
                     "date": row.date.isoformat() if row.date else None,
                     "sender": {
-                        "name": row.sender_name
-                        or f"{row.first_name or ''} {row.last_name or ''}".strip()
-                        or row.username
+                        "name": resolve_sender_display_name(
+                            row.sender_name, row.first_name, row.last_name, row.username
+                        )
                         or "Unknown",
                         "username": row.username,
                     },

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -37,6 +37,28 @@ def sender_display_name(sender: object | None) -> str | None:
     return None
 
 
+def resolve_sender_display_name(
+    sender_name: str | None,
+    first_name: str | None,
+    last_name: str | None,
+    username: str | None,
+) -> str | None:
+    """Resolve a stored message row's sender to a display name.
+
+    Single source of truth for "who sent this row" on the read side, so the
+    message list, the media gallery, the export stream and the reply-quote block
+    can never drift apart. Precedence matches the viewer's getSenderName: the
+    capture-time ``messages.sender_name`` snapshot first (it is what was true
+    when the message arrived), then the user's current first/last name, then the
+    username. Returns ``None`` when nothing is known — each caller picks its own
+    placeholder ("Unknown", the numeric id, or nothing at all).
+    """
+    for value in (sender_name, f"{first_name or ''} {last_name or ''}", username):
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
 def compute_directory_size(path: str) -> int:
     """Return total on-disk size (bytes) of regular files under `path`.
 

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -182,7 +182,32 @@ class BackupScheduler:
         if not self.config.enable_listener:
             return
 
-        if not self._connection or not self._connection.is_connected:
+        if not self._connection:
+            logger.error("Cannot start listener: not connected to Telegram")
+            return
+
+        # ``TelegramConnection.is_connected`` is an app-level flag: it stays True
+        # after Telethon's sender exhausts its own reconnect budget (~55s) and
+        # marks itself disconnected, so it cannot tell us the socket is dead.
+        # Without re-establishing the connection here, the watchdog restarts the
+        # listener into "Shared client is not connected" every 5 seconds forever
+        # once an outage outlives Telethon's budget (#265). ensure_connected()
+        # checks the live client and calls connect() when it is down.
+        #
+        # This runs on the watchdog loop, which shares an event loop with the
+        # scheduled backup job, so it can fire while a backup is suspended at an
+        # await. That is safe because TelegramConnection heals the SAME client
+        # object in place and serialises healers on its own lock — the backup's
+        # client reference heals with it instead of being left behind. Skipping
+        # the heal while a backup holds the connection would be the wrong trade:
+        # a backup can run for hours, and the listener would stay dead for all
+        # of it, which is the outage #265 is about.
+        try:
+            await self._connection.ensure_connected()
+        except Exception as e:
+            logger.warning(f"Could not re-establish the shared connection before starting the listener: {e}")
+
+        if not self._connection.is_connected:
             logger.error("Cannot start listener: not connected to Telegram")
             return
 

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -5,6 +5,7 @@ Handles Telegram client connection, message fetching, and incremental backup log
 
 import asyncio
 import base64
+import inspect
 import json
 import logging
 import os
@@ -190,11 +191,79 @@ def _pre_generate_thumbnail(source_path: str, media_root: str) -> None:
         logger.debug("Thumbnail pre-generation failed: %s", e)
 
 
+def _client_like(obj: object | None) -> bool:
+    """True for anything exposing the client half of the reconnect contract."""
+    return callable(getattr(obj, "is_connected", None)) and callable(getattr(obj, "connect", None))
+
+
+def _retry_client(coro_fn, explicit: object | None) -> object | None:
+    """Find the TelegramClient behind a retried call, for reconnect purposes.
+
+    Every call shape this repo actually uses must resolve, or that path silently
+    keeps the pre-#265 behaviour of retrying a dead client:
+
+    * ``call_with_flood_retry(self.client.download_media, ...)`` — a bound method
+      of the client, so ``__self__`` IS the client (this is the shape in the
+      reported log).
+    * ``call_with_flood_retry(self.client, GetContactsRequest(...))`` — Telethon
+      invokes a raw request by *calling the client*, so ``coro_fn`` itself is the
+      client and there is no ``__self__`` at all.
+    * ``call_with_flood_retry(self._fetch_media_bytes_bounded, ...)`` — a bound
+      method of a component that owns a client.
+
+    A locally-defined closure (``_get_messages_once``) has no owner to inspect;
+    those call sites pass ``client=`` explicitly.
+    """
+    if explicit is not None:
+        return explicit
+    if _client_like(coro_fn):
+        return coro_fn
+    owner = getattr(coro_fn, "__self__", None)
+    if owner is None:
+        return None
+    if _client_like(owner):
+        return owner
+    return getattr(owner, "client", None)
+
+
+async def _reconnect_before_retry(client: object | None, call_name: object) -> bool:
+    """Re-establish a dropped Telegram connection before spending a retry (#265).
+
+    "Cannot send requests while disconnected" is not fixed by waiting: without
+    this, a network blip burned the entire retry budget on a client that could
+    never succeed, and the log showed no reconnection attempt at all — which is
+    half the bug, since an operator cannot tell a silent retry loop from a stuck
+    one. Best-effort by design: it never raises, so a still-down network simply
+    fails the next attempt and backs off exactly as before, and Telethon's own
+    reconnect (when it wins the race) leaves this a no-op.
+    """
+    if client is None:
+        return False
+    if not _client_like(client):
+        return False
+    is_connected = client.is_connected
+    connect = client.connect
+    try:
+        connected = is_connected()
+        if inspect.isawaitable(connected):
+            connected = await connected
+        if connected:
+            return False
+        logger.warning("Connection is down — reconnecting before retrying %s", call_name)
+        await connect()
+    except Exception as exc:  # noqa: BLE001 — reconnect is best effort, never fatal
+        logger.warning("Reconnect before retrying %s failed: %s", call_name, exc)
+        return False
+    logger.info("Reconnected to Telegram before retrying %s", call_name)
+    return True
+
+
 async def call_with_flood_retry(
     coro_fn,
     *args,
     max_retries=MAX_FLOOD_RETRIES,
     non_retryable: Callable[[BaseException], bool] | None = None,
+    client: object | None = None,
     **kwargs,
 ):
     """Retry a single async call on FloodWaitError with bounded sleep and
@@ -208,6 +277,9 @@ async def call_with_flood_retry(
     raised exception, that exception is re-raised immediately instead of being
     retried here, letting the caller handle it (e.g. refresh a stale media
     reference and retry with its own backoff).
+
+    ``client`` overrides the client this helper reconnects between transient
+    retries; by default it is inferred from ``coro_fn`` (see ``_retry_client``).
     """
     retries = 0
     while True:
@@ -295,6 +367,10 @@ async def call_with_flood_retry(
                 exc,
             )
             await asyncio.sleep(sleep_duration)
+            # Reconnect AFTER the backoff so the network has had the pause to come
+            # back, and immediately BEFORE the next attempt, which is what the
+            # retry actually needs (#265).
+            await _reconnect_before_retry(_retry_client(coro_fn, client), getattr(coro_fn, "__name__", coro_fn))
 
 
 @asynccontextmanager
@@ -366,6 +442,16 @@ async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
     output for short waits — those are routine and noisy in healthy backfills.
     Set to 0 to log every wait.
 
+    Dropped connections are handled the same way (#265). A long backfill easily
+    outlives Telethon's internal reconnect budget (5 attempts, then it marks the
+    sender disconnected and stops retrying by itself), after which every request
+    raises ``ConnectionError("Cannot send requests while disconnected")``. That
+    used to abort the whole chat on the first such error, and — because nothing
+    ever called ``connect()`` again — every later chat in the sweep died the same
+    way. Now the connection is re-established and iteration resumes from the last
+    yielded id, sharing the same bounded retry budget. Errors Telegram raises for
+    a permanent condition (``RPCError`` and friends) still propagate untouched.
+
     Note: resume tracking uses ``max(resume_from, msg.id)`` which is only
     correct for ascending iteration (``reverse=True``).
     """
@@ -417,6 +503,33 @@ async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
                     MAX_FLOOD_RETRIES,
                 )
             await asyncio.sleep(sleep_duration)
+        except (TimeoutError, ConnectionError, OSError) as exc:
+            # Connection-shaped failures only: RPCError and other Telegram-level
+            # errors keep propagating to the caller exactly as before, so a
+            # permanent condition is never retried five times first.
+            retries += 1
+            if retries > MAX_FLOOD_RETRIES:
+                logger.error(
+                    "Transient Error: exceeded %d retries without progress while iterating, giving up: %s",
+                    MAX_FLOOD_RETRIES,
+                    exc,
+                )
+                raise
+            backoff = min(BACKOFF_MAX_SECONDS, BACKOFF_MIN_SECONDS * (2.0 ** (retries - 1)))
+            jitter = random.uniform(0.5, 1.5)
+            sleep_duration = backoff + jitter
+            logger.warning(
+                "Transient Error (%s): sleeping %.2fs before resuming iteration (retry=%d/%d): %s",
+                exc.__class__.__name__,
+                sleep_duration,
+                retries,
+                MAX_FLOOD_RETRIES,
+                exc,
+            )
+            await asyncio.sleep(sleep_duration)
+            # Reconnect after the backoff and immediately before the next
+            # attempt, mirroring call_with_flood_retry (#265).
+            await _reconnect_before_retry(client, "iter_messages")
 
 
 class TelegramBackup:
@@ -2609,6 +2722,10 @@ class TelegramBackup:
             fresh_messages = await call_with_flood_retry(
                 _get_messages_once,
                 non_retryable=lambda exc: isinstance(exc, TimeoutError),
+                # A local closure has no owner to infer the client from, and this
+                # runs on the media path that reported #265 — pass it explicitly
+                # or the refresh retries against a disconnected client.
+                client=self.client,
             )
         except (TimeoutError, RPCError, ConnectionError, OSError) as e:
             logger.debug("Could not refresh media reference (%s)", type(e).__name__)

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1738,15 +1738,26 @@ async def get_chat_media(
     types: str = Query(default=""),
     limit: int = Query(default=50, ge=1, le=200),
     before_id: str = Query(default=""),
+    after_id: str = Query(default=""),
     user: UserContext = Depends(require_auth),
 ):
-    """Get paginated media items for a chat, with optional type filtering."""
+    """Get paginated media items for a chat, with optional type filtering.
+
+    ``before_id`` pages BACKWARD (older) and ``after_id`` pages FORWARD (newer);
+    both are the same opaque composite media-id token. They are mutually
+    exclusive — asking for a page both before X and after Y has no meaning here,
+    so it is rejected instead of silently honouring one. An unresolvable or
+    foreign token yields an empty page in either direction (#266).
+    """
     allowed = get_user_chat_ids(user)
     if allowed is not None and chat_id not in allowed:
         raise HTTPException(status_code=403, detail="Access denied")
 
     if not db:
         raise HTTPException(status_code=503, detail="Database not available")
+
+    if before_id and after_id:
+        raise HTTPException(status_code=400, detail="before_id and after_id are mutually exclusive")
 
     media_types = [t.strip() for t in types.split(",") if t.strip()] or None
 
@@ -1756,6 +1767,7 @@ async def get_chat_media(
             media_types=media_types,
             limit=limit,
             before_id=before_id or None,
+            after_id=after_id or None,
         )
         for item in result["items"]:
             file_path = item.get("file_path", "") or ""

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -5725,6 +5725,13 @@
                 let audioQueueCursorNewer = null // media id of the NEWEST item the queue knows
                 let audioQueueHasNewer = false
                 let audioQueueFetching = false
+                // #268: the promise of the seed started by the CLICK, kept so a forward
+                // advance that lands while it is still in flight can await it instead of
+                // reading "a page is on its way" as "the queue ended". It matters now
+                // because buildAudioQueue contributes ONLY the clicked track from a
+                // sparse view: at the start of every sparse-view playback the queue is
+                // one entry long and this fetch is the only way forward.
+                let audioQueueSeeding = null
 
                 // Voice and music are queried separately — the endpoint would happily
                 // return both in one call ("voice,audio"), which is exactly what must
@@ -5816,14 +5823,16 @@
                 // The queue is sorted ascending, so its edges are its first and last
                 // entries — but a descriptor is only usable as a cursor if it carries a
                 // media id, so scan inwards until one does.
-                const audioQueueEdgeMediaId = (newest) => {
+                const audioQueueEdgeTrack = (newest) => {
                     const queue = audioQueue.value
                     for (let i = 0; i < queue.length; i++) {
                         const track = newest ? queue[queue.length - 1 - i] : queue[i]
-                        if (track && track.mediaId) return track.mediaId
+                        if (track && track.mediaId) return track
                     }
                     return null
                 }
+
+                const audioQueueEdgeMediaId = (newest) => audioQueueEdgeTrack(newest)?.mediaId || null
 
                 const seedAudioQueueAroundTrack = async (track) => {
                     // #266: ONE page older than the PLAYING track, anchored on its own
@@ -5896,7 +5905,30 @@
                     // entry is older than this page's last item. Paging from the page
                     // would then re-fetch rows the queue already has and report no
                     // progress, so the cursor follows the QUEUE's edge.
-                    audioQueueCursor = audioQueueEdgeMediaId(false) || audioQueueCursor
+                    //
+                    // #268: ...but ONLY while that edge really is older, because the
+                    // fixup can otherwise move the cursor BACKWARDS.
+                    // audioTracksFromMediaItems drops every item with no media_url (a
+                    // file_path outside the media root is never given one), so a whole
+                    // page can be unplayable and add nothing at all — the edge is then
+                    // the oldest track ALREADY queued, which from a sparse view is the
+                    // playing track itself, i.e. the very anchor this page was fetched
+                    // from. "Previous" would then spend a request re-asking the question
+                    // the seed just asked and report 'exhausted' (restarting the track)
+                    // although older playable audio exists.
+                    //
+                    // The test is on TIME rather than on "did the merge add anything":
+                    // that also covers a partly unplayable page, where tracks are added
+                    // but none of them older than the page's own last item. Both sides
+                    // go through audioTrackTime, so they share one parse rule and an
+                    // unreadable date reads as 0 and simply keeps the page cursor —
+                    // failing towards progress.
+                    const pageOldest = items[items.length - 1]
+                    const pageOldestTime = audioTrackTime({ date: pageOldest?.message_date })
+                    const queueOldest = audioQueueEdgeTrack(false)
+                    if (queueOldest && pageOldestTime && audioTrackTime(queueOldest) < pageOldestTime) {
+                        audioQueueCursor = queueOldest.mediaId
+                    }
                     return true
                 }
 
@@ -6134,7 +6166,37 @@
                     // direction playback is moving, so its cost tracks how much is
                     // PLAYED, not how deep in the chat the first track was.
                     const outcome = await extendAudioQueueNewer()
-                    return outcome === 'extended' && playAdjacentAudio(1)
+                    if (outcome === 'extended' && playAdjacentAudio(1)) return true
+                    // #268: 'pending' is a page still ON ITS WAY, not an exhausted
+                    // queue — playPrevAudio has always kept the two apart and this path
+                    // must too. It is reachable now because a sparse view seeds ONLY
+                    // the clicked track: for the first ~50ms of every sparse playback
+                    // the queue has one entry and the click's own seed fetch is the only
+                    // way forward. A sub-second voice note ('ended'), or a file missing
+                    // on disk whose error event beats the media request ('error'), lands
+                    // here inside that window — and collapsing 'pending' into false
+                    // ended auto-advance for the whole session with a full page of
+                    // playable tracks about to arrive.
+                    //
+                    // Await THAT fetch and re-attempt: no polling, no timer, and bounded
+                    // by construction — audioQueueSeeding settles exactly once, and the
+                    // re-attempt does not consult 'pending' again.
+                    if (outcome !== 'pending' || !audioQueueSeeding) return false
+                    const owner = audioTrack.value
+                    await audioQueueSeeding
+                    // The same ownership question the request-id / belongs-to-track
+                    // guards ask, at track granularity: audioTrack.value is replaced by
+                    // loadAudioTrack and cleared by closeAudioPlayer, so a different
+                    // object means the user started something else (or closed the
+                    // player) while we waited and this advance belongs to nobody. A
+                    // queue that halted auto-advance in the meantime stays halted.
+                    if (!owner || audioTrack.value !== owner || audioAutoAdvanceHalted.value) return false
+                    // The seed pages OLDER than the playing track, so it rarely supplies
+                    // the next one itself — the forward page usually still has to be
+                    // asked for, this time with a cursor that is no longer in flight.
+                    if (playAdjacentAudio(1)) return true
+                    const retried = await extendAudioQueueNewer()
+                    return retried === 'extended' && playAdjacentAudio(1)
                 }
 
                 const playPrevAudio = async () => {
@@ -6178,7 +6240,10 @@
                     // Start on the user gesture, THEN grow the queue: awaiting the fetch
                     // first would spend the gesture and hand iOS a blocked play().
                     loadAudioTrack(track)
-                    extendAudioQueueFromMedia(track)
+                    // Still NOT awaited — but kept, so an auto-advance that reaches the
+                    // end of this one-entry queue before the page lands can wait for it
+                    // rather than declaring the queue finished (see playNextAudio).
+                    audioQueueSeeding = extendAudioQueueFromMedia(track)
                 }
 
                 const toggleAudioPlayback = () => {
@@ -6224,6 +6289,8 @@
                     audioQueueFetching = false
                     audioQueueAbort?.abort()
                     audioQueueAbort = null
+                    // Nothing may wait on the closed player's seed any more.
+                    audioQueueSeeding = null
                     audioQueueCursor = null
                     audioQueueHasOlder = false
                     audioQueueCursorNewer = null

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1258,8 +1258,8 @@
                                     <!-- Reply Context -->
                                     <div v-if="msg.reply_to_msg_id" @click="jumpToReply(msg.reply_to_msg_id)"
                                         class="border-l-2 border-blue-400/50 pl-2 mb-2 text-xs bg-black/20 rounded p-2 cursor-pointer hover:bg-black/30 transition">
-                                        <div class="font-semibold text-blue-400 mb-0.5">Reply to</div>
-                                        <div class="truncate opacity-70">{{ msg.reply_to_text || 'Message' }}</div>
+                                        <div class="font-semibold text-blue-400 mb-0.5 truncate">{{ replyToLabel(msg) }}</div>
+                                        <div class="truncate opacity-70">{{ replyToSnippet(msg) }}</div>
                                     </div>
 
                                     <!-- Forwarded Message Info -->
@@ -1380,12 +1380,23 @@
                                                         <span>🎵</span>
                                                         <span class="truncate">{{ getDocumentDisplayName(msg) }}</span>
                                                     </div>
+                                                    <!-- #267: every span in this row needs whitespace-nowrap.
+                                                         .message-bubble sets `overflow-wrap: anywhere`, which is
+                                                         inherited here and drops the MIN-CONTENT width of a text
+                                                         box to a single character. These spans are flex items of a
+                                                         row inside `min-w-0 flex-1`, so once the row is squeezed
+                                                         (the #261 download anchor is a sibling) they shrink to that
+                                                         one-character minimum and "0:12" renders as 0 / : / 1 / 2
+                                                         stacked. nowrap is the whole fix: it restores min-content to
+                                                         the full string, which flex `min-width: auto` then refuses
+                                                         to shrink below. shrink-0 is NOT needed and is not added —
+                                                         it guards the flex-basis, not the wrapping. -->
                                                     <div class="flex items-center gap-2 mt-1 text-[11px] text-gray-400">
-                                                        <span v-if="msg.media?.duration">{{ formatAudioTime(msg.media.duration) }}</span>
-                                                        <span v-if="isCurrentAudioMessage(msg)" class="text-blue-400">
+                                                        <span v-if="msg.media?.duration" class="whitespace-nowrap">{{ formatAudioTime(msg.media.duration) }}</span>
+                                                        <span v-if="isCurrentAudioMessage(msg)" class="text-blue-400 whitespace-nowrap">
                                                             {{ audioIsPlaying ? 'Now playing' : 'Paused' }}
                                                         </span>
-                                                        <span v-else-if="noDownload">Playback disabled</span>
+                                                        <span v-else-if="noDownload" class="whitespace-nowrap">Playback disabled</span>
                                                     </div>
                                                 </div>
                                                 <!-- #261: per-message download. Deliberately here on the
@@ -2273,6 +2284,25 @@
                 // heuristic alone would hide the button).
                 const viewingPinnedWindow = ref(false)
 
+                // #268: is what is currently in `messages.value` a CONTIGUOUS slice of the
+                // chat's timeline — every message between its oldest and newest row present,
+                // nothing filtered out of the middle? Only the code that WROTE the array can
+                // answer that, so every wholesale producer declares it, and the answer
+                // DEFAULTS TO NO: resetMessagePagination (the chokepoint every view entry
+                // passes through) clears it, so a producer that declares nothing leaves the
+                // window sparse.
+                //
+                // The default is the whole point. Naming the sparse views instead — "not
+                // pinned-only, not search, not a topic" — is a blacklist: it is wrong by
+                // default, and the next filtered view anyone adds silently claims to be a
+                // timeline slice. This flag inverts that: unproven means sparse, and the
+                // audio queue then takes its safe anchored path (one or two extra requests,
+                // never a skipped track).
+                //
+                // Non-reactive would be a stale-cache bug: `messageView` reads it inside a
+                // computed, so it has to be a ref for that cache to invalidate.
+                const messageWindowIsContiguous = ref(false)
+
                 const messageIdKey = (msg) => msg?.id == null ? null : String(msg.id)
 
                 const messageCursor = (msg) => {
@@ -2343,6 +2373,10 @@
                     // here, so clear the pinned-window flag (loadMessagesAroundId re-sets it after
                     // its own reset). This also re-enables the realtime poll.
                     viewingPinnedWindow.value = false
+                    // #268: same chokepoint, and the reason contiguity can default to "no".
+                    // The list is about to be rebuilt by SOME producer; until that producer
+                    // says what it wrote, the window is treated as sparse.
+                    messageWindowIsContiguous.value = false
                     // View-entry chokepoint: every message-list swap goes through here, so the
                     // unseen-badge from the previous view resets alongside pagination.
                     unseenMessageCount.value = 0
@@ -2354,6 +2388,64 @@
                     const topicId = activeTopicId()
                     if (topicId == null) return true
                     return Number(msg?.reply_to_top_id ?? GENERAL_TOPIC_ID) === Number(topicId)
+                }
+
+                // #268: would appending `added` to the CURRENT window still leave one
+                // unbroken run of the timeline? Answered here, at the single append path,
+                // rather than in each caller: the poll, the WS new_message frame and both
+                // pagination loaders all arrive through upsertMessages, and a check placed
+                // one level up has to be re-derived by whoever adds the next caller.
+                //
+                // How "adjoins" is decided for THIS list, since the next reader will need it:
+                //  - The rows are ordered (date desc, id desc) and carry integer ids. Per-chat
+                //    Telegram ids increase with time, which the backend already leans on in
+                //    both cursor directions (src/db/adapter.py: the lone before_id branch and
+                //    the after_id branch both order by id for exactly that reason). So "no id
+                //    strictly between them" means "no message between them".
+                //  - A batch is ONE bounded server page, dense between its own oldest and
+                //    newest row. Gaps inside a batch are the archive's own (ids that were
+                //    deleted or never stored), not holes the client invented — so the only
+                //    place an append can open a hole is the SEAM between batch and window.
+                //  - Two proofs of a joined seam, either one is enough:
+                //      overlap  — the batch also carried a row the window already holds, so
+                //                 the two dense ranges intersect and their union is one run;
+                //      successor — the lowest added id above the window's newest is exactly
+                //                 newest + 1 (mirrored below the oldest). Nothing can exist
+                //                 between n and n+1.
+                //    Rows landing INSIDE the window's id range need no proof: they can only
+                //    fill it in, never split it.
+                //  - Anything else is UNPROVEN, and unproven clears the flag. This function
+                //    only ever clears — declaring a window contiguous stays the privilege of
+                //    the wholesale producers that know what they wrote (loadMessages,
+                //    loadMessagesAroundId). A false clear costs the audio queue one anchored
+                //    request; a false keep costs a silently skipped track, which is the bug
+                //    this batch has now found four times.
+                const appendKeepsWindowContiguous = (added, overlapsWindow) => {
+                    if (overlapsWindow) return true
+                    let windowOldestId = null
+                    let windowNewestId = null
+                    for (const msg of messages.value) {
+                        const id = Number(msg?.id)
+                        if (!Number.isFinite(id)) continue
+                        if (windowNewestId === null || id > windowNewestId) windowNewestId = id
+                        if (windowOldestId === null || id < windowOldestId) windowOldestId = id
+                    }
+                    // Nothing to break: an empty window simply BECOMES the batch, and the
+                    // producer that fetched it declares what that is.
+                    if (windowNewestId === null) return true
+                    let firstAbove = null
+                    let lastBelow = null
+                    for (const msg of added) {
+                        const id = Number(msg?.id)
+                        // An unusable id cannot be placed on the timeline at all, so where it
+                        // sits relative to the window is unknowable: treat it as a hole.
+                        if (!Number.isFinite(id)) return false
+                        if (id > windowNewestId && (firstAbove === null || id < firstAbove)) firstAbove = id
+                        if (id < windowOldestId && (lastBelow === null || id > lastBelow)) lastBelow = id
+                    }
+                    if (firstAbove !== null && firstAbove !== windowNewestId + 1) return false
+                    if (lastBelow !== null && lastBelow !== windowOldestId - 1) return false
+                    return true
                 }
 
                 // In-place merge keyed by message id. Preserves row object identity so long-lived
@@ -2373,35 +2465,51 @@
                         if (key != null) existingById.set(key, existingMsg)
                     }
                     const added = []
+                    // Keys this batch itself introduced, so a duplicate WITHIN the batch is
+                    // not mistaken for a row shared with the window (that would prove a seam
+                    // that does not exist).
+                    const addedKeys = new Set()
+                    let overlapsWindow = false
                     for (const newMsg of incomingMessages) {
                         const key = messageIdKey(newMsg)
                         if (key == null) continue
                         const existingMsg = existingById.get(key)
                         if (existingMsg === undefined) {
                             existingById.set(key, newMsg)
+                            addedKeys.add(key)
                             added.push(newMsg)
-                        } else if (updateExisting) {
-                            // Field-level in-place merge: only write fields that actually changed,
-                            // so Vue bindings on untouched fields never re-evaluate. Object/list
-                            // fields (media, raw_data, reactions) arrive as fresh instances every
-                            // poll, so compare those structurally — rows come from res.json()
-                            // (plain JSON, stable key order per shape), making stringify reliable.
-                            for (const field of Object.keys(newMsg)) {
-                                // date is invariant (edits change edit_date) and its sort key is
-                                // cached by row object — never rewrite it (the WS and API paths
-                                // serialize the same instant with different tz markers).
-                                if (field === 'date') continue
-                                const oldValue = existingMsg[field]
-                                const newValue = newMsg[field]
-                                if (oldValue === newValue) continue
-                                if (oldValue !== null && newValue !== null &&
-                                    typeof oldValue === 'object' && typeof newValue === 'object' &&
-                                    JSON.stringify(oldValue) === JSON.stringify(newValue)) continue
-                                existingMsg[field] = newValue
-                            }
+                            continue
+                        }
+                        // A row the window already held: the batch and the window overlap.
+                        if (!addedKeys.has(key)) overlapsWindow = true
+                        if (!updateExisting) continue
+                        // Field-level in-place merge: only write fields that actually changed,
+                        // so Vue bindings on untouched fields never re-evaluate. Object/list
+                        // fields (media, raw_data, reactions) arrive as fresh instances every
+                        // poll, so compare those structurally — rows come from res.json()
+                        // (plain JSON, stable key order per shape), making stringify reliable.
+                        for (const field of Object.keys(newMsg)) {
+                            // date is invariant (edits change edit_date) and its sort key is
+                            // cached by row object — never rewrite it (the WS and API paths
+                            // serialize the same instant with different tz markers).
+                            if (field === 'date') continue
+                            const oldValue = existingMsg[field]
+                            const newValue = newMsg[field]
+                            if (oldValue === newValue) continue
+                            if (oldValue !== null && newValue !== null &&
+                                typeof oldValue === 'object' && typeof newValue === 'object' &&
+                                JSON.stringify(oldValue) === JSON.stringify(newValue)) continue
+                            existingMsg[field] = newValue
                         }
                     }
                     if (added.length > 0) {
+                        // #268: adjacency is checked HERE, before the rows land, because this
+                        // is the one place every append passes through. Clearing only — and
+                        // skipped outright once the window is already sparse, which is the
+                        // same answer for no walk.
+                        if (messageWindowIsContiguous.value && !appendKeepsWindowContiguous(added, overlapsWindow)) {
+                            messageWindowIsContiguous.value = false
+                        }
                         // Raw array order is irrelevant (sortedMessages re-sorts; v-for is keyed
                         // by msg.id), so appending is enough.
                         messages.value.push(...added)
@@ -3760,6 +3868,13 @@
                         if (!isCurrentIntent()) return
                         messages.value = [...afterRows, ...windowRows]
                         resetMessagePagination()
+                        // #268: declare what was just written. Both halves are pages of the
+                        // timeline hinged on the same id, so an unscoped jump window IS a
+                        // contiguous slice. A TOPIC-scoped one is not: it holds one topic's
+                        // rows while the audio queue's /media endpoint is chat-wide, so its
+                        // newest row is not the newest media before it. Declared AFTER
+                        // resetMessagePagination, which clears the flag by design.
+                        messageWindowIsContiguous.value = topicId == null
                         newestMessageId = newestLoadedMessageId()
                         hasMoreNewer.value = !afterFetchComplete || afterRows.length === windowLimit
                         // A short after-page proves the window already reaches the newest
@@ -3843,18 +3958,30 @@
                     return chats.value
                 })
 
-                const sortedMessages = computed(() => {
+                // #268: the rendered rows and whether they form a CONTIGUOUS slice of the
+                // timeline are ONE value, produced by ONE branch. A view added here cannot
+                // return rows without also answering the contiguity question, and copying
+                // the branch above it gets the safe answer — where a separate predicate
+                // that enumerated the sparse views would keep saying "contiguous" about a
+                // view it had never heard of. That is the failure this shape removes.
+                const messageView = computed(() => {
                     // If in pinned-only view, show only pinned messages
                     if (showPinnedOnly.value) {
-                        // pinnedMessages are already sorted by date descending from API
-                        return pinnedMessages.value
+                        // pinnedMessages are already sorted by date descending from API.
+                        // Chronologically SPARSE by construction: two pinned rows can sit
+                        // months and hundreds of messages apart.
+                        return { rows: pinnedMessages.value, contiguous: false }
                     }
                     // Sort messages by date (newest first) - flex-col-reverse displays them chronologically
                     // This gives instant "scroll to bottom" experience on mobile.
                     // The message v-for is keyed by msg.id, so in-place row merges from
                     // upsertMessages patch bindings without re-rendering the list.
-                    return sortedLoadedMessages()
+                    // Contiguity here is whatever the producer that filled messages.value
+                    // declared — false until one of them positively says otherwise.
+                    return { rows: sortedLoadedMessages(), contiguous: messageWindowIsContiguous.value }
                 })
+
+                const sortedMessages = computed(() => messageView.value.rows)
 
                 // Group consecutive messages that belong to an album (same grouped_id)
                 // Note: grouped_id may be string or number depending on source, so compare as strings
@@ -3940,8 +4067,9 @@
                 // outright, so re-observing on list changes — not on scroll — is what keeps
                 // the pill from going stale.
                 // Placement note: this watch eagerly evaluates `sortedMessages`, which reads
-                // `showPinnedOnly`, so it must be declared after it (same
-                // state-before-watcher rule as the media gallery refs).
+                // `messageView`, which reads `showPinnedOnly`/`pinnedMessages`, so it must be
+                // declared after them (same state-before-watcher rule as the media gallery
+                // refs). The computeds themselves are lazy, so THEIR order does not matter.
                 watch(sortedMessages, () => {
                     nextTick(updateFloatingDate)
                 }, { flush: 'post' })
@@ -4259,8 +4387,28 @@
                             updateOldestMessageCursor(newMessages)
                         }
 
+                        // #268: this page is only the WHOLE window when the window was empty
+                        // before it landed — which is every first page, since every view entry
+                        // (selectChat/selectTopic/search/back-to-live) empties messages.value
+                        // before calling in. Captured before the upsert, used by the
+                        // declaration below.
+                        const windowWasEmpty = messages.value.length === 0
                         // Prefer messages from pagination with joins over temporary realtime rows.
                         upsertMessages(newMessages)
+                        // #268: declare what this page actually is, straight from the request
+                        // that was just built above. A plain chat page IS the timeline. A
+                        // SEARCH page holds matching rows only, and a TOPIC-scoped page holds
+                        // one topic out of many while the audio queue's /media endpoint is
+                        // chat-wide — both are sparse, so the window stays undeclared.
+                        //
+                        // Only a page that IS the window may raise the flag. A later page is
+                        // appended to rows this call never saw, so it cannot vouch for them:
+                        // if a burst of arrivals already punched a hole above (upsertMessages
+                        // clears the flag when an append does not adjoin), scrolling up must
+                        // not re-declare the holed window contiguous. Below the first page the
+                        // declaration can therefore only KEEP or clear, never resurrect.
+                        messageWindowIsContiguous.value = !messageSearchQuery.value && topicId == null &&
+                            (windowWasEmpty || messageWindowIsContiguous.value)
                         page.value++  // Still increment for search pagination
                     } catch (e) {
                         console.error("Failed to load messages", e)
@@ -4685,6 +4833,36 @@
                         return `ID: ${msg.forward_from_id}`
                     }
                     return null
+                }
+
+                // #268: the reply quote block. The backend sends reply_to_sender_name
+                // and reply_to_media_type alongside reply_to_text for every message that
+                // IS a reply, with BOTH null when the replied-to message is not in the
+                // archive. Everything here therefore degrades to the pre-#268 output
+                // ("Reply to" + "Message") on an older backend that sends neither key,
+                // rather than rendering "undefined".
+                const replyMediaLabels = {
+                    photo: 'Photo',
+                    video: 'Video',
+                    voice: 'Voice message',
+                    audio: 'Audio',
+                    animation: 'GIF',
+                    sticker: 'Sticker',
+                    document: 'File',
+                }
+
+                const replyToLabel = (msg) => {
+                    const name = msg?.reply_to_sender_name
+                    return name ? `Reply to ${name}` : 'Reply to'
+                }
+
+                const replyToSnippet = (msg) => {
+                    if (msg?.reply_to_text) return msg.reply_to_text
+                    // A media-only reply has no text to quote; naming the media beats
+                    // the bare word "Message", which said nothing at all.
+                    const type = msg?.reply_to_media_type
+                    if (type) return replyMediaLabels[type] || type
+                    return 'Message'
                 }
 
                 const isDeletedChat = (chat) => {
@@ -5342,9 +5520,38 @@
 
                 const audioMessageChatId = (msg) => msg.chat_id ?? selectedChat.value?.id ?? null
 
+                // #266: the media endpoint's cursor is a composite media id, and it is
+                // what lets the queue page in both directions from a track the endpoint
+                // has never returned — the window-seeded queue — instead of first
+                // walking backwards from the newest item to reach it.
+                //
+                // #268: PREFER the id the payload already carries. Both message paths
+                // that feed this view select Media.id into `media.id`
+                // (get_messages_paginated / get_pinned_messages), and the no_download
+                // strip only blanks file_path, so the authoritative cursor is in hand
+                // and never has to be guessed.
+                //
+                // The rebuild below is only a FALLBACK, for a payload that predates
+                // that field or a writer that omits it. It reproduces the shape the
+                // capture path writes, `{chat}_{message}_{type}` — which is NOT the
+                // only shape in use (the importer writes `import_{chat}_{message}`), so
+                // guessing it is exactly how a legacy/imported archive ended up with a
+                // cursor the server cannot resolve. An unresolvable cursor answers with
+                // an empty page, which every caller here already reads as "nothing more
+                // that way", so the fallback degrades quietly rather than erroring.
+                const audioMessageMediaId = (msg) => {
+                    const delivered = msg?.media?.id
+                    if (delivered) return String(delivered)
+                    const chatId = audioMessageChatId(msg)
+                    const type = msg?.media?.type
+                    if (chatId == null || msg?.id == null || !type) return null
+                    return `${chatId}_${msg.id}_${type}`
+                }
+
                 const audioTrackFromMessage = (msg) => ({
                     id: msg.id,
                     chatId: audioMessageChatId(msg),
+                    mediaId: audioMessageMediaId(msg),
                     chatName: selectedChat.value ? getChatName(selectedChat.value) : '',
                     url: getMediaUrl(msg),
                     sender: getSenderName(msg),
@@ -5455,12 +5662,32 @@
                     })
                 }
 
+                // #268: the seed is only a valid slice of the timeline when the visible
+                // list IS one. Several views are chronologically SPARSE — pinned-only
+                // (entries months apart), in-chat search (matching rows only), a forum
+                // topic (one topic while /media is chat-wide) — and from any of them
+                // seeding the queue puts non-adjacent tracks next to each other (#257's
+                // hole, in the forward direction), which is also exactly what the forward
+                // cursor must never be armed from.
+                //
+                // So this asks the ONE positive question instead of listing those views:
+                // did the code that produced the visible list declare it a contiguous
+                // timeline slice? Undeclared reads as sparse, which is the safe answer.
+                const audioQueueSeedIsContiguous = () => messageView.value.contiguous
+
                 const buildAudioQueue = (msg) => {
                     // Same type class only: voice notes and music are separate queues,
                     // so a voice run never rolls into a music file. This is only the
                     // SEED, taken from the already-loaded window of this chat so the
                     // queue is usable on the click itself; extendAudioQueueFromMedia
                     // then grows it past that window. Oldest -> newest.
+                    //
+                    // #268: from a sparse view there is no usable seed at all — the
+                    // clicked track alone is the only entry known to sit where it
+                    // claims to. The anchored paging then rebuilds the REAL neighbours
+                    // around it (one page older on the click, forward on demand), which
+                    // is both correct and no more expensive than the sparse seed was.
+                    if (!audioQueueSeedIsContiguous()) return [audioTrackFromMessage(msg)]
                     const kind = audioMediaKind(msg)
                     const chatId = audioMessageChatId(msg)
                     return sortedMessages.value
@@ -5489,8 +5716,14 @@
                 // keying the flag on it leaks (the finally then never matches) and
                 // head-of-queue paging dies for the session.
                 let audioQueueFetchSeq = 0
-                let audioQueueCursor = null      // media id of the OLDEST item fetched so far
+                let audioQueueCursor = null      // media id of the OLDEST item the queue knows
                 let audioQueueHasOlder = false
+                // #266: the mirror pair. The endpoint pages BACKWARD, so pre-collecting
+                // every track newer than the playing one cost a page per 50 tracks of
+                // depth and hit the cap in a big chat; a forward cursor lets the queue
+                // grow one page per page CONSUMED, in the direction playback is moving.
+                let audioQueueCursorNewer = null // media id of the NEWEST item the queue knows
+                let audioQueueHasNewer = false
                 let audioQueueFetching = false
 
                 // Voice and music are queried separately — the endpoint would happily
@@ -5502,14 +5735,17 @@
                 // a response to land on a player the user has already closed.
                 let audioQueueAbort = null
 
-                const fetchAudioQueuePage = async (chatId, kind, beforeId) => {
+                const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') => {
                     const params = new URLSearchParams({
                         types: audioQueueTypes(kind),
                         limit: String(AUDIO_QUEUE_PAGE_SIZE),
                     })
                     // Cursor is the composite media id of the last item seen; the
-                    // endpoint pages backwards in time from it.
-                    if (beforeId) params.set('before_id', beforeId)
+                    // endpoint pages AWAY from it in the requested direction —
+                    // before_id back in time, after_id forward in time. Either way the
+                    // page's LAST item is the one farthest from the cursor, so it is
+                    // always the cursor for the next page in the same direction.
+                    if (cursor) params.set(direction === 'newer' ? 'after_id' : 'before_id', cursor)
                     audioQueueAbort?.abort()
                     const controller = new AbortController()
                     audioQueueAbort = controller
@@ -5530,6 +5766,9 @@
                 const audioTrackFromMediaItem = (item, kind, chatName) => ({
                     id: item.message_id,
                     chatId: item.chat_id,
+                    // Authoritative cursor, straight from the endpoint — unlike the one
+                    // audioMessageMediaId has to rebuild for a window-seeded track.
+                    mediaId: item.id ?? null,
                     chatName,
                     url: item.media_url || '',
                     sender: item.sender_name || 'Deleted Account',
@@ -5574,11 +5813,103 @@
                     return !!current && current.chatId === track.chatId && current.kind === track.kind
                 }
 
+                // The queue is sorted ascending, so its edges are its first and last
+                // entries — but a descriptor is only usable as a cursor if it carries a
+                // media id, so scan inwards until one does.
+                const audioQueueEdgeMediaId = (newest) => {
+                    const queue = audioQueue.value
+                    for (let i = 0; i < queue.length; i++) {
+                        const track = newest ? queue[queue.length - 1 - i] : queue[i]
+                        if (track && track.mediaId) return track.mediaId
+                    }
+                    return null
+                }
+
+                const seedAudioQueueAroundTrack = async (track) => {
+                    // #266: ONE page older than the PLAYING track, anchored on its own
+                    // media id. That page is contiguous with the playing track by
+                    // construction, so there is no second block to splice and no
+                    // chronological hole to guard against — and it costs one request no
+                    // matter how deep in the chat the track sits, where the backward
+                    // walk below cost one per 50 tracks of depth and gave up at the cap.
+                    // The forward cursor normally needs no request at all: it is anchored
+                    // in playAudioMessage, on the seeded window's newest track when that
+                    // window is contiguous and on the playing track itself otherwise.
+                    //
+                    // Returns false ONLY when the anchor turns out to be unusable, so
+                    // the caller can fall back to the unanchored walk.
+                    const requestId = ++audioQueueRequestId
+                    const fetchToken = ++audioQueueFetchSeq
+                    audioQueueFetching = true
+                    let data
+                    let forward = null
+                    try {
+                        data = await fetchAudioQueuePage(track.chatId, track.kind, track.mediaId, 'older')
+                        if (!(Array.isArray(data?.items) ? data.items : []).length && !data?.has_more) {
+                            // #268: an empty backward page has two causes that LOOK
+                            // identical — the track is the oldest audio of its kind, or
+                            // the anchor does not resolve in this archive. One more
+                            // anchored request tells them apart, because
+                            // get_media_paginated answers an unresolvable cursor with an
+                            // empty page in BOTH directions: items here mean the anchor
+                            // resolves. That matters because handing the oldest track to
+                            // the walk makes it traverse the WHOLE chat backwards to
+                            // reach it, which is the cost #266 exists to remove.
+                            forward = await fetchAudioQueuePage(track.chatId, track.kind, track.mediaId, 'newer')
+                        }
+                    } catch (e) {
+                        // A page that fails to load is not a bad anchor, and retrying it
+                        // as a walk would just fail again. Report it as handled: the
+                        // seeded window queue stays exactly as it is, which is what a
+                        // failed page has always done here.
+                        return true
+                    } finally {
+                        if (fetchToken === audioQueueFetchSeq) audioQueueFetching = false
+                    }
+                    if (requestId !== audioQueueRequestId || !audioQueueBelongsToTrack(track)) return true
+                    const items = Array.isArray(data?.items) ? data.items : []
+                    if (!items.length && !data?.has_more) {
+                        const forwardItems = Array.isArray(forward?.items) ? forward.items : []
+                        if (!forwardItems.length) {
+                            // Empty BOTH ways: this archive does not use the id shape
+                            // the anchor carries (or the chat holds nothing else of this
+                            // kind). The walk settles both without needing an anchor, so
+                            // hand back to it.
+                            return false
+                        }
+                        // The anchor resolves and there is genuinely nothing older: the
+                        // playing track is the oldest audio of its kind. The forward
+                        // page is contiguous with it by construction, so seed from that
+                        // and skip the walk entirely.
+                        audioQueueCursor = null
+                        audioQueueHasOlder = false
+                        audioQueue.value = mergeAudioQueue(audioTracksFromMediaItems(forwardItems, track))
+                        audioQueueCursorNewer = forwardItems[forwardItems.length - 1].id
+                        audioQueueHasNewer = !!forward.has_more
+                        return true
+                    }
+                    audioQueueCursor = items.length ? items[items.length - 1].id : null
+                    audioQueueHasOlder = !!data.has_more && !!audioQueueCursor
+                    audioQueue.value = mergeAudioQueue(audioTracksFromMediaItems(items, track))
+                    // The already-loaded window can hold MORE than one page of audio
+                    // older than the playing track, in which case the queue's own oldest
+                    // entry is older than this page's last item. Paging from the page
+                    // would then re-fetch rows the queue already has and report no
+                    // progress, so the cursor follows the QUEUE's edge.
+                    audioQueueCursor = audioQueueEdgeMediaId(false) || audioQueueCursor
+                    return true
+                }
+
                 const extendAudioQueueFromMedia = async (track) => {
                     // Playback advances forward in time while the endpoint pages
                     // backwards from the newest item, so paging back until the playing
                     // track shows up puts EVERY possible next track in hand.
                     if (!track || track.chatId == null || noDownload.value) return
+                    // #266: with a usable anchor none of that walking is needed — both
+                    // directions extend on demand instead. Only a track whose media id
+                    // cannot be rebuilt, or that this archive cannot resolve, falls
+                    // through to the walk (and to its #257 hole guard).
+                    if (track.mediaId && await seedAudioQueueAroundTrack(track)) return
                     const requestId = ++audioQueueRequestId
                     const fetchToken = ++audioQueueFetchSeq
                     audioQueueFetching = true
@@ -5588,7 +5919,7 @@
                     let foundPlaying = false
                     try {
                         for (let page = 0; page < AUDIO_QUEUE_MAX_PAGES; page++) {
-                            const data = await fetchAudioQueuePage(track.chatId, track.kind, cursor)
+                            const data = await fetchAudioQueuePage(track.chatId, track.kind, cursor, 'older')
                             const items = Array.isArray(data?.items) ? data.items : []
                             if (!items.length) {
                                 // An empty page is NOT self-evidently "exhausted": it has
@@ -5661,6 +5992,77 @@
                     audioQueueCursor = cursor
                     audioQueueHasOlder = hasOlder
                     audioQueue.value = mergeAudioQueue(audioTracksFromMediaItems(collected, track))
+                    // The walk starts at the newest item of the chat, so an adopted walk
+                    // leaves nothing newer to page to: the forward cursor is the very
+                    // first item collected, and there is no forward page after it.
+                    audioQueueCursorNewer = collected[0].id
+                    audioQueueHasNewer = false
+                }
+
+                const extendAudioQueueNewer = async () => {
+                    // #266: one page NEWER, on demand, for auto-advance standing at the
+                    // newest end of the queue. Both cursors stay contiguous with the
+                    // playing track by construction, so #257's disjoint-block hole
+                    // cannot come back and no page cap is needed for correctness.
+                    const track = audioTrack.value
+                    // Same three separate states as extendAudioQueueOlder: an in-flight
+                    // page is not the end of the queue.
+                    if (!track) return 'aborted'
+                    if (audioQueueFetching) return 'pending'
+                    if (!audioQueueHasNewer || !audioQueueCursorNewer) return 'exhausted'
+                    const requestId = ++audioQueueRequestId
+                    const fetchToken = ++audioQueueFetchSeq
+                    audioQueueFetching = true
+                    try {
+                        // Loops only while a page yields NO usable track — a whole page
+                        // of items this viewer cannot play (no media_url) would
+                        // otherwise end auto-advance exactly the way #266 did. Every
+                        // exit is progress-driven: an empty page, a cursor that did not
+                        // move, has_more false, or a track actually added. Never a count
+                        // of successful page loads — that is the cap that broke the walk.
+                        //
+                        // #268: "did not move" compares against EVERY cursor this walk
+                        // has already asked from, not just the previous one. Comparing
+                        // only the previous one leaves a response that alternates
+                        // A -> B -> A spinning forever; a forward walk never legitimately
+                        // revisits a cursor, so a repeat is proof of no progress. The
+                        // set is bounded by the pages actually walked, so this is still
+                        // not a request budget — a genuine 40-page run of unplayable
+                        // media is allowed to finish.
+                        const seenCursors = new Set([audioQueueCursorNewer])
+                        while (true) {
+                            const data = await fetchAudioQueuePage(
+                                track.chatId, track.kind, audioQueueCursorNewer, 'newer')
+                            if (requestId !== audioQueueRequestId || !audioQueueBelongsToTrack(track)) return 'aborted'
+                            const items = Array.isArray(data?.items) ? data.items : []
+                            if (!items.length) {
+                                audioQueueHasNewer = false   // genuinely nothing newer
+                                return 'exhausted'
+                            }
+                            const nextCursor = items[items.length - 1].id
+                            if (!nextCursor || seenCursors.has(nextCursor)) {
+                                // The page did not move the cursor anywhere new, so
+                                // another round would ask a question already asked.
+                                audioQueueHasNewer = false
+                                return 'exhausted'
+                            }
+                            seenCursors.add(nextCursor)
+                            audioQueueCursorNewer = nextCursor
+                            audioQueueHasNewer = !!data.has_more
+                            const before = audioQueue.value.length
+                            audioQueue.value = mergeAudioQueue(audioTracksFromMediaItems(items, track))
+                            if (audioQueue.value.length > before) return 'extended'
+                            if (!audioQueueHasNewer) return 'exhausted'
+                        }
+                    } catch (e) {
+                        // Paging failure is not end-of-queue and never touches the
+                        // playback failure counter.
+                        if (e?.name === 'AbortError') return 'aborted'
+                        audioError.value = 'Could not load more audio. Try again.'
+                        return 'error'
+                    } finally {
+                        if (fetchToken === audioQueueFetchSeq) audioQueueFetching = false
+                    }
                 }
 
                 const extendAudioQueueOlder = async () => {
@@ -5678,7 +6080,7 @@
                     audioQueueFetching = true
                     let data
                     try {
-                        data = await fetchAudioQueuePage(track.chatId, track.kind, audioQueueCursor)
+                        data = await fetchAudioQueuePage(track.chatId, track.kind, audioQueueCursor, 'older')
                     } catch (e) {
                         // A transport failure is NOT the end of the queue. Collapsing the
                         // two makes "previous" restart the track on a 401/403/429 as if
@@ -5724,7 +6126,16 @@
                     return true
                 }
 
-                const playNextAudio = () => playAdjacentAudio(1)
+                const playNextAudio = async () => {
+                    if (playAdjacentAudio(1)) return true
+                    // #266: at the newest end of the queue, page ONE step forward on
+                    // demand. This is the whole reason auto-advance no longer dies at
+                    // the seeded window's edge after ~40 tracks: the queue grows in the
+                    // direction playback is moving, so its cost tracks how much is
+                    // PLAYED, not how deep in the chat the first track was.
+                    const outcome = await extendAudioQueueNewer()
+                    return outcome === 'extended' && playAdjacentAudio(1)
+                }
 
                 const playPrevAudio = async () => {
                     if (playAdjacentAudio(-1)) return
@@ -5748,6 +6159,22 @@
                     audioQueueHasOlder = false
                     audioQueue.value = buildAudioQueue(msg)
                     const track = audioTrackFromMessage(msg)
+                    // #266: arm the FORWARD cursor from the seeded window itself — its
+                    // newest track, or the clicked one when the window yields no usable
+                    // media id. No request is needed for this, and it is what lets
+                    // auto-advance page past the window the moment it reaches its edge.
+                    // hasNewer starts optimistic: "unknown" must not read as "ended", and
+                    // the first forward page is what settles it.
+                    //
+                    // #268: the window's edge qualifies as an anchor ONLY while that
+                    // window is contiguous with the real timeline. Armed from a sparse
+                    // view's edge, the first forward page starts past everything between
+                    // the clicked track and that edge, and auto-advance silently skips
+                    // it. The playing track's own media id is contiguous by definition,
+                    // so it is the anchor whenever the window is not one.
+                    audioQueueCursorNewer =
+                        (audioQueueSeedIsContiguous() && audioQueueEdgeMediaId(true)) || track.mediaId
+                    audioQueueHasNewer = !!audioQueueCursorNewer
                     // Start on the user gesture, THEN grow the queue: awaiting the fetch
                     // first would spend the gesture and hand iOS a blocked play().
                     loadAudioTrack(track)
@@ -5799,6 +6226,8 @@
                     audioQueueAbort = null
                     audioQueueCursor = null
                     audioQueueHasOlder = false
+                    audioQueueCursorNewer = null
+                    audioQueueHasNewer = false
                     audioIsPlaying.value = false
                     audioCurrentTime.value = 0
                     audioDuration.value = 0
@@ -5859,9 +6288,12 @@
                     syncAudioMediaSession()
                 })
 
-                audioEngine.addEventListener('ended', () => {
+                audioEngine.addEventListener('ended', async () => {
                     audioIsPlaying.value = false
-                    if (audioAutoAdvanceHalted.value || !playNextAudio()) {
+                    // playNextAudio may have to fetch the next page (#266), so it returns
+                    // a PROMISE and the result has to be awaited: `!promise` is always
+                    // false, which would silently skip the end-of-queue reset below.
+                    if (audioAutoAdvanceHalted.value || !(await playNextAudio())) {
                         audioCurrentTime.value = 0
                         syncAudioMediaSession()
                     }
@@ -6387,6 +6819,8 @@
                     openSenderInfoFromChat,
                     closeSenderInfo,
                     getForwardName,
+                    replyToLabel,
+                    replyToSnippet,
                     getSenderRunKey,
                     showSenderName,
                     isRunEnd,

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -618,12 +618,16 @@ async def test_disconnect_handles_exception():
 
 @pytest.mark.asyncio
 async def test_ensure_connected_calls_connect_when_not_connected():
-    """ensure_connected() calls connect() when not connected."""
+    """ensure_connected() runs the connect body when not connected.
+
+    It calls ``_connect_locked`` rather than ``connect`` because it already
+    holds the connect lock (see TestHealingIsSerialised).
+    """
     config = MagicMock()
     conn = TelegramConnection(config)
     mock_client = AsyncMock()
 
-    with patch.object(conn, "connect", new_callable=AsyncMock, return_value=mock_client) as mock_connect:
+    with patch.object(conn, "_connect_locked", new_callable=AsyncMock, return_value=mock_client) as mock_connect:
         result = await conn.ensure_connected()
 
     mock_connect.assert_awaited_once()
@@ -675,7 +679,7 @@ async def test_ensure_connected_reconnects_on_check_failure():
     conn._connected = True
 
     mock_new_client = AsyncMock()
-    with patch.object(conn, "connect", new_callable=AsyncMock, return_value=mock_new_client):
+    with patch.object(conn, "_connect_locked", new_callable=AsyncMock, return_value=mock_new_client):
         result = await conn.ensure_connected()
 
     assert result is mock_client  # Returns self._client at end

--- a/tests/test_connection_heal_race.py
+++ b/tests/test_connection_heal_race.py
@@ -1,0 +1,443 @@
+"""Connection healing must be safe while a backup is mid-run — #265 follow-up.
+
+The #265 fix made ``_start_listener`` call ``ensure_connected()``. That method
+runs on the listener watchdog loop, which shares an event loop with the
+APScheduler backup job, so it can now execute while a backup is suspended at an
+await. Before this change ``ensure_connected`` could REPLACE
+``TelegramConnection._client`` (its failure path built a brand new
+``TelegramClient``) — and the backup holds the client object it was handed for
+the whole run. The backup would then keep talking to a client that had been
+disconnected and abandoned, while the healthy one lived somewhere else, with two
+``TelegramClient`` instances on one session database.
+
+These tests pin the two properties that make healing safe:
+
+- IN PLACE: healing never swaps the client object out from under a holder.
+- SERIALISED: two coroutines cannot be inside connect() at the same time.
+
+plus the one case where rebuilding is mandatory (a restored session file), and
+the #265 failure itself — a sender that gave up and only ``connect()`` revives.
+"""
+
+import asyncio
+import os
+import sqlite3
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from telethon import TelegramClient
+from telethon.sessions import MemorySession
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.connection import TelegramConnection
+
+
+def _shared_client():
+    """A Telethon-shaped shared client that can die and be revived in place."""
+    state = {"alive": True, "connects": 0, "disconnects": 0, "fail_next_connect": False, "slow_connect": False}
+
+    client = MagicMock()
+
+    def is_connected():
+        return state["alive"]
+
+    async def connect():
+        state["connects"] += 1
+        if state["slow_connect"]:
+            # Yield control so a second healer can interleave if nothing stops it.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+        if state["fail_next_connect"]:
+            state["fail_next_connect"] = False
+            raise OSError("Network is unreachable")
+        state["alive"] = True
+
+    async def disconnect():
+        state["disconnects"] += 1
+        state["alive"] = False
+
+    client.is_connected = MagicMock(side_effect=is_connected)
+    client.connect = AsyncMock(side_effect=connect)
+    client.disconnect = AsyncMock(side_effect=disconnect)
+    client.is_user_authorized = AsyncMock(return_value=True)
+    client.get_me = AsyncMock(return_value=MagicMock(first_name="Test", phone="+10000000000"))
+    client.session = MagicMock()
+    client.session._conn = None
+    return client, state
+
+
+def _connection(tmp_path, client):
+    """A real TelegramConnection that already owns ``client`` and believes it is up."""
+    session_path = os.path.join(str(tmp_path), "test_session")
+    # connect() copies the live session file to the golden backup on success.
+    with open(session_path + ".session", "wb") as handle:
+        handle.write(b"placeholder")
+
+    config = MagicMock()
+    config.session_path = session_path
+    config.api_id = 12345
+    config.api_hash = "test-api-hash"
+    config.get_telegram_client_kwargs.return_value = {}
+
+    conn = TelegramConnection(config)
+    conn._client = client
+    conn._connected = True
+    return conn
+
+
+def _never_built():
+    """Patch target that fails loudly if a second TelegramClient is constructed."""
+    return patch(
+        "src.connection.TelegramClient",
+        side_effect=AssertionError("healing built a new TelegramClient instead of reviving the existing one"),
+    )
+
+
+class TestHealingIsInPlace:
+    async def test_dead_sender_is_revived_on_the_same_object(self, tmp_path):
+        """The #265 state: Telethon gave up, the app-level flag still says up."""
+        client, state = _shared_client()
+        state["alive"] = False
+        conn = _connection(tmp_path, client)
+
+        with _never_built():
+            healed = await conn.ensure_connected()
+
+        assert healed is client
+        assert conn.client is client
+        assert client.is_connected()
+        assert state["connects"] == 1
+
+    async def test_failed_health_check_reconnects_the_same_object(self, tmp_path):
+        """The old failure path built a new client here; now it revives this one."""
+        client, state = _shared_client()
+        client.is_connected = MagicMock(side_effect=Exception("socket gone"))
+        conn = _connection(tmp_path, client)
+
+        with _never_built():
+            healed = await conn.ensure_connected()
+
+        assert healed is client
+        assert conn.client is client
+        assert conn.is_connected is True
+        assert state["connects"] == 1
+
+    async def test_a_failed_reconnect_still_ends_on_the_same_object(self, tmp_path):
+        """First connect() attempt fails, the retry inside connect() succeeds."""
+        client, state = _shared_client()
+        state["alive"] = False
+        state["fail_next_connect"] = True
+        conn = _connection(tmp_path, client)
+
+        with _never_built():
+            healed = await conn.ensure_connected()
+
+        assert healed is client
+        assert conn.client is client
+        assert client.is_connected()
+        assert state["connects"] == 2  # the failed attempt, then the one inside connect()
+
+    async def test_client_identity_survives_a_disconnect_reconnect_cycle(self, tmp_path):
+        """disconnect() then connect() must not mint a new object either."""
+        client, _ = _shared_client()
+        conn = _connection(tmp_path, client)
+
+        with patch("src.connection.asyncio.sleep", new_callable=AsyncMock):
+            await conn.disconnect()
+        assert conn.client is client
+
+        with _never_built():
+            await conn.connect()
+
+        assert conn.client is client
+        assert conn.is_connected is True
+
+
+class TestWatchdogHealsWhileABackupIsSuspended:
+    """The interleaving itself, driven through the real scheduler."""
+
+    def _scheduler(self, connection):
+        with patch("src.scheduler.signal.signal"):
+            from src.scheduler import BackupScheduler
+
+            config = MagicMock()
+            config.enable_listener = True
+            config.fill_gaps = False
+            scheduler = BackupScheduler(config)
+        scheduler._connection = connection
+        scheduler._listener_enabled = True
+        return scheduler
+
+    class _StubListener:
+        @classmethod
+        async def create(cls, config, client=None):
+            listener = cls()
+            listener.client = client
+            return listener
+
+        async def connect(self):
+            # Mirrors the real guard in src/listener.py.
+            if not self.client.is_connected():
+                raise RuntimeError("Shared client is not connected")
+
+        async def run(self):
+            await asyncio.sleep(3600)
+
+        async def _load_tracked_chats(self):
+            return None
+
+    async def test_backup_still_holds_a_live_client_after_the_watchdog_heals(self, tmp_path):
+        client, state = _shared_client()
+        conn = _connection(tmp_path, client)
+        scheduler = self._scheduler(conn)
+
+        # A replacement is made available on purpose: the assertions below prove
+        # it is never reached. Before the fix the watchdog installed it as
+        # `connection.client` and left the parked backup on the old, now
+        # disconnected object.
+        replacement, _ = _shared_client()
+        builder = MagicMock(return_value=replacement)
+
+        backup_started = asyncio.Event()
+        watchdog_done = asyncio.Event()
+        seen = {}
+
+        async def fake_run_backup(config, client=None):
+            seen["at_start"] = client
+            backup_started.set()
+            # Suspended mid-run: every await inside a real backup is a point
+            # where the watchdog gets to run.
+            await watchdog_done.wait()
+            seen["at_resume"] = client
+            seen["still_the_connections_client"] = client is conn.client
+            seen["usable_at_resume"] = client.is_connected()
+
+        with patch("src.scheduler.run_backup", fake_run_backup):
+            backup_task = asyncio.create_task(scheduler._run_backup_job())
+            await backup_started.wait()
+
+            # The shared sender dies while the backup is parked, and the first
+            # reconnect attempt loses too — the exact path that used to abandon
+            # the client and build a new one. The listener task is dead, so the
+            # watchdog restarts it: the #265 path that calls ensure_connected().
+            state["alive"] = False
+            state["fail_next_connect"] = True
+            with (
+                patch("src.listener.TelegramListener", self._StubListener),
+                patch("src.connection.TelegramClient", builder),
+            ):
+                await scheduler._start_listener()
+
+            watchdog_done.set()
+            await backup_task
+
+        assert scheduler._listener is not None
+        scheduler._listener_task.cancel()
+
+        assert builder.call_count == 0, "healing built a new client instead of reviving the shared one"
+        assert seen["at_start"] is client
+        assert seen["at_resume"] is client
+        assert seen["still_the_connections_client"] is True, "the watchdog replaced the client under the backup"
+        assert seen["usable_at_resume"] is True, "the backup resumed on a disconnected client"
+        # The listener was started on the very same client the backup is using.
+        assert scheduler._listener.client is client
+
+    async def test_the_backup_never_overlaps_the_watchdogs_connect(self, tmp_path):
+        """Both reach ensure_connected(); the lock keeps them out of each other."""
+        client, state = _shared_client()
+        state["alive"] = False
+        state["slow_connect"] = True
+        conn = _connection(tmp_path, client)
+        scheduler = self._scheduler(conn)
+
+        inside = {"now": 0, "max": 0}
+        original_connect = client.connect.side_effect
+
+        async def counting_connect():
+            inside["now"] += 1
+            inside["max"] = max(inside["max"], inside["now"])
+            try:
+                await original_connect()
+            finally:
+                inside["now"] -= 1
+
+        client.connect = AsyncMock(side_effect=counting_connect)
+
+        async def fake_run_backup(config, client=None):
+            return None
+
+        with (
+            patch("src.scheduler.run_backup", fake_run_backup),
+            patch("src.listener.TelegramListener", self._StubListener),
+            _never_built(),
+        ):
+            await asyncio.gather(scheduler._run_backup_job(), scheduler._start_listener())
+
+        if scheduler._listener_task:
+            scheduler._listener_task.cancel()
+
+        assert inside["max"] == 1, "a backup and the watchdog were inside connect() at the same time"
+        # The loser of the race finds a healthy client and does not connect again.
+        assert state["connects"] == 1
+
+
+class TestHealingIsSerialised:
+    async def test_two_healers_produce_one_connect(self, tmp_path):
+        client, state = _shared_client()
+        state["alive"] = False
+        state["slow_connect"] = True
+        conn = _connection(tmp_path, client)
+
+        with _never_built():
+            first, second = await asyncio.gather(conn.ensure_connected(), conn.ensure_connected())
+
+        assert first is client
+        assert second is client
+        assert state["connects"] == 1
+
+    async def test_teardown_cannot_interleave_with_a_heal(self, tmp_path):
+        """disconnect() waits for an in-flight heal instead of racing it."""
+        client, state = _shared_client()
+        state["alive"] = False
+        state["slow_connect"] = True
+        conn = _connection(tmp_path, client)
+
+        with patch("src.connection.asyncio.sleep", new_callable=AsyncMock), _never_built():
+            heal = asyncio.create_task(conn.ensure_connected())
+            await asyncio.sleep(0)
+            await asyncio.gather(heal, conn.disconnect())
+
+        assert conn.is_connected is False
+        assert state["connects"] == 1
+        assert state["disconnects"] == 1  # only the teardown's
+
+
+class TestRebuildingIsReservedForARestoredSession:
+    """The one case where reviving in place would be WRONG.
+
+    Telethon reads ``auth_key`` once, when the session object is built, so a
+    client that already exists would keep using the dead key after we restore a
+    backup file over the session database. That case — and only that case —
+    still constructs a fresh client.
+    """
+
+    def _session_db(self, path, auth_key):
+        conn = sqlite3.connect(path)
+        conn.execute("CREATE TABLE sessions (auth_key BLOB)")
+        conn.execute("INSERT INTO sessions (auth_key) VALUES (?)", (auth_key,))
+        conn.commit()
+        conn.close()
+
+    async def test_authless_session_is_restored_onto_a_fresh_client(self, tmp_path):
+        session_path = os.path.join(str(tmp_path), "test_session")
+        self._session_db(session_path + ".session", None)
+        self._session_db(session_path + ".session.authenticated", b"\x01\x02\x03")
+
+        old_client, old_state = _shared_client()
+        config = MagicMock()
+        config.session_path = session_path
+        config.api_id = 12345
+        config.api_hash = "test-api-hash"
+        config.get_telegram_client_kwargs.return_value = {}
+        conn = TelegramConnection(config)
+        conn._client = old_client
+        conn._connected = False
+
+        new_client, _ = _shared_client()
+        with patch("src.connection.TelegramClient", return_value=new_client):
+            result = await conn.connect()
+
+        assert result is new_client
+        assert conn.client is new_client
+        assert old_state["disconnects"] == 1, "the stale client must be torn down, not leaked"
+
+        # The restored auth_key is on disk for the fresh client to read.
+        probe = sqlite3.connect(session_path + ".session")
+        row = probe.execute("SELECT auth_key FROM sessions LIMIT 1").fetchone()
+        probe.close()
+        assert row[0] == b"\x01\x02\x03"
+
+
+class TestTheOriginalFailureStillHeals:
+    """#265 must still be fixed: only connect() revives a sender that gave up."""
+
+    def _dead_telethon_client(self) -> TelegramClient:
+        client = TelegramClient(MemorySession(), 1, "test-api-hash")
+        client._sender._user_connected = False
+        client._sender._connection = None
+        return client
+
+    async def test_start_listener_revives_a_really_dead_sender_in_place(self, tmp_path):
+        client = self._dead_telethon_client()
+        revived = {"n": 0}
+
+        async def fake_connect():
+            revived["n"] += 1
+            client._sender._user_connected = True
+
+        client.connect = fake_connect
+        client.get_me = AsyncMock(return_value=SimpleNamespace(first_name="Test", phone="+10000000000"))
+
+        conn = _connection(tmp_path, client)
+        assert conn.is_connected is True  # stale app-level flag
+        assert not client.is_connected()  # real state
+
+        with patch("src.scheduler.signal.signal"):
+            from src.scheduler import BackupScheduler
+
+            config = MagicMock()
+            config.enable_listener = True
+            config.fill_gaps = False
+            scheduler = BackupScheduler(config)
+        scheduler._connection = conn
+
+        seen = {}
+
+        class StubListener:
+            @classmethod
+            async def create(cls, config, client=None):
+                listener = cls()
+                listener.client = client
+                return listener
+
+            async def connect(self):
+                seen["connected_at_connect"] = self.client.is_connected()
+                if not self.client.is_connected():
+                    raise RuntimeError("Shared client is not connected")
+
+            async def run(self):
+                await asyncio.sleep(3600)
+
+        with patch("src.listener.TelegramListener", StubListener), _never_built():
+            await scheduler._start_listener()
+
+        assert revived["n"] == 1
+        assert seen["connected_at_connect"] is True
+        assert scheduler._listener.client is client, "the listener must share the connection's own client"
+        assert conn.client is client
+        scheduler._listener_task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_client_property_is_stable_across_every_heal(tmp_path):
+    """Belt and braces: whatever happens, `connection.client` keeps its identity."""
+    client, state = _shared_client()
+    conn = _connection(tmp_path, client)
+    identities = set()
+
+    for scenario in ("healthy", "dead", "connect fails once", "check raises"):
+        if scenario == "dead":
+            state["alive"] = False
+        elif scenario == "connect fails once":
+            state["alive"] = False
+            state["fail_next_connect"] = True
+        elif scenario == "check raises":
+            client.is_connected = MagicMock(side_effect=[Exception("boom"), True, True])
+
+        with _never_built():
+            identities.add(id(await conn.ensure_connected()))
+
+    assert identities == {id(client)}

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -1476,7 +1476,7 @@ def test_audio_queue_extension_never_drives_message_pagination():
     next_body = _setup_slice(html, "const playNextAudio = async () =>")
     assert "if (playAdjacentAudio(1)) return true" in next_body
     assert "const outcome = await extendAudioQueueNewer()" in next_body
-    assert "return outcome === 'extended' && playAdjacentAudio(1)" in next_body
+    assert "if (outcome === 'extended' && playAdjacentAudio(1)) return true" in next_body
     assert "if (audioAutoAdvanceHalted.value || !(await playNextAudio())) {" in ended_body
 
     advance_body = _setup_slice(html, "const playAdjacentAudio = (step) =>")
@@ -1885,6 +1885,7 @@ _AUDIO_QUEUE_EXEC_DECLARATIONS = (
     "const audioTrackTime = (track) =>",
     "const mergeAudioQueue = (tracks) =>",
     "const audioQueueBelongsToTrack = (track) =>",
+    "const audioQueueEdgeTrack = (newest) =>",
     "const audioQueueEdgeMediaId = (newest) =>",
 )
 
@@ -2655,6 +2656,7 @@ const run = async ({ search = '', topic = null, pinnedIds = null, rowIds }, clic
                 "const audioTrackTime = (track) =>",
                 "const mergeAudioQueue = (tracks) =>",
                 "const audioQueueBelongsToTrack = (track) =>",
+                "const audioQueueEdgeTrack = (newest) =>",
                 "const audioQueueEdgeMediaId = (newest) =>",
                 "const seedAudioQueueAroundTrack = async (track) =>",
                 "const extendAudioQueueFromMedia = async (track) =>",
@@ -2702,6 +2704,338 @@ const run = async ({ search = '', topic = null, pinnedIds = null, rowIds }, clic
         self.assertEqual(out["window"]["seeded"]["queue"], [1, 2, 3, 4, 5])
         window_forward = [r for r in out["window"]["requested"] if r[1] == "newer"]
         self.assertEqual(window_forward[0], ["m5", "newer"])
+
+
+# Shared stubs for the two "the one-entry sparse queue must keep making
+# progress" programs below. Both drive REAL helpers over a 12-track chat whose
+# media endpoint is a faithful stand-in for ``get_media_paginated``: an opaque
+# cursor resolved against the table, paged away from it in the requested
+# direction. ``PLAYED`` is the only record of what actually reached the element,
+# which is what makes these tests behavioural rather than flag-shaped.
+_SPARSE_PROGRESS_PRELUDE = """
+const noDownload = { value: false }
+const audioError = { value: '' }
+const audioQueue = { value: [] }
+const audioTrack = { value: null }
+const audioAutoAdvanceHalted = { value: false }
+let audioConsecutiveFailures = 0
+const selectedChat = { value: { id: 7, title: 'chat' } }
+// The clicked row comes from a SPARSE view (search results), which is what
+// leaves the queue one entry long until the anchored seed lands.
+const messageView = { value: { contiguous: false } }
+const sortedMessages = { value: [] }
+const getChatName = (chat) => chat.title
+const getMediaUrl = (msg) => `/media/${msg.id}.ogg`
+const getSenderName = () => 'someone'
+const isAudioFile = (msg) => msg.media?.type === 'voice'
+const isCurrentAudioMessage = () => false
+const toggleAudioPlayback = () => {}
+const PLAYED = []
+const loadAudioTrack = (track) => { audioTrack.value = track; PLAYED.push(track.id) }
+const SEEKS = []
+const seekAudioTo = (seconds) => { SEEKS.push(seconds) }
+const stamp = (n) => `2026-07-01T00:00:${String(n).padStart(2, '0')}`
+const messageRow = (n) => ({
+    id: n, chat_id: 7, date: stamp(n),
+    media: { id: `m${n}`, type: 'voice', duration: 1 },
+})
+// Small pages, so the walk really pages instead of getting the whole chat back
+// in one answer.
+const PAGE = 3
+const mediaRow = (n) => ({
+    id: `m${n}`, message_id: n, chat_id: 7,
+    media_url: `/media/${n}.ogg`, message_date: stamp(n),
+})
+const REQUESTED = []
+const answerPage = (table, cursor, direction) => {
+    const at = cursor ? table.findIndex(m => m.id === cursor) : -1
+    if (cursor && at < 0) return { items: [], has_more: false }
+    const rest = direction === 'newer'
+        ? table.slice(at + 1)
+        : (at < 0 ? table.slice() : table.slice(0, at)).reverse()
+    return { items: rest.slice(0, PAGE), has_more: rest.length > PAGE }
+}
+// playAudioMessage deliberately does NOT await the queue growth (the click
+// gesture has to reach play() first), so drain the microtask/timer queues.
+const flush = async () => { for (let i = 0; i < 8; i++) await new Promise(r => setImmediate(r)) }
+"""
+
+
+class TestSparseQueueKeepsMakingProgress(unittest.TestCase):
+    """#268 follow-up: a one-entry seed queue has no slack for "close enough".
+
+    ``buildAudioQueue`` now contributes ONLY the clicked track from a sparse
+    view, so the queue really is one entry long at the start of every sparse
+    playback and the anchored pages are the only way out of it. Two places
+    treated "no answer yet" and "nothing playable here" as "the queue ended",
+    which was survivable while the queue arrived pre-filled from the window and
+    is not survivable now.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_a_track_that_fails_while_its_seed_is_in_flight_still_auto_advances(self) -> None:
+        """``playNextAudio`` collapsed 'pending' — a page ON ITS WAY — into false.
+
+        Reachable shape: in search results the user clicks a voice note whose
+        file is missing on disk. ``playAudioMessage`` seeds ``[clicked]``, starts
+        the track and fires the anchored seed fetch; the element's ``error``
+        event and the media request race in the same tick, and when the error
+        wins, the handler calls ``playNextAudio`` while the queue still holds one
+        entry. ``extendAudioQueueNewer`` answers 'pending' (a fetch is already in
+        flight), the old code read that as an exhausted queue, and auto-advance
+        was over for the session — with the seed page ~50ms away. The same shape
+        reaches the 'ended' handler for a sub-second voice note.
+
+        ``playPrevAudio`` has always kept 'pending' and 'exhausted' apart, so
+        this was an inconsistency rather than a decision.
+
+        The fetch is HELD here, which is exactly that window; the scenarios
+        differ only in what happens inside it.
+        """
+        prelude = (
+            _SPARSE_PROGRESS_PRELUDE
+            + """
+const MEDIA = Array.from({ length: 12 }, (_, i) => mediaRow(i + 1))
+// The seed page is held until RELEASE is called: everything that happens in
+// between happens while the fetch is genuinely in flight.
+let RELEASE = null
+const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') => {
+    REQUESTED.push([cursor ?? null, direction])
+    if (direction === 'older' && !RELEASE) {
+        return new Promise(resolve => { RELEASE = () => resolve(answerPage(MEDIA, cursor, direction)) })
+    }
+    return answerPage(MEDIA, cursor, direction)
+}
+"""
+        )
+        epilogue = """
+const scenario = async (duringHold) => {
+    REQUESTED.length = 0
+    PLAYED.length = 0
+    RELEASE = null
+    audioQueue.value = []
+    audioTrack.value = null
+    audioAutoAdvanceHalted.value = false
+    audioQueueCursor = null
+    audioQueueHasOlder = false
+    audioQueueCursorNewer = null
+    audioQueueHasNewer = false
+    audioQueueFetching = false
+    audioQueueSeeding = null
+
+    playAudioMessage(messageRow(2))
+    await flush()
+    const seeded = audioQueue.value.map(t => t.id)
+    // What the real 'error'/'ended' handlers do: call playNextAudio without
+    // awaiting it, while the seed is still in flight.
+    const advancing = playNextAudio()
+    await flush()
+    const beforeRelease = PLAYED.slice()
+    if (duringHold) duringHold()
+    RELEASE()
+    const advanced = await advancing
+    await flush()
+    return { seeded, beforeRelease, advanced, played: PLAYED.slice(), requested: REQUESTED.slice() }
+};
+(async () => {
+    // 1. Nothing else happens: the page lands and the advance goes through.
+    const landsLate = await scenario(null)
+    // 2. The user tapped ANOTHER voice note while the page was in flight — one
+    //    the landing page puts in the queue, so a re-attempt would walk from
+    //    THAT track and replay 2.
+    const switched = await scenario(() => {
+        audioTrack.value = {
+            id: 1, chatId: 7, kind: 'voice', chatName: 'chat',
+            mediaId: 'm1', url: '/media/1.ogg', date: stamp(1),
+        }
+    })
+    // 3. Auto-advance was halted while we waited (a second failed file).
+    const halted = await scenario(() => { audioAutoAdvanceHalted.value = true })
+    console.log(JSON.stringify({ landsLate, switched, halted }))
+})();
+"""
+        out = _run_setup_program(
+            self.html,
+            (
+                "const AUDIO_QUEUE_MAX_PAGES = ",
+                "const audioMediaKind = (msg) =>",
+                "const audioMessageChatId = (msg) =>",
+                "const audioMessageMediaId = (msg) =>",
+                "const audioTrackFromMessage = (msg) =>",
+                "const audioQueueSeedIsContiguous = () =>",
+                "const buildAudioQueue = (msg) =>",
+                "const audioTrackFromMediaItem = (item, kind, chatName) =>",
+                "const audioTracksFromMediaItems = (items, track) =>",
+                "const audioTrackTime = (track) =>",
+                "const mergeAudioQueue = (tracks) =>",
+                "const audioQueueBelongsToTrack = (track) =>",
+                "const audioQueueEdgeTrack = (newest) =>",
+                "const audioQueueEdgeMediaId = (newest) =>",
+                "const seedAudioQueueAroundTrack = async (track) =>",
+                "const extendAudioQueueFromMedia = async (track) =>",
+                "const extendAudioQueueNewer = async () =>",
+                "const currentAudioQueueIndex = () =>",
+                "const playAdjacentAudio = (step) =>",
+                "const playNextAudio = async () =>",
+                "const playAudioMessage = (msg) =>",
+            ),
+            prelude,
+            epilogue,
+        )
+
+        # The premise: the sparse seed really is one entry, and the advance is
+        # still undecided while the page is in flight (no track played, and no
+        # forward request issued off a cursor that is mid-fetch).
+        self.assertEqual(out["landsLate"]["seeded"], [2])
+        self.assertEqual(out["landsLate"]["beforeRelease"], [2])
+
+        # THE assertion: the page lands and playback moves on, once. The forward
+        # page is asked for AFTER the seed settles, anchored on the playing
+        # track — the seed itself only pages older, so it cannot supply track 3.
+        self.assertTrue(out["landsLate"]["advanced"])
+        self.assertEqual(out["landsLate"]["played"], [2, 3])
+        self.assertEqual(out["landsLate"]["requested"], [["m2", "older"], ["m2", "newer"]])
+
+        # ...and the re-attempt is owned. A different track means this advance
+        # belongs to nobody: no replay of 2 from track 1's position, and no
+        # request either.
+        self.assertFalse(out["switched"]["advanced"])
+        self.assertEqual(out["switched"]["played"], [2])
+        self.assertEqual(out["switched"]["requested"], [["m2", "older"]])
+
+        # Halting auto-advance while the page was in flight must survive the
+        # wait — the re-attempt may not resurrect it.
+        self.assertFalse(out["halted"]["advanced"])
+        self.assertEqual(out["halted"]["played"], [2])
+        self.assertEqual(out["halted"]["requested"], [["m2", "older"]])
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_an_unplayable_seed_page_does_not_park_the_cursor_on_the_playing_track(self) -> None:
+        """The older-cursor fixup could move the cursor BACKWARDS.
+
+        ``seedAudioQueueAroundTrack`` sets the cursor to the page's last item and
+        then overwrites it with the queue's own oldest edge — right for its
+        intended case (the loaded window already holds more than a page of older
+        audio), wrong when the page adds nothing. ``audioTracksFromMediaItems``
+        drops every item with no ``media_url``, which is what the server returns
+        for media whose ``file_path`` falls outside the media root, so a WHOLE
+        page can vanish; the edge is then the oldest track already queued, and
+        from a sparse view that is the playing track itself — the very anchor the
+        page was fetched from. ``audioQueueHasOlder`` was computed before the
+        fixup, so it stays true and 'previous' re-asks the question the seed just
+        asked, reports 'exhausted' and restarts the track although older playable
+        audio is one page further back.
+        """
+        prelude = (
+            _SPARSE_PROGRESS_PRELUDE
+            + """
+// Tracks 9-11 are downloaded but outside the media root, so the endpoint hands
+// back rows with no media_url and the queue can play none of them. With PAGE=3
+// they are exactly the page the seed fetches from track 12.
+const MEDIA = Array.from({ length: 12 }, (_, i) => {
+    const row = mediaRow(i + 1)
+    return (i + 1 >= 9 && i + 1 <= 11) ? { ...row, media_url: '' } : row
+})
+const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') => {
+    REQUESTED.push([cursor ?? null, direction])
+    return answerPage(MEDIA, cursor, direction)
+}
+"""
+        )
+        epilogue = """
+const scenario = async ({ contiguous, visible, clicked }) => {
+    REQUESTED.length = 0
+    PLAYED.length = 0
+    SEEKS.length = 0
+    audioQueue.value = []
+    audioTrack.value = null
+    audioQueueCursor = null
+    audioQueueHasOlder = false
+    audioQueueCursorNewer = null
+    audioQueueHasNewer = false
+    audioQueueFetching = false
+    audioQueueSeeding = null
+    messageView.value = { contiguous }
+    // The pane renders newest-first.
+    sortedMessages.value = visible.slice().sort((a, b) => b - a).map(messageRow)
+
+    playAudioMessage(messageRow(clicked))
+    await flush()
+    const seeded = {
+        queue: audioQueue.value.map(t => t.id),
+        cursor: audioQueueCursor,
+        hasOlder: audioQueueHasOlder,
+        requested: REQUESTED.slice(),
+    }
+    await playPrevAudio()
+    return { seeded, played: PLAYED.slice(), seeks: SEEKS.slice(), requested: REQUESTED.slice() }
+};
+(async () => {
+    // Sparse view: the queue is the clicked track alone, and the page anchored
+    // on it is wholly unplayable.
+    const unplayable = await scenario({ contiguous: false, visible: [12], clicked: 12 })
+    // The case the fixup exists for: a contiguous window holding MORE than one
+    // page of audio older than the playing track. Its own oldest entry really
+    // is older than the page's last item, so the cursor must still follow it.
+    const deepWindow = await scenario({ contiguous: true, visible: [1, 2, 3, 4, 5], clicked: 5 })
+    console.log(JSON.stringify({ unplayable, deepWindow }));
+})();
+"""
+        out = _run_setup_program(
+            self.html,
+            (
+                "const AUDIO_QUEUE_MAX_PAGES = ",
+                "const audioMediaKind = (msg) =>",
+                "const audioMessageChatId = (msg) =>",
+                "const audioMessageMediaId = (msg) =>",
+                "const audioTrackFromMessage = (msg) =>",
+                "const audioQueueSeedIsContiguous = () =>",
+                "const buildAudioQueue = (msg) =>",
+                "const audioTrackFromMediaItem = (item, kind, chatName) =>",
+                "const audioTracksFromMediaItems = (items, track) =>",
+                "const audioTrackTime = (track) =>",
+                "const mergeAudioQueue = (tracks) =>",
+                "const audioQueueBelongsToTrack = (track) =>",
+                "const audioQueueEdgeTrack = (newest) =>",
+                "const audioQueueEdgeMediaId = (newest) =>",
+                "const seedAudioQueueAroundTrack = async (track) =>",
+                "const extendAudioQueueFromMedia = async (track) =>",
+                "const extendAudioQueueOlder = async () =>",
+                "const currentAudioQueueIndex = () =>",
+                "const playAdjacentAudio = (step) =>",
+                "const playPrevAudio = async () =>",
+                "const playAudioMessage = (msg) =>",
+            ),
+            prelude,
+            epilogue,
+        )
+
+        # The premise: one anchored request, and it contributed nothing playable.
+        self.assertEqual(out["unplayable"]["seeded"]["queue"], [12])
+        self.assertEqual(out["unplayable"]["seeded"]["requested"], [["m12", "older"]])
+        self.assertTrue(out["unplayable"]["seeded"]["hasOlder"])
+
+        # THE assertion: the cursor is the page's own last item, NOT the playing
+        # track, so 'previous' walks PAST the unplayable page instead of asking
+        # for it again — and lands on real audio rather than restarting track 12.
+        self.assertEqual(out["unplayable"]["seeded"]["cursor"], "m9")
+        self.assertEqual(out["unplayable"]["requested"], [["m12", "older"], ["m9", "older"]])
+        self.assertEqual(out["unplayable"]["played"], [12, 8])
+        self.assertEqual(out["unplayable"]["seeks"], [])
+
+        # No regression on what the fixup is for: the window holds tracks 1-4
+        # older than the playing one while the page only reaches back to 2, so
+        # the cursor follows the QUEUE's edge and paging does not re-fetch rows
+        # the queue already has.
+        self.assertEqual(out["deepWindow"]["seeded"]["queue"], [1, 2, 3, 4, 5])
+        self.assertEqual(out["deepWindow"]["seeded"]["cursor"], "m1")
+        # 'previous' is served from the window itself — no request at all.
+        self.assertEqual(out["deepWindow"]["requested"], [["m5", "older"]])
+        self.assertEqual(out["deepWindow"]["played"], [5, 4])
 
 
 # Setup-scope stubs for EXECUTING the whole APPEND path end to end: the real
@@ -2891,6 +3225,7 @@ _APPEND_DECLARATIONS = (
     "const audioTrackTime = (track) =>",
     "const mergeAudioQueue = (tracks) =>",
     "const audioQueueBelongsToTrack = (track) =>",
+    "const audioQueueEdgeTrack = (newest) =>",
     "const audioQueueEdgeMediaId = (newest) =>",
     "const seedAudioQueueAroundTrack = async (track) =>",
     "const extendAudioQueueFromMedia = async (track) =>",

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -2959,6 +2959,10 @@ const scenario = async ({ contiguous, visible, clicked }) => {
     audioQueueHasNewer = false
     audioQueueFetching = false
     audioQueueSeeding = null
+    // Reset the auto-advance state too, so a later scenario cannot inherit a
+    // halt raised by an earlier one and fail in the wrong place.
+    audioAutoAdvanceHalted.value = false
+    audioConsecutiveFailures = 0
     messageView.value = { contiguous }
     // The pane renders newest-first.
     sortedMessages.value = visible.slice().sort((a, b) => b - a).map(messageRow)

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -33,6 +33,29 @@ def _setup_slice(html: str, declaration: str) -> str:
     return html[start : html.index("\n                const ", start + len(declaration))]
 
 
+def _setup_function(html: str, declaration: str) -> str:
+    """Return exactly one setup-scope function, ended by its matching brace.
+
+    ``_setup_slice`` stops at the next 16-space ``const``, which OVERSHOOTS when
+    what follows is a ``let`` or a bare ``watch(...)`` call — the extra code then
+    runs inside the test program and fails on identifiers the test never stubbed.
+    Brace matching is exact here because the template's function bodies keep
+    their braces balanced (template literals included).
+    """
+    start = html.index(declaration)
+    index = html.index("{", start)
+    depth = 0
+    while True:
+        char = html[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return html[start : index + 1]
+        index += 1
+
+
 def _run_setup_program(html: str, declarations: tuple[str, ...], prelude: str, epilogue: str) -> Any:
     """EXECUTE real setup-scope declarations under a stubbed environment.
 
@@ -295,14 +318,17 @@ def test_realtime_display_uses_api_message_order():
 
     helper_start = html.index("const messageSortTime = (msg) =>")
     helper_body = html[helper_start : html.index("// v6.2.0: Find the topics nav entry", helper_start)]
-    sorted_start = html.index("const sortedMessages = computed(() =>")
+    # #268: the ordinary view's rows are produced by messageView, alongside the
+    # contiguity answer that goes with them; sortedMessages is its projection.
+    sorted_start = html.index("const messageView = computed(() =>")
     sorted_body = html[sorted_start : html.index("// Group consecutive messages", sorted_start)]
 
     assert "moment.utc(msg.date)" in helper_body
     assert "sortTimeCache" in helper_body
     assert "messageSortTime(b) - messageSortTime(a)" in helper_body
     assert "(Number(b?.id) || 0) - (Number(a?.id) || 0)" in helper_body
-    assert "return sortedLoadedMessages()" in sorted_body
+    assert "rows: sortedLoadedMessages()" in sorted_body
+    assert "const sortedMessages = computed(() => messageView.value.rows)" in sorted_body
 
 
 def test_history_cursor_is_not_advanced_by_realtime_refresh():
@@ -1367,8 +1393,10 @@ def test_audio_auto_advance_does_not_drive_pagination():
 # --- Pagination-aware audio queue (#254) ---------------------------------------
 
 _AUDIO_QUEUE_DECLARATIONS = (
-    "const fetchAudioQueuePage = async (chatId, kind, beforeId) =>",
+    "const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') =>",
+    "const seedAudioQueueAroundTrack = async (track) =>",
     "const extendAudioQueueFromMedia = async (track) =>",
+    "const extendAudioQueueNewer = async () =>",
     "const extendAudioQueueOlder = async () =>",
 )
 
@@ -1376,18 +1404,19 @@ _AUDIO_QUEUE_DECLARATIONS = (
 def test_audio_queue_pages_the_media_endpoint_with_a_capped_cursor_walk():
     """#254: the queue grows from the media endpoint's own cursor, not the pane's.
 
-    Playback runs oldest -> newest while ``/media`` pages newest -> oldest, so
-    paging back until the playing track appears puts every possible next track in
-    hand. The walk must be capped so a huge chat cannot spin forever.
+    The unanchored backward walk is now the FALLBACK path (#266 anchors on the
+    playing track's own media id instead), but it is still what runs for an
+    archive whose media ids the client cannot rebuild, and it is still capped so
+    a huge chat cannot spin forever.
     """
     html = INDEX_HTML.read_text(encoding="utf-8")
 
-    fetch_body = _setup_slice(html, "const fetchAudioQueuePage = async (chatId, kind, beforeId) =>")
+    fetch_body = _setup_slice(html, "const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') =>")
     assert "`/api/chats/${chatId}/media?${params}`" in fetch_body
     assert "types: audioQueueTypes(kind)," in fetch_body
     assert "limit: String(AUDIO_QUEUE_PAGE_SIZE)," in fetch_body
-    # The cursor is the composite media id of the last item seen.
-    assert "params.set('before_id', beforeId)" in fetch_body
+    # One cursor shape, two directions: before_id walks older, after_id newer.
+    assert "params.set(direction === 'newer' ? 'after_id' : 'before_id', cursor)" in fetch_body
     assert "credentials: 'include'" in fetch_body
 
     assert "const AUDIO_QUEUE_PAGE_SIZE = 50" in html
@@ -1395,7 +1424,7 @@ def test_audio_queue_pages_the_media_endpoint_with_a_capped_cursor_walk():
 
     extend_body = _setup_slice(html, "const extendAudioQueueFromMedia = async (track) =>")
     assert "for (let page = 0; page < AUDIO_QUEUE_MAX_PAGES; page++)" in extend_body
-    assert "await fetchAudioQueuePage(track.chatId, track.kind, cursor)" in extend_body
+    assert "await fetchAudioQueuePage(track.chatId, track.kind, cursor, 'older')" in extend_body
     assert "cursor = items[items.length - 1].id" in extend_body
     # Stop as soon as the playing track is in hand, or nothing older is left.
     assert "items.some(item => item.message_id === track.id)" in extend_body
@@ -1406,7 +1435,7 @@ def test_audio_queue_pages_the_media_endpoint_with_a_capped_cursor_walk():
 
     # "Previous" at the head of the queue pages one more time from the same cursor.
     older_body = _setup_slice(html, "const extendAudioQueueOlder = async () =>")
-    assert "await fetchAudioQueuePage(track.chatId, track.kind, audioQueueCursor)" in older_body
+    assert "await fetchAudioQueuePage(track.chatId, track.kind, audioQueueCursor, 'older')" in older_body
     prev_body = _setup_slice(html, "const playPrevAudio = async () =>")
     assert "await extendAudioQueueOlder()" in prev_body
     assert "seekAudioTo(0)" in prev_body
@@ -1423,7 +1452,7 @@ def test_audio_queue_extension_never_drives_message_pagination():
 
     advance_declarations = _AUDIO_QUEUE_DECLARATIONS + (
         "const playAdjacentAudio = (step) =>",
-        "const playNextAudio = () => playAdjacentAudio(1)",
+        "const playNextAudio = async () =>",
         "const playPrevAudio = async () =>",
         "const playAudioMessage = (msg) =>",
     )
@@ -1439,9 +1468,17 @@ def test_audio_queue_extension_never_drives_message_pagination():
     assert "loadMessages" not in ended_body
     assert "loadNewerMessages" not in ended_body
 
-    # Auto-advance itself stays a synchronous walk over the player's own queue,
-    # so the 'ended' handler can still branch on its boolean result.
-    assert "const playNextAudio = () => playAdjacentAudio(1)" in html
+    # The step over the queue itself stays synchronous. playNextAudio wraps it
+    # with the on-demand forward page (#266) and is therefore async, so the
+    # 'ended' handler has to AWAIT its boolean — `!promise` is always false and
+    # would skip the end-of-queue reset.
+    assert "const playNextAudio = async () =>" in html
+    next_body = _setup_slice(html, "const playNextAudio = async () =>")
+    assert "if (playAdjacentAudio(1)) return true" in next_body
+    assert "const outcome = await extendAudioQueueNewer()" in next_body
+    assert "return outcome === 'extended' && playAdjacentAudio(1)" in next_body
+    assert "if (audioAutoAdvanceHalted.value || !(await playNextAudio())) {" in ended_body
+
     advance_body = _setup_slice(html, "const playAdjacentAudio = (step) =>")
     assert "audioQueue.value[index + step]" in advance_body
 
@@ -1528,11 +1565,17 @@ def test_audio_queue_keeps_voice_and_music_on_separate_types():
     # Never the combined filter the media gallery uses.
     assert "'voice,audio'" not in types_body
 
-    # Every page request is keyed on the playing track's own kind.
+    # Every page request is keyed on the playing track's own kind, in EVERY
+    # direction — a forward page that dropped the kind would roll a voice run
+    # into music the moment auto-advance left the seeded window.
     extend_body = _setup_slice(html, "const extendAudioQueueFromMedia = async (track) =>")
-    assert "fetchAudioQueuePage(track.chatId, track.kind, cursor)" in extend_body
+    assert "fetchAudioQueuePage(track.chatId, track.kind, cursor, 'older')" in extend_body
     older_body = _setup_slice(html, "const extendAudioQueueOlder = async () =>")
-    assert "fetchAudioQueuePage(track.chatId, track.kind, audioQueueCursor)" in older_body
+    assert "fetchAudioQueuePage(track.chatId, track.kind, audioQueueCursor, 'older')" in older_body
+    seed_body = _setup_slice(html, "const seedAudioQueueAroundTrack = async (track) =>")
+    assert "fetchAudioQueuePage(track.chatId, track.kind, track.mediaId, 'older')" in seed_body
+    newer_body = _setup_slice(html, "const extendAudioQueueNewer = async () =>")
+    assert "track.chatId, track.kind, audioQueueCursorNewer, 'newer')" in newer_body
 
     # Fetched descriptors inherit that kind, so a merged queue stays single-class.
     tracks_body = _setup_slice(html, "const audioTracksFromMediaItems = (items, track) =>")
@@ -1551,8 +1594,10 @@ def test_audio_queue_in_flight_flag_cannot_leak():
     html = INDEX_HTML.read_text(encoding="utf-8")
 
     assert "let audioQueueFetchSeq = 0" in html
-    # Both fetch paths release the flag by ownership token, not by request id.
-    assert html.count("if (fetchToken === audioQueueFetchSeq) audioQueueFetching = false") == 2
+    # EVERY fetch path releases the flag by ownership token, not by request id:
+    # the anchored seed and the forward extension (#266) as well as the original
+    # walk and the head-of-queue page.
+    assert html.count("if (fetchToken === audioQueueFetchSeq) audioQueueFetching = false") == 4
     assert "if (requestId === audioQueueRequestId) audioQueueFetching = false" not in html
 
     # Teardown releases it outright.
@@ -1579,7 +1624,7 @@ class TestAudioQueuePagingOutcomes(unittest.TestCase):
         same falsy result as an exhausted cursor and "previous" restarted the
         current track as though the oldest message had been reached.
         """
-        fetch_body = self._slice("const fetchAudioQueuePage = async (chatId, kind, beforeId) =>")
+        fetch_body = self._slice("const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') =>")
         self.assertIn("error.status = res.status", fetch_body)
         # Stale pages are aborted rather than landing on a closed player.
         self.assertIn("new AbortController()", fetch_body)
@@ -1825,6 +1870,1346 @@ const scenario = async (pages) => {
         self.assertLess(
             body.index("findMessageElement(track.id)"),
             body.index("scrollToMessage(track.id)"),
+        )
+
+
+# --- Directional, on-demand audio queue (#266) ---------------------------------
+
+_AUDIO_QUEUE_EXEC_DECLARATIONS = (
+    # Brings AUDIO_QUEUE_MAX_PAGES *and* every module-scope `let` the queue owns
+    # (request id, fetch seq, both cursors, both has-more flags, fetching), which
+    # is why none of them may be re-declared in a prelude.
+    "const AUDIO_QUEUE_MAX_PAGES = ",
+    "const audioTrackFromMediaItem = (item, kind, chatName) =>",
+    "const audioTracksFromMediaItems = (items, track) =>",
+    "const audioTrackTime = (track) =>",
+    "const mergeAudioQueue = (tracks) =>",
+    "const audioQueueBelongsToTrack = (track) =>",
+    "const audioQueueEdgeMediaId = (newest) =>",
+)
+
+_AUDIO_QUEUE_EXEC_PRELUDE = """
+const noDownload = { value: false }
+const audioError = { value: '' }
+const audioQueue = { value: [] }
+const audioTrack = { value: null }
+let PAGES = []
+let REPEAT = null
+const REQUESTED = []
+const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') => {
+    REQUESTED.push([cursor ?? null, direction])
+    return PAGES.shift() ?? REPEAT ?? { items: [], has_more: false }
+}
+// Ascending ids double as ascending dates, so mergeAudioQueue's sort is stable
+// and the queue's first/last entries really are its oldest/newest.
+const mediaItem = (n) => ({
+    id: `m${n}`, message_id: n, chat_id: 7,
+    media_url: `/media/${n}.ogg`, message_date: `2026-07-01T00:00:${String(n).padStart(2, '0')}`,
+})
+// Downloaded, but with no URL this viewer can play: the queue drops it, so a
+// page of these adds NOTHING even though it was a perfectly successful fetch.
+const unplayableItem = (n) => ({ ...mediaItem(n), media_url: '' })
+const seedTrack = (n) => ({
+    id: n, chatId: 7, kind: 'voice', mediaId: `m${n}`,
+    date: `2026-07-01T00:00:${String(n).padStart(2, '0')}`, url: `/media/${n}.ogg`,
+})
+"""
+
+
+class TestAudioQueueExtendsInTheDirectionOfTravel(unittest.TestCase):
+    """#266: auto-advance died after ~40 tracks in a 1,764-note chat.
+
+    The queue was pre-collected by walking BACKWARD from the newest item until
+    the playing track appeared — a cost of one page per 50 tracks of DEPTH,
+    capped at ``AUDIO_QUEUE_MAX_PAGES``. Past that cap the walk never reached the
+    playing track, #257's hole guard (correctly) refused the disjoint result, and
+    the queue stayed at the seeded message window: 9 requests, ~40 tracks, then
+    silence with no error and no 'ended'.
+
+    Raising the cap only moves the wall. The fix is to stop pre-collecting: page
+    forward, one page at a time, in the direction playback is actually moving.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+
+    def test_forward_paging_uses_the_after_id_cursor(self) -> None:
+        """The endpoint pages backward by default; forward needs the #266 cursor."""
+        fetch_body = _setup_slice(
+            self.html, "const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') =>"
+        )
+        self.assertIn("params.set(direction === 'newer' ? 'after_id' : 'before_id', cursor)", fetch_body)
+        # One cursor per request: before_id and after_id are mutually exclusive
+        # server-side, and sending both is a 400.
+        self.assertEqual(fetch_body.count("params.set("), 1)
+
+    def test_forward_cursor_is_armed_without_a_request(self) -> None:
+        """The seeded window already names the newest track — no walk needed.
+
+        This is what makes the fix depth-independent: the queue can page forward
+        from its own edge the instant auto-advance reaches it, whether the
+        playing track is the 5th voice note of the chat or the 1,700th.
+        """
+        play_body = _setup_slice(self.html, "const playAudioMessage = (msg) =>")
+        # #268 qualified the edge: it is an anchor only while the window is a
+        # contiguous slice of the timeline (see TestAudioQueueForwardCursorContiguity).
+        self.assertIn(
+            "(audioQueueSeedIsContiguous() && audioQueueEdgeMediaId(true)) || track.mediaId",
+            play_body,
+        )
+        self.assertIn("audioQueueHasNewer = !!audioQueueCursorNewer", play_body)
+        # ...and both are released with the player, like the backward pair.
+        close_body = _setup_slice(self.html, "const closeAudioPlayer = () =>")
+        self.assertIn("audioQueueCursorNewer = null", close_body)
+        self.assertIn("audioQueueHasNewer = false", close_body)
+
+    def test_no_page_cap_gates_the_forward_extension(self) -> None:
+        """A cap is what put the wall there. Correctness must not need one."""
+        newer_body = _code_only(_setup_slice(self.html, "const extendAudioQueueNewer = async () =>"))
+        self.assertNotIn("AUDIO_QUEUE_MAX_PAGES", newer_body)
+        # No counter of any kind drives termination — Igor's report blamed a
+        # consecutive-load counter, and inventing one would be the wrong fix.
+        self.assertNotIn("page++", newer_body)
+        self.assertNotIn("attempts", newer_body)
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_forward_extension_executed(self) -> None:
+        """Four walks over the REAL helper, distinguishable only by execution."""
+        epilogue = """
+const scenario = async (pages, repeat) => {
+    PAGES = pages.slice()
+    REPEAT = repeat ?? null
+    REQUESTED.length = 0
+    audioQueueCursor = null
+    audioQueueHasOlder = false
+    audioQueue.value = [seedTrack(10)]
+    audioTrack.value = { chatId: 7, kind: 'voice', id: 10, chatName: 'c', mediaId: 'm10' }
+    audioQueueCursorNewer = audioQueueEdgeMediaId(true)
+    audioQueueHasNewer = true
+    const outcome = await extendAudioQueueNewer()
+    return {
+        outcome,
+        cursor: audioQueueCursorNewer,
+        hasNewer: audioQueueHasNewer,
+        ids: audioQueue.value.map(t => t.id),
+        requested: REQUESTED.slice(),
+    }
+};
+(async () => {
+    // 1. The ordinary case: one page forward, appended in date order.
+    const extended = await scenario([
+        { items: [mediaItem(11), mediaItem(12)], has_more: true },
+    ]);
+    // 2. Nothing newer: the forward walk really is finished.
+    const empty = await scenario([{ items: [], has_more: false }]);
+    // 3. A page that adds nothing usable is NOT the end — keep going. A stop
+    //    here would be #266 all over again, just one page further along.
+    const skipped = await scenario([
+        { items: [unplayableItem(11), unplayableItem(12)], has_more: true },
+        { items: [mediaItem(13)], has_more: true },
+    ]);
+    // 4. Runaway: a server that keeps handing back the SAME page while
+    //    promising more. Terminates on "the cursor did not move", never on a
+    //    page count, and must not spin.
+    const stuck = await scenario([], { items: [unplayableItem(11)], has_more: true });
+    console.log(JSON.stringify({ extended, empty, skipped, stuck }));
+})();
+"""
+        out = _run_setup_program(
+            self.html,
+            _AUDIO_QUEUE_EXEC_DECLARATIONS + ("const extendAudioQueueNewer = async () =>",),
+            _AUDIO_QUEUE_EXEC_PRELUDE,
+            epilogue,
+        )
+
+        # 1. Travelling forward: one request, after_id on the queue's own edge.
+        self.assertEqual(out["extended"]["requested"], [["m10", "newer"]])
+        self.assertEqual(out["extended"]["outcome"], "extended")
+        self.assertEqual(out["extended"]["ids"], [10, 11, 12])
+        self.assertEqual(out["extended"]["cursor"], "m12")
+        self.assertTrue(out["extended"]["hasNewer"])
+
+        # 2. Genuine end of the chat.
+        self.assertEqual(out["empty"]["outcome"], "exhausted")
+        self.assertEqual(out["empty"]["ids"], [10])
+        self.assertFalse(out["empty"]["hasNewer"])
+
+        # 3. Progress, not page count, decides: the unusable page advanced the
+        #    cursor, so the walk continued and the NEXT page delivered a track.
+        self.assertEqual(out["skipped"]["outcome"], "extended")
+        self.assertEqual(out["skipped"]["ids"], [10, 13])
+        self.assertEqual(out["skipped"]["requested"], [["m10", "newer"], ["m12", "newer"]])
+
+        # 4. No progress -> stop. Reaching this assertion at all is the proof
+        #    that the runaway guard fired instead of looping forever.
+        self.assertEqual(out["stuck"]["outcome"], "exhausted")
+        self.assertEqual(out["stuck"]["ids"], [10])
+        self.assertFalse(out["stuck"]["hasNewer"])
+        self.assertEqual(out["stuck"]["requested"], [["m10", "newer"], ["m11", "newer"]])
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_seeding_is_anchored_on_the_playing_track_executed(self) -> None:
+        """The backward direction is anchored too, so nothing walks by depth.
+
+        ``before_id`` is an opaque media id and the PLAYING track's own id is a
+        valid one, so a single request yields the page immediately older than it
+        — contiguous by construction, whatever its depth. Only a track whose id
+        this archive does not use falls through to the legacy walk.
+        """
+        epilogue = """
+const scenario = async (track, pages) => {
+    PAGES = pages.slice()
+    REPEAT = null
+    REQUESTED.length = 0
+    audioQueueCursor = null
+    audioQueueHasOlder = false
+    audioQueueCursorNewer = null
+    audioQueueHasNewer = false
+    audioQueue.value = [seedTrack(500)]
+    audioTrack.value = { chatId: 7, kind: 'voice', id: 500, chatName: 'c' }
+    await extendAudioQueueFromMedia(track)
+    return {
+        cursor: audioQueueCursor,
+        hasOlder: audioQueueHasOlder,
+        cursorNewer: audioQueueCursorNewer,
+        hasNewer: audioQueueHasNewer,
+        ids: audioQueue.value.map(t => t.id),
+        requested: REQUESTED.slice(),
+    }
+};
+(async () => {
+    const anchored = { chatId: 7, kind: 'voice', id: 500, chatName: 'c', mediaId: 'm500' };
+    // The endpoint answers a backward page newest-first.
+    const seeded = await scenario(anchored, [
+        { items: [mediaItem(499), mediaItem(498)], has_more: true },
+    ]);
+    // #268: an empty backward page is settled with ONE anchored probe forward.
+    // Empty both ways = an id shape this archive does not use, which only the
+    // unanchored walk can settle.
+    const unresolvable = await scenario(anchored, [
+        { items: [], has_more: false },
+        { items: [], has_more: false },
+        { items: [mediaItem(501), mediaItem(500), mediaItem(499)], has_more: false },
+    ]);
+    // ...but items forward mean the anchor RESOLVES and the track really is the
+    // oldest of its kind. That must stay on the anchored path.
+    const oldestOfItsKind = await scenario(anchored, [
+        { items: [], has_more: false },
+        { items: [mediaItem(501), mediaItem(502)], has_more: true },
+    ]);
+    // No id to anchor on at all -> straight to the walk.
+    const noAnchor = await scenario({ chatId: 7, kind: 'voice', id: 500, chatName: 'c' }, [
+        { items: [mediaItem(501), mediaItem(500)], has_more: false },
+    ]);
+    console.log(JSON.stringify({ seeded, unresolvable, oldestOfItsKind, noAnchor }));
+})();
+"""
+        out = _run_setup_program(
+            self.html,
+            _AUDIO_QUEUE_EXEC_DECLARATIONS
+            + (
+                "const seedAudioQueueAroundTrack = async (track) =>",
+                "const extendAudioQueueFromMedia = async (track) =>",
+            ),
+            _AUDIO_QUEUE_EXEC_PRELUDE,
+            epilogue,
+        )
+
+        # ONE request, anchored on the playing track — not a walk from the newest
+        # item, which is what cost Igor 9 requests and still missed him.
+        self.assertEqual(out["seeded"]["requested"], [["m500", "older"]])
+        self.assertEqual(out["seeded"]["ids"], [498, 499, 500])
+        self.assertEqual(out["seeded"]["cursor"], "m498")
+        self.assertTrue(out["seeded"]["hasOlder"])
+
+        # Anchor rejected in BOTH directions -> the walk runs, starting from no
+        # cursor as before.
+        self.assertEqual(
+            out["unresolvable"]["requested"],
+            [["m500", "older"], ["m500", "newer"], [None, "older"]],
+        )
+        self.assertEqual(out["unresolvable"]["ids"], [499, 500, 501])
+
+        # #268: the oldest track of its kind never reaches the walk. Two anchored
+        # requests settle it, and the forward page it already paid for becomes the
+        # queue AND the forward cursor. Handing this to the walk instead would make
+        # it page backwards through the entire chat to find the very last track.
+        self.assertEqual(
+            out["oldestOfItsKind"]["requested"],
+            [["m500", "older"], ["m500", "newer"]],
+        )
+        self.assertEqual(out["oldestOfItsKind"]["ids"], [500, 501, 502])
+        self.assertIsNone(out["oldestOfItsKind"]["cursor"])
+        self.assertFalse(out["oldestOfItsKind"]["hasOlder"])
+        self.assertEqual(out["oldestOfItsKind"]["cursorNewer"], "m502")
+        self.assertTrue(out["oldestOfItsKind"]["hasNewer"])
+
+        # No anchor -> no wasted anchored request at all.
+        self.assertEqual(out["noAnchor"]["requested"], [[None, "older"]])
+        self.assertEqual(out["noAnchor"]["ids"], [500, 501])
+
+    def test_media_id_is_carried_on_every_descriptor(self) -> None:
+        """A cursor the queue cannot name is a queue that cannot page."""
+        item_body = _setup_slice(self.html, "const audioTrackFromMediaItem = (item, kind, chatName) =>")
+        self.assertIn("mediaId: item.id ?? null,", item_body)
+
+        msg_body = _setup_slice(self.html, "const audioTrackFromMessage = (msg) =>")
+        self.assertIn("mediaId: audioMessageMediaId(msg),", msg_body)
+
+        # #268: taken from the payload first — the rebuild is only the fallback.
+        built = _setup_slice(self.html, "const audioMessageMediaId = (msg) =>")
+        self.assertIn("const delivered = msg?.media?.id", built)
+        self.assertLess(built.index("msg?.media?.id"), built.index("`${chatId}_${msg.id}_${type}`"))
+        self.assertIn("return `${chatId}_${msg.id}_${type}`", built)
+        self.assertIn("if (chatId == null || msg?.id == null || !type) return null", built)
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_rebuilt_media_id_executed(self) -> None:
+        out = _run_setup_helpers(
+            self.html,
+            (
+                "const audioMessageChatId = (msg) =>",
+                "const audioMessageMediaId = (msg) =>",
+            ),
+            "cases.map(audioMessageMediaId)",
+            prelude="""
+const selectedChat = { value: null }
+const cases = [
+    { id: 12, chat_id: -100, media: { type: 'voice' } },
+    { id: 12, chat_id: -100, media: {} },
+    { id: 12, media: { type: 'voice' } },
+]
+""",
+        )
+        self.assertEqual(out, ["-100_12_voice", None, None])
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_delivered_media_id_wins_over_the_rebuild_executed(self) -> None:
+        """#268: the authoritative cursor is already in the payload — use it.
+
+        ``get_messages_paginated`` and ``get_pinned_messages`` both select
+        ``Media.id`` into ``media.id`` (src/db/adapter.py), and the no_download
+        strip only blanks ``file_path``, so the client never has to guess. It
+        matters because ``{chat}_{message}_{type}`` is NOT the only shape in
+        use: the importer writes ``import_{chat}_{message}``
+        (src/telegram_import.py). Rebuilding invented a cursor those archives
+        have no row for, ``get_media_paginated`` answered the empty page it
+        answers for any unresolvable cursor, and #266 stayed unfixed for
+        exactly those users — silently, with nothing to show for it.
+        """
+        out = _run_setup_helpers(
+            self.html,
+            (
+                "const audioMessageChatId = (msg) =>",
+                "const audioMessageMediaId = (msg) =>",
+            ),
+            "cases.map(audioMessageMediaId)",
+            prelude="""
+const selectedChat = { value: null }
+const cases = [
+    // Imported archive: the rebuild would have produced "-100_12_voice".
+    { id: 12, chat_id: -100, media: { id: 'import_-100_12', type: 'voice' } },
+    // Capture path: same shape as the rebuild, still taken from the payload.
+    { id: 12, chat_id: -100, media: { id: '-100_12_voice', type: 'voice' } },
+    // Numeric ids survive the trip as cursor strings.
+    { id: 12, chat_id: -100, media: { id: 4242, type: 'voice' } },
+    // No id delivered -> the documented best-effort rebuild.
+    { id: 12, chat_id: -100, media: { type: 'voice' } },
+]
+""",
+        )
+        self.assertEqual(out, ["import_-100_12", "-100_12_voice", "4242", "-100_12_voice"])
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_forward_walk_stops_on_a_cursor_it_has_already_asked_from(self) -> None:
+        """The forward loop is unbounded by design, so it needs a real progress rule.
+
+        "Nothing playable on this page" must not end auto-advance (that is #266
+        one page further along), so the loop keeps going. Comparing the new
+        cursor only against the PREVIOUS one leaves a response that alternates
+        A -> B -> A spinning forever. A forward walk never legitimately revisits
+        a cursor, so a repeat — of any age — is proof of no progress.
+
+        The stub throws once the walk exceeds a sane number of requests, so a
+        regression surfaces as ``'error'`` instead of hanging the suite.
+        """
+        prelude = """
+const noDownload = { value: false }
+const audioError = { value: '' }
+const audioQueue = { value: [] }
+const audioTrack = { value: { chatId: 7, kind: 'voice', id: 10 } }
+const REQUESTED = []
+let CALLS = 0
+// Downloaded but unplayable for this viewer, so no page ever adds a track and
+// the loop is never allowed to exit on "extended".
+const unplayableItem = (n) => ({
+    id: `m${n}`, message_id: n, chat_id: 7, media_url: '',
+    message_date: `2026-07-01T00:00:${String(n).padStart(2, '0')}`,
+})
+const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'newer') => {
+    REQUESTED.push([cursor ?? null, direction])
+    if (++CALLS > 20) throw new Error('forward walk never terminated')
+    // Always promises more, and swings the cursor back and forth between two
+    // values it has already handed out.
+    return { items: [unplayableItem(cursor === 'm11' ? 12 : 11)], has_more: true }
+}
+"""
+        epilogue = """
+(async () => {
+    audioQueueCursorNewer = 'm10'
+    audioQueueHasNewer = true
+    const outcome = await extendAudioQueueNewer()
+    console.log(JSON.stringify({ outcome, requested: REQUESTED, hasNewer: audioQueueHasNewer }))
+})();
+"""
+        out = _run_setup_program(
+            self.html,
+            (
+                "const AUDIO_QUEUE_MAX_PAGES = ",
+                "const audioTrackFromMediaItem = (item, kind, chatName) =>",
+                "const audioTracksFromMediaItems = (items, track) =>",
+                "const audioTrackTime = (track) =>",
+                "const mergeAudioQueue = (tracks) =>",
+                "const audioQueueBelongsToTrack = (track) =>",
+                "const extendAudioQueueNewer = async () =>",
+            ),
+            prelude,
+            epilogue,
+        )
+        # m10 -> m11 -> m12 -> m11 (already asked) -> stop. Three requests, and
+        # 'exhausted' rather than the stub's runaway error.
+        self.assertEqual(out["outcome"], "exhausted")
+        self.assertEqual(out["requested"], [["m10", "newer"], ["m11", "newer"], ["m12", "newer"]])
+        self.assertFalse(out["hasNewer"])
+
+
+# Setup-scope stubs for EXECUTING the real message-pane producers
+# (resetMessagePagination / loadMessages / loadMessagesAroundId) under node, so
+# a test can ask what each one DECLARES about the window it just wrote.
+# ``PANE_ROWS`` is what the stubbed endpoint returns, ``TOPIC`` is what
+# ``activeTopicId()`` reports, and ``URLS`` records the requests actually built.
+_PRODUCER_PRELUDE = """
+const messages = { value: [] }
+const page = { value: 0 }
+const hasMore = { value: true }
+const loading = { value: false }
+const hasMoreNewer = { value: false }
+const loadingNewer = { value: false }
+const newerLoadError = { value: '' }
+const viewingPinnedWindow = { value: false }
+const unseenMessageCount = { value: 0 }
+const messageWindowIsContiguous = { value: false }
+const isAuthenticated = { value: true }
+const messageSearchQuery = { value: '' }
+const selectedChat = { value: { id: 7, title: 'chat' } }
+let oldestMessageCursor = null
+let loadFailureStreak = 0
+let newestMessageId = null
+let newerLoadRequestSeq = 0
+let chatVersion = 0
+let messagesScrollObserver = null
+const loadMoreSentinel = { value: null }
+let TOPIC = null
+const activeTopicId = () => TOPIC
+const resetCalendarAvailability = () => {}
+const updateOldestMessageCursor = () => {}
+const oldestMessageFrom = () => null
+const messageCursor = () => null
+const showToast = () => {}
+const nextTick = async () => {}
+const stamp = (n) => `2026-07-01T00:00:${String(n).padStart(2, '0')}`
+const messageRow = (n) => ({
+    id: n, chat_id: 7, date: stamp(n),
+    media: { id: `m${n}`, type: 'voice', duration: 1 },
+})
+let PANE_ROWS = []
+const URLS = []
+const fetch = async (url) => {
+    URLS.push(url)
+    // The after-context half of a jump window comes back SHORT, so the window
+    // counts as tail-inclusive instead of a detached jump window.
+    return { ok: true, status: 200, json: async () => url.includes('after_id=') ? [] : PANE_ROWS }
+}
+"""
+
+
+class TestMessageWindowContiguityIsDeclaredByProducers(unittest.TestCase):
+    """#268: contiguity is a POSITIVE property the producer records, not a blacklist.
+
+    Three times in this batch the same defect shipped: an anchor taken from a
+    list that is not a contiguous slice of the timeline (#257 backward, then
+    pinned-only forward, then search/topic forward). Every one of them came from
+    asking "is this one of the sparse views I know about?" — a question that is
+    wrong by default and that a newly added filtered view answers incorrectly
+    without anyone noticing.
+
+    So the question is inverted here: ``messageWindowIsContiguous`` starts false,
+    ``resetMessagePagination`` (the chokepoint every view entry passes through)
+    re-clears it, and only a producer that KNOWS it wrote a timeline slice sets
+    it. These tests execute the real producers and check what each declares.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+
+    def test_the_flag_defaults_to_sparse(self) -> None:
+        """The default is the safety property — a ref that starts true buys nothing."""
+        self.assertIn("const messageWindowIsContiguous = ref(false)", self.html)
+        reset = _setup_slice(self.html, "const resetMessagePagination = () =>")
+        self.assertIn("messageWindowIsContiguous.value = false", reset)
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_load_messages_declares_only_the_unfiltered_chat_page(self) -> None:
+        """``loadMessages`` builds four different requests; only one is the timeline.
+
+        A search page holds matching rows only. A topic page holds one topic out
+        of many, while the audio queue's ``/media`` endpoint is chat-wide — so
+        the topic pane's newest row is NOT the newest media before it.
+        """
+        prelude = _PRODUCER_PRELUDE
+        epilogue = """
+(async () => {
+    const shape = async (search, topic) => {
+        TOPIC = topic
+        messageSearchQuery.value = search
+        messages.value = []
+        loading.value = false
+        URLS.length = 0
+        resetMessagePagination()
+        const afterReset = messageWindowIsContiguous.value
+        await loadMessages()
+        return { afterReset, contiguous: messageWindowIsContiguous.value, url: URLS[0] }
+    }
+    console.log(JSON.stringify({
+        plain: await shape('', null),
+        search: await shape('needle', null),
+        topic: await shape('', 4),
+        searchInTopic: await shape('needle', 4),
+    }))
+})();
+"""
+        out = _run_setup_program(
+            self.html,
+            (
+                "const messageIdKey = (msg) =>",
+                "const upsertMessages = (incomingMessages, ",
+                "const resetMessagePagination = () =>",
+                "const loadMessages = async () =>",
+            ),
+            prelude,
+            epilogue,
+        )
+        # resetMessagePagination clears it every time, whatever the previous view left.
+        for name, result in out.items():
+            self.assertFalse(result["afterReset"], name)
+        self.assertTrue(out["plain"]["contiguous"])
+        self.assertFalse(out["search"]["contiguous"])
+        self.assertFalse(out["topic"]["contiguous"])
+        self.assertFalse(out["searchInTopic"]["contiguous"])
+        # ...and the classification really does track the request that was sent.
+        self.assertNotIn("search=", out["plain"]["url"])
+        self.assertNotIn("topic_id=", out["plain"]["url"])
+        self.assertIn("search=needle", out["search"]["url"])
+        self.assertIn("topic_id=4", out["topic"]["url"])
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_a_jump_window_is_contiguous_unless_it_is_topic_scoped(self) -> None:
+        """Both halves of a jump window are pages hinged on the same id.
+
+        That makes it a real slice of the timeline — and the whole point of
+        keeping the flag rather than banning anchors outright, because a normal
+        window must still arm the forward cursor from its own edge with no extra
+        request. A topic-scoped window is a slice of the TOPIC, not the chat.
+        """
+        # loadMessagesAroundId is followed by a `let` and a `watch(...)`, not by
+        # another `const`, so it is lifted brace-matched and handed over in the
+        # prelude — still VERBATIM template code, just cut at the right place.
+        prelude = (
+            _PRODUCER_PRELUDE
+            + """
+const newestLoadedMessageId = () => 9
+const setupMessagesScrollObserver = () => {}
+const scrollToMessage = () => {}
+const startMessageRefresh = () => {}
+let messagesNewerObserver = null
+const loadNewerSentinel = { value: null }
+"""
+            + _setup_function(self.html, "const loadMessagesAroundId = async (messageId, externalGuard = null) =>")
+        )
+        epilogue = """
+(async () => {
+    const jump = async (topic) => {
+        TOPIC = topic
+        messageSearchQuery.value = ''
+        messages.value = []
+        loading.value = false
+        URLS.length = 0
+        await loadMessagesAroundId(5)
+        return { contiguous: messageWindowIsContiguous.value, urls: URLS.slice() }
+    }
+    console.log(JSON.stringify({ plain: await jump(null), topic: await jump(4) }))
+})();
+"""
+        out = _run_setup_program(
+            self.html,
+            (
+                "const messageIdKey = (msg) =>",
+                "const upsertMessages = (incomingMessages, ",
+                "const resetMessagePagination = () =>",
+            ),
+            prelude,
+            epilogue,
+        )
+        self.assertTrue(out["plain"]["contiguous"])
+        self.assertFalse(out["topic"]["contiguous"])
+        # The declaration survives resetMessagePagination, which runs in between and
+        # clears the flag by design.
+        self.assertEqual(len(out["plain"]["urls"]), 2)
+        for url in out["topic"]["urls"]:
+            self.assertIn("topic_id=4", url)
+
+
+class TestAudioQueueForwardCursorContiguity(unittest.TestCase):
+    """#268: #257's hole, recreated in the FORWARD direction by a sparse seed.
+
+    ``sortedMessages`` is not always a contiguous slice of the timeline. The
+    pinned-only view swaps in ``pinnedMessages`` (entries months apart); an
+    in-chat search leaves only matching rows; a forum topic leaves one topic's
+    rows while the audio queue's ``/media`` endpoint is chat-wide.
+    ``buildAudioQueue`` seeded the queue from any of them, so two tracks that are
+    nowhere near each other in the chat ended up ADJACENT in the queue, and
+    ``playAudioMessage`` then armed the forward cursor from that sparse queue's
+    newest entry — cementing the gap, because the first page forward starts past
+    everything in between.
+
+    The rule the whole batch turns on: adjacent queue entries must be adjacent
+    in time. An anchor is only usable when it is contiguous with the real
+    timeline — the playing track's own media id, or the edge of a window that
+    really is a slice of the chat.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+
+    def test_the_gate_asks_a_positive_question_instead_of_listing_views(self) -> None:
+        """A predicate that enumerates the sparse views is the defect, not the fix."""
+        contiguous = _setup_slice(self.html, "const audioQueueSeedIsContiguous = () =>")
+        self.assertIn("messageView.value.contiguous", contiguous)
+        # No view names in the gate: adding a filtered view must not require
+        # editing it, because whoever adds one will not know it exists.
+        for view in ("showPinnedOnly", "messageSearchQuery", "activeTopicId", "selectedPaneTopic"):
+            self.assertNotIn(view, contiguous, view)
+
+        build_body = _setup_slice(self.html, "const buildAudioQueue = (msg) =>")
+        # A sparse view contributes the clicked track and nothing else...
+        self.assertIn("if (!audioQueueSeedIsContiguous()) return [audioTrackFromMessage(msg)]", build_body)
+        # ...and that check precedes every read of the sparse list.
+        self.assertLess(
+            build_body.index("audioQueueSeedIsContiguous()"),
+            build_body.index("sortedMessages.value"),
+        )
+
+    def test_rows_and_their_contiguity_cannot_diverge(self) -> None:
+        """One branch yields both, so a new view cannot return rows and forget the flag."""
+        view = _setup_slice(self.html, "const messageView = computed(() =>")
+        self.assertIn("rows: pinnedMessages.value, contiguous: false", view)
+        self.assertIn("contiguous: messageWindowIsContiguous.value", view)
+        # sortedMessages is a projection of that pair — not a second, driftable branch.
+        self.assertIn("const sortedMessages = computed(() => messageView.value.rows)", self.html)
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_playback_never_skips_a_track_from_any_sparse_view(self) -> None:
+        """Auto-advance over a REAL 12-track chat, entered from each sparse view.
+
+        End to end and all real code: the producer (``loadMessages``) fills the
+        pane and declares its contiguity, ``messageView`` turns that into the
+        gate's answer, and ``playAudioMessage``/``playNextAudio`` walk the chat.
+        The stubbed endpoint is a genuine cursor-paged media table, so the walk
+        has to be right rather than merely plausible.
+
+        Pre-fix each sparse view played the gap it was shown: pinned-only
+        2 -> 11 -> 12, search 2 -> 11 -> 12, topic 2 -> 6 -> 11 -> 12. Tracks
+        3-10 were never asked for at all.
+        """
+        prelude = (
+            _PRODUCER_PRELUDE
+            + """
+const computed = (fn) => ({ get value() { return fn() } })
+const pinnedMessages = { value: [] }
+const showPinnedOnly = { value: false }
+// Stand-in for the date sort: in this fixture message ids ascend with time.
+const sortedLoadedMessages = () => [...messages.value].sort((a, b) => Number(b.id) - Number(a.id))
+
+const noDownload = { value: false }
+const audioError = { value: '' }
+const audioQueue = { value: [] }
+const audioTrack = { value: null }
+const audioAutoAdvanceHalted = { value: false }
+let audioConsecutiveFailures = 0
+const getChatName = (chat) => chat.title
+const getMediaUrl = (msg) => `/media/${msg.id}.ogg`
+const getSenderName = () => 'someone'
+const isAudioFile = (msg) => msg.media?.type === 'voice'
+const isCurrentAudioMessage = () => false
+const toggleAudioPlayback = () => {}
+const PLAYED = []
+const loadAudioTrack = (track) => { audioTrack.value = track; PLAYED.push(track.id) }
+// A small page size so the forward walk really pages instead of getting the
+// whole chat in one answer.
+const PAGE = 3
+const mediaRow = (n) => ({
+    id: `m${n}`, message_id: n, chat_id: 7,
+    media_url: `/media/${n}.ogg`, message_date: stamp(n),
+})
+// The chat's real audio timeline, oldest -> newest. Contiguous by definition:
+// any gap in what gets PLAYED is a gap the client invented.
+const MEDIA = Array.from({ length: 12 }, (_, i) => mediaRow(i + 1))
+const REQUESTED = []
+// A faithful stand-in for get_media_paginated: an opaque cursor resolved
+// against the table, paged away from it in the requested direction, answering
+// an unresolvable cursor with an empty page in EITHER direction.
+const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') => {
+    REQUESTED.push([cursor ?? null, direction])
+    const at = cursor ? MEDIA.findIndex(m => m.id === cursor) : -1
+    if (cursor && at < 0) return { items: [], has_more: false }
+    const rest = direction === 'newer'
+        ? MEDIA.slice(at + 1)
+        : (at < 0 ? MEDIA.slice() : MEDIA.slice(0, at)).reverse()
+    return { items: rest.slice(0, PAGE), has_more: rest.length > PAGE }
+}
+// playAudioMessage deliberately does NOT await the queue growth (the click
+// gesture has to reach play() first), so drain the microtask/timer queues.
+const flush = async () => { for (let i = 0; i < 8; i++) await new Promise(r => setImmediate(r)) }
+"""
+        )
+        epilogue = """
+const run = async ({ search = '', topic = null, pinnedIds = null, rowIds }, clickedId) => {
+    REQUESTED.length = 0
+    PLAYED.length = 0
+    audioQueue.value = []
+    audioTrack.value = null
+    audioQueueCursor = null
+    audioQueueHasOlder = false
+    audioQueueCursorNewer = null
+    audioQueueHasNewer = false
+    audioQueueFetching = false
+    // The REAL producer fills the pane and declares what it wrote. The message
+    // pane renders newest-first.
+    PANE_ROWS = rowIds.slice().sort((a, b) => b - a).map(messageRow)
+    TOPIC = topic
+    messageSearchQuery.value = search
+    messages.value = []
+    loading.value = false
+    resetMessagePagination()
+    await loadMessages()
+    // The pinned-only view is entered on top of whatever the producer wrote —
+    // here a genuinely contiguous window, so only the view branch can catch it.
+    showPinnedOnly.value = pinnedIds != null
+    pinnedMessages.value = (pinnedIds || []).slice().sort((a, b) => b - a).map(messageRow)
+
+    playAudioMessage(messageRow(clickedId))
+    await flush()
+    const seeded = { queue: audioQueue.value.map(t => t.id), requested: REQUESTED.slice() }
+    for (let i = 0; i < 40; i++) {
+        if (!await playNextAudio()) break
+    }
+    return {
+        visible: sortedMessages.value.map(m => m.id),
+        contiguous: messageView.value.contiguous,
+        played: PLAYED.slice(), seeded, requested: REQUESTED.slice(),
+    }
+};
+(async () => {
+    // Two pinned voice notes nine tracks apart, over a contiguous window.
+    const pinned = await run({ rowIds: [1, 2, 3, 4, 5], pinnedIds: [2, 11] }, 2)
+    // An in-chat search: only the matching rows survive.
+    const search = await run({ search: 'needle', rowIds: [2, 11] }, 2)
+    // A forum topic: this topic's rows, scattered through a chat-wide timeline.
+    const topic = await run({ topic: 4, rowIds: [2, 6, 11] }, 2)
+    // The ordinary view: a contiguous window of the same chat.
+    const window = await run({ rowIds: [1, 2, 3, 4, 5] }, 2)
+    console.log(JSON.stringify({ pinned, search, topic, window }))
+})();
+"""
+        out = _run_setup_program(
+            self.html,
+            (
+                "const messageIdKey = (msg) =>",
+                "const upsertMessages = (incomingMessages, ",
+                "const resetMessagePagination = () =>",
+                "const loadMessages = async () =>",
+                "const messageView = computed(() =>",
+                "const sortedMessages = computed(() => messageView.value.rows)",
+                "const AUDIO_QUEUE_MAX_PAGES = ",
+                "const audioMediaKind = (msg) =>",
+                "const audioMessageChatId = (msg) =>",
+                "const audioMessageMediaId = (msg) =>",
+                "const audioTrackFromMessage = (msg) =>",
+                "const audioQueueSeedIsContiguous = () =>",
+                "const buildAudioQueue = (msg) =>",
+                "const audioTrackFromMediaItem = (item, kind, chatName) =>",
+                "const audioTracksFromMediaItems = (items, track) =>",
+                "const audioTrackTime = (track) =>",
+                "const mergeAudioQueue = (tracks) =>",
+                "const audioQueueBelongsToTrack = (track) =>",
+                "const audioQueueEdgeMediaId = (newest) =>",
+                "const seedAudioQueueAroundTrack = async (track) =>",
+                "const extendAudioQueueFromMedia = async (track) =>",
+                "const extendAudioQueueNewer = async () =>",
+                "const currentAudioQueueIndex = () =>",
+                "const playAdjacentAudio = (step) =>",
+                "const playNextAudio = async () =>",
+                "const playAudioMessage = (msg) =>",
+            ),
+            prelude,
+            epilogue,
+        )
+
+        # The fixtures really are the sparse views they claim to be...
+        self.assertEqual(out["pinned"]["visible"], [11, 2])
+        self.assertEqual(out["search"]["visible"], [11, 2])
+        self.assertEqual(out["topic"]["visible"], [11, 6, 2])
+        # ...and each is classified sparse, the pinned one DESPITE sitting on a
+        # window its producer declared contiguous.
+        for name in ("pinned", "search", "topic"):
+            with self.subTest(view=name):
+                self.assertFalse(out[name]["contiguous"])
+
+        # THE assertion: every track from the clicked one to the end of the chat,
+        # in order, with nothing skipped. subTest so a regression names EVERY
+        # view it broke, not just the first one checked.
+        for name in ("pinned", "search", "topic"):
+            with self.subTest(view=name):
+                self.assertEqual(out[name]["played"], [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+                # The sparse view contributes no neighbours at all — the seed is
+                # the clicked track plus the page anchored on it, both contiguous.
+                self.assertEqual(out[name]["seeded"]["queue"], [1, 2])
+                self.assertEqual(out[name]["seeded"]["requested"], [["m2", "older"]])
+                # ...so the FIRST forward page is anchored on the playing track
+                # itself, never on the far-away visible row (that would be "m11").
+                forward = [r for r in out[name]["requested"] if r[1] == "newer"]
+                self.assertEqual(forward[0], ["m2", "newer"])
+
+        # No regression on the contiguous path: the window is still a valid
+        # anchor, so the first forward page starts at its EDGE rather than
+        # re-fetching tracks the window already provided — and costs no extra
+        # request to arm.
+        self.assertTrue(out["window"]["contiguous"])
+        self.assertEqual(out["window"]["played"], [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+        self.assertEqual(out["window"]["seeded"]["queue"], [1, 2, 3, 4, 5])
+        window_forward = [r for r in out["window"]["requested"] if r[1] == "newer"]
+        self.assertEqual(window_forward[0], ["m5", "newer"])
+
+
+# Setup-scope stubs for EXECUTING the whole APPEND path end to end: the real
+# ``loadMessages`` fills the pane, the real ``checkForNewMessages`` and
+# ``handleWebSocketMessage`` bring arrivals in through the real
+# ``upsertMessages``, and the real audio queue then plays what that leaves
+# behind. ``SERVER`` is the archive's message table (ids ascending with time)
+# and ``PANE_PAGE`` bounds every page the message endpoint returns — exactly
+# what ``limit=50`` does in production, shrunk so the ids stay readable.
+_APPEND_PRELUDE = """
+// The real poll logs what it added; keep stdout to the one JSON line the runner
+// parses, and hand the tests a private channel for it (``emit``).
+const emit = console.log.bind(console)
+console.log = () => {}
+const ref = (v) => ({ value: v })
+const computed = (fn) => ({ get value() { return fn() } })
+const moment = { utc: (s) => { const t = Date.parse(/(Z|[+-]\\d\\d:?\\d\\d)$/.test(s) ? s : s + 'Z')
+    return { isValid: () => !Number.isNaN(t), valueOf: () => t } } }
+const messages = ref([])
+const page = ref(0)
+const hasMore = ref(true)
+const loading = ref(false)
+const hasMoreNewer = ref(false)
+const loadingNewer = ref(false)
+const newerLoadError = ref('')
+const viewingPinnedWindow = ref(false)
+const unseenMessageCount = ref(0)
+const isAuthenticated = ref(true)
+const messageSearchQuery = ref('')
+const selectedChat = ref({ id: 7, title: 'chat' })
+const selectedPaneTopic = ref(null)
+const pinnedMessages = ref([])
+const showPinnedOnly = ref(false)
+const messagesContainer = ref({ scrollTop: 0 })
+const notificationPermission = ref('denied')
+const document = { hidden: false }
+let newestMessageId = null
+let newerLoadRequestSeq = 0
+let chatVersion = 0
+let isRefreshing = false
+let messagesScrollObserver = null
+const loadMoreSentinel = ref(null)
+const GENERAL_TOPIC_ID = 1
+let TOPIC = null
+const activeTopicId = () => TOPIC
+const resetCalendarAvailability = () => {}
+const showToast = () => {}
+const showNotification = () => {}
+const clearMessageVersionsCache = () => {}
+const isVersionsPanelOpenFor = () => false
+const loadMessageVersions = () => {}
+const loadPinnedMessages = () => {}
+const scrollToBottom = () => {}
+const nextTick = async (fn) => { if (fn) fn() }
+
+// The archive: message ids ascending with time, every one a voice note.
+const stamp = (n) => `2026-07-01T00:00:${String(n).padStart(2, '0')}`
+const messageRow = (n) => ({
+    id: n, chat_id: 7, date: stamp(n),
+    media: { id: `m${n}`, type: 'voice', duration: 1 },
+})
+let SERVER = []
+// Every page the endpoint returns is BOUNDED. That bound is the whole reason a
+// poll can fail to reach back to the loaded window.
+const PANE_PAGE = 3
+const URLS = []
+const fetch = async (url) => {
+    URLS.push(url)
+    const params = new URL(url, 'http://viewer').searchParams
+    const beforeId = params.get('before_id')
+    const afterId = params.get('after_id')
+    let rows = SERVER.slice()
+    if (afterId != null) {
+        rows = rows.filter(n => n > Number(afterId)).slice(0, PANE_PAGE)
+    } else {
+        if (beforeId != null) rows = rows.filter(n => n < Number(beforeId))
+        rows = rows.slice(-PANE_PAGE)
+    }
+    rows = rows.slice().reverse().map(messageRow)   // newest-first response contract
+    return { ok: true, status: 200, json: async () => rows }
+}
+
+// ---- audio queue: the media endpoint, paged like the real one ----
+const noDownload = ref(false)
+const audioError = ref('')
+const audioQueue = ref([])
+const audioTrack = ref(null)
+const audioAutoAdvanceHalted = ref(false)
+let audioConsecutiveFailures = 0
+const getChatName = (chat) => chat.title
+const getMediaUrl = (msg) => `/media/${msg.id}.ogg`
+const getSenderName = () => 'someone'
+const isAudioFile = (msg) => msg.media?.type === 'voice'
+const isCurrentAudioMessage = () => false
+const toggleAudioPlayback = () => {}
+const PLAYED = []
+const loadAudioTrack = (track) => { audioTrack.value = track; PLAYED.push(track.id) }
+const MEDIA_PAGE = 3
+const REQUESTED = []
+const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') => {
+    REQUESTED.push([cursor ?? null, direction])
+    const table = SERVER.map(n => ({
+        id: `m${n}`, message_id: n, chat_id: 7,
+        media_url: `/media/${n}.ogg`, message_date: stamp(n),
+    }))
+    const at = cursor ? table.findIndex(m => m.id === cursor) : -1
+    if (cursor && at < 0) return { items: [], has_more: false }
+    const rest = direction === 'newer'
+        ? table.slice(at + 1)
+        : (at < 0 ? table.slice() : table.slice(0, at)).reverse()
+    return { items: rest.slice(0, MEDIA_PAGE), has_more: rest.length > MEDIA_PAGE }
+}
+// playAudioMessage deliberately does NOT await the queue growth (the click
+// gesture has to reach play() first), so drain the microtask/timer queues.
+const flush = async () => { for (let i = 0; i < 12; i++) await new Promise(r => setImmediate(r)) }
+"""
+
+# Driving helpers shared by every test in the class below: open a chat through
+# the REAL producer, then report what the window and the audio queue became.
+_APPEND_EPILOGUE_HELPERS = """
+const openChat = async (ids) => {
+    SERVER = ids.slice()
+    messages.value = []
+    loading.value = false
+    messageSearchQuery.value = ''
+    URLS.length = 0
+    resetMessagePagination()
+    await loadMessages()
+}
+const windowState = () => ({
+    visible: sortedMessages.value.map(m => m.id),
+    contiguous: messageView.value.contiguous,
+})
+const playFrom = async (clickedId) => {
+    REQUESTED.length = 0
+    PLAYED.length = 0
+    audioQueue.value = []
+    audioTrack.value = null
+    audioQueueCursor = null
+    audioQueueHasOlder = false
+    audioQueueCursorNewer = null
+    audioQueueHasNewer = false
+    audioQueueFetching = false
+    playAudioMessage(messageRow(clickedId))
+    await flush()
+    const seeded = { queue: audioQueue.value.map(t => t.id), requested: REQUESTED.slice() }
+    const armedFrom = audioQueueCursorNewer
+    for (let i = 0; i < 60; i++) {
+        if (!await playNextAudio()) break
+    }
+    return { seeded, armedFrom, played: PLAYED.slice(), requested: REQUESTED.slice() }
+}
+"""
+
+_APPEND_DECLARATIONS = (
+    "const STICK_TO_BOTTOM_PX = ",
+    "const sortTimeCache = new WeakMap()",
+    "const messageSortTime = (msg) =>",
+    "const compareMessagesDesc = (a, b) =>",
+    # Overshoots onto `let oldestMessageCursor` / `let loadFailureStreak`, which
+    # is what we want: those two are the real pagination state, lifted verbatim.
+    "const sortedLoadedMessages = () =>",
+    "const messageWindowIsContiguous = ref(false)",
+    "const messageIdKey = (msg) =>",
+    "const messageCursor = (msg) =>",
+    "const oldestMessageFrom = (messageList) =>",
+    "const updateOldestMessageCursor = (loadedMessages) =>",
+    "const newestLoadedMessageId = () =>",
+    "const resetMessagePagination = () =>",
+    "const messageBelongsToCurrentTopic = (msg) =>",
+    "const appendKeepsWindowContiguous = (added, overlapsWindow) =>",
+    "const upsertMessages = (incomingMessages, ",
+    "const isNearMessageBottom = (container) =>",
+    "const checkForNewMessages = async () =>",
+    "const loadMessages = async () =>",
+    "const messageView = computed(() =>",
+    "const sortedMessages = computed(() => messageView.value.rows)",
+    "const AUDIO_QUEUE_MAX_PAGES = ",
+    "const audioMediaKind = (msg) =>",
+    "const audioMessageChatId = (msg) =>",
+    "const audioMessageMediaId = (msg) =>",
+    "const audioTrackFromMessage = (msg) =>",
+    "const audioQueueSeedIsContiguous = () =>",
+    "const buildAudioQueue = (msg) =>",
+    "const audioTrackFromMediaItem = (item, kind, chatName) =>",
+    "const audioTracksFromMediaItems = (items, track) =>",
+    "const audioTrackTime = (track) =>",
+    "const mergeAudioQueue = (tracks) =>",
+    "const audioQueueBelongsToTrack = (track) =>",
+    "const audioQueueEdgeMediaId = (newest) =>",
+    "const seedAudioQueueAroundTrack = async (track) =>",
+    "const extendAudioQueueFromMedia = async (track) =>",
+    "const extendAudioQueueNewer = async () =>",
+    "const currentAudioQueueIndex = () =>",
+    "const playAdjacentAudio = (step) =>",
+    "const playNextAudio = async () =>",
+    "const playAudioMessage = (msg) =>",
+)
+
+
+class TestAppendsCannotPunchAHoleInTheWindow(unittest.TestCase):
+    """#268, fourth sighting: the hole opened by an APPEND, not by a view.
+
+    ``messageWindowIsContiguous`` was written only by the wholesale producers,
+    so a window they had declared contiguous stayed "contiguous" while other
+    code appended to it. Two appenders can land past the loaded window:
+
+    * the 3s poll fetches the LATEST page. More arrivals than fit in one page
+      and that page no longer reaches back to the window — the rows in between
+      are never fetched, and nothing heals them (later polls fetch the same
+      latest page; "load older" pages the other way).
+    * the WebSocket ``new_message`` frame after a reconnect gap appends a single
+      row from far past the window's edge.
+
+    Either way the pane held two blocks with a gap between them while still
+    claiming to be one slice of the timeline, so the audio queue seeded straight
+    across the gap — adjacent queue entries that are not adjacent in time, which
+    is the defect this whole batch is about.
+
+    The check therefore lives in ``upsertMessages``, the single append path all
+    of them pass through, and it only ever CLEARS: declaring a window contiguous
+    stays the privilege of the producer that wrote it.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+
+    def _run(self, epilogue: str) -> Any:
+        return _run_setup_program(
+            self.html,
+            _APPEND_DECLARATIONS,
+            _APPEND_PRELUDE + _setup_function(self.html, "const handleWebSocketMessage = (data) => {"),
+            _APPEND_EPILOGUE_HELPERS + epilogue,
+        )
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_a_burst_bigger_than_one_page_leaves_the_window_sparse(self) -> None:
+        """More arrivals than one page fit: the poll cannot reach back, so playback must not either.
+
+        Pre-fix the poll left the pane holding 12, 11, 10, 5, 4, 3 — messages
+        6-9 never fetched — and still called it contiguous, so the queue seeded
+        [1, 2, 3, 4, 5, 10, 11, 12], armed the forward cursor from m12 (past
+        everything missing) and auto-advance PLAYED [3, 4, 5, 10, 11, 12]: four
+        voice notes silently skipped.
+        """
+        out = self._run("""
+(async () => {
+    await openChat([1, 2, 3, 4, 5])
+    const before = windowState()
+    // Seven messages arrive between two ticks; the poll's page holds three.
+    SERVER = Array.from({ length: 12 }, (_, i) => i + 1)
+    await checkForNewMessages()
+    const after = windowState()
+    emit(JSON.stringify({ before, after, playback: await playFrom(3) }))
+})();
+""")
+        # The window really is the sparse one the poll produced.
+        self.assertEqual(out["before"]["visible"], [5, 4, 3])
+        self.assertTrue(out["before"]["contiguous"])
+        self.assertEqual(out["after"]["visible"], [12, 11, 10, 5, 4, 3])
+        # THE flag: the append did not adjoin (lowest new id 10, window newest
+        # 5, and no row in common), so the window is no longer a timeline slice.
+        self.assertFalse(out["after"]["contiguous"])
+        # THE consequence: nothing skipped between the click and the end of the
+        # chat, where pre-fix it played [3, 4, 5, 10, 11, 12].
+        self.assertEqual(out["playback"]["played"], [3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+        # The sparse pane contributes no neighbours at all — the seed is the
+        # clicked track plus the page anchored on it.
+        self.assertEqual(out["playback"]["seeded"]["queue"], [1, 2, 3])
+        self.assertEqual(out["playback"]["armedFrom"], "m3")
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_a_burst_smaller_than_one_page_keeps_the_optimisation(self) -> None:
+        """The ordinary case must stay cheap: the poll's page still overlaps the window.
+
+        A check that cleared on every append would cost the queue an anchored
+        request per poll tick forever, which is why "adjoins" is a real
+        question and not just "did anything arrive".
+        """
+        out = self._run("""
+(async () => {
+    await openChat([1, 2, 3, 4, 5])
+    // Two arrivals: the latest page (7, 6, 5) still carries a row we hold.
+    SERVER = [1, 2, 3, 4, 5, 6, 7]
+    await checkForNewMessages()
+    const after = windowState()
+    emit(JSON.stringify({ after, playback: await playFrom(3) }))
+})();
+""")
+        self.assertEqual(out["after"]["visible"], [7, 6, 5, 4, 3])
+        self.assertTrue(out["after"]["contiguous"])
+        # The window is still a usable seed AND a usable anchor: the queue takes
+        # its rows, and the forward cursor is armed from the window's own edge
+        # with no request at all (the only seeding request is the backward page).
+        self.assertEqual(out["playback"]["seeded"]["queue"], [1, 2, 3, 4, 5, 6, 7])
+        self.assertEqual(out["playback"]["seeded"]["requested"], [["m3", "older"]])
+        self.assertEqual(out["playback"]["armedFrom"], "m7")
+        self.assertEqual(out["playback"]["played"], [3, 4, 5, 6, 7])
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_a_removal_only_tick_leaves_the_flag_alone(self) -> None:
+        """A deleted message is not a hole — the timeline no longer has it.
+
+        This is the boundary the check has to respect: the ids in a contiguous
+        window are NOT required to be consecutive, so the question can only ever
+        be asked about the seam an append lands on. A tick that only removes
+        rows appends nothing and must not touch the flag, and the next arrival
+        on top of the resulting id gap must not either.
+        """
+        out = self._run("""
+(async () => {
+    await openChat([1, 2, 3])
+    const before = windowState()
+    SERVER = [1, 3]                       // message 2 was hard-deleted upstream
+    await checkForNewMessages()
+    const afterRemoval = windowState()
+    SERVER = [1, 3, 4]                    // ...and now a new message arrives
+    await checkForNewMessages()
+    emit(JSON.stringify({ before, afterRemoval, afterArrival: windowState() }))
+})();
+""")
+        self.assertEqual(out["before"]["visible"], [3, 2, 1])
+        self.assertTrue(out["before"]["contiguous"])
+        # The row is gone from the pane, the flag is untouched...
+        self.assertEqual(out["afterRemoval"]["visible"], [3, 1])
+        self.assertTrue(out["afterRemoval"]["contiguous"])
+        # ...and an append over that id gap is still an append that adjoins.
+        self.assertEqual(out["afterArrival"]["visible"], [4, 3, 1])
+        self.assertTrue(out["afterArrival"]["contiguous"])
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_the_socket_frame_is_checked_at_the_same_chokepoint(self) -> None:
+        """The WS append is a different caller, not a different rule.
+
+        Pre-fix a frame delivered after a reconnect gap appended one row from
+        far past the window's edge and the pane still claimed contiguity, so the
+        queue seeded [1, 2, 3, 12] and playback went [3, 12] — nine tracks gone.
+        The live case (the very next message) must still be free.
+        """
+        out = self._run("""
+(async () => {
+    await openChat([1, 2, 3])
+    // The socket was down while 4..12 were archived; on reconnect it delivers 12.
+    SERVER = Array.from({ length: 12 }, (_, i) => i + 1)
+    handleWebSocketMessage({ type: 'new_message', chat_id: 7, message: messageRow(12) })
+    const afterGap = windowState()
+    const playback = await playFrom(3)
+    // The live case: the pane is the tail and the frame is the next message.
+    await openChat([1, 2, 3])
+    SERVER = [1, 2, 3, 4]
+    handleWebSocketMessage({ type: 'new_message', chat_id: 7, message: messageRow(4) })
+    emit(JSON.stringify({ afterGap, playback, live: windowState() }))
+})();
+""")
+        self.assertEqual(out["afterGap"]["visible"], [12, 3, 2, 1])
+        self.assertFalse(out["afterGap"]["contiguous"])
+        self.assertEqual(out["playback"]["seeded"]["queue"], [1, 2, 3])
+        self.assertEqual(out["playback"]["played"], [3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+        # ...while the ordinary live frame is the window's own successor.
+        self.assertEqual(out["live"]["visible"], [4, 3, 2, 1])
+        self.assertTrue(out["live"]["contiguous"])
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_a_later_page_cannot_re_declare_a_holed_window(self) -> None:
+        """Scrolling up after a burst must not undo what the append proved.
+
+        ``loadMessages`` declares contiguity from the REQUEST it built, which is
+        only the whole answer for the first page — every later page is appended
+        to rows that call never saw. Pre-fix the first scroll-up re-declared the
+        holed window contiguous and the queue went back to seeding across the
+        gap ([1, 2, 3, 4, 5, 10, 11, 12]), playing [3, 4, 5, 10, 11, 12].
+        """
+        out = self._run("""
+(async () => {
+    await openChat([1, 2, 3, 4, 5])
+    SERVER = Array.from({ length: 12 }, (_, i) => i + 1)
+    await checkForNewMessages()
+    const afterBurst = windowState()
+    // In production the first page comes back FULL (50 of 50), which is what
+    // leaves the scroll-up sentinel armed; this fixture's pages are three rows
+    // long, so re-arm it by hand and let the sentinel fire.
+    hasMore.value = true
+    await loadMessages()
+    const afterOlderPage = windowState()
+    emit(JSON.stringify({ afterBurst, afterOlderPage, playback: await playFrom(3) }))
+})();
+""")
+        self.assertFalse(out["afterBurst"]["contiguous"])
+        # The older page really did land — and the hole really did survive it.
+        self.assertEqual(out["afterOlderPage"]["visible"], [12, 11, 10, 5, 4, 3, 2, 1])
+        self.assertFalse(out["afterOlderPage"]["contiguous"])
+        self.assertEqual(out["playback"]["played"], [3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+
+
+class TestAudioBubbleMetadataStaysOnOneLine(unittest.TestCase):
+    """#267: "0:12" rendered as 0 / : / 1 / 2, one character per line.
+
+    ``.message-bubble`` sets ``overflow-wrap: anywhere``, which every descendant
+    inherits and which drops a text box's MIN-CONTENT width to a single
+    character. The duration span is a flex item of a row inside
+    ``min-w-0 flex-1``, so once that row is squeezed — the #261 download anchor
+    became a sibling in 7.32.0 — it shrinks all the way to that one-character
+    minimum. ``whitespace-nowrap`` restores min-content to the whole string,
+    which flex ``min-width: auto`` then refuses to shrink below.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+        start = cls.html.index('v-else-if="isAudioFile(msg)"')
+        cls.bubble = cls.html[start : cls.html.index("<!-- GIFs / Animations", start)]
+
+    def test_the_wrapping_rule_that_makes_nowrap_load_bearing_is_still_there(self) -> None:
+        """If this ever goes, the assertions below stop protecting anything."""
+        rule_start = self.html.index(".message-bubble {")
+        rule = self.html[rule_start : self.html.index("}", rule_start)]
+        self.assertIn("overflow-wrap: anywhere;", rule)
+        # ...and the squeezable ancestor that lets the row shrink at all.
+        self.assertIn('<div class="min-w-0 flex-1">', self.bubble)
+
+    def test_every_span_in_the_metadata_row_is_nowrap(self) -> None:
+        """Row-wide, not span-by-span: a NEW status span must not regress it."""
+        row_start = self.bubble.index('class="flex items-center gap-2 mt-1 text-[11px] text-gray-400"')
+        row = self.bubble[row_start : self.bubble.index("</div>", row_start)]
+        spans = re.findall(r"<span\b[^>]*>", row)
+        self.assertGreaterEqual(len(spans), 3)
+        for span in spans:
+            self.assertIn("whitespace-nowrap", span, span)
+
+    def test_the_specific_spans_reported_in_267(self) -> None:
+        self.assertIn('<span v-if="msg.media?.duration" class="whitespace-nowrap">', self.bubble)
+        self.assertIn('<span v-if="isCurrentAudioMessage(msg)" class="text-blue-400 whitespace-nowrap">', self.bubble)
+        self.assertIn('<span v-else-if="noDownload" class="whitespace-nowrap">Playback disabled</span>', self.bubble)
+
+    def test_the_filename_span_keeps_its_own_protection(self) -> None:
+        """``truncate`` implies nowrap; the duration span never had either."""
+        self.assertIn('<span class="truncate">{{ getDocumentDisplayName(msg) }}</span>', self.bubble)
+
+
+class TestReplyQuoteNamesItsSender(unittest.TestCase):
+    """#268: the quote block showed no sender and a bare "Message"."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+
+    def test_markup_delegates_to_the_helpers(self) -> None:
+        start = self.html.index('v-if="msg.reply_to_msg_id"')
+        block = self.html[start : self.html.index("Forwarded Message Info", start)]
+        self.assertIn("{{ replyToLabel(msg) }}", block)
+        self.assertIn("{{ replyToSnippet(msg) }}", block)
+        # The old inline expression is gone, sender and all.
+        self.assertNotIn("msg.reply_to_text || 'Message'", block)
+        self.assertNotIn(">Reply to</div>", block)
+        # A long sender name must not break per character either (#267's rule
+        # applies to this block too — it is inside the same bubble).
+        self.assertIn('class="font-semibold text-blue-400 mb-0.5 truncate"', block)
+
+    def test_helpers_are_exported_to_the_template(self) -> None:
+        self.assertIn("\n                    replyToLabel,\n", self.html)
+        self.assertIn("\n                    replyToSnippet,\n", self.html)
+
+    @unittest.skipUnless(NODE, "node is required to execute the helper")
+    def test_label_and_snippet_executed(self) -> None:
+        """Named when the backend names it, silent when it cannot.
+
+        ``reply_to_sender_name`` / ``reply_to_media_type`` are null when the
+        replied-to message is not in the archive, and absent entirely on an
+        older backend. Both must degrade to the pre-#268 output rather than
+        render "undefined" or throw.
+        """
+        out = _run_setup_helpers(
+            self.html,
+            (
+                "const replyMediaLabels = {",
+                "const replyToLabel = (msg) =>",
+                "const replyToSnippet = (msg) =>",
+            ),
+            "cases.map(msg => [replyToLabel(msg), replyToSnippet(msg)])",
+            prelude="""
+const cases = [
+    { reply_to_msg_id: 1, reply_to_sender_name: 'Ada L', reply_to_text: 'see below', reply_to_media_type: null },
+    { reply_to_msg_id: 1, reply_to_sender_name: 'Ada L', reply_to_text: null, reply_to_media_type: 'photo' },
+    { reply_to_msg_id: 1, reply_to_sender_name: 'Ada L', reply_to_text: null, reply_to_media_type: 'voice' },
+    { reply_to_msg_id: 1, reply_to_sender_name: null, reply_to_text: null, reply_to_media_type: null },
+    { reply_to_msg_id: 1, reply_to_sender_name: 'Ada L', reply_to_text: null, reply_to_media_type: 'venue' },
+    { reply_to_msg_id: 1 },
+    {},
+    undefined,
+]
+""",
+        )
+        self.assertEqual(
+            out,
+            [
+                ["Reply to Ada L", "see below"],
+                ["Reply to Ada L", "Photo"],
+                ["Reply to Ada L", "Voice message"],
+                # Target not in the archive: exactly the pre-#268 output.
+                ["Reply to", "Message"],
+                # Unmapped media kind: the raw type beats the bare word.
+                ["Reply to Ada L", "venue"],
+                # Older backend, neither key present.
+                ["Reply to", "Message"],
+                ["Reply to", "Message"],
+                ["Reply to", "Message"],
+            ],
         )
 
 

--- a/tests/test_media_forward_cursor.py
+++ b/tests/test_media_forward_cursor.py
@@ -1,0 +1,220 @@
+"""Forward (``after_id``) media pagination — #266.
+
+The audio queue must be able to extend FORWARD in time on demand. Without a
+forward cursor it had to pre-collect every item newer than the playing track,
+costing pages proportional to depth.
+
+Everything here runs against real in-memory SQLite so the actual SQL (cursor
+predicate + ORDER BY) is exercised, and uses production-format composite media
+ids (``f"{chat_id}_{msg_id}_{type}"``) — toy ids hide the string-vs-numeric
+ordering trap that #257 was about.
+"""
+
+import os
+import sys
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Base, Chat, Media, Message, User
+
+CHAT_ID = -1001234567890
+OTHER_CHAT_ID = -1009876543210
+
+# Deliberately spans a lexical/numeric divergence (8, 9, 89, 98, 99, 100...) and
+# ties several voice notes onto shared timestamps so the tiebreak is exercised.
+MESSAGE_IDS = [8, 9, 89, 98, 99, 100, 700, 701, 3150, 3350, 3653, 3739]
+
+
+def _media_id(chat_id: int, msg_id: int, media_type: str = "voice") -> str:
+    """Production composite media id."""
+    return f"{chat_id}_{msg_id}_{media_type}"
+
+
+async def _build_adapter() -> DatabaseAdapter:
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db_manager = DatabaseManager.__new__(DatabaseManager)
+    db_manager.engine = engine
+    db_manager.database_url = "sqlite+aiosqlite://"
+    db_manager._is_sqlite = True
+    db_manager.async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with db_manager.async_session_factory() as session:
+        session.add(Chat(id=CHAT_ID, type="channel", title="Voice Chat"))
+        session.add(Chat(id=OTHER_CHAT_ID, type="channel", title="Other Chat"))
+        session.add(User(id=100, first_name="Alice", last_name="Smith", username="alice"))
+
+        # Three timestamps only, so most rows tie and the (message_id, id)
+        # tiebreak decides the order.
+        dates = {
+            8: datetime(2026, 1, 1, 10),
+            9: datetime(2026, 1, 1, 10),
+            89: datetime(2026, 1, 1, 10),
+            98: datetime(2026, 1, 1, 10),
+            99: datetime(2026, 1, 1, 10),
+            100: datetime(2026, 1, 1, 10),
+            700: datetime(2026, 1, 2, 10),
+            701: datetime(2026, 1, 2, 10),
+            3150: datetime(2026, 1, 3, 10),
+            3350: datetime(2026, 1, 3, 10),
+            3653: datetime(2026, 1, 3, 10),
+            3739: datetime(2026, 1, 3, 10),
+        }
+        for msg_id in MESSAGE_IDS:
+            session.add(Message(id=msg_id, chat_id=CHAT_ID, sender_id=100, date=dates[msg_id], text=None))
+            session.add(
+                Media(
+                    id=_media_id(CHAT_ID, msg_id),
+                    message_id=msg_id,
+                    chat_id=CHAT_ID,
+                    type="voice",
+                    file_path=f"{CHAT_ID}/voice_{msg_id}.ogg",
+                    file_name=f"voice_{msg_id}.ogg",
+                    file_size=1000 + msg_id,
+                    mime_type="audio/ogg",
+                    duration=5,
+                    downloaded=1,
+                )
+            )
+
+        # A foreign chat's row, used for the cross-chat cursor test.
+        session.add(Message(id=555, chat_id=OTHER_CHAT_ID, sender_id=100, date=datetime(2026, 6, 1, 10)))
+        session.add(
+            Media(
+                id=_media_id(OTHER_CHAT_ID, 555),
+                message_id=555,
+                chat_id=OTHER_CHAT_ID,
+                type="voice",
+                file_path=f"{OTHER_CHAT_ID}/voice_555.ogg",
+                file_name="voice_555.ogg",
+                file_size=999,
+                mime_type="audio/ogg",
+                downloaded=1,
+            )
+        )
+        await session.commit()
+
+    return DatabaseAdapter(db_manager)
+
+
+@pytest_asyncio.fixture
+async def adapter():
+    return await _build_adapter()
+
+
+async def _walk_forward(adapter: DatabaseAdapter, page_size: int) -> list[dict]:
+    """Page forward from the oldest row to exhaustion."""
+    first = await adapter.get_media_paginated(CHAT_ID, limit=1_000)
+    oldest = first["items"][-1]
+    collected = [oldest]
+    cursor = oldest["id"]
+    while True:
+        page = await adapter.get_media_paginated(CHAT_ID, limit=page_size, after_id=cursor)
+        collected.extend(page["items"])
+        if not page["has_more"]:
+            break
+        assert page["items"], "has_more=True with an empty page would loop forever"
+        cursor = page["items"][-1]["id"]
+    return collected
+
+
+async def _walk_backward(adapter: DatabaseAdapter, page_size: int) -> list[dict]:
+    """Page backward from the newest row to exhaustion."""
+    page = await adapter.get_media_paginated(CHAT_ID, limit=page_size)
+    collected = list(page["items"])
+    while page["has_more"]:
+        cursor = page["items"][-1]["id"]
+        page = await adapter.get_media_paginated(CHAT_ID, limit=page_size, before_id=cursor)
+        collected.extend(page["items"])
+    return collected
+
+
+class TestForwardWalk:
+    async def test_forward_walk_returns_every_row_exactly_once(self, adapter):
+        collected = await _walk_forward(adapter, page_size=3)
+        ids = [item["id"] for item in collected]
+        assert len(ids) == len(MESSAGE_IDS)
+        assert len(set(ids)) == len(ids), "a forward walk must not duplicate rows"
+        assert set(ids) == {_media_id(CHAT_ID, m) for m in MESSAGE_IDS}, "no row may be skipped"
+
+    async def test_forward_walk_is_non_decreasing_by_date(self, adapter):
+        collected = await _walk_forward(adapter, page_size=5)
+        dates = [item["message_date"] for item in collected]
+        assert dates == sorted(dates)
+
+    async def test_forward_ties_break_numerically_by_message_id(self, adapter):
+        """#257's bug in the other direction: composite ids are strings, so a
+        lexical tiebreak would order 8, 89, 9, 98, 99 instead of 8, 9, 89, 98, 99."""
+        collected = await _walk_forward(adapter, page_size=4)
+        same_day = [item["message_id"] for item in collected if item["message_date"].startswith("2026-01-01")]
+        assert same_day == [8, 9, 89, 98, 99, 100]
+
+    async def test_forward_page_is_ordered_oldest_first(self, adapter):
+        page = await adapter.get_media_paginated(CHAT_ID, limit=4, after_id=_media_id(CHAT_ID, 8))
+        assert [item["message_id"] for item in page["items"]] == [9, 89, 98, 99]
+        assert page["has_more"] is True
+
+    async def test_has_more_false_on_the_last_forward_page(self, adapter):
+        page = await adapter.get_media_paginated(CHAT_ID, limit=50, after_id=_media_id(CHAT_ID, 3653))
+        assert [item["message_id"] for item in page["items"]] == [3739]
+        assert page["has_more"] is False
+
+    async def test_newest_row_has_no_forward_page(self, adapter):
+        page = await adapter.get_media_paginated(CHAT_ID, limit=50, after_id=_media_id(CHAT_ID, 3739))
+        assert page == {"items": [], "has_more": False}
+
+    async def test_forward_and_backward_walks_are_exact_reverses(self, adapter):
+        forward = [item["id"] for item in await _walk_forward(adapter, page_size=5)]
+        backward = [item["id"] for item in await _walk_backward(adapter, page_size=5)]
+        assert forward == list(reversed(backward))
+
+    async def test_forward_walk_respects_the_type_filter(self, adapter):
+        page = await adapter.get_media_paginated(
+            CHAT_ID, media_types=["photo"], limit=50, after_id=_media_id(CHAT_ID, 8)
+        )
+        assert page == {"items": [], "has_more": False}
+
+
+class TestForwardCursorContract:
+    async def test_unknown_token_returns_an_empty_page(self, adapter):
+        """Matches the backward path exactly, so a client can treat both alike."""
+        forward = await adapter.get_media_paginated(CHAT_ID, limit=50, after_id="no_such_media_id")
+        backward = await adapter.get_media_paginated(CHAT_ID, limit=50, before_id="no_such_media_id")
+        assert forward == {"items": [], "has_more": False}
+        assert backward == {"items": [], "has_more": False}
+
+    async def test_foreign_chat_token_leaks_nothing(self, adapter):
+        """A cursor from a chat the caller did not ask for must not shape this
+        chat's window, and must be indistinguishable from a deleted token."""
+        foreign = _media_id(OTHER_CHAT_ID, 555)
+        page = await adapter.get_media_paginated(CHAT_ID, limit=50, after_id=foreign)
+        deleted = await adapter.get_media_paginated(CHAT_ID, limit=50, after_id="deleted_token")
+        assert page == deleted == {"items": [], "has_more": False}
+
+    async def test_both_cursors_is_rejected(self, adapter):
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            await adapter.get_media_paginated(
+                CHAT_ID,
+                limit=50,
+                before_id=_media_id(CHAT_ID, 3739),
+                after_id=_media_id(CHAT_ID, 8),
+            )
+
+    async def test_no_cursor_still_returns_the_newest_page(self, adapter):
+        page = await adapter.get_media_paginated(CHAT_ID, limit=2)
+        assert [item["message_id"] for item in page["items"]] == [3739, 3653]
+        assert page["has_more"] is True

--- a/tests/test_media_page.py
+++ b/tests/test_media_page.py
@@ -169,6 +169,7 @@ class TestMediaPaginated:
             media_types=["photo", "video"],
             limit=50,
             before_id=None,
+            after_id=None,
         )
 
     def test_passes_limit(self, anon_env):
@@ -180,6 +181,7 @@ class TestMediaPaginated:
             media_types=None,
             limit=20,
             before_id=None,
+            after_id=None,
         )
 
     def test_passes_before_id(self, anon_env):
@@ -191,7 +193,29 @@ class TestMediaPaginated:
             media_types=None,
             limit=50,
             before_id="abc",
+            after_id=None,
         )
+
+    def test_passes_after_id(self, anon_env):
+        """#266: the forward cursor reaches the adapter as the same opaque string."""
+        client, _, mock_db = _get_client()
+        resp = client.get("/api/chats/-1001/media?after_id=-1001_2428_voice")
+        assert resp.status_code == 200
+        mock_db.get_media_paginated.assert_called_once_with(
+            -1001,
+            media_types=None,
+            limit=50,
+            before_id=None,
+            after_id="-1001_2428_voice",
+        )
+
+    def test_before_id_and_after_id_are_mutually_exclusive(self, anon_env):
+        """#266: asking for both directions at once is rejected, not silently halved."""
+        client, _, mock_db = _get_client()
+        resp = client.get("/api/chats/-1001/media?before_id=a&after_id=b")
+        assert resp.status_code == 400
+        assert "mutually exclusive" in resp.json()["detail"]
+        mock_db.get_media_paginated.assert_not_called()
 
     def test_empty_types_means_all(self, anon_env):
         client, _, mock_db = _get_client()
@@ -202,6 +226,7 @@ class TestMediaPaginated:
             media_types=None,
             limit=50,
             before_id=None,
+            after_id=None,
         )
 
     def test_items_include_thumb_url(self, anon_env):

--- a/tests/test_reconnect_before_retry.py
+++ b/tests/test_reconnect_before_retry.py
@@ -1,0 +1,644 @@
+"""Reconnect before spending a retry on a disconnected client — #265.
+
+Reported symptom: a few minutes of network loss produced
+
+    Transient Error (ConnectionError): sleeping 3.19s before retrying
+    _fetch_media_bytes_bounded (retry=1/5): Cannot send requests while disconnected
+
+five times in a row, then "giving up" — "with no sign of any reconnection
+attempt". Waiting cannot fix "cannot send requests while disconnected", so the
+whole retry budget was spent on a client that could not possibly succeed, and
+the log gave an operator no way to tell that from a stuck loop.
+
+These tests pin both halves: the client is re-established before the next
+attempt, and the attempt is visible in the log.
+"""
+
+import logging
+import os
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from telethon import TelegramClient
+from telethon.errors import ChatIdInvalidError
+from telethon.sessions import MemorySession
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src import telegram_backup
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    """Make backoff instant and record the requested durations."""
+    sleeps: list[float] = []
+
+    async def fake_sleep(seconds):
+        sleeps.append(seconds)
+
+    monkeypatch.setattr(telegram_backup.asyncio, "sleep", fake_sleep)
+    return sleeps
+
+
+def _disconnected_client(events: list[str] | None = None):
+    """A Telethon-shaped client that is down until connect() is awaited."""
+    client = MagicMock()
+    state = {"connected": False}
+
+    def is_connected():
+        return state["connected"]
+
+    async def connect():
+        state["connected"] = True
+        if events is not None:
+            events.append("connect")
+
+    client.is_connected = MagicMock(side_effect=is_connected)
+    client.connect = AsyncMock(side_effect=connect)
+    return client, state
+
+
+class TestReconnectHappens:
+    async def test_disconnected_client_is_reconnected_instead_of_retried_blindly(self, no_sleep):
+        events: list[str] = []
+        client, state = _disconnected_client(events)
+
+        class Downloader:
+            def __init__(self):
+                self.client = client
+                self.attempts = 0
+
+            async def _fetch_media_bytes_bounded(self):
+                self.attempts += 1
+                events.append("attempt")
+                if not state["connected"]:
+                    raise ConnectionError("Cannot send requests while disconnected")
+                return "downloaded"
+
+        downloader = Downloader()
+        result = await telegram_backup.call_with_flood_retry(downloader._fetch_media_bytes_bounded, max_retries=5)
+
+        assert result == "downloaded"
+        # One failed attempt, ONE reconnect, then success — not five blind retries.
+        assert events == ["attempt", "connect", "attempt"]
+        assert downloader.attempts == 2
+        assert client.connect.await_count == 1
+
+    async def test_reconnect_precedes_the_next_attempt(self, no_sleep):
+        """Ordering is the whole point: reconnect must come before the retry."""
+        events: list[str] = []
+        client, state = _disconnected_client(events)
+
+        class Owner:
+            def __init__(self):
+                self.client = client
+
+            async def call(self):
+                events.append("attempt")
+                raise ConnectionError("Cannot send requests while disconnected")
+
+        owner = Owner()
+        with pytest.raises(ConnectionError):
+            await telegram_backup.call_with_flood_retry(owner.call, max_retries=2)
+
+        assert events == ["attempt", "connect", "attempt", "attempt"]
+
+    async def test_client_bound_methods_resolve_the_client_itself(self, no_sleep):
+        """``call_with_flood_retry(self.client.download_media, ...)`` — the
+        retried callable IS a client method, so the client is the owner."""
+        client, state = _disconnected_client()
+        calls = {"n": 0}
+
+        async def download_media():
+            calls["n"] += 1
+            if not state["connected"]:
+                raise ConnectionError("Cannot send requests while disconnected")
+            return "file"
+
+        download_media.__self__ = client
+
+        result = await telegram_backup.call_with_flood_retry(download_media, max_retries=3)
+        assert result == "file"
+        assert client.connect.await_count == 1
+
+    async def test_explicit_client_argument_wins(self, no_sleep):
+        client, state = _disconnected_client()
+
+        async def plain_call():
+            if not state["connected"]:
+                raise ConnectionError("Cannot send requests while disconnected")
+            return "ok"
+
+        result = await telegram_backup.call_with_flood_retry(plain_call, max_retries=3, client=client)
+        assert result == "ok"
+        assert client.connect.await_count == 1
+
+
+class TestReconnectIsObservable:
+    async def test_reconnect_attempt_and_success_are_logged(self, no_sleep, caplog):
+        client, state = _disconnected_client()
+
+        async def plain_call():
+            if not state["connected"]:
+                raise ConnectionError("Cannot send requests while disconnected")
+            return "ok"
+
+        with caplog.at_level(logging.INFO, logger="src.telegram_backup"):
+            await telegram_backup.call_with_flood_retry(plain_call, max_retries=3, client=client)
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("reconnecting before retrying" in m for m in messages), messages
+        assert any("Reconnected to Telegram" in m for m in messages), messages
+
+    async def test_failed_reconnect_is_logged_and_never_escapes(self, no_sleep, caplog):
+        """A still-down network must degrade to the old behaviour, loudly."""
+        client = MagicMock()
+        client.is_connected = MagicMock(return_value=False)
+        client.connect = AsyncMock(side_effect=OSError("Network is unreachable"))
+
+        async def plain_call():
+            raise ConnectionError("Cannot send requests while disconnected")
+
+        with (
+            caplog.at_level(logging.WARNING, logger="src.telegram_backup"),
+            pytest.raises(ConnectionError, match="Cannot send requests while disconnected"),
+        ):
+            await telegram_backup.call_with_flood_retry(plain_call, max_retries=2, client=client)
+
+        messages = [record.getMessage() for record in caplog.records]
+        assert any("Reconnect before retrying" in m and "failed" in m for m in messages), messages
+        assert client.connect.await_count == 2
+
+    async def test_log_lines_carry_no_identifiers(self, no_sleep, caplog):
+        """PII rule: reconnect logging names the call, never a chat/user/message."""
+        client, state = _disconnected_client()
+
+        async def plain_call():
+            if not state["connected"]:
+                raise ConnectionError("Cannot send requests while disconnected")
+            return "ok"
+
+        with caplog.at_level(logging.INFO, logger="src.telegram_backup"):
+            await telegram_backup.call_with_flood_retry(plain_call, max_retries=3, client=client)
+
+        reconnect_messages = [
+            record.getMessage() for record in caplog.records if "reconnect" in record.getMessage().lower()
+        ]
+        assert reconnect_messages
+        for message in reconnect_messages:
+            assert not any(char.isdigit() for char in message), message
+
+
+class TestReconnectStaysOutOfTheWay:
+    async def test_connected_client_is_never_reconnected(self, no_sleep):
+        """Telethon's own reconnect may win the race; then this is a no-op."""
+        client = MagicMock()
+        client.is_connected = MagicMock(return_value=True)
+        client.connect = AsyncMock()
+        calls = {"n": 0}
+
+        async def flaky():
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise ConnectionError("transient")
+            return "ok"
+
+        result = await telegram_backup.call_with_flood_retry(flaky, max_retries=5, client=client)
+        assert result == "ok"
+        assert client.connect.await_count == 0
+
+    async def test_call_without_a_discoverable_client_behaves_as_before(self, no_sleep):
+        calls = {"n": 0}
+
+        async def flaky():
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise ConnectionError("transient")
+            return "ok"
+
+        result = await telegram_backup.call_with_flood_retry(flaky, max_retries=5)
+        assert result == "ok"
+        assert calls["n"] == 3
+        assert len(no_sleep) == 2
+
+    async def test_backoff_schedule_is_unchanged(self, no_sleep, monkeypatch):
+        """The fix adds a reconnect; it must not alter the retry budget or waits."""
+        monkeypatch.setattr(telegram_backup, "BACKOFF_MIN_SECONDS", 2.0)
+        monkeypatch.setattr(telegram_backup, "BACKOFF_MAX_SECONDS", 300.0)
+        monkeypatch.setattr(telegram_backup.random, "uniform", lambda a, b: 1.0)
+
+        client, _ = _disconnected_client()
+        client.connect = AsyncMock(side_effect=OSError("still down"))
+
+        async def plain_call():
+            raise ConnectionError("Cannot send requests while disconnected")
+
+        with pytest.raises(ConnectionError):
+            await telegram_backup.call_with_flood_retry(plain_call, max_retries=3, client=client)
+
+        assert no_sleep == [3.0, 5.0, 9.0]
+
+
+class TestRetryClientResolution:
+    def test_prefers_explicit_client(self):
+        explicit = object()
+        assert telegram_backup._retry_client(lambda: None, explicit) is explicit
+
+    def test_returns_none_for_a_plain_function(self):
+        assert telegram_backup._retry_client(lambda: None, None) is None
+
+    def test_returns_none_when_owner_has_no_client(self):
+        class Owner:
+            def method(self):
+                return None
+
+        assert telegram_backup._retry_client(Owner().method, None) is None
+
+    async def test_reconnect_is_a_noop_without_a_client(self):
+        assert await telegram_backup._reconnect_before_retry(None, "call") is False
+
+    async def test_reconnect_is_a_noop_for_a_client_without_the_api(self):
+        assert await telegram_backup._reconnect_before_retry(object(), "call") is False
+
+    async def test_awaitable_is_connected_is_supported(self):
+        client = MagicMock()
+        client.is_connected = AsyncMock(return_value=True)
+        client.connect = AsyncMock()
+        assert await telegram_backup._reconnect_before_retry(client, "call") is False
+        assert client.connect.await_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Real-client tests.
+#
+# A MagicMock whose is_connected() returns False proves nothing here: the whole
+# defect is a REAL Telethon client that reports itself disconnected while the
+# app still believes it is connected. Everything below runs against a real
+# TelegramClient (memory session, never connected to the network).
+# ---------------------------------------------------------------------------
+
+
+def _dead_client() -> TelegramClient:
+    """A real client in the exact state Telethon leaves after it gives up.
+
+    ``MTProtoSender._reconnect`` retries 5 times (~1s apart, each bounded by a
+    10s connect timeout) and then calls ``_disconnect``, which sets
+    ``_user_connected = False`` and ``_connection = None``. From that point
+    ``send()`` raises ``ConnectionError('Cannot send requests while
+    disconnected')`` unconditionally and ``_start_reconnect`` is guarded by
+    ``if self._user_connected`` — so Telethon never retries by itself again
+    until someone calls ``connect()``. An outage longer than ~55s lands here,
+    which is why the report showed no reconnection attempt at all.
+    """
+    client = TelegramClient(MemorySession(), 1, "test-api-hash")
+    client._sender._user_connected = False
+    client._sender._connection = None
+    return client
+
+
+class TestRealDeadSenderState:
+    async def test_the_failure_mode_is_what_we_think_it_is(self):
+        """Pin the premise with real library code, not a mock."""
+        client = _dead_client()
+        assert not client.is_connected()
+        with pytest.raises(ConnectionError, match="Cannot send requests while disconnected"):
+            await client.get_me()
+
+    async def test_real_dead_client_is_reconnected_before_the_next_attempt(self, no_sleep):
+        """End-to-end on a real client: the first attempt raises the real
+        ConnectionError from the real sender, and the retry is preceded by a
+        real ``connect()``."""
+        client = _dead_client()
+        events: list[str] = []
+
+        async def fake_connect():
+            # What a successful connect() achieves: the sender is usable again.
+            events.append("connect")
+            client._sender._user_connected = True
+
+        client.connect = fake_connect
+
+        async def probe(self):
+            events.append("attempt")
+            if not self.is_connected():
+                await self.get_me()  # real Telethon raises from the dead sender
+            return "ok"
+
+        # A genuine bound method of the real client — the same resolution path
+        # as ``call_with_flood_retry(self.client.download_media, ...)``.
+        bound = types.MethodType(probe, client)
+        assert bound.__self__ is client
+
+        result = await telegram_backup.call_with_flood_retry(bound, max_retries=5)
+
+        assert result == "ok"
+        assert events == ["attempt", "connect", "attempt"]
+        assert client.is_connected()
+
+    async def test_connect_is_attempted_on_every_retry_while_the_network_stays_down(self, no_sleep):
+        client = _dead_client()
+        attempts = {"connect": 0}
+
+        async def fake_connect():
+            attempts["connect"] += 1
+            raise OSError("Network is unreachable")
+
+        client.connect = fake_connect
+
+        with pytest.raises(ConnectionError, match="Cannot send requests while disconnected"):
+            await telegram_backup.call_with_flood_retry(client.get_me, max_retries=3)
+
+        assert attempts["connect"] == 3
+
+
+class TestEveryCallShapeResolvesTheClient:
+    """One assertion per call shape this repo actually uses, against a real client."""
+
+    def test_bound_method_of_the_client(self):
+        """``call_with_flood_retry(self.client.download_media, ...)`` — the shape
+        in the reported log, and ``get_entity``/``get_messages``/``get_dialogs``."""
+        client = _dead_client()
+        assert telegram_backup._retry_client(client.download_media, None) is client
+        assert telegram_backup._retry_client(client.get_entity, None) is client
+        assert telegram_backup._retry_client(client.get_messages, None) is client
+
+    def test_the_client_itself_as_the_callable(self):
+        """``call_with_flood_retry(self.client, GetContactsRequest(hash=0))`` —
+        Telethon invokes a raw request by calling the client, so there is no
+        ``__self__`` to inspect."""
+        client = _dead_client()
+        assert telegram_backup._retry_client(client, None) is client
+
+    def test_bound_method_of_a_component_that_owns_the_client(self):
+        """``call_with_flood_retry(self._fetch_media_bytes_bounded, ...)``."""
+        client = _dead_client()
+
+        class Backup:
+            def __init__(self):
+                self.client = client
+
+            async def _fetch_media_bytes_bounded(self):
+                return None
+
+        assert telegram_backup._retry_client(Backup()._fetch_media_bytes_bounded, None) is client
+
+    def test_local_closure_passes_the_client_explicitly(self):
+        """``_refresh_message_for_media`` wraps a closure, so it must pass
+        ``client=``; without it the closure resolves to nothing."""
+        client = _dead_client()
+
+        async def _get_messages_once():
+            return None
+
+        assert telegram_backup._retry_client(_get_messages_once, None) is None
+        assert telegram_backup._retry_client(_get_messages_once, client) is client
+
+    async def test_raw_request_call_reconnects_end_to_end(self, no_sleep, monkeypatch):
+        """The ``client(request)`` shape must actually reconnect, not just resolve.
+
+        Before the fix this shape resolved to no client at all, so raw requests
+        (``GetContactsRequest``, ``GetForumTopicsRequest``,
+        ``GetCustomEmojiDocumentsRequest``) never reconnected.
+        """
+        client = _dead_client()
+        connects = {"n": 0}
+
+        async def fake_connect():
+            connects["n"] += 1
+            client._sender._user_connected = True
+
+        client.connect = fake_connect
+        calls = {"n": 0}
+
+        async def fake_call(self, request, *args, **kwargs):
+            calls["n"] += 1
+            if not self.is_connected():
+                raise ConnectionError("Cannot send requests while disconnected")
+            return "contacts"
+
+        # ``client(request)`` resolves __call__ on the type, so patch it there.
+        monkeypatch.setattr(TelegramClient, "__call__", fake_call)
+
+        result = await telegram_backup.call_with_flood_retry(client, object())
+
+        assert result == "contacts"
+        assert connects["n"] == 1
+        assert calls["n"] == 2
+
+
+class TestMediaRefreshPassesItsClient:
+    async def test_refresh_message_for_media_reconnects(self, no_sleep):
+        """``_refresh_message_for_media`` runs on the media path that reported
+        #265; its retried callable is a closure, so the client must be passed."""
+        from src.telegram_backup import TelegramBackup
+
+        client = _dead_client()
+        connects = {"n": 0}
+
+        async def fake_connect():
+            connects["n"] += 1
+            client._sender._user_connected = True
+
+        client.connect = fake_connect
+        calls = {"n": 0}
+
+        async def get_messages(chat_id, ids=None):
+            calls["n"] += 1
+            if not client.is_connected():
+                raise ConnectionError("Cannot send requests while disconnected")
+            return [SimpleNamespace(id=7)]
+
+        client.get_messages = get_messages
+
+        backup = TelegramBackup.__new__(TelegramBackup)
+        backup.client = client
+        backup.config = MagicMock()
+
+        fresh = await backup._refresh_message_for_media(-100123, SimpleNamespace(id=7))
+
+        assert fresh is not None
+        assert connects["n"] == 1
+        assert calls["n"] == 2
+
+
+class TestIterMessagesReconnects:
+    """#265 for long iterations: a disconnect used to abort the whole chat."""
+
+    async def _drain(self, client):
+        return [m.id async for m in telegram_backup.iter_messages_with_flood_retry(client, "chat", reverse=True)]
+
+    async def test_disconnect_mid_iteration_reconnects_and_resumes(self, no_sleep):
+        client = _dead_client()
+        events: list[str] = []
+
+        async def fake_connect():
+            events.append("connect")
+            client._sender._user_connected = True
+
+        client.connect = fake_connect
+        calls = {"n": 0}
+
+        async def iter_messages(entity, min_id=0, **_):
+            calls["n"] += 1
+            events.append(f"iter(min_id={min_id})")
+            if calls["n"] == 1:
+                yield SimpleNamespace(id=11)
+                raise ConnectionError("Cannot send requests while disconnected")
+            for i in (12, 13):
+                yield SimpleNamespace(id=i)
+
+        client.iter_messages = iter_messages
+
+        assert await self._drain(client) == [11, 12, 13]
+        # Reconnect happens before the resumed iteration, which starts after the
+        # last yielded id instead of restarting the chat.
+        assert events == ["iter(min_id=0)", "connect", "iter(min_id=11)"]
+
+    async def test_iteration_gives_up_after_the_bounded_retries(self, no_sleep):
+        client = _dead_client()
+        connects = {"n": 0}
+
+        async def fake_connect():
+            connects["n"] += 1  # still down: never restores the sender
+
+        client.connect = fake_connect
+
+        async def iter_messages(entity, min_id=0, **_):
+            raise ConnectionError("Cannot send requests while disconnected")
+            yield  # pragma: no cover — satisfies the async-generator contract
+
+        client.iter_messages = iter_messages
+
+        with pytest.raises(ConnectionError, match="Cannot send requests while disconnected"):
+            await self._drain(client)
+
+        assert connects["n"] == telegram_backup.MAX_FLOOD_RETRIES
+
+    async def test_permanent_rpc_errors_still_propagate_untouched(self, no_sleep):
+        """Only connection-shaped failures are retried; a permanent Telegram
+        error must not spend five backoffs first."""
+        client = _dead_client()
+        connects = {"n": 0}
+
+        async def fake_connect():
+            connects["n"] += 1
+
+        client.connect = fake_connect
+
+        async def iter_messages(entity, min_id=0, **_):
+            raise ChatIdInvalidError(request=None)
+            yield  # pragma: no cover
+
+        client.iter_messages = iter_messages
+
+        with pytest.raises(ChatIdInvalidError):
+            await self._drain(client)
+
+        assert connects["n"] == 0
+        assert no_sleep == []
+
+
+class TestListenerRestartAfterAGiveUp:
+    """The listener half of #265: the scheduler restarted it into a dead client
+    every 5 seconds forever, because the gate reads an app-level flag."""
+
+    def _scheduler(self, connection):
+        with patch("src.scheduler.signal.signal"):
+            from src.scheduler import BackupScheduler
+
+            config = MagicMock()
+            config.enable_listener = True
+            scheduler = BackupScheduler(config)
+        scheduler._connection = connection
+        return scheduler
+
+    def _connection(self, client, *, ensure_raises=None):
+        """A stand-in for TelegramConnection with its real flag semantics: the
+        app-level ``is_connected`` stays True after Telethon gave up."""
+        state = {"ensure": 0}
+
+        class Connection:
+            def __init__(self):
+                self.client = client
+                self._connected = True
+
+            @property
+            def is_connected(self):
+                return self._connected and self.client is not None
+
+            async def ensure_connected(self):
+                state["ensure"] += 1
+                if ensure_raises is not None:
+                    self._connected = False
+                    raise ensure_raises
+                if not self.client.is_connected():
+                    await self.client.connect()
+                return self.client
+
+        return Connection(), state
+
+    async def test_real_listener_guard_rejects_a_dead_shared_client(self):
+        """Why the restart loop never ended, straight from listener.py."""
+        from src.listener import TelegramListener
+
+        client = _dead_client()
+        with pytest.raises(RuntimeError, match="Shared client is not connected"):
+            await TelegramListener.connect(SimpleNamespace(client=client, _owns_client=False))
+
+    async def test_start_listener_reconnects_the_dead_client_first(self):
+        client = _dead_client()
+
+        async def fake_connect():
+            client._sender._user_connected = True
+
+        client.connect = fake_connect
+        connection, state = self._connection(client)
+        scheduler = self._scheduler(connection)
+
+        # The stale app-level flag says "connected" while the client is dead —
+        # exactly the state the old gate waved through.
+        assert connection.is_connected is True
+        assert not client.is_connected()
+
+        seen = {}
+
+        class StubListener:
+            @classmethod
+            async def create(cls, config, client=None):
+                listener = cls()
+                listener.client = client
+                return listener
+
+            async def connect(self):
+                # Mirrors the real guard (src/listener.py, TelegramListener.connect).
+                seen["connected_at_connect"] = self.client.is_connected()
+                if not self.client.is_connected():
+                    raise RuntimeError("Shared client is not connected")
+
+            async def run(self):
+                return None
+
+        with patch("src.listener.TelegramListener", StubListener):
+            await scheduler._start_listener()
+
+        assert state["ensure"] == 1
+        assert seen["connected_at_connect"] is True
+        assert scheduler._listener is not None
+        assert scheduler._listener_task is not None
+        scheduler._listener_task.cancel()
+
+    async def test_start_listener_gives_up_cleanly_when_the_network_is_still_down(self, caplog):
+        client = _dead_client()
+        connection, state = self._connection(client, ensure_raises=OSError("Network is unreachable"))
+        scheduler = self._scheduler(connection)
+
+        with caplog.at_level(logging.WARNING, logger="src.scheduler"):
+            await scheduler._start_listener()
+
+        assert state["ensure"] == 1
+        assert scheduler._listener is None
+        assert scheduler._listener_task is None
+        assert any("Cannot start listener" in r.getMessage() for r in caplog.records)

--- a/tests/test_reply_sender.py
+++ b/tests/test_reply_sender.py
@@ -1,0 +1,442 @@
+"""Replied-to sender/media exposed on the messages payload — #268.
+
+The reply quote block could only render the bare word "Message" because the
+payload carried ``reply_to_msg_id``/``reply_to_text`` and nothing about WHO was
+replied to. These tests pin the new fields, the null contract for targets that
+are not in the archive, and — because the endpoint is paginated — the fact that
+resolving them costs ONE extra query for the whole page, not one per row.
+"""
+
+import os
+import sys
+from datetime import datetime
+
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Base, Chat, Media, Message, User
+
+CHAT_ID = -1001111111111
+OTHER_CHAT_ID = -1002222222222
+
+
+class _QueryCounter:
+    """Counts SQL statements executed on an engine."""
+
+    def __init__(self, engine):
+        self._sync_engine = engine.sync_engine
+        self.statements: list[str] = []
+
+    def _record(self, conn, cursor, statement, parameters, context, executemany):
+        self.statements.append(statement)
+
+    def __enter__(self):
+        event.listen(self._sync_engine, "before_cursor_execute", self._record)
+        return self
+
+    def __exit__(self, *exc):
+        event.remove(self._sync_engine, "before_cursor_execute", self._record)
+        return False
+
+    @property
+    def count(self) -> int:
+        return len(self.statements)
+
+    def matching(self, needle: str) -> list[str]:
+        return [s for s in self.statements if needle in s]
+
+
+async def _make_adapter():
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db_manager = DatabaseManager.__new__(DatabaseManager)
+    db_manager.engine = engine
+    db_manager.database_url = "sqlite+aiosqlite://"
+    db_manager._is_sqlite = True
+    db_manager.async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    return DatabaseAdapter(db_manager), engine, db_manager
+
+
+@pytest_asyncio.fixture
+async def env():
+    adapter, engine, db_manager = await _make_adapter()
+
+    async with db_manager.async_session_factory() as session:
+        session.add(Chat(id=CHAT_ID, type="supergroup", title="Group"))
+        session.add(Chat(id=OTHER_CHAT_ID, type="supergroup", title="Other Group"))
+        # 100: has a capture-time snapshot AND a current profile (snapshot wins)
+        session.add(User(id=100, first_name="Alice", last_name="Smith", username="alice"))
+        # 200: no snapshot, current profile name only
+        session.add(User(id=200, first_name="Bob", last_name=None, username="bob"))
+        # 300: no snapshot, no names, username only
+        session.add(User(id=300, first_name=None, last_name=None, username="carol"))
+        # 400: nothing resolvable at all
+        session.add(User(id=400, first_name=None, last_name=None, username=None))
+
+        base = datetime(2026, 3, 1, 12)
+
+        def msg(mid, sender_id, text, sender_name=None, reply_to=None, is_deleted=0):
+            return Message(
+                id=mid,
+                chat_id=CHAT_ID,
+                sender_id=sender_id,
+                sender_name=sender_name,
+                date=base.replace(minute=mid % 60, second=mid % 60),
+                text=text,
+                reply_to_msg_id=reply_to,
+                is_deleted=is_deleted,
+            )
+
+        # Reply targets
+        session.add(msg(1, 100, "target with snapshot", sender_name="Alice (2024)"))
+        session.add(msg(2, 200, "target with profile only"))
+        session.add(msg(3, 300, "target with username only"))
+        session.add(msg(4, 400, "target with no resolvable name"))
+        session.add(msg(5, 100, None, sender_name="Alice (2024)"))  # voice-only target
+        session.add(msg(6, 200, "soft-deleted target", is_deleted=1))
+
+        # Repliers
+        session.add(msg(11, 200, "re: snapshot", reply_to=1))
+        session.add(msg(12, 200, "re: profile", reply_to=2))
+        session.add(msg(13, 200, "re: username", reply_to=3))
+        session.add(msg(14, 200, "re: nameless", reply_to=4))
+        session.add(msg(15, 200, "re: voice", reply_to=5))
+        session.add(msg(16, 200, "re: soft-deleted", reply_to=6))
+        session.add(msg(17, 200, "re: missing", reply_to=9999))
+        session.add(msg(18, 200, "re: other chat only", reply_to=7777))
+        session.add(msg(19, 200, "not a reply"))
+
+        session.add(
+            Media(
+                id=f"{CHAT_ID}_5_voice",
+                message_id=5,
+                chat_id=CHAT_ID,
+                type="voice",
+                file_path=f"{CHAT_ID}/voice_5.ogg",
+                file_name="voice_5.ogg",
+                file_size=1234,
+                mime_type="audio/ogg",
+                duration=7,
+                downloaded=1,
+            )
+        )
+
+        # Same message id, different chat — must NOT resolve for CHAT_ID.
+        session.add(
+            Message(
+                id=7777,
+                chat_id=OTHER_CHAT_ID,
+                sender_id=100,
+                sender_name="Somebody Else",
+                date=base,
+                text="secret",
+            )
+        )
+        await session.commit()
+
+    return adapter, engine
+
+
+async def _by_id(adapter, **kwargs) -> dict[int, dict]:
+    messages = await adapter.get_messages_paginated(CHAT_ID, limit=100, **kwargs)
+    return {m["id"]: m for m in messages}
+
+
+class TestReplySenderName:
+    async def test_uses_capture_time_snapshot_first(self, env):
+        adapter, _ = env
+        rows = await _by_id(adapter)
+        assert rows[11]["reply_to_sender_name"] == "Alice (2024)"
+
+    async def test_falls_back_to_current_profile_name(self, env):
+        adapter, _ = env
+        rows = await _by_id(adapter)
+        assert rows[12]["reply_to_sender_name"] == "Bob"
+
+    async def test_falls_back_to_username(self, env):
+        adapter, _ = env
+        rows = await _by_id(adapter)
+        assert rows[13]["reply_to_sender_name"] == "carol"
+
+    async def test_unnameable_sender_is_null_not_a_placeholder(self, env):
+        """The server states "not known"; the viewer owns the placeholder."""
+        adapter, _ = env
+        rows = await _by_id(adapter)
+        assert rows[14]["reply_to_sender_name"] is None
+        assert rows[14]["reply_to_media_type"] is None
+
+    async def test_matches_the_senders_own_resolution(self, env):
+        """The name shown in the quote block is the same string the target
+        message's own bubble resolves to — one rule, no drift."""
+        adapter, _ = env
+        rows = await _by_id(adapter)
+        assert rows[11]["reply_to_sender_name"] == rows[1]["sender_name"]
+
+
+class TestReplyMediaKind:
+    async def test_media_only_target_reports_its_kind(self, env):
+        adapter, _ = env
+        rows = await _by_id(adapter)
+        assert rows[15]["reply_to_media_type"] == "voice"
+        assert rows[15]["reply_to_sender_name"] == "Alice (2024)"
+
+    async def test_text_target_has_no_media_kind(self, env):
+        adapter, _ = env
+        rows = await _by_id(adapter)
+        assert rows[11]["reply_to_media_type"] is None
+
+
+class TestReplyNullContract:
+    async def test_target_missing_from_the_archive_degrades_to_null(self, env):
+        adapter, _ = env
+        rows = await _by_id(adapter)
+        assert rows[17]["reply_to_sender_name"] is None
+        assert rows[17]["reply_to_media_type"] is None
+        assert rows[17]["reply_to_text"] is None
+
+    async def test_target_in_another_chat_does_not_resolve(self, env):
+        adapter, _ = env
+        rows = await _by_id(adapter)
+        assert rows[18]["reply_to_sender_name"] is None
+        assert rows[18]["reply_to_media_type"] is None
+
+    async def test_soft_deleted_target_still_resolves(self, env):
+        """A deleted-on-Telegram message is still archived history."""
+        adapter, _ = env
+        rows = await _by_id(adapter)
+        assert rows[16]["reply_to_sender_name"] == "Bob"
+
+    async def test_non_reply_carries_neither_key(self, env):
+        adapter, _ = env
+        rows = await _by_id(adapter)
+        assert "reply_to_sender_name" not in rows[19]
+        assert "reply_to_media_type" not in rows[19]
+
+    async def test_reply_text_backfill_still_works(self, env):
+        adapter, _ = env
+        rows = await _by_id(adapter)
+        assert rows[11]["reply_to_text"] == "target with snapshot"
+
+
+async def _seed_replies(count: int, *, pinned: bool = False):
+    """A chat of ``count`` replies, each to a distinct target."""
+    adapter, engine, db_manager = await _make_adapter()
+    async with db_manager.async_session_factory() as session:
+        session.add(Chat(id=CHAT_ID, type="supergroup", title="Group"))
+        session.add(User(id=200, first_name="Bob", last_name=None, username="bob"))
+        base = datetime(2026, 4, 1, 9)
+        for i in range(count):
+            target = 1000 + i
+            session.add(
+                Message(
+                    id=target,
+                    chat_id=CHAT_ID,
+                    sender_id=200,
+                    sender_name=f"Sender {i}",
+                    date=base,
+                    text=f"target {i}",
+                )
+            )
+            session.add(
+                Message(
+                    id=2000 + i,
+                    chat_id=CHAT_ID,
+                    sender_id=200,
+                    date=base,
+                    text=f"reply {i}",
+                    reply_to_msg_id=target,
+                    is_pinned=1 if pinned else 0,
+                )
+            )
+        await session.commit()
+    return adapter, engine
+
+
+class TestNoNPlusOne:
+    async def test_query_count_is_flat_as_replies_grow(self, env):
+        """1 reply and 25 distinct reply targets cost the SAME number of
+        statements — the proof that reply resolution is batched, not per row."""
+        small_adapter, small_engine = await _seed_replies(1)
+        with _QueryCounter(small_engine) as small:
+            await small_adapter.get_messages_paginated(CHAT_ID, limit=100)
+
+        big_adapter, big_engine = await _seed_replies(25)
+        with _QueryCounter(big_engine) as big:
+            await big_adapter.get_messages_paginated(CHAT_ID, limit=100)
+
+        assert small.count == big.count, f"query count grew with reply count: {small.count} -> {big.count} (N+1)"
+
+    async def test_exactly_one_statement_resolves_the_pages_replies(self, env):
+        adapter, engine = await _seed_replies(25)
+        with _QueryCounter(engine) as counter:
+            messages = await adapter.get_messages_paginated(CHAT_ID, limit=100)
+
+        assert sum(1 for m in messages if m.get("reply_to_msg_id")) == 25
+        reply_statements = counter.matching("messages.reply_to_msg_id IN")
+        reply_statements += [s for s in counter.matching("messages.id IN") if "media" in s]
+        assert len(reply_statements) == 1, counter.statements
+        assert counter.count <= 5, counter.statements
+
+    async def test_page_without_replies_skips_the_reply_query(self, env):
+        adapter, engine, db_manager = await _make_adapter()
+        async with db_manager.async_session_factory() as session:
+            session.add(Chat(id=CHAT_ID, type="supergroup", title="Group"))
+            session.add(Message(id=1, chat_id=CHAT_ID, sender_id=None, date=datetime(2026, 5, 1, 9), text="hi"))
+            await session.commit()
+
+        with _QueryCounter(engine) as counter:
+            messages = await adapter.get_messages_paginated(CHAT_ID, limit=100)
+
+        assert "reply_to_sender_name" not in messages[0]
+        assert not [s for s in counter.statements if "media" in s and "messages.id IN" in s]
+
+
+_REPLY_KEYS = ("reply_to_sender_name", "reply_to_media_type", "reply_to_text")
+_MISSING = object()
+
+
+class TestPinnedListParity:
+    """The pinned-only view swaps its list into the SAME message renderer, so a
+    pinned reply must arrive with the same fields as in the normal list.
+    Before this, one message rendered "Reply to <name>" in the list and a bare
+    "Reply to / Message" in the pinned view."""
+
+    async def _pinned_by_id(self, adapter, ids):
+        await adapter.sync_pinned_messages(CHAT_ID, ids)
+        return {m["id"]: m for m in await adapter.get_pinned_messages(CHAT_ID)}
+
+    async def test_pinned_rows_carry_the_same_reply_fields_as_the_list(self, env):
+        adapter, _ = env
+        ids = [11, 12, 13, 14, 15, 16, 17, 18, 19]
+        pinned = await self._pinned_by_id(adapter, ids)
+        listed = await _by_id(adapter)
+
+        assert set(pinned) == set(ids)
+        for mid in ids:
+            for key in _REPLY_KEYS:
+                assert pinned[mid].get(key, _MISSING) == listed[mid].get(key, _MISSING), (
+                    f"message {mid} renders differently in the pinned list ({key})"
+                )
+
+    async def test_pinned_reply_names_the_sender(self, env):
+        adapter, _ = env
+        pinned = await self._pinned_by_id(adapter, [11])
+        assert pinned[11]["reply_to_sender_name"] == "Alice (2024)"
+        assert pinned[11]["reply_to_text"] == "target with snapshot"
+
+    async def test_pinned_reply_to_media_reports_the_kind(self, env):
+        adapter, _ = env
+        pinned = await self._pinned_by_id(adapter, [15])
+        assert pinned[15]["reply_to_media_type"] == "voice"
+        assert pinned[15]["reply_to_sender_name"] == "Alice (2024)"
+
+    async def test_pinned_null_contract_matches(self, env):
+        adapter, _ = env
+        pinned = await self._pinned_by_id(adapter, [17, 19])
+        assert pinned[17]["reply_to_sender_name"] is None
+        assert pinned[17]["reply_to_media_type"] is None
+        assert "reply_to_sender_name" not in pinned[19]
+        assert "reply_to_media_type" not in pinned[19]
+
+    async def test_pinned_list_resolves_every_reply_in_one_query(self, env):
+        adapter, engine = await _seed_replies(25, pinned=True)
+        with _QueryCounter(engine) as counter:
+            pinned = await adapter.get_pinned_messages(CHAT_ID)
+
+        assert sum(1 for m in pinned if m.get("reply_to_sender_name")) == 25
+        reply_statements = [s for s in counter.matching("messages.id IN") if "media" in s]
+        assert len(reply_statements) == 1, counter.statements
+        # A small fixed set of statements for 25 replies — nothing per row.
+        assert counter.count <= 4, counter.statements
+
+    async def test_pinned_query_count_is_flat_as_pinned_replies_grow(self, env):
+        small_adapter, small_engine = await _seed_replies(1, pinned=True)
+        with _QueryCounter(small_engine) as small:
+            await small_adapter.get_pinned_messages(CHAT_ID)
+
+        big_adapter, big_engine = await _seed_replies(25, pinned=True)
+        with _QueryCounter(big_engine) as big:
+            await big_adapter.get_pinned_messages(CHAT_ID)
+
+        assert small.count == big.count, f"query count grew with reply count: {small.count} -> {big.count} (N+1)"
+
+    async def test_pinned_list_without_replies_skips_the_reply_query(self, env):
+        adapter, engine, db_manager = await _make_adapter()
+        async with db_manager.async_session_factory() as session:
+            session.add(Chat(id=CHAT_ID, type="supergroup", title="Group"))
+            session.add(
+                Message(id=1, chat_id=CHAT_ID, sender_id=None, date=datetime(2026, 5, 1, 9), text="hi", is_pinned=1)
+            )
+            await session.commit()
+
+        with _QueryCounter(engine) as counter:
+            pinned = await adapter.get_pinned_messages(CHAT_ID)
+
+        assert "reply_to_sender_name" not in pinned[0]
+        assert not [s for s in counter.matching("messages.id IN") if "media" in s], counter.statements
+
+
+class TestByDateLookupParity:
+    """``/messages/by-date`` used to run its own text-only reply lookup — a
+    second resolution rule for the same field, which is exactly the drift that
+    produced #259. It now shares the one helper."""
+
+    async def test_by_date_row_matches_the_list_row(self, env):
+        adapter, _ = env
+        listed = await _by_id(adapter)
+        found = await adapter.find_message_by_date_with_joins(CHAT_ID, datetime(2026, 3, 1, 12, 11))
+
+        assert found["id"] == 11
+        for key in _REPLY_KEYS:
+            assert found.get(key, _MISSING) == listed[11].get(key, _MISSING)
+        assert found["reply_to_sender_name"] == "Alice (2024)"
+
+    async def test_by_date_media_only_target_reports_its_kind(self, env):
+        adapter, _ = env
+        found = await adapter.find_message_by_date_with_joins(CHAT_ID, datetime(2026, 3, 1, 12, 15))
+        assert found["id"] == 15
+        assert found["reply_to_media_type"] == "voice"
+
+    async def test_by_date_non_reply_carries_neither_key(self, env):
+        adapter, _ = env
+        found = await adapter.find_message_by_date_with_joins(CHAT_ID, datetime(2026, 3, 1, 12, 19))
+        assert found["id"] == 19
+        assert "reply_to_sender_name" not in found
+        assert "reply_to_media_type" not in found
+
+    async def test_by_date_still_costs_one_reply_statement(self, env):
+        adapter, engine = env
+        with _QueryCounter(engine) as counter:
+            await adapter.find_message_by_date_with_joins(CHAT_ID, datetime(2026, 3, 1, 12, 11))
+
+        reply_statements = [s for s in counter.matching("messages.id IN") if "media" in s]
+        assert len(reply_statements) == 1, counter.statements
+
+
+class TestPathsAuditedAsUnaffected:
+    """Read paths that return reply information but never feed the quote block.
+
+    ``get_messages_for_export`` backs the JSON export download, whose ``reply_to``
+    is the raw target id in an archival document — not a rendered quote. Adding
+    resolved names there would change a published file format, and the export is
+    streamed row by row, so it is left alone deliberately."""
+
+    async def test_export_rows_expose_the_target_id_only(self, env):
+        adapter, _ = env
+        rows = {m["id"]: m async for m in adapter.get_messages_for_export(CHAT_ID)}
+
+        assert rows[11]["reply_to"] == 1
+        assert "reply_to_sender_name" not in rows[11]
+        assert "reply_to_media_type" not in rows[11]


### PR DESCRIPTION
Addresses #265 (@samnyan) and #266, #267, #268 (@625801). Two of these are regressions from v7.32.0, which this batch owns rather than works around.

## #266 — auto-advance stopped after ~40 tracks

The reported cause was a runaway guard counting consecutive page-loads. There is no such counter. The real mechanism: the queue pre-collected every track *newer* than the playing one by paging backward from the newest item, capped at ten pages. In a chat with more audio than that cap covers, the walk never reached the playing track — and v7.32.0's #257 fix then correctly refused to merge the disjoint result, so the queue ended at the loaded window. Igor's measurement matches exactly: 9 `before_id` requests, ~40 tracks.

Raising the cap only moves the wall (his chat needs ~35 pages), and removing the guard reintroduces #257's chronological hole. So the endpoint gained a forward cursor (`after_id`) and the queue is now **anchored on the playing track's own media id** and extended on demand in the direction playback is moving. Both directions are contiguous with that anchor by construction — no cap is needed for correctness, and a chat of any size plays through.

### Contiguity is now declared, not assumed

Fixing this surfaced the same defect class three more times, each in a different view. Rather than enumerating the sparse views — a blacklist that is wrong by default — contiguity became a positive property:

- only a producer that rebuilt the list as a real slice of the timeline may declare it contiguous;
- **anything else defaults to sparse**, including any view added later by someone unaware of this constraint;
- appends are checked at the single `upsertMessages` chokepoint: a page that does not adjoin the window clears the flag.

That last one closed two paths that had gone unnoticed — the refresh poll is bounded at 50, so more than 50 messages arriving between ticks punches a permanent hole in the window (reproduced: the threshold is exactly 51), and a websocket message after a reconnect gap can land arbitrarily far away with no backfill.

## #267 — duration wrapped one character per line

`.message-bubble` sets `overflow-wrap: anywhere`, which drops a flex item's min-content width to a single glyph. (Without that, `word-break: normal` would not split `0:12` at all — UAX#14 forbids breaking between digits around a colon.) The filename escaped through `truncate`; the duration and playback-status spans had no protection. Measured: span height 20px vs 80px before, bubble 64px vs 124px.

Two v7.32.0 changes made a latent defect visible — the #261 download button consumed horizontal space, and the #263 capture fix made durations non-null for the first time.

## #268 — reply quote showed no sender

The block rendered only `reply_to_text`, falling back to the literal "Message" — which is every reply to a media message. It never rendered a sender at all. Now shows the replied-to sender and a media-kind label, resolved for a whole page in one query (no N+1, proven by a query-count test), degrading cleanly when the replied-to message is not in the archive. The pinned list uses the same enrichment, so the two views no longer disagree.

## #265 — retries without reconnecting

Reported on 7.22.0; verified still present on 7.32.0 and reproduced by executing the retry wrapper. Telethon's sender gives up after ~55s (5 attempts, each bounded by a 10s connect timeout), calls `_disconnect`, and sets `_user_connected = False` — after which its own `_start_reconnect` is guarded off, so it **never retries again** until something calls `connect()`. Only the scheduled job did, so an outage longer than that budget could leave downloads failing until the next run (up to 6h on the default schedule), with the listener restarting into the same error indefinitely.

Connection failures now heal before the retry budget is spent, across every call shape used here — including Telethon's raw-request form, where the callable *is* the client. The message iterator previously caught only `FloodWaitError`, so a connection error abandoned the whole chat on the first failure. Healing takes a lock so the watchdog cannot swap the client out from under a backup that is mid-run.

## Verification

Suite **2671 passed** (2561 on v7.32.0), ruff clean, both inline `<script>` blocks parse.

Because this repo's frontend tests are string assertions — which have shipped a broken feature with green CI more than once — the queue behaviour was verified two further ways:

- **Real browser**, 704-voice-note chat: **692 tracks walked** unattended from the old end, `nonMonotonic = 0` across 691 transitions, largest date step 0.5h (equal to the seeded spacing, so provably no hole), 12 forward pages. Zero console errors.
- **Executed-JS probes** driving the real template functions, with counterfactuals: forcing the contiguity flag true reproduces skipping (`100 → 104 → 108 → 400 → 404 → 405`), and every new test was proven load-bearing by reverting its hunk.

Four review rounds ran; each found a defect of the same class in the previous round's fix, and each fix was then verified by mutation rather than assertion.

Closes #265, #266, #267, #268

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added forward media pagination with `after_id` cursors.
  - Reply previews now include sender names and media types when available.
  - Improved audio queue navigation with bidirectional paging and safer playback continuity.
- **Bug Fixes**
  - Improved connection recovery during reconnects, scheduled tasks, and transient failures.
  - Message iteration now resumes reliably after connection interruptions.
  - Improved sender-name fallbacks and media metadata display.
  - Connection logs no longer expose account names or phone numbers.
- **Chores**
  - Updated the project version to 7.33.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->