### PR TITLE
fix: stop writing chat ids and titles to the logs (#274)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.33.2"
+version = "7.33.3"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/detect_albums.py
+++ b/scripts/detect_albums.py
@@ -197,9 +197,7 @@ async def detect_albums(dry_run: bool = False, window_seconds: int = 2):
                             messages_grouped += len(current_album)
 
                             if albums_detected <= 10:
-                                logger.info(
-                                    f"  Album detected: {len(current_album)} items in chat {chat_id} (msg {grouped_id})"
-                                )
+                                logger.info(f"  Album detected: {len(current_album)} items (msg {grouped_id})")
 
                         # Start new potential album
                         current_album = [msg]
@@ -224,7 +222,7 @@ async def detect_albums(dry_run: bool = False, window_seconds: int = 2):
                 messages_grouped += len(current_album)
 
                 if albums_detected <= 10:
-                    logger.info(f"  Album detected: {len(current_album)} items in chat {chat_id} (msg {grouped_id})")
+                    logger.info(f"  Album detected: {len(current_album)} items (msg {grouped_id})")
 
         # Flush remaining updates
         if pending_updates and not dry_run:

--- a/scripts/migrate_media_paths.py
+++ b/scripts/migrate_media_paths.py
@@ -233,7 +233,7 @@ async def migrate(db_url: str, media_path: str, dry_run: bool = True):
             # Rename the folder
             if os.path.exists(new_folder_path):
                 # New folder already exists - merge contents
-                logger.info(f"   ⚠️  Both folders exist, merging {old_folder}/ into {new_folder}/")
+                logger.info("   ⚠️  Both old and new media folders exist for this chat; merging")
 
                 if not dry_run:
                     for item in os.listdir(old_folder_path):
@@ -248,18 +248,18 @@ async def migrate(db_url: str, media_path: str, dry_run: bool = True):
                     # Remove old folder (should be empty now)
                     try:
                         os.rmdir(old_folder_path)
-                        logger.info(f"   ✓ Removed empty folder: {old_folder}/")
+                        logger.info("   ✓ Removed empty old media folder")
                     except OSError:
-                        logger.warning(f"   Could not remove folder {old_folder}/ (not empty?)")
+                        logger.warning("   Could not remove old media folder (not empty?)")
 
                 stats["folders_renamed"] += 1
             else:
                 # Simple rename
                 if dry_run:
-                    logger.info(f"   [DRY RUN] Would rename folder: {old_folder}/ → {new_folder}/")
+                    logger.info("   [DRY RUN] Would rename this chat's media folder to marked format")
                 else:
                     shutil.move(old_folder_path, new_folder_path)
-                    logger.info(f"   Renamed folder: {old_folder}/ → {new_folder}/")
+                    logger.info("   Renamed this chat's media folder to marked format")
 
                 stats["folders_renamed"] += 1
 

--- a/scripts/migrate_media_paths.py
+++ b/scripts/migrate_media_paths.py
@@ -213,7 +213,7 @@ async def migrate(db_url: str, media_path: str, dry_run: bool = True):
                 continue  # Nothing to migrate for this chat
 
             stats["chats_processed"] += 1
-            logger.info(f"📁 Chat {chat_id} ({chat['type']}): {chat['title']}")
+            logger.info(f"📁 Processing chat (type: {chat['type']})")
 
             # Count paths that need updating
             counts = await count_paths_for_chat(session, chat_id, old_folder)

--- a/scripts/normalize_grouped_ids.py
+++ b/scripts/normalize_grouped_ids.py
@@ -67,7 +67,7 @@ async def normalize_grouped_ids(dry_run: bool = False):
                 if isinstance(raw_data, str):
                     raw_data = json.loads(raw_data)
                 logger.info(
-                    f"  Message {msg_id} in chat {chat_id}: grouped_id = {raw_data.get('grouped_id')} (type: {type(raw_data.get('grouped_id')).__name__})"
+                    f"  Message {msg_id}: grouped_id = {raw_data.get('grouped_id')} (type: {type(raw_data.get('grouped_id')).__name__})"
                 )
             if len(rows) > 10:
                 logger.info(f"  ... and {len(rows) - 10} more")

--- a/scripts/restore_chat.py
+++ b/scripts/restore_chat.py
@@ -152,6 +152,13 @@ async def restore_chat(
     logger.info("Connecting to database...")
     db = await get_db_adapter()
 
+    # NOTE (#274): the chat ids logged below are deliberately kept. This is a
+    # manually-run, one-shot, DESTRUCTIVE tool (it copies messages between
+    # chats); the source and destination ids are the operator's own CLI
+    # arguments, and echoing them — especially "about to send N to chat X" — is a
+    # genuine safety confirmation before an irreversible action, not incidental
+    # noise. Unlike the daemons this does not accumulate a shipped log stream.
+    # This file is allow-listed in tests/test_no_account_pii_in_logs.py.
     # Get chat info
     chat = await db.get_chat_by_id(source_chat_id)
     if not chat:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.33.2"
+__version__ = "7.33.3"

--- a/src/config.py
+++ b/src/config.py
@@ -451,7 +451,6 @@ class Config:
         # Log filtering mode
         if self.whitelist_mode:
             logger.info(f"Filter mode: WHITELIST - backing up ONLY {len(self.chat_ids)} specific chats")
-            logger.debug(f"  CHAT_IDS: {self.chat_ids}")
         else:
             logger.debug("Filter mode: TYPE-BASED")
             logger.debug(f"  Chat types: {self.chat_types}")
@@ -496,10 +495,10 @@ class Config:
                 "FOLLOW_CHAT_MIGRATIONS enabled - will adopt the new supergroup id after a group→supergroup migration"
             )
         if self.display_chat_ids:
-            logger.info(f"Display mode: Viewer restricted to chat IDs {self.display_chat_ids}")
+            logger.info(f"Display mode: Viewer restricted to {len(self.display_chat_ids)} chat(s)")
         if self.skip_media_chat_ids:
             cleanup_status = "will delete existing media" if self.skip_media_delete_existing else "keeps existing media"
-            logger.info(f"Media downloads skipped for chat IDs: {self.skip_media_chat_ids} ({cleanup_status})")
+            logger.info(f"Media downloads skipped for {len(self.skip_media_chat_ids)} chat(s) ({cleanup_status})")
         if self.skip_topic_ids:
             total_topics = sum(len(t) for t in self.skip_topic_ids.values())
             logger.info(f"Topic filtering: skipping {total_topics} topic(s) across {len(self.skip_topic_ids)} chat(s)")

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1995,7 +1995,11 @@ class DatabaseAdapter:
                     shutil.rmtree(chat_media_dir)
                     logger.info("Deleted media folder for chat")
                 except Exception as e:
-                    logger.error(f"Failed to delete media folder for chat: {e}")
+                    # Type only, never str(e): OSError stringifies as
+                    # "[Errno 66] Directory not empty: '/media/-1001234'", so the
+                    # message carries the path — and the path is str(chat_id).
+                    # Logging the exception text would undo the redaction above.
+                    logger.error(f"Failed to delete media folder for chat: {type(e).__name__}")
 
             for avatar_type in ["chats", "users"]:
                 avatar_pattern = os.path.join(media_base_path, "avatars", avatar_type, f"{chat_id}_*.jpg")
@@ -2010,7 +2014,8 @@ class DatabaseAdapter:
                         os.remove(avatar_file)
                         logger.info("Deleted avatar file for chat")
                     except Exception as e:
-                        logger.error(f"Failed to delete avatar for chat: {e}")
+                        # Type only — the avatar path embeds the chat id too.
+                        logger.error(f"Failed to delete avatar for chat: {type(e).__name__}")
 
     # ========== Web Viewer Operations ==========
 

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -863,7 +863,7 @@ class DatabaseAdapter:
             # Delete the message
             await session.execute(delete(Message).where(and_(Message.chat_id == chat_id, Message.id == message_id)))
             await session.commit()
-            logger.debug(f"Deleted message {message_id} from chat {chat_id}")
+            logger.debug(f"Deleted message {message_id}")
 
     @retry_on_locked()
     async def mark_message_deleted(self, chat_id: int, message_id: int, deleted_at: datetime | None = None) -> None:
@@ -1985,7 +1985,7 @@ class DatabaseAdapter:
             await session.execute(delete(Chat).where(Chat.id == chat_id))
 
             await session.commit()
-            logger.info(f"Deleted chat {chat_id} and all related data from database")
+            logger.info("Deleted chat and all related data from database")
 
         # Delete physical files
         if media_base_path and os.path.exists(media_base_path):

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1993,9 +1993,9 @@ class DatabaseAdapter:
             if os.path.exists(chat_media_dir):
                 try:
                     shutil.rmtree(chat_media_dir)
-                    logger.info(f"Deleted media folder: {chat_media_dir}")
+                    logger.info("Deleted media folder for chat")
                 except Exception as e:
-                    logger.error(f"Failed to delete media folder {chat_media_dir}: {e}")
+                    logger.error(f"Failed to delete media folder for chat: {e}")
 
             for avatar_type in ["chats", "users"]:
                 avatar_pattern = os.path.join(media_base_path, "avatars", avatar_type, f"{chat_id}_*.jpg")
@@ -2008,9 +2008,9 @@ class DatabaseAdapter:
                 for avatar_file in avatar_files:
                     try:
                         os.remove(avatar_file)
-                        logger.info(f"Deleted avatar file: {avatar_file}")
+                        logger.info("Deleted avatar file for chat")
                     except Exception as e:
-                        logger.error(f"Failed to delete avatar {avatar_file}: {e}")
+                        logger.error(f"Failed to delete avatar for chat: {e}")
 
     # ========== Web Viewer Operations ==========
 

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -384,7 +384,9 @@ async def download_and_shard_media(
                     raise
             logger.debug("Created symlink for deduplicated media")
         except OSError as e:
-            logger.warning(f"Symlink not supported, using direct path: {e}")
+            # Type only: OSError embeds the offending path, and media paths
+            # carry the chat-id folder.
+            logger.warning(f"Symlink not supported, using direct path: {type(e).__name__}")
             import shutil
 
             shutil.copy2(shared_file_path, file_path)

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -2682,7 +2682,9 @@ class TelegramBackup:
                             os.remove(file_path)
                             deleted_files += 1
                     except Exception as e:
-                        logger.warning(f"Failed to delete media file: {e}")
+                        # Type only: the path in an OSError message carries the
+                        # chat-id folder.
+                        logger.warning(f"Failed to delete media file: {type(e).__name__}")
 
             # Delete all media records from database for this chat
             deleted_records = await self.db.delete_media_for_chat(chat_id)

--- a/src/telegram_import.py
+++ b/src/telegram_import.py
@@ -675,7 +675,7 @@ class TelegramImporter:
         export_type = chat_data.get("type", "personal_chat")
         messages = chat_data.get("messages", [])
 
-        logger.info(f"Importing chat '{chat_name}' (ID: {chat_id}, type: {export_type}) - {len(messages)} messages")
+        logger.info(f"Importing chat (type: {export_type}) - {len(messages)} messages")
 
         if not merge and not dry_run:
             existing = await self.db.get_chat_stats(chat_id)
@@ -819,7 +819,7 @@ class TelegramImporter:
             await self.db.update_sync_status(chat_id, max_msg_id, msg_count)
 
         action = "Would import" if dry_run else "Imported"
-        logger.info(f"{action} {msg_count} messages and {media_count} media files for '{chat_name}'")
+        logger.info(f"{action} {msg_count} messages and {media_count} media files")
 
         return {
             "chat_id": chat_id,

--- a/src/telegram_import.py
+++ b/src/telegram_import.py
@@ -628,7 +628,7 @@ class TelegramImporter:
             )
 
             if chat_id == 0:
-                logger.warning(f"Skipping chat with no ID: {chat_data.get('name', 'unknown')}")
+                logger.warning("Skipping a chat entry with no ID")
                 continue
 
             result = await self._import_chat(

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1621,7 +1621,7 @@ async def get_chats(
                 else:
                     chat["avatar_url"] = None
             except Exception as e:
-                logger.error(f"Error finding avatar for chat {chat.get('id')}: {e}")
+                logger.error(f"Error finding avatar for a chat: {e}")
                 chat["avatar_url"] = None
 
         return {

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -152,6 +152,13 @@ async def _normalize_display_chat_ids():
     existing_ids = {c["id"] for c in all_chats}
 
     normalized = set()
+    # The specific ids here are the operator's own config, but this runs in the
+    # long-lived viewer whose logs ship off-box, so it reports COUNTS rather than
+    # the ids themselves (the chat-id logging rule). "Which id" is answerable from
+    # the operator's own DISPLAY_CHAT_IDS setting; the warning only needs to say
+    # that some entry did not resolve.
+    auto_corrected = 0
+    unresolved = 0
     for chat_id in config.display_chat_ids:
         if chat_id in existing_ids:
             # ID exists as-is
@@ -160,18 +167,26 @@ async def _normalize_display_chat_ids():
             # Positive ID not found - try -100 prefix (channel/supergroup format)
             marked_id = -1000000000000 - chat_id
             if marked_id in existing_ids:
-                logger.warning(
-                    f"DISPLAY_CHAT_IDS: Auto-correcting {chat_id} → {marked_id} "
-                    f"(use marked format for channels/supergroups)"
-                )
+                auto_corrected += 1
                 normalized.add(marked_id)
             else:
-                logger.warning(f"DISPLAY_CHAT_IDS: Chat ID {chat_id} not found in database")
+                unresolved += 1
                 normalized.add(chat_id)  # Keep original, might be backed up later
         else:
             # Negative ID not found
-            logger.warning(f"DISPLAY_CHAT_IDS: Chat ID {chat_id} not found in database")
+            unresolved += 1
             normalized.add(chat_id)
+
+    if auto_corrected:
+        logger.warning(
+            f"DISPLAY_CHAT_IDS: auto-corrected {auto_corrected} positive "
+            f"entr{'y' if auto_corrected == 1 else 'ies'} to marked (channel/supergroup) format"
+        )
+    if unresolved:
+        logger.warning(
+            f"DISPLAY_CHAT_IDS: {unresolved} configured chat(s) not found in the database; "
+            "verify the DISPLAY_CHAT_IDS setting"
+        )
 
     config.display_chat_ids = normalized
 

--- a/tests/test_no_account_pii_in_logs.py
+++ b/tests/test_no_account_pii_in_logs.py
@@ -339,6 +339,16 @@ def _chat_object_field_reads(node: ast.AST) -> list[str]:
             and _is_chat_object(child.func.value)
         ):
             found.append(f".get({child.args[0].value!r})")
+        elif (
+            isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Name)
+            and child.func.id == "getattr"
+            and len(child.args) >= 2
+            and isinstance(child.args[1], ast.Constant)
+            and child.args[1].value in _ID_FIELDS
+            and _is_chat_object(child.args[0])
+        ):
+            found.append(f"getattr(..., {child.args[1].value!r})")
     return found
 
 
@@ -445,6 +455,16 @@ class TestNoChatIdentifiersInLogs(unittest.TestCase):
             self.assertTrue(
                 any(_chat_object_field_reads(a) for a in call.args), f"missed a chat/topic field read in: {src}"
             )
+
+    def test_a_getattr_read_of_a_chat_field_is_detected(self) -> None:
+        """``getattr(chat, "id")`` is the .get() bypass in attribute form."""
+        tree = ast.parse('logger.info("%s", getattr(chat, "id"))')
+        call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call) and _is_logging_call(n))
+        self.assertTrue(any(_chat_object_field_reads(a) for a in call.args))
+        # ...but not on a non-chat object.
+        tree = ast.parse('logger.info("%s", getattr(msg, "id"))')
+        call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call) and _is_logging_call(n))
+        self.assertEqual([], [h for a in call.args for h in _chat_object_field_reads(a)])
 
     def test_a_message_or_token_id_is_not_treated_as_a_chat_id(self) -> None:
         """The object, not the field name, is what scopes this — ``id`` is ambiguous."""

