### PR TITLE
fix(viewer): stop the bubble stretch rule from eating the audio row (#270)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.33.0"
+version = "7.33.1"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.33.0"
+__version__ = "7.33.1"

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -124,10 +124,19 @@
             overflow-x: hidden;
         }
 
+        /* Media and full-width link cards stretch to the bubble. The `a` arm is
+           why an icon-sized anchor needs an opt-out: this selector is (0,1,1),
+           which OUTRANKS a Tailwind `w-9` utility at (0,1,0), so `width: 100%`
+           silently wins over the utility and `shrink-0` then protects that
+           100% basis instead of the intended 36px. The anchor eats the row and
+           its `min-w-0 flex-1` sibling is starved to 0, which is invisible
+           rather than merely ugly (a `truncate` child paints nothing at 0
+           width). Any anchor that must keep its own size opts out with
+           `bubble-icon-action`. */
         .message-bubble img,
         .message-bubble video,
         .message-bubble audio,
-        .message-bubble a,
+        .message-bubble a:not(.bubble-icon-action),
         .message-bubble .media-wrapper {
             max-width: 100%;
             width: 100%;
@@ -1377,7 +1386,7 @@
                                                 </button>
                                                 <div class="min-w-0 flex-1">
                                                     <div class="flex items-center gap-2 text-xs text-gray-300">
-                                                        <span>🎵</span>
+                                                        <span class="shrink-0">🎵</span>
                                                         <span class="truncate">{{ getDocumentDisplayName(msg) }}</span>
                                                     </div>
                                                     <!-- #267: every span in this row needs whitespace-nowrap.
@@ -1410,7 +1419,7 @@
                                                     :download="getDocumentDisplayName(msg)"
                                                     @click.stop
                                                     :aria-label="'Download ' + getDocumentDisplayName(msg)"
-                                                    class="w-9 h-9 shrink-0 rounded-full flex items-center justify-center text-gray-300 hover:text-white hover:bg-white/10 transition focus:outline-none focus:ring-2 focus:ring-blue-400">
+                                                    class="bubble-icon-action w-9 h-9 shrink-0 rounded-full flex items-center justify-center text-gray-300 hover:text-white hover:bg-white/10 transition focus:outline-none focus:ring-2 focus:ring-blue-400">
                                                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                                                             d="M12 4v12m0 0l-4-4m4 4l4-4M4 20h16"></path>

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -125,14 +125,15 @@
         }
 
         /* Media and full-width link cards stretch to the bubble. The `a` arm is
-           why an icon-sized anchor needs an opt-out: this selector is (0,1,1),
-           which OUTRANKS a Tailwind `w-9` utility at (0,1,0), so `width: 100%`
-           silently wins over the utility and `shrink-0` then protects that
-           100% basis instead of the intended 36px. The anchor eats the row and
-           its `min-w-0 flex-1` sibling is starved to 0, which is invisible
-           rather than merely ugly (a `truncate` child paints nothing at 0
-           width). Any anchor that must keep its own size opts out with
-           `bubble-icon-action`. */
+           why an icon-sized anchor needs an opt-out: the plain `.message-bubble a`
+           this replaces is (0,1,1), which OUTRANKS a Tailwind `w-9` utility at
+           (0,1,0), so `width: 100%` silently won over the utility and `shrink-0`
+           then protected that 100% basis instead of the intended 36px. The anchor
+           ate the row and its `min-w-0 flex-1` sibling was starved to 0, which is
+           invisible rather than merely ugly (a `truncate` child paints nothing at
+           0 width). Any anchor that must keep its own size opts out with
+           `bubble-icon-action`; adding that `:not()` raises this arm to (0,2,1),
+           which only widens the gap over the utility it must not beat. */
         .message-bubble img,
         .message-bubble video,
         .message-bubble audio,

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -4243,3 +4243,49 @@ class TestAudioBubbleDownload(unittest.TestCase):
         """#263: duration already exists on the bubble — no duplicate element."""
         bubble = self._audio_bubble()
         self.assertEqual(bubble.count("formatAudioTime(msg.media.duration)"), 1)
