### PR TITLE
fix: stop one unreadable attachment from freezing a chat's backup forever

### DIFF
--- a/src/listener.py
+++ b/src/listener.py
@@ -678,8 +678,14 @@ class TelegramListener:
         elif isinstance(media, MessageMediaDocument):
             # Check document attributes to determine specific type
             if hasattr(media, "document") and media.document:
+                # DocumentEmpty is truthy but carries no .attributes at all. Its reference
+                # is unusable, so treat it exactly like a missing document rather than
+                # classifying it as a real one and sending it down the download path.
+                attributes = getattr(media.document, "attributes", None)
+                if attributes is None:
+                    return None
                 is_animated = False
-                for attr in media.document.attributes:
+                for attr in attributes:
                     attr_type = type(attr).__name__
                     if "Animated" in attr_type:
                         is_animated = True
@@ -712,7 +718,7 @@ class TelegramListener:
         if hasattr(message.media, "document") and message.media.document:
             doc = message.media.document
             mime_type = getattr(doc, "mime_type", None)
-            for attr in doc.attributes:
+            for attr in getattr(doc, "attributes", None) or ():
                 if hasattr(attr, "file_name") and attr.file_name:
                     original_name = attr.file_name
                     break

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -3119,8 +3119,14 @@ class TelegramBackup:
         elif isinstance(media, MessageMediaDocument):
             # Check document attributes to determine specific type
             if hasattr(media, "document") and media.document:
+                # DocumentEmpty is truthy but carries no .attributes at all. Its reference
+                # is unusable, so treat it exactly like a missing document rather than
+                # classifying it as a real one and sending it down the download path.
+                attributes = getattr(media.document, "attributes", None)
+                if attributes is None:
+                    return None
                 is_animated = False
-                for attr in media.document.attributes:
+                for attr in attributes:
                     attr_type = type(attr).__name__
                     if "Animated" in attr_type:
                         is_animated = True
@@ -3160,7 +3166,7 @@ class TelegramBackup:
             doc = message.media.document
             mime_type = getattr(doc, "mime_type", None)
 
-            for attr in doc.attributes:
+            for attr in getattr(doc, "attributes", None) or ():
                 if hasattr(attr, "file_name") and attr.file_name:
                     original_name = attr.file_name
                     break
@@ -3321,7 +3327,7 @@ class TelegramBackup:
                                 self.client, GetCustomEmojiDocumentsRequest(document_id=emoji_ids)
                             )
                             for doc in docs:
-                                for attr in doc.attributes:
+                                for attr in getattr(doc, "attributes", None) or ():
                                     if hasattr(attr, "alt") and attr.alt:
                                         emoji_map[doc.id] = attr.alt
                                         break