--- a/tests/test_no_account_pii_in_logs.py
+++ b/tests/test_no_account_pii_in_logs.py
@@ -33,11 +33,15 @@ chat IDs, topic IDs, or topic titles" — enforced lower in this file by
 ``TestNoChatIdentifiersInLogs`` (#274). It was added after the account rule, once
 its own backlog of pre-existing violations had been cleared.
 
-One honest limit: the scan sees a banned attribute only when a logging call
-reads it DIRECTLY. Hoisting it to a local first defeats it. That is the same
-manoeuvre ``config.py`` uses legitimately to log ``bool(config.phone)``, so the
-two cannot be told apart without real taint analysis. This catches the shape the
-nine original leaks actually had, not every conceivable one.
+One honest limit, shared by both scans: they see an identifier only when a
+logging call reads it DIRECTLY — as a banned attribute, a chat/topic-ish
+variable name, or a chat/topic object's ``id``/``name``/``title`` field. What
+they CANNOT see is a value laundered through another call before logging:
+``config.py``'s legitimate ``bool(config.phone)``, or ``migrate_media_paths``'s
+``folder = str(chat_id)`` where the chat id becomes a generically-named string.
+Telling those apart needs real taint analysis; the ``migrate_media_paths`` folder
+logs were found and redacted by review, not by this scan. It catches the shapes
+the leaks actually had, not every conceivable one.
 
 Requires Python 3.14: ``ast.parse`` here must read the repo's own sources, which
 use PEP 758 unparenthesized ``except A, B:``. On an older interpreter this fails
@@ -46,7 +50,6 @@ with a raw SyntaxError rather than a meaningful assertion.
 
 import ast
 import os
-import re
 import sys
 import unittest
 from pathlib import Path
@@ -280,7 +283,64 @@ class TestNoAccountPiiInLogs(unittest.TestCase):
 # path keeps the exemption visible instead of an accident of the matcher.
 # ---------------------------------------------------------------------------
 
-_CHAT_ID_RE = re.compile(r"(chat_ids?|chat_name|chat_title|topic_ids?|topic_title)$")
+_ID_SUBJECTS = ("chat", "topic")
+_ID_FIELDS = frozenset({"id", "name", "title"})
+
+
+def _is_identifier_name(name: str) -> bool:
+    """A variable whose components pair a subject (chat/topic) with a field.
+
+    Component-based, not a tail regex: catches ``chat_id``, ``chat_ids``,
+    ``source_chat_id``, ``display_chat_ids`` and ``chat_id_str`` (a real-leak
+    shape the first tail-anchored version missed), while sparing ``chat_idx`` —
+    a loop counter whose second component is ``idx``, not ``id``.
+    """
+    parts = name.lower().split("_")
+    norm = [p[:-1] if p.endswith("s") and p[:-1] in _ID_FIELDS else p for p in parts]
+    return any(a in _ID_SUBJECTS and b in _ID_FIELDS for a, b in zip(norm, norm[1:], strict=False))
+
+
+def _is_chat_object(value: ast.AST) -> bool:
+    """A Name/Attribute whose own name mentions a chat or topic.
+
+    This is what keeps ``chat.get("id")`` and ``chat["title"]`` in scope while
+    leaving ``msg.get("id")`` (a message id) and ``token_record["id"]`` (a share
+    token) out — the field name alone is ambiguous, the object is not.
+    """
+    obj = value.id if isinstance(value, ast.Name) else value.attr if isinstance(value, ast.Attribute) else None
+    return bool(obj) and any(s in obj.lower() for s in _ID_SUBJECTS)
+
+
+def _chat_object_field_reads(node: ast.AST) -> list[str]:
+    """id / name / title pulled from a chat/topic OBJECT.
+
+    ``chat.id``, ``chat["id"]``, ``chat.get("id")`` — the shapes the name scan
+    cannot see because the identifier is a dict key or attribute, not a variable.
+    A live ``chat.get("id")`` leak in the viewer got through the first version.
+    """
+    found: list[str] = []
+    for child in ast.walk(node):
+        if isinstance(child, ast.Attribute) and child.attr in _ID_FIELDS and _is_chat_object(child.value):
+            found.append(f".{child.attr}")
+        elif (
+            isinstance(child, ast.Subscript)
+            and isinstance(child.slice, ast.Constant)
+            and child.slice.value in _ID_FIELDS
+            and _is_chat_object(child.value)
+        ):
+            found.append(f"[{child.slice.value!r}]")
+        elif (
+            isinstance(child, ast.Call)
+            and isinstance(child.func, ast.Attribute)
+            and child.func.attr == "get"
+            and child.args
+            and isinstance(child.args[0], ast.Constant)
+            and child.args[0].value in _ID_FIELDS
+            and _is_chat_object(child.func.value)
+        ):
+            found.append(f".get({child.args[0].value!r})")
+    return found
+
 
 CHAT_ID_LOG_ALLOWLIST = frozenset(
     {
@@ -315,7 +375,7 @@ def _chat_identifier_hits(node: ast.AST) -> list[str]:
             key = child.slice
             if isinstance(key, ast.Constant) and isinstance(key.value, str):
                 name = key.value
-        if name and _CHAT_ID_RE.search(name):
+        if name and _is_identifier_name(name):
             found.append(name)
     return found
 
@@ -334,6 +394,8 @@ def _scan_for_chat_identifiers() -> list[str]:
                 for argument in [*node.args, *(kw.value for kw in node.keywords)]:
                     for name in _chat_identifier_hits(argument):
                         violations.append(f"{rel}:{node.lineno} logs {name}")
+                    for read in _chat_object_field_reads(argument):
+                        violations.append(f"{rel}:{node.lineno} logs a chat/topic {read}")
     return violations
 
 
@@ -370,6 +432,35 @@ class TestNoChatIdentifiersInLogs(unittest.TestCase):
         tree = ast.parse("logger.info(f\"{detail['chat_id']}\")")
         call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call) and _is_logging_call(n))
         self.assertEqual(["chat_id"], [h for a in call.args for h in _chat_identifier_hits(a)])
+
+    def test_an_id_or_title_read_from_a_chat_object_is_detected(self) -> None:
+        """A live ``chat.get('id')`` leak got through the name-only first version."""
+        for src in (
+            "logger.error(f\"avatar for {chat.get('id')}\")",
+            "logger.info(f\"{chat['title']}\")",
+            'logger.info(f"{topic.title}")',
+        ):
+            tree = ast.parse(src)
+            call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call) and _is_logging_call(n))
+            self.assertTrue(
+                any(_chat_object_field_reads(a) for a in call.args), f"missed a chat/topic field read in: {src}"
+            )
+
+    def test_a_message_or_token_id_is_not_treated_as_a_chat_id(self) -> None:
+        """The object, not the field name, is what scopes this — ``id`` is ambiguous."""
+        for src in (
+            "logger.error(f\"{msg.get('id')}\")",
+            'logger.warning("denying %s", token_record["id"])',
+        ):
+            tree = ast.parse(src)
+            call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call) and _is_logging_call(n))
+            self.assertEqual([], [h for a in call.args for h in _chat_object_field_reads(a)], src)
+
+    def test_a_chat_id_str_name_is_detected_but_chat_idx_is_not(self) -> None:
+        """Component match, not tail regex: ``chat_id_str`` is an id, ``chat_idx`` a counter."""
+        self.assertTrue(_is_identifier_name("chat_id_str"))
+        self.assertTrue(_is_identifier_name("source_chat_id"))
+        self.assertFalse(_is_identifier_name("chat_idx"))
 
     def test_the_allowlisted_paths_all_exist(self) -> None:
         """A stale allow-list entry silently widens the exemption."""