+
+
+class TestAudioBubbleDownloadKeepsFixedSize(unittest.TestCase):
+    """#270: the round #261 download anchor was stretched to fill its row.
+
+    ``.message-bubble a`` is (0,1,1) specificity, which OUTRANKS the Tailwind
+    ``w-9`` utility at (0,1,0). Without the ``:not(.bubble-icon-action)``
+    exclusion, ``width: 100%`` silently wins over the 36px utility, and
+    ``shrink-0`` then protects that 100% basis instead of the intended 36px:
+    the anchor eats the row and its ``min-w-0 flex-1`` sibling (icon +
+    filename + duration) is starved to 0px width — invisible, since
+    ``truncate`` paints nothing at 0 width, not merely ugly.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.html = INDEX_HTML.read_text(encoding="utf-8")
+
+    def _bubble_media_rule(self) -> str:
+        rule_start = self.html.index(".message-bubble img,")
+        return self.html[rule_start : self.html.index("}", rule_start)]
+
+    def _download_anchor_tag(self) -> str:
+        start = self.html.index('<div v-else-if="isAudioFile(msg)"')
+        bubble = self.html[start : self.html.index("<!-- GIFs / Animations", start)]
+        anchor_start = bubble.index('<a v-if="!noDownload && getMediaUrl(msg)"')
+        return bubble[anchor_start : bubble.index(">", anchor_start) + 1]
+
+    def test_the_anchor_arm_of_the_stretch_rule_excludes_icon_actions(self) -> None:
+        """If ``:not(.bubble-icon-action)`` is dropped, every icon anchor in
+        ``.message-bubble`` (not just the download button) silently gets
+        stretched to 100% width/height:auto again."""
+        rule = self._bubble_media_rule()
+        self.assertIn(".message-bubble a:not(.bubble-icon-action),", rule)
+
+    def test_the_download_anchor_opts_out_via_the_icon_action_class(self) -> None:
+        """Without ``bubble-icon-action`` on the anchor itself, the CSS
+        exclusion above has nothing to match and the anchor is stretched
+        exactly as it was pre-fix."""
+        anchor = self._download_anchor_tag()
+        self.assertIn("bubble-icon-action", anchor)
+        # The opt-out is meaningless without the actual 36px sizing utilities
+        # it is meant to protect.
+        self.assertIn("w-9", anchor)
+        self.assertIn("h-9", anchor)
+        self.assertIn("shrink-0", anchor)

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -4289,3 +4289,18 @@ class TestAudioBubbleDownloadKeepsFixedSize(unittest.TestCase):
         self.assertIn("w-9", anchor)
         self.assertIn("h-9", anchor)
         self.assertIn("shrink-0", anchor)
+
+    def test_the_note_icon_cannot_be_squeezed_out_of_the_filename_row(self) -> None:
+        """The bare emoji span was the last unprotected item in that row.
+
+        It is a flex item beside a ``truncate`` filename, and ``.message-bubble``
+        sets ``overflow-wrap: anywhere``, which drops a text box's min-content
+        width to a single character — so without ``shrink-0`` the icon can be
+        squeezed away whenever the row is under pressure, the same class of bug
+        as the duration spans in #267.
+        """
+        start = self.html.index('<div v-else-if="isAudioFile(msg)"')
+        bubble = self.html[start : self.html.index("<!-- GIFs / Animations", start)]
+        icon_start = bubble.index("🎵")
+        icon_span = bubble[bubble.rindex("<span", 0, icon_start) : icon_start]
+        self.assertIn("shrink-0", icon_span)


### PR DESCRIPTION
Fixes the audio bubble's invisible filename and oversized download hover area, both reported by @625801.

## Cause

A CSS specificity collision. The media-stretch rule's anchor arm is `(0,1,1)`, which outranks a Tailwind `w-9` utility at `(0,1,0)`:

```css
.message-bubble a { max-width: 100%; width: 100%; height: auto; }
```

So the round download anchor introduced in v7.32.0 (#261) was given `width: 100%`, and `shrink-0` then defended *that* basis instead of 36px. The anchor took the row and its `min-w-0 flex-1` sibling was starved to 0 — hiding the filename outright, because a `truncate` element paints nothing at zero width.

Both symptoms are real; neither of the mechanisms proposed in the report is what actually happens. `shrink-0` **is** present on the anchor and always has been. That matters, because "add shrink-0" would have changed nothing.

## Fix

Anchors that carry their own size opt out of the stretch rule via `bubble-icon-action`. I used an explicit marker class rather than `a:not(.shrink-0)` — keying a layout rule off a utility class would silently alter any future anchor that happens to use `shrink-0`.

Also gave the note icon `shrink-0`; it was the last unprotected item in that row.

## Verification

Measured in headless Chrome at 1280 / 600 / 453 / 390 / 360 (results identical at every width — the bubble is `inline-block` shrink-to-fit, so this was never viewport-specific):

| element | before | after |
|---|---|---|
| download `<a>` | 209.3 x 16 | **36 x 36** |
| `div.min-w-0.flex-1` | 0 x 40 | 129.3 x 40 |
| filename span | 0 x 16 (blank) | 106.3 x 16, visible, ellipsized |
| play `<button>` | 40 x 40 | 40 x 40 (unchanged) |

Checked for collateral damage: the two anchors that legitimately span the bubble — the image-preview download link and the generic-document card — still render full width. An audit of every `<a>` in the template found no other icon-sized anchor inside a bubble, so nothing else needed the opt-out.

Two regression tests added, each proven to fail with its own hunk reverted. Suite 2675, ruff clean, both inline `<script>` blocks parse.

Closes #270

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message bubble media layout by allowing media links to use the available width.
  * Preserved compact sizing for audio controls and per-message download buttons.

* **Tests**
  * Added coverage to verify audio download controls retain their fixed-size appearance.

* **Chores**
  * Updated the project version to 7.33.1.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->