### PR TITLE
docs: refresh install pins, changelog, env reference, and contributor docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -234,7 +234,10 @@ VERIFY_MEDIA=false
 # Both backup and viewer containers MUST use the same database settings.
 
 # Option 1: Full DATABASE_URL (takes priority over all below)
-# SQLite:     DATABASE_URL=sqlite:///data/telegram_backup.db
+# SQLite paths need FOUR slashes to be absolute. Three slashes is a path
+# relative to the container's working directory (/app), which is NOT the
+# mounted volume — the archive would be lost on the next container recreate.
+# SQLite:     DATABASE_URL=sqlite:////data/backups/telegram_backup.db
 # PostgreSQL: DATABASE_URL=postgresql://user:password@localhost:5432/telegram_backup
 
 # Option 2: Individual settings

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,7 @@ Examples:
 
 ### Pull Requests
 
-1. Create a feature branch from `master`
+1. Create a feature branch from `main` (the default branch)
 2. Make your changes
 3. Run tests: `python -m pytest tests/ -v`
 4. Run linting: `ruff check .`

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@
 
 ## 🗺️ Roadmap
 
-See **[docs/CHANGELOG.md](docs/CHANGELOG.md)** for complete version history.
+See **[docs/ROADMAP.md](docs/ROADMAP.md)** for what's planned, and
+**[docs/CHANGELOG.md](docs/CHANGELOG.md)** for complete version history.
 
 Have a feature request? [Open an issue](https://github.com/GeiserX/Telegram-Archive/issues)!
 
@@ -154,7 +155,7 @@ docker run -it --rm \
   -e TELEGRAM_PHONE=+YOUR_PHONE_NUMBER \
   -e SESSION_NAME=telegram_backup \
   -v /path/to/your/session:/data/session \
-  drumsergio/telegram-archive:7.7.0 \
+  drumsergio/telegram-archive:7.33.6 \
   python -m src auth
 ```
 
@@ -165,7 +166,7 @@ docker run -it --rm \
 docker run -it --rm \
   --env-file .env \
   -v ./data:/data \
-  drumsergio/telegram-archive:7.7.0 \
+  drumsergio/telegram-archive:7.33.6 \
   python -m src auth
 
 # Then restart the backup container
@@ -206,7 +207,7 @@ The standalone viewer image (`drumsergio/telegram-archive-viewer`) lets you brow
 # Example: Viewer-only deployment
 services:
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:7.7.0
+    image: drumsergio/telegram-archive-viewer:7.33.6
     ports:
       - "127.0.0.1:8000:8000"
     environment:
@@ -253,6 +254,9 @@ The **Scope** column shows whether each variable applies to the backup scheduler
 | `MEDIA_MAX_FILENAME_BYTES` | `143` | B | Usable filename byte budget for downloaded media. Raise to `255` on plain ext4/xfs; keep `143` for Synology/eCryptfs encrypted shares |
 | `MEDIA_MAX_DOWNLOAD_ATTEMPTS` | `5` | B | Stop retrying a file's download after this many failed attempts. Re-requesting the download resets the counter |
 | `MEDIA_FLOOD_SLEEP_THRESHOLD` | `60` | B | Mid-download FloodWaits up to this many seconds are absorbed in place so the transfer resumes instead of restarting from byte 0 (issue #232). `0` restores the old raise-immediately behavior. Absorbed pauses count toward `DOWNLOAD_TIMEOUT_SECONDS` |
+| `DOWNLOAD_TIMEOUT_SECONDS` | `3600` | B | Give up on a single media download after this many seconds. `0` disables the timeout |
+| `MEDIA_REFRESH_MAX_ATTEMPTS` | `3` | B | How many times a media item whose file reference expired is re-fetched and retried before it is left for the next scheduled run |
+| `MEDIA_REFRESH_TIMEOUT_SECONDS` | `120` | B | Upper bound on one message-refresh round trip, so a wedged connection cannot stall the run |
 | `PARALLEL_DOWNLOAD_ENABLED` | `false` | B | Fetch large files over several connections to lift the single-stream speed cap (see below) |
 | `PARALLEL_DOWNLOAD_MIN_SIZE_MB` | `20` | B | Only files at least this large use the parallel path (min 1) |
 | `PARALLEL_DOWNLOAD_CONNECTIONS` | `4` | B | Concurrent connections per file (clamped 2–8) |
@@ -261,21 +265,32 @@ The **Scope** column shows whether each variable applies to the backup scheduler
 | `CHECKPOINT_INTERVAL` | `1` | B | Save backup progress every N batch inserts (lower = safer resume after crash) |
 | `DATABASE_TIMEOUT` | `60.0` | B/V | Database operation timeout in seconds |
 | `SESSION_NAME` | `telegram_backup` | B | Telethon session file name |
+| `SESSION_DIR` | `/data/session` | B | Directory holding the session file. Defaults to a `session/` directory alongside `BACKUP_PATH` |
 | `DEDUPLICATE_MEDIA` | `true` | B | Symlink identical media files across chats to save disk space |
 | `SYNC_DELETIONS_EDITS` | `false` | B | Batch-check ALL messages for edits/deletions each run (expensive!) |
 | `VERIFY_MEDIA` | `false` | B | Re-download missing or corrupted media files |
+| `FILL_GAPS` | `false` | B | After each scheduled backup, look for runs of missing message IDs and fetch them |
+| `GAP_THRESHOLD` | `50` | B | How many consecutive missing message IDs count as a gap worth filling |
 | `STATS_CALCULATION_HOUR` | `3` | B | Hour (0-23) to recalculate backup statistics daily |
 | `PRIORITY_CHAT_IDS` | - | B | Comma-separated chat IDs to process first in all operations |
 | `SKIP_MEDIA_CHAT_IDS` | - | B | Skip media downloads for specific chats (messages still backed up with text) |
 | `SKIP_MEDIA_DELETE_EXISTING` | `true` | B | Delete existing media files and DB records for chats in skip list to reclaim storage |
 | `SKIP_TOPIC_IDS` | - | B | Skip specific topics in forum supergroups (format: `chat_id:topic_id,...`) |
 | `LOG_LEVEL` | `INFO` | B/V | Logging verbosity: `DEBUG`, `INFO`, `WARNING`/`WARN`, `ERROR` |
+| **Flood & Retry Tuning** | | | |
+| `MAX_FLOOD_RETRIES` | `5` | B | How many times a Telegram call is retried after a FloodWait before it gives up |
+| `MAX_FLOOD_WAIT_SECONDS` | `3600` | B | A FloodWait longer than this is not waited out — the call fails instead |
+| `BACKOFF_MIN_SECONDS` | `2.0` | B | First delay of the exponential backoff used for transient connection errors |
+| `BACKOFF_MAX_SECONDS` | `300.0` | B | Ceiling for that backoff delay |
+| `FLOOD_WAIT_LOG_THRESHOLD` | `10` | B | FloodWaits shorter than this are routine and logged at `DEBUG` instead of `WARNING`. `0` logs every one |
 | **Chat Filtering** | | | See [Chat Filtering](#chat-filtering) below |
 | `CHAT_IDS` | - | B | **Whitelist mode**: backup ONLY these chats (ignores all other filters) |
 | `WHITELIST_RESOLVE_DIALOG_LIMIT` | `1000` | B | When a `CHAT_IDS` entry cannot be resolved (typically a DM on a fresh session), scan up to this many dialogs once to warm the entity cache — it then resolves permanently (issue #234). `0` disables |
 | `CHAT_TYPES` | `private,groups,channels` | B | **Type-based mode**: comma-separated chat types to backup |
 | `GLOBAL_EXCLUDE_CHAT_IDS` | - | B | Exclude specific chats (any type) |
 | `GLOBAL_INCLUDE_CHAT_IDS` | - | B | Force-include specific chats (any type) |
+| `EXCLUDE_CHAT_IDS` | - | B | Legacy alias for `GLOBAL_EXCLUDE_CHAT_IDS`, read only when that variable is unset or empty |
+| `INCLUDE_CHAT_IDS` | - | B | Legacy alias for `GLOBAL_INCLUDE_CHAT_IDS`, read only when that variable is unset or empty |
 | `PRIVATE_EXCLUDE_CHAT_IDS` | - | B | Exclude specific private chats |
 | `PRIVATE_INCLUDE_CHAT_IDS` | - | B | Force-include specific private chats |
 | `GROUPS_EXCLUDE_CHAT_IDS` | - | B | Exclude specific groups |
@@ -310,6 +325,7 @@ The **Scope** column shows whether each variable applies to the backup scheduler
 | `POSTGRES_USER` | `telegram` | B/V | PostgreSQL username |
 | `POSTGRES_PASSWORD` | - | B/V | PostgreSQL password (required when using PostgreSQL) |
 | `POSTGRES_DB` | `telegram_backup` | B/V | PostgreSQL database name |
+| `DB_ECHO` | `false` | B/V | Log every SQL statement. Debugging only — extremely verbose |
 | **Viewer & Authentication** | | | |
 | `VIEWER_USERNAME` | - | V | Master web viewer username |
 | `VIEWER_PASSWORD` | - | V | Master web viewer password |
@@ -325,11 +341,13 @@ The **Scope** column shows whether each variable applies to the backup scheduler
 | `VIEWER_PORT` | `8080` | B | Viewer port for SQLite realtime push from backup/listener |
 | `VIEWER_TIMEZONE` | `Europe/Madrid` | V | Timezone for displayed timestamps ([tz database names](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)) |
 | `SHOW_STATS` | `true` | V | Show backup statistics dropdown in viewer header |
+| `THUMBNAIL_CACHE_DIR` | `$BACKUP_PATH/media/.thumbs` | V | Where generated thumbnails are cached. Falls back to `/tmp/telegram-archive-thumbs` when the media directory is not writable |
 | **Security** | | | |
 | `CORS_ORIGINS` | `*` | V | Allowed CORS origins, comma-separated (e.g., `https://my.domain.com`). Credentials auto-disabled when `*` |
 | `SECURE_COOKIES` | `auto` | V | `Secure` flag on auth cookies. Auto-detects from request protocol (`X-Forwarded-Proto` / scheme). Override with `true` or `false` |
 | **Notifications** | | | |
 | `PUSH_NOTIFICATIONS` | `basic` | V | `off` = disabled, `basic` = in-browser only, `full` = Web Push (works with browser closed) |
+| `ENABLE_NOTIFICATIONS` | `false` | V | Older master switch kept for compatibility. Notifications are active when this is `true` **or** `PUSH_NOTIFICATIONS` is `basic`/`full` — prefer `PUSH_NOTIFICATIONS` |
 | `VAPID_PRIVATE_KEY` | *auto-generated* | V | Custom VAPID private key for Web Push |
 | `VAPID_PUBLIC_KEY` | *auto-generated* | V | Custom VAPID public key for Web Push |
 | `VAPID_CONTACT` | `mailto:admin@example.com` | V | Contact email included in Web Push requests |
@@ -470,6 +488,13 @@ Telegram Archive supports **SQLite** (default, zero-config) and **PostgreSQL** (
 
 **SQLite path resolution** (highest priority first): `DATABASE_URL` → `DATABASE_PATH` → `DATABASE_DIR` → `DB_PATH` → `$BACKUP_PATH/telegram_backup.db`
 
+> **Using `DATABASE_URL` for SQLite? Count the slashes.** Four slashes is an absolute
+> path; three is a path relative to the container's working directory (`/app`), which
+> is not the mounted volume — the archive would be written outside your data directory
+> and lost on the next container recreate. Use
+> `DATABASE_URL=sqlite:////data/backups/telegram_backup.db`. The `DB_PATH` route does
+> not have this trap; it always resolves to an absolute path.
+
 **Using PostgreSQL:**
 
 1. Uncomment the `postgres` service in `docker-compose.yml`
@@ -481,43 +506,46 @@ Telegram Archive supports **SQLite** (default, zero-config) and **PostgreSQL** (
 
 ### Using Pre-built Images (Recommended)
 
-If you're using the default `docker-compose.yml` with images from Docker Hub:
+The shipped `docker-compose.yml` pins an exact release rather than `latest`, so
+you always know which version is running and nothing changes underneath you. That
+also means `docker compose pull` on its own gets you nothing — it re-pulls the tag
+you already have. **Moving the pin is the upgrade.**
 
 ```bash
-# Pull latest images and recreate containers
-docker compose pull
-docker compose up -d
-```
-
-Or in one command:
-```bash
-docker compose up -d --pull always
-```
-
-> **Note:** Running `git pull` only updates source code, not Docker images. You must use `docker compose pull` to get new container versions.
-
-### Building from Source
-
-If you've modified the code or prefer building locally:
-
-```bash
+# Take the new compose file, which carries the new pin
 git pull
-docker build -t drumsergio/telegram-archive:latest .
-docker build -t drumsergio/telegram-archive-viewer:latest -f Dockerfile.viewer .
+
+# Then recreate the containers on it
 docker compose up -d
 ```
 
-### Pinning Versions
-
-For production stability, pin to specific versions instead of `latest`:
+If you keep your own compose file, edit the two `image:` tags to the release you
+want and run `docker compose up -d`:
 
 ```yaml
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:7.7.0  # Pin to a reviewed release
+    image: drumsergio/telegram-archive:7.33.6
+  telegram-viewer:
+    image: drumsergio/telegram-archive-viewer:7.33.6
 ```
 
-Check [Releases](https://github.com/GeiserX/Telegram-Archive/releases) for available versions.
+Check [Releases](https://github.com/GeiserX/Telegram-Archive/releases) for available
+versions, and [docs/CHANGELOG.md](docs/CHANGELOG.md) for what changed. Only the
+newest release gets fixes — see [SECURITY.md](SECURITY.md).
+
+### Building from Source
+
+If you've modified the code or prefer building locally, build under the tag your
+compose file already references, so the images you just built are the ones that
+start:
+
+```bash
+git pull
+docker build -t drumsergio/telegram-archive:7.33.6 .
+docker build -t drumsergio/telegram-archive-viewer:7.33.6 -f Dockerfile.viewer .
+docker compose up -d
+```
 
 ## ⚠️ Upgrading (Breaking Changes)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,12 +2,13 @@
 
 ## Supported Versions
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 7.x.x  | :white_check_mark: |
-| 6.x.x  | :white_check_mark: |
-| 5.x.x  | :x:                |
-| < 5.0   | :x:                |
+**Only the latest release is supported.** That is `7.33.6` today; see
+[Releases](https://github.com/GeiserX/Telegram-Archive/releases) for the current one.
+
+There are no maintenance branches and nothing is backported. Every fix lands on
+`main` and ships as a new tag, so the remedy for any advisory is always "upgrade
+to the newest release". If you are pinned to an older tag — including an older
+7.x — you are not receiving fixes, however recent that tag looks.
 
 ## Reporting a Vulnerability
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:7.7.0
+    image: drumsergio/telegram-archive:7.33.6
     container_name: telegram-backup
     restart: unless-stopped
     command: ["python", "-m", "src", "schedule"]
@@ -135,7 +135,7 @@ services:
     #       memory: 512M
 
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:7.7.0
+    image: drumsergio/telegram-archive-viewer:7.33.6
     container_name: telegram-viewer
     restart: unless-stopped
     ports:
@@ -208,7 +208,7 @@ services:
   # Example: Restricted Channel Viewer (optional)
   # Use this to share specific channels publicly with authentication
   # telegram-channel-viewer:
-  #   image: drumsergio/telegram-archive-viewer:7.7.0
+  #   image: drumsergio/telegram-archive-viewer:7.33.6
   #   container_name: telegram-channel-viewer
   #   restart: unless-stopped
   #   ports:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,109 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [7.33.6] - 2026-08-14
+
+### Changed
+- The README banner is now a single image built around the project logo, replacing the previous banner-plus-standalone-logo pair. Documentation only — nothing in the backup or viewer changed. ([#282](https://github.com/GeiserX/Telegram-Archive/pull/282))
+
+## [7.33.5] - 2026-08-14
+
+### Fixed
+- **Media whose Telegram filename contains characters Windows rejects now downloads instead of failing five times and giving up.** A file name carrying a newline, a carriage return or any of the characters Windows reserves (`<`, `>`, `:`, `"`, `|`, `?`, `*`) could not be created there, so every attempt raised the same error and the item was retried to exhaustion on every run. Such names are now cleaned on every platform — not only on Windows — so a name computed on one machine matches the one computed on another and archives stay portable; trailing dots and spaces are stripped and reserved device names (`CON`, `NUL`, `COM1` and friends, including their superscript variants) are prefixed. Existing archives are unaffected: files already stored keep serving under their stored path. ([#280](https://github.com/GeiserX/Telegram-Archive/issues/280))
+
+### Changed
+- Dependency updates: `aiohttp` and `cryptography`.
+
+## [7.33.4] - 2026-08-02
+
+### Fixed
+- **Error text no longer puts identifiers back into log lines that had just stopped naming them.** A filesystem error stringifies with the file it failed on, and a media path contains the chat-id folder, so any handler that logged the raw error reintroduced the identifier the previous two releases removed — including one line that shipped in 7.33.3 believing it was fixed. Filenames are now reduced to their basename where the parent folder is the identifier, so you can still see which file failed; avatar filenames are dropped outright, because there the identifier *is* the name. Error messages are kept wherever they cannot contain a path — a flood wait, an RPC reason — since that is where their diagnostic value is. Applied across the download, cleanup, thumbnail, deduplication and migration paths, plus the timeout and subprocess errors that print an entire command line. ([#277](https://github.com/GeiserX/Telegram-Archive/pull/277))
+
+### Changed
+- The check for this now fails on the whole class of mistake — any handler around a filesystem call that interpolates a raw error — rather than on the specific lines known to have leaked. It found seven further sites when it was introduced.
+
+## [7.33.3] - 2026-08-02
+
+### Fixed
+- **Chat ids and chat titles are no longer written to the logs.** Deletion and import lines drop the id, the startup lines report how many chats are configured rather than which ones, and the viewer reports "N configured chat(s) not found" instead of naming each. The manually-run restore script deliberately keeps its ids: they are the operator's own arguments and the line is a confirmation before a destructive send. ([#274](https://github.com/GeiserX/Telegram-Archive/issues/274))
+
+### Notes
+- This stops new leakage only. Logs already written still contain chat ids and titles — rotate or delete them if that matters for your deployment.
+
+## [7.33.2] - 2026-08-01
+
+### Fixed
+- **Your own account's first name, last name, username, phone number and Telegram id are no longer written to the logs.** Eleven places did so, all of them older than the rule that forbids it. The reason those lines existed — telling the operator that authentication succeeded and which account answered — is kept and improved: setup now compares the authenticated account against the configured phone number and reports whether they agree, instead of printing who it is. This covers the interactive setup flow too, since it logs through the same handler as the daemons and that stream may well be shipped off the machine.
+- **Setup now fails when the stored session belongs to a different account.** It previously reported success in silence — a stale session from another account looked exactly like a clean login, and nothing further down the line checks identity, only authorization. A number written with `00` or with `+` is treated as the same number.
+- A login credential that was printed to stdout, despite already being written to a private file, is no longer printed. ([#272](https://github.com/GeiserX/Telegram-Archive/issues/272))
+
+### Changed
+- A check now scans the whole source and script trees for any logging call reading an identifying attribute, rather than pinning the known lines, so this cannot quietly return.
+
+## [7.33.1] - 2026-08-01
+
+### Fixed
+- **The filename in a voice or audio message is visible again.** The per-message download button added in 7.32.0 was being stretched to the full width of the bubble by a rule meant for inline media, which left its sibling text column at zero width — so the filename did not merely shift, it disappeared. The button is now 36×36 at every screen width, and the two links that are meant to span the bubble still do. ([#270](https://github.com/GeiserX/Telegram-Archive/issues/270))
+
+## [7.33.0] - 2026-07-31
+
+### Fixed
+- **Audio auto-advance now plays through a chat of any size.** It previously stopped after roughly forty tracks in a large chat: the queue was collected by paging backwards from the newest item with a page cap, and in a big chat that walk never reached the track you were playing. The queue is now anchored on the playing track and extended in whichever direction playback is moving, so no page cap is needed. Views that are not a straight slice of the timeline — pinned-only, in-chat search, a topic pane, a jump window — seed the queue from the playing track rather than from a neighbouring row that is not really its neighbour. ([#266](https://github.com/GeiserX/Telegram-Archive/issues/266))
+- **Audio bubbles are no longer stiltingly tall.** The duration and the playback status wrapped one character per line, because the bubble's text-wrapping rule let them collapse to a single glyph wide. ([#267](https://github.com/GeiserX/Telegram-Archive/issues/267))
+- **A reply quote now shows who is being replied to** and what kind of media it was, rather than falling back to the word "Message" — which was every reply to a photo, voice note or file. Resolved for a whole page in one query, and degrading cleanly when the replied-to message is not in the archive. The pinned list shows the same. ([#268](https://github.com/GeiserX/Telegram-Archive/issues/268))
+- **Media downloads recover from a long connection outage instead of failing until the next scheduled run.** After about a minute of failures Telethon marks itself disconnected and refuses every later request; only the scheduled job reconnected, so the listener could restart into the same error indefinitely. Connections now heal before the retry budget is spent, across every kind of call, and a chat is no longer abandoned on the first connection error while its messages are being read. ([#265](https://github.com/GeiserX/Telegram-Archive/issues/265))
+- Connection logs no longer carry the account holder's name or phone number.
+
+## [7.32.0] - 2026-07-31
+
+### Added
+- **Every media message has its own download button**, and downloads arrive under the file's original name rather than the internal storage name. This also repairs the download button in the media gallery. ([#261](https://github.com/GeiserX/Telegram-Archive/issues/261))
+
+### Fixed
+- **The audio queue can no longer skip across a hole in the timeline.** A page of tracks that could not be tied back to the one playing is now left unused instead of being merged, and media pages order correctly when several items share the same timestamp (they previously sorted as text: 9, 99, 8, 89, 80, 7). Jumping from the playbar to a track outside the loaded window now loads the messages around it. ([#257](https://github.com/GeiserX/Telegram-Archive/issues/257))
+- **Media whose filename contains `#` or `?` loads instead of returning "not found."** URLs are now percent-encoded per path segment on both the client and the server. ([#258](https://github.com/GeiserX/Telegram-Archive/issues/258))
+- **Service messages captured before 7.28.0 show their text again.** They were stored with empty text and are now rendered at display time from what was captured. "added" and "removed" messages deliberately say "Someone" rather than naming anyone: the affected person was never stored, and the sender is the admin who acted, so naming them would state the wrong person. ([#259](https://github.com/GeiserX/Telegram-Archive/issues/259))
+- **The person named in a service message opens the sender popup**, for the actions where that person is the subject of the sentence. ([#260](https://github.com/GeiserX/Telegram-Archive/issues/260))
+- **The playbar shows the message's date converted to your configured viewer timezone**, so it can no longer report the wrong calendar day near midnight. ([#262](https://github.com/GeiserX/Telegram-Archive/issues/262))
+- **Voice notes captured by the real-time listener now carry their duration**, along with file size, type and dimensions, exactly like ones picked up by a scheduled backup — they previously rendered without a duration. Rows captured before this keep their empty duration until they are captured again. ([#263](https://github.com/GeiserX/Telegram-Archive/issues/263))
+- **A media file that goes missing is retried again.** A failed re-download used to leave the row marked as downloaded with a path pointing at nothing, so the every-run retry never saw it and the file was gone for good.
+
+## [7.31.2] - 2026-07-30
+
+### Fixed
+- **A failed request while loading more audio is no longer treated as "you have reached the oldest clip."** Pressing "previous" at the head of the queue silently restarted the current track when the request failed — a rate limit, an expired session, a server error — with nothing shown. The failure is now surfaced, the button keeps working so a later press can succeed, and only genuinely running out of older clips restarts the track. ([#254](https://github.com/GeiserX/Telegram-Archive/issues/254))
+
+## [7.31.1] - 2026-07-29
+
+### Added
+- **Audio auto-advance continues past the messages currently loaded on screen.** The player pages the chat's voice and music history on its own — separately from the message list, so the two cannot interfere — and "previous" at the top of the queue fetches an older page on demand. Voice notes and music stay in separate queues. ([#254](https://github.com/GeiserX/Telegram-Archive/issues/254))
+
+### Fixed
+- Closing the player while it was fetching more of the queue no longer disables "previous" for the rest of the session.
+
+## [7.31.0] - 2026-07-29
+
+### Added
+- **One global voice and audio player, replacing the separate player in every message bubble.** Starting a clip now stops the one before it, playback keeps going when you scroll away, and a persistent playbar gives you play/pause, previous/next, seeking, elapsed and total time, playback speed, the sender, chat and timestamp, and a close button. Clicking the playbar's details takes you to the source message. ([#250](https://github.com/GeiserX/Telegram-Archive/issues/250))
+- **Playback continues automatically to the next clip.** Voice notes and music are separate queues, matching the official clients, so a run of voice messages never spills into a music file.
+- **Playback speed (0.5×, 1×, 1.5×, 2×) is remembered per media type across sessions** and survives a change of track.
+- Operating-system and lock-screen media keys work where the browser supports them.
+
+### Notes
+- Auto-advance is off for viewer accounts that are not permitted to download media, and stops after repeated load failures.
+- Auto-advance does not load more messages into the list — that is left to the existing scroll behaviour — and the queue does not span chats.
+
+## [7.30.0] - 2026-07-29
+
+### Added
+- **Sender details show the sender's photo at a readable size**, with the usual initials-on-gradient fallback when there is no photo.
+- **The chat header avatar opens sender details in one-to-one chats.** Deliberately limited to private chats: in a group the header photo belongs to the group, not to a person. ([#240](https://github.com/GeiserX/Telegram-Archive/issues/240))
+
+## [7.29.2] - 2026-07-29
+
+### Fixed
+- **The floating date while you scroll a chat shows the day you are actually looking at.** Every day's separator pinned itself to the top of the message list at the same time, so several dates stacked in one place and whichever painted last won — routinely a day unrelated to what was on screen. There is now a single date indicator above the message list that follows the topmost visible message, stays correct after an older page loads, reads the oldest loaded day when you are at the very beginning of a chat's history, and still opens the date picker when clicked. ([#249](https://github.com/GeiserX/Telegram-Archive/issues/249))
+
 ## [7.29.1] - 2026-07-28
 
 ### Fixed

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,8 +10,6 @@ For version history and changes, see [CHANGELOG.md](./CHANGELOG.md).
 
 ### Security Hardening
 
-- [ ] Rate limiting on `/api/login` endpoint (slowapi or similar)
-- [ ] JWT or session tokens with expiration (replace static PBKDF2 token)
 - [ ] Search input validation and length limits
 - [ ] Telegram session file encryption at rest
 - [ ] Docker HEALTHCHECK instructions in Dockerfiles
@@ -33,7 +31,7 @@ For version history and changes, see [CHANGELOG.md](./CHANGELOG.md).
 - [x] Media Gallery Phase 1+2 (grid view for photos/videos, list view for voice/files) — v7.10.0
 - [ ] Media Gallery Phase 3: Links tab (shared URLs extracted from messages)
 - [ ] Custom themes (light mode, OLED dark, Telegram classic)
-- [ ] Voice message player with waveform visualization
+- [ ] Waveform visualization in the voice/audio player
 - [ ] Keyboard shortcuts (j/k navigation, Esc to close, etc.)
 - [ ] Message deep links (shareable URLs to specific messages)
 - [ ] i18n / localization (viewer is English-only currently)
@@ -47,9 +45,10 @@ For version history and changes, see [CHANGELOG.md](./CHANGELOG.md).
 
 ---
 
-## v7.0.0 — Search & Discovery
+## Search & Discovery
 
-### Full-text Search
+Substring search over chat names and message text already ships. What is left is
+the indexed and semantic work, which is not scheduled against a version yet.
 
 - [ ] Elasticsearch or Meilisearch integration for full-text search across all messages
 - [ ] Semantic search (find by meaning, not just keywords)
@@ -126,7 +125,6 @@ AUDIT_LOG_RETENTION=forever
 - [ ] Single instance serving multiple users
 - [ ] Per-user isolated databases or schemas
 - [ ] Shared channel access between users
-- [ ] Admin panel for user management
 
 ### Authentication Providers
 
@@ -137,10 +135,7 @@ AUDIT_LOG_RETENTION=forever
 
 ### Role-Based Permissions
 
-- [ ] Admin: full access, user management
 - [ ] Archivist: backup operations, no deletion
-- [ ] Viewer: read-only access to assigned chats
-- [ ] Per-chat access control lists
 
 ---
 
@@ -198,6 +193,12 @@ Features that were previously on this roadmap and have been implemented:
 | Ruff linter/formatter | v6.2.3 | CI enforcement + pre-commit hooks |
 | Security hardening | v6.2.3 | CSP, CORS, secure cookies, container hardening |
 | PBKDF2 auth tokens | v6.2.4 | Replaced weak SHA256 hashing |
+| Login rate limiting | v7.0.0 | Sliding window on the login and share-token endpoints |
+| Session tokens with expiration | v7.0.0 | Random per-login tokens honoring `AUTH_SESSION_DAYS`; DB-backed and restart-safe since v7.1.0 |
+| Admin panel for user management | v7.0.0 | Create, edit and delete viewer accounts from the viewer |
+| Per-chat access control lists | v7.0.0 | Per-account chat whitelists, enforced on messages and media |
+| Read-only access to assigned chats | v7.0.0 | Viewer accounts see only their chats; writes stay with the master account |
+| Voice/audio player | v7.31.0 | One global player with a queue and auto-advance; waveform display is still open |
 
 ---
 
@@ -205,4 +206,4 @@ Features that were previously on this roadmap and have been implemented:
 
 Have a feature request? [Open an issue](https://github.com/GeiserX/Telegram-Archive/issues)!
 
-See [AGENTS.md](../AGENTS.md) for development guidelines.
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for development guidelines.


### PR DESCRIPTION
## The problem

The docs actively mislead users of a backup tool, which is worse than missing docs.

- The shipped `docker-compose.yml` and every README install snippet pinned image **7.7.0** — 26 minor releases behind HEAD — and the documented upgrade path could never leave it.
- The changelog stopped at **7.29.1** while the project shipped **7.33.6** — 13 released versions undocumented.
- `CONTRIBUTING.md` told contributors to branch from **`master`**, which does not exist (default is `main`).
- The `.env.example` `DATABASE_URL` example wrote the archive **outside** the mounted volume — follow it and a container recreation loses your data.
- The README env table omitted implemented variables, including flood/backoff tuning the prose tells you to adjust.
- `ROADMAP.md` listed already-shipped features as unbuilt; `SECURITY.md` promised support for versions that never receive fixes.

## The fix

- Compose + README install pins → `7.33.6`. Semver tags, never `:latest`.
- Changelog reconstructed for 7.30.0 → 7.33.6; every entry traces to a real tag and matches the existing style.
- `CONTRIBUTING.md` branches from `main`.
- `.env.example` `DATABASE_URL` points inside the volume.
- README env table gains the missing variables with their real defaults.
- `ROADMAP.md` / `SECURITY.md` reflect reality.

## Verification

- Every changelog version added maps to a real git tag (checked against `git tag`).
- Every env var added is actually read in the code (checked against `src/`; several are read at module scope in `connection.py`/`telegram_backup.py`, not `config.py`).
- Pre-existing note, out of scope: `CONTRIBUTING.md` links to `AGENTS.md`, which is not tracked in the repo — a dead link that predates this change.

Requires #285 (which makes `ruff`/`test` runnable on docs-only PRs) to merge first, otherwise the required checks never queue for this PR.