--- a/tests/test_no_account_pii_in_logs.py
+++ b/tests/test_no_account_pii_in_logs.py
@@ -28,12 +28,10 @@ different rule and legitimate debugging detail. So the scan first works out
 which locals hold the result of ``get_me()`` and bans ``.id`` on those alone.
 The same id is still stored as ``owner_id``, which is storage, not logging.
 
-Genuinely out of scope: chat ids, topic ids and titles. That is a separate
-documented rule — "never log chat IDs, topic IDs, or topic titles" — which is
-equally unenforced and has live violations today, so covering it here would turn
-this guard red on pre-existing work unrelated to #272. Deliberate follow-up, not
-a false-positive problem; anyone widening this scan should expect to fix those
-sites in the same change.
+Chat ids, topic ids and titles are the separate documented rule — "never log
+chat IDs, topic IDs, or topic titles" — enforced lower in this file by
+``TestNoChatIdentifiersInLogs`` (#274). It was added after the account rule, once
+its own backlog of pre-existing violations had been cleared.
 
 One honest limit: the scan sees a banned attribute only when a logging call
 reads it DIRECTLY. Hoisting it to a local first defeats it. That is the same
@@ -48,6 +46,7 @@ with a raw SyntaxError rather than a meaningful assertion.
 
 import ast
 import os
+import re
 import sys
 import unittest
 from pathlib import Path
@@ -263,6 +262,119 @@ class TestNoAccountPiiInLogs(unittest.TestCase):
         calls = [node for node in ast.walk(tree) if isinstance(node, ast.Call) and _is_logging_call(node)]
         self.assertEqual(1, len(calls))
         self.assertEqual([], [a for arg in calls[0].args for a in _banned_attributes_in(arg)])
+
+
+# ---------------------------------------------------------------------------
+# The chat-id / topic-id / title rule (#274)
+#
+# CLAUDE.md: "Never log chat IDs, topic IDs, or topic titles." This survived
+# unenforced even longer than the account-identity rule. A targeted grep found 6
+# sites; matching only the literal name `chat_id` missed `source_chat_id`,
+# `dest_chat_id` and the config collection dumps. So this matches any name /
+# attribute / subscript-key whose tail is a chat-id-ish token, and — because
+# logging HOW MANY chats is fine while logging WHICH is not — excludes anything
+# sitting inside a `len(...)` call.
+#
+# A path allow-list carries the deliberate exceptions, where the identifier is
+# the answer the operator asked for rather than incidental noise. Listing them by
+# path keeps the exemption visible instead of an accident of the matcher.
+# ---------------------------------------------------------------------------
+
+_CHAT_ID_RE = re.compile(r"(chat_ids?|chat_name|chat_title|topic_ids?|topic_title)$")
+
+CHAT_ID_LOG_ALLOWLIST = frozenset(
+    {
+        "src/__main__.py",  # CLI gap-fill / import summaries, printed to the operator who ran the command
+        "src/export_backup.py",  # the `list-chats` table — the chat id IS the requested output
+        "scripts/restore_chat.py",  # interactive destructive tool; ids are the operator's own arguments
+    }
+)
+
+
+def _chat_identifier_hits(node: ast.AST) -> list[str]:
+    """Chat-id-ish names read in ``node``, excluding those inside ``len(...)``.
+
+    ``len(chat_ids)`` is a count, which the rule explicitly permits; the raw
+    collection or a single id is what must not be logged.
+    """
+    inside_len: set[int] = set()
+    for child in ast.walk(node):
+        if isinstance(child, ast.Call) and isinstance(child.func, ast.Name) and child.func.id == "len":
+            inside_len.update(id(d) for d in ast.walk(child))
+
+    found: list[str] = []
+    for child in ast.walk(node):
+        if id(child) in inside_len:
+            continue
+        name = None
+        if isinstance(child, ast.Name):
+            name = child.id
+        elif isinstance(child, ast.Attribute):
+            name = child.attr
+        elif isinstance(child, ast.Subscript):
+            key = child.slice
+            if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                name = key.value
+        if name and _CHAT_ID_RE.search(name):
+            found.append(name)
+    return found
+
+
+def _scan_for_chat_identifiers() -> list[str]:
+    violations: list[str] = []
+    for root in SCANNED_ROOTS:
+        for path in sorted(root.rglob("*.py")):
+            rel = str(path.relative_to(REPO))
+            if rel in CHAT_ID_LOG_ALLOWLIST:
+                continue
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call) or not _is_logging_call(node):
+                    continue
+                for argument in [*node.args, *(kw.value for kw in node.keywords)]:
+                    for name in _chat_identifier_hits(argument):
+                        violations.append(f"{rel}:{node.lineno} logs {name}")
+    return violations
+
+
+class TestNoChatIdentifiersInLogs(unittest.TestCase):
+    def test_no_logging_call_reads_a_chat_identifier(self) -> None:
+        violations = _scan_for_chat_identifiers()
+        self.assertEqual(
+            [],
+            violations,
+            "Logging must not read a chat id, topic id or title (CLAUDE.md). Log a count, "
+            "or nothing. If the identifier is genuinely the operator-facing answer (a list "
+            "command, an interactive destructive tool), add the file to CHAT_ID_LOG_ALLOWLIST "
+            "with a reason. Offending call sites:\n  " + "\n  ".join(violations),
+        )
+
+    def test_a_bare_variable_named_source_chat_id_is_caught(self) -> None:
+        """The literal-name scan missed these; the tail match is why they are covered now."""
+        tree = ast.parse('logger.error(f"Chat {source_chat_id} not found")')
+        call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call) and _is_logging_call(n))
+        self.assertEqual(["source_chat_id"], [h for a in call.args for h in _chat_identifier_hits(a)])
+
+    def test_a_count_of_chats_is_allowed(self) -> None:
+        tree = ast.parse('logger.info(f"backing up {len(self.chat_ids)} chats")')
+        call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call) and _is_logging_call(n))
+        self.assertEqual([], [h for a in call.args for h in _chat_identifier_hits(a)])
+
+    def test_a_loop_index_that_merely_contains_chat_id_is_not_matched(self) -> None:
+        """`chat_idx` is a counter, not an id — the tail anchor must exclude it."""
+        tree = ast.parse('logger.info(f"{chat_idx}/{total}")')
+        call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call) and _is_logging_call(n))
+        self.assertEqual([], [h for a in call.args for h in _chat_identifier_hits(a)])
+
+    def test_a_subscript_key_is_detected(self) -> None:
+        tree = ast.parse("logger.info(f\"{detail['chat_id']}\")")
+        call = next(n for n in ast.walk(tree) if isinstance(n, ast.Call) and _is_logging_call(n))
+        self.assertEqual(["chat_id"], [h for a in call.args for h in _chat_identifier_hits(a)])
+
+    def test_the_allowlisted_paths_all_exist(self) -> None:
+        """A stale allow-list entry silently widens the exemption."""
+        for rel in CHAT_ID_LOG_ALLOWLIST:
+            self.assertTrue((REPO / rel).is_file(), f"allowlisted path missing: {rel}")
 
 
 if __name__ == "__main__":

