### PR TITLE
fix: stop Windows-invalid media filenames from failing downloads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "7.33.4"
+version = "7.33.5"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "7.33.4"
+__version__ = "7.33.5"

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -83,20 +83,42 @@ def compute_directory_size(path: str) -> int:
     return total
 
 
+# Characters Windows rejects in filenames beyond the path separators handled via
+# basename(): the reserved punctuation set. Control chars (0x00-0x1F) are handled
+# alongside; both raise OSError [Errno 22] at file creation on Windows (#280).
+_WINDOWS_RESERVED_CHARS = frozenset('<>:"|?*')
+
+# Device names Windows refuses to create as files, with or without an extension
+# (``CON.pdf`` fails the same way ``CON`` does). Compared case-insensitively
+# against the portion before the first dot.
+_WINDOWS_RESERVED_NAMES = frozenset(
+    {"CON", "PRN", "AUX", "NUL", *(f"COM{i}" for i in range(1, 10)), *(f"LPT{i}" for i in range(1, 10))}
+)
+
+
 def sanitize_media_filename(name: str) -> str:
-    """Strip path components from an attacker-controlled media filename.
+    """Strip path components and OS-invalid characters from a media filename.
 
     Telegram document ``file_name`` attributes are remote-controlled and may
     contain ``/``, ``\\``, or ``..`` segments. Left unchecked these survive into
     ``media.file_name`` and later into on-disk ``os.replace`` targets, allowing a
     write outside the media store (#175 repair pass made this reachable). Collapse
     to a bare basename and neutralise residual traversal/separators.
+
+    Windows additionally rejects control characters (``\\n``, ``\\r``, ...) and
+    the ``<>:"|?*`` set with ``OSError [Errno 22]`` at ``.part`` creation, and
+    silently strips trailing dots/spaces (so the on-disk name would no longer
+    match the recorded one). Sanitize those on every platform so the computed
+    name stays deterministic and archives stay portable across OSes (#280).
     """
     name = name.replace("\\", "/")
     name = os.path.basename(name)
-    name = name.replace("\x00", "")
+    name = "".join("_" if ord(ch) < 32 or ch in _WINDOWS_RESERVED_CHARS else ch for ch in name)
+    name = name.rstrip(". ")
     if name in ("", ".", ".."):
         return "_"
+    if name.split(".", 1)[0].upper() in _WINDOWS_RESERVED_NAMES:
+        return f"_{name}"
     return name
 
 
@@ -148,6 +170,10 @@ def build_media_filename(file_id: str, original_name: str, name_max_bytes: int) 
 
     # Truncate the stem to the byte budget without splitting a multibyte codepoint.
     safe_stem = stem.encode("utf-8")[:budget].decode("utf-8", errors="ignore")
+    if not ext:
+        # With no extension the stem ends the filename, and a truncation cut can
+        # leave a trailing dot/space there — invalid on Windows (#280).
+        safe_stem = safe_stem.rstrip(". ")
     if not safe_stem:
         digest = hashlib.sha1(safe_name.encode("utf-8")).hexdigest()[:8]
         return f"{safe_id}_{digest}{ext}"

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -90,9 +90,19 @@ _WINDOWS_RESERVED_CHARS = frozenset('<>:"|?*')
 
 # Device names Windows refuses to create as files, with or without an extension
 # (``CON.pdf`` fails the same way ``CON`` does). Compared case-insensitively
-# against the portion before the first dot.
+# against the portion before the first dot. Windows treats the ISO 8859-1
+# superscript digits as digits in device names, so COM¹/LPT³ are reserved too.
 _WINDOWS_RESERVED_NAMES = frozenset(
-    {"CON", "PRN", "AUX", "NUL", *(f"COM{i}" for i in range(1, 10)), *(f"LPT{i}" for i in range(1, 10))}
+    {
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        *(f"COM{i}" for i in range(1, 10)),
+        *(f"COM{s}" for s in "¹²³"),
+        *(f"LPT{i}" for i in range(1, 10)),
+        *(f"LPT{s}" for s in "¹²³"),
+    }
 )
 
 

--- a/tests/test_media_filename.py
+++ b/tests/test_media_filename.py
@@ -3,7 +3,12 @@ and fallback_media_filename (backup/listener ingest-path parity)."""
 
 from unittest.mock import MagicMock, patch
 
-from src.message_utils import _MEDIA_PART_SUFFIX_RESERVE, build_media_filename, fallback_media_filename
+from src.message_utils import (
+    _MEDIA_PART_SUFFIX_RESERVE,
+    build_media_filename,
+    fallback_media_filename,
+    sanitize_media_filename,
+)
 
 SYNOLOGY_BUDGET = 143
 
@@ -194,3 +199,78 @@ def test_backup_and_listener_fallback_filenames_match():
         backup_result = backup._get_media_filename(msg, media_type, telegram_file_id)
         listener_result = listener._get_media_filename(msg, media_type, telegram_file_id)
         assert backup_result == listener_result, f"Mismatch for {media_type}/{mime_type}/{telegram_file_id}"
+
+
+# --- #280: Windows-invalid characters in Telegram file_name ---
+
+
+def test_control_characters_replaced_with_underscore():
+    """Newline/CR in file_name raised OSError [Errno 22] on Windows at .part creation (#280)."""
+    result = sanitize_media_filename("Werner Furrer\nKlima-Wandel?\rKlima-Schwindel!.pdf")
+
+    assert result == "Werner Furrer_Klima-Wandel__Klima-Schwindel!.pdf"
+
+
+def test_windows_reserved_punctuation_replaced():
+    """The <>:"|?* set fails file creation on Windows exactly like control chars."""
+    result = sanitize_media_filename('a<b>c:d"e|f?g*h.txt')
+
+    assert result == "a_b_c_d_e_f_g_h.txt"
+
+
+def test_every_ascii_control_char_is_neutralized():
+    for code in range(32):
+        name = f"a{chr(code)}b.bin"
+        result = sanitize_media_filename(name)
+        assert result == "a_b.bin", f"control char {code:#04x} survived: {result!r}"
+
+
+def test_trailing_dots_and_spaces_stripped():
+    """Win32 silently strips trailing dots/spaces, desyncing disk name from recorded name."""
+    assert sanitize_media_filename("report.pdf. ") == "report.pdf"
+    assert sanitize_media_filename("notes. . .") == "notes"
+    assert sanitize_media_filename("...") == "_"
+
+
+def test_windows_reserved_device_names_prefixed():
+    """CON/NUL/COM1... fail creation on Windows even with an extension attached."""
+    assert sanitize_media_filename("CON") == "_CON"
+    assert sanitize_media_filename("con.pdf") == "_con.pdf"
+    assert sanitize_media_filename("Nul.tar.gz") == "_Nul.tar.gz"
+    assert sanitize_media_filename("COM7.log") == "_COM7.log"
+    # Near-misses must pass through untouched.
+    assert sanitize_media_filename("CONFERENCE.pdf") == "CONFERENCE.pdf"
+    assert sanitize_media_filename("COM10.log") == "COM10.log"
+    assert sanitize_media_filename(".config") == ".config"
+
+
+def test_normal_names_unchanged():
+    """The sanitizer must not disturb ordinary names (determinism/dedup contract)."""
+    for name in ("photo_2024.jpg", "Informe fiscal (año 2025).pdf", "видео.mp4", "no_extension"):
+        assert sanitize_media_filename(name) == name
+
+
+def test_issue_280_full_path_via_build():
+    """End to end through build_media_filename: the composed name must be Windows-creatable."""
+    result = build_media_filename("5276091715084619737", "Werner Furrer\nKlima-Wandel?\rKlima-Schwindel!.pdf", 255)
+
+    assert result.startswith("5276091715084619737_")
+    assert not any(ord(ch) < 32 for ch in result)
+    assert not any(ch in '<>:"|?*' for ch in result)
+    assert result.endswith(".pdf")
+
+
+def test_truncated_extensionless_stem_cannot_end_with_dot_or_space():
+    """A truncation cut landing inside an INTERNAL dot/space run must not leave a dot/space end (#280).
+
+    The run sits mid-name (sanitize's own rstrip only sees the far tail), and the
+    oversized fake extension forces the ext="" path, so only the truncation guard
+    in build_media_filename can prevent a Windows-invalid trailing dot.
+    """
+    name = "a" * 80 + ". . ." + "b" * 40  # splitext ext is >16 bytes -> treated as extensionless
+    budget = _MEDIA_PART_SUFFIX_RESERVE + len("1_") + 83  # cut lands on the run's second dot
+    result = build_media_filename("1", name, budget)
+
+    assert result == "1_" + "a" * 80
+    assert not result.endswith(".")
+    assert not result.endswith(" ")

--- a/tests/test_media_filename.py
+++ b/tests/test_media_filename.py
@@ -238,6 +238,10 @@ def test_windows_reserved_device_names_prefixed():
     assert sanitize_media_filename("con.pdf") == "_con.pdf"
     assert sanitize_media_filename("Nul.tar.gz") == "_Nul.tar.gz"
     assert sanitize_media_filename("COM7.log") == "_COM7.log"
+    # Windows parses ISO 8859-1 superscript digits as digits in device names:
+    # `echo test > COM¹` fails the same way COM1 does (MS file-naming docs).
+    assert sanitize_media_filename("COM¹.pdf") == "_COM¹.pdf"
+    assert sanitize_media_filename("lpt³") == "_lpt³"
     # Near-misses must pass through untouched.
     assert sanitize_media_filename("CONFERENCE.pdf") == "CONFERENCE.pdf"
     assert sanitize_media_filename("COM10.log") == "COM10.log"

--- a/uv.lock
+++ b/uv.lock
@@ -1192,7 +1192,7 @@ wheels = [
 
 [[package]]
 name = "telegram-archive"
-version = "7.33.4"
+version = "7.33.5"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Problem

On Windows, a Telegram document whose `file_name` contains a newline or carriage return — @WalterLederer's real example: `Werner Furrer\nKlima-Wandel?\rKlima-Schwindel!.pdf` — blows up at `.part` file creation with `OSError: [Errno 22] Invalid argument`. The download retries five times and permanently fails. `sanitize_media_filename()` only stripped path separators and NUL, so every other Windows-invalid character sailed through. Closes #280.

## Fix

`sanitize_media_filename()` now neutralises the full set Windows rejects, not just the two characters from the report — note the example filename itself also contains `?`, which fails on Windows exactly the same way, so a control-chars-only fix would have left the reporter's own PDF still failing:

- control characters (0x00–0x1F) and the reserved punctuation `<>:"|?*` → `_`
- trailing dots/spaces stripped (Win32 silently drops them, which would desync the on-disk name from the recorded one)
- reserved device names (`CON`, `NUL`, `COM1`…, extension included — `con.pdf` fails too) get a `_` prefix
- `build_media_filename()` gets a matching guard for the one path that can reintroduce a trailing dot: a truncation cut landing inside a dot/space run when the name has no extension

Sanitization is deliberately unconditional (not `os.name == "nt"`): `build_media_filename` is documented as a pure function of its inputs so retries/dedup recompute identical names, and platform-conditional names would break that the moment an archive moves between OSes.

## Compatibility

Existing archives are unaffected for serving: the viewer resolves media from the `file_path` stored at download time, never by recomputing. The only behavioural edge is media re-forwarded later whose old name contained one of these characters — it recomputes to the new sanitized name and stores one fresh copy.

## Verification

- The reporter's exact filename now sanitizes to `Werner Furrer_Klima-Wandel__Klima-Schwindel!.pdf` and composes end-to-end through `build_media_filename` with zero Windows-invalid characters.
- 8 new regression tests, including one per character class; the truncation guard is mutation-proven (reverting it turns the new test red).
- Full suite: 2725 passed + 171 subtests. `ruff check` + `ruff format --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media filename sanitization for Windows-invalid characters, control characters, trailing dots and spaces, and reserved device names.
  * Prevented truncated filenames from ending with invalid characters.
  * Preserved valid filenames and supported safe handling of empty or basename-only names.

* **Tests**
  * Added regression coverage for media filename sanitization and truncation scenarios.

* **Chores**
  * Updated the project version to 7.33.5.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->