--- a/tests/test_poison_message_isolation.py
+++ b/tests/test_poison_message_isolation.py
@@ -1,0 +1,79 @@
+"""Unreadable documents must never crash a capture path.
+
+Telegram returns ``documentEmpty`` for a document that is no longer retrievable.
+Telethon deserializes that into ``DocumentEmpty``, which is truthy but carries no
+``.attributes``. Walking it raises ``AttributeError``, which used to abort the whole
+dialog in the sweep and drop the message outright in the listener -- and because the
+sync cursor is checkpointed before the offending message, every later run resumed at
+the same message and failed the same way, so that chat never advanced again.
+
+These tests pin the defensive probe in every copy of the pattern.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from telethon.tl.types import DocumentEmpty, MessageMediaDocument
+
+from src.listener import TelegramListener
+from src.telegram_backup import TelegramBackup
+
+
+def _poison_media():
+    """The exact shape Telegram sends for an expired document."""
+    return MessageMediaDocument(document=DocumentEmpty(id=99887766))
+
+
+class TestDocumentEmptyIsNotFatal(unittest.TestCase):
+    """Both capture paths classify an expired document instead of raising."""
+
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.listener = TelegramListener.__new__(TelegramListener)
+
+    def test_documentempty_is_truthy_but_has_no_attributes(self):
+        """Guard the assumption the whole bug rests on."""
+        doc = DocumentEmpty(id=99887766)
+        self.assertTrue(doc, "DocumentEmpty is truthy, which is why the guard is needed")
+        self.assertFalse(hasattr(doc, "attributes"))
+
+    def test_backup_get_media_type_returns_none(self):
+        self.assertIsNone(self.backup._get_media_type(_poison_media()))
+
+    def test_listener_get_media_type_returns_none(self):
+        self.assertIsNone(self.listener._get_media_type(_poison_media()))
+
+    def test_backup_get_media_filename_does_not_raise(self):
+        message = MagicMock()
+        message.reply_to = None
+        message.id = 4242
+        message.media = _poison_media()
+        name = self.backup._get_media_filename(message, "document", telegram_file_id="fid1")
+        self.assertIsInstance(name, str)
+        self.assertTrue(name)
+
+    def test_listener_get_media_filename_does_not_raise(self):
+        message = MagicMock()
+        message.reply_to = None
+        message.id = 4242
+        message.media = _poison_media()
+        name = self.listener._get_media_filename(message, "document", telegram_file_id="fid1")
+        self.assertIsInstance(name, str)
+        self.assertTrue(name)
+
+    def test_real_document_still_classified(self):
+        """Positive control for the guard itself: a normal document is unaffected."""
+        attr = MagicMock()
+        attr.file_name = "report.pdf"
+        type(attr).__name__ = "DocumentAttributeFilename"
+        document = MagicMock()
+        document.attributes = [attr]
+        document.mime_type = "application/pdf"
+        media = MagicMock(spec=MessageMediaDocument)
+        media.document = document
+        self.assertEqual(self.backup._get_media_type(media), "document")
+        self.assertEqual(self.listener._get_media_type(media), "document")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The problem

If Telegram ever hands back an attachment it can no longer retrieve, that chat stops being backed up — permanently — and the log still says the backup succeeded.

Telegram represents an unretrievable document as `documentEmpty`. Telethon turns that into `DocumentEmpty`, which is truthy but has no `.attributes`, so the media probe raised `AttributeError` while walking it.

What that cost:

- **In the scheduled sweep**, the exception aborted the entire dialog. The sync cursor had last been checkpointed *before* the offending message, so the next run resumed at the same message and failed identically. Every message newer than it was never archived, on any future run.
- **In the real-time listener**, the classification runs one line before the insert, so the message was dropped entirely — text included, with no row written.
- **Gap-fill cannot rescue it.** Gap detection only compares rows that already exist, so a missing tail is structurally invisible, and the gap-fill path calls the same failing code anyway.
- The run still printed `Backup completed successfully!`, and the PII policy strips chat identity from the error line, so an operator seeing it cannot tell which chat is stuck.

## The fix

An unusable document reference is now treated exactly like a missing one, which is the behaviour this code already documents for `document=None`.

Worth noting: simply guarding the attribute walk is *not* enough. With an empty iterable the loop body never runs and control falls through to `return "document"`, which would classify an expired attachment as a real one and send it down the download path. The document has to be recognised as unusable and returned as such.

The same unguarded walk existed in **four** other places — both `_get_media_filename` copies and the custom-emoji resolver. All of them now use the defensive form `message_utils.py` was already using; that file had the correct pattern all along and it had never been mirrored into the others.

## Verification

- New regression test asserts the classification in both capture paths and that neither filename builder raises.
- **Positive control:** reverting the guard reproduces the original failure exactly — `AttributeError: 'DocumentEmpty' object has no attribute 'attributes'` at `src/listener.py:682` — and restoring it goes green. The test was watched failing before it was trusted.
- Full suite: **2731 passed**, 171 subtests, 0 failures (baseline was 2725).
- `ruff check` and `ruff format --check` both clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete or expired media documents during backup and message capture.
  * Prevented errors when document metadata is missing.
  * Ensured unsupported media is skipped safely while valid documents continue to be recognized.
  * Preserved safe filename handling for documents without metadata.

* **Tests**
  * Added coverage for expired documents and standard document processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->