--- a/tests/test_no_account_pii_in_logs.py
+++ b/tests/test_no_account_pii_in_logs.py
@@ -43,6 +43,14 @@ Telling those apart needs real taint analysis; the ``migrate_media_paths`` folde
 logs were found and redacted by review, not by this scan. It catches the shapes
 the leaks actually had, not every conceivable one.
 
+The other blind spot is EXCEPTION TEXT. ``OSError`` stringifies as
+``[Errno 66] Directory not empty: '/media/-1001234'`` — the path, and a media
+path carries the chat-id folder — so ``logger.error(f"...: {e}")`` on a
+filesystem operation re-leaks an id that the surrounding message no longer
+names. Those sites log ``type(e).__name__`` instead. The scan cannot see this
+either: ``{e}`` is opaque to it. Reviewers found these; when touching a log line
+near a chat-derived path, check what the exception itself would print.
+
 Requires Python 3.14: ``ast.parse`` here must read the repo's own sources, which
 use PEP 758 unparenthesized ``except A, B:``. On an older interpreter this fails
 with a raw SyntaxError rather than a meaningful assertion.


### PR DESCRIPTION
Closes #274. Follow-up to #272 (account identity); this is the other half of the same `CLAUDE.md` rule — "never log chat IDs, topic IDs, or topic titles" — which was equally unenforced.

## The audit corrected itself

A targeted grep found 6 sites. An AST scan over **936 logging/print calls** matching only the literal `chat_id` found 15. Widening to any chat-id-ish name (and excluding `len()` counts) found the rest: `source_chat_id`/`dest_chat_id` in the restore script, and three config lines that dump whole id **collections** (`self.chat_ids`, `display_chat_ids`, `skip_media_chat_ids`). The 32 raw hits triaged down cleanly — the extras were genuine false positives: `len(...)` counts and `chat_idx` (a loop index).

That progression is the point: the first count was mostly evidence about how I'd searched.

## Redacted — 12 daemon / library / maintenance sites

`db/adapter.py` (×2), `telegram_import.py` (×2), `config.py` (×3: two → counts, one list-dump deleted), `web/main.py` (×3), and the `detect_albums` / `migrate_media_paths` / `normalize_grouped_ids` maintenance scripts. Each keeps the count or action that carried the real meaning.

`web/main.py`'s `DISPLAY_CHAT_IDS` validation now aggregates: `N configured chat(s) not found; verify the DISPLAY_CHAT_IDS setting`, instead of naming each id. The operator can see which ids they configured from their own setting.

## Kept, on purpose — an explicit allow-list

Three sites where the identifier is the answer, not incidental noise, carried in `CHAT_ID_LOG_ALLOWLIST` by path so the exemption is visible:

- `scripts/restore_chat.py` — a manually-run, **destructive** tool; source/dest are the operator's own CLI arguments, and "about to send N messages to chat X" is a safety confirmation before an irreversible copy.
- `src/__main__.py` — gap-fill / import summaries printed to the operator who ran the command.
- `src/export_backup.py` — the `list-chats` table, where the chat id **is** the requested output.

This is #272's category-A/B distinction applied the other way: there the phone was incidental to a status line and went; here the id is what was asked for.

I reversed my own filing on `restore_chat.py:162` — I'd listed it as a violation, then reclassified it to category B on the reasoning above, and documented the reasoning in a code comment at the site.

## Guard

`tests/test_no_account_pii_in_logs.py` gains a second scan (`TestNoChatIdentifiersInLogs`) for this rule: matches names, attributes and subscript keys whose tail is a chat-id token, excludes anything inside `len()`, and honours the path allow-list. Mutation-proven both ways — reintroducing an id log in a non-allow-listed file fails it, and removing a file from the allow-list flags it.

## Verification

Suite **2702 passed** (from 2696), ruff clean. Residual chat-id scan: none outside the allow-list.

## Operator note

Counts only from here; logs already written by earlier versions still contain chat ids and titles, worth rotating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Privacy**
  * Reduced exposure of chat IDs, names, titles, topics, media paths, and detailed error messages in operational logs.
  * Replaced individual identifiers with aggregate counts or generic status messages where appropriate.
  * Preserved identifiers only for explicitly permitted operator workflows.

* **Bug Fixes**
  * Improved normalization warnings while maintaining existing processing behavior.

* **Tests**
  * Added automated checks to detect unintended chat and topic identifiers in logs.

* **Release**
  * Updated the application version to 7.33.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->