### PR TITLE
fix: contain per-message capture failures, media symlinks, and archiver thumbnail memory

### DIFF
--- a/src/listener.py
+++ b/src/listener.py
@@ -285,6 +285,13 @@ class TelegramListener:
         # Real-time notifier for viewer WebSocket updates
         self._notifier: RealtimeNotifier | None = None
 
+        # Callbacks handed to client.add_event_handler, kept so stop() can detach
+        # them again. Telethon only ever appends, and the scheduler builds a NEW
+        # listener on the SAME shared client after every network blip, so without
+        # this every restart left another live instance dispatching the same
+        # updates: duplicate writes, duplicate broadcasts, duplicate downloads.
+        self._registered_handlers: list = []
+
         # Statistics
         self.stats = {
             "edits_received": 0,
@@ -789,8 +796,27 @@ class TelegramListener:
                 os.makedirs(shared_dir, exist_ok=True)
 
                 async def _download_fn(tmp_path):
-                    async with absorb_media_floods(self.client, getattr(self.config, "media_flood_sleep_threshold", 0)):
-                        return await call_with_flood_retry(self.client.download_media, message, tmp_path)
+                    # absorb_media_floods raises a CLIENT-WIDE attribute, so it may only be
+                    # held for one transfer attempt — never across the retry wrapper's flood
+                    # sleeps, which would leave every other coroutine (the scheduled backup
+                    # shares this client) silently sleeping inside Telethon for hours. Same
+                    # ordering as the backup path's _fetch_media_bytes.
+                    async def _attempt():
+                        async with absorb_media_floods(
+                            self.client, getattr(self.config, "media_flood_sleep_threshold", 0)
+                        ):
+                            return await self.client.download_media(message, tmp_path)
+
+                    try:
+                        return await call_with_flood_retry(_attempt, client=self.client)
+                    except BaseException:
+                        # Never leave a partial .part behind on failure or cancellation.
+                        if os.path.exists(tmp_path):
+                            try:
+                                os.remove(tmp_path)
+                            except OSError:
+                                pass
+                        raise
 
                 shared_file_path, content_hash = await download_and_shard_media(
                     db=self.db,
@@ -812,8 +838,23 @@ class TelegramListener:
                     tmp_file_path = f"{file_path}.{os.getpid()}.{task_id}.part"
                     if os.path.exists(tmp_file_path):
                         os.remove(tmp_file_path)
-                    async with absorb_media_floods(self.client, getattr(self.config, "media_flood_sleep_threshold", 0)):
-                        actual_path = await call_with_flood_retry(self.client.download_media, message, tmp_file_path)
+
+                    async def _attempt():
+                        async with absorb_media_floods(
+                            self.client, getattr(self.config, "media_flood_sleep_threshold", 0)
+                        ):
+                            return await self.client.download_media(message, tmp_file_path)
+
+                    try:
+                        actual_path = await call_with_flood_retry(_attempt, client=self.client)
+                    except BaseException:
+                        # Never leave a partial .part behind on failure or cancellation.
+                        if os.path.exists(tmp_file_path):
+                            try:
+                                os.remove(tmp_file_path)
+                            except OSError:
+                                pass
+                        raise
                     file_path = finalize_atomic_download(
                         actual_path if isinstance(actual_path, str) else None,
                         tmp_file_path,
@@ -1327,7 +1368,7 @@ class TelegramListener:
                             if photo_changed:
                                 await self._download_avatar(entity, chat_id)
                     except Exception as e:
-                        logger.warning(f"Failed to update chat metadata: {e}")
+                        logger.warning(f"Failed to update chat metadata: {type(e).__name__}")
 
             except Exception as e:
                 self.stats["errors"] += 1
@@ -1424,6 +1465,28 @@ class TelegramListener:
                 self.stats["errors"] += 1
                 logger.error(f"Error in reaction handler: {type(e).__name__}")
 
+        # Paired with _remove_handlers() in stop(); keep both lists in step.
+        self._registered_handlers = [
+            on_message_edited,
+            on_message_deleted,
+            on_new_message,
+            on_chat_action,
+            on_pinned_messages,
+            on_message_reactions,
+        ]
+
+    def _remove_handlers(self) -> None:
+        """Detach this listener's handlers from the (possibly shared) client."""
+        if not self.client:
+            self._registered_handlers = []
+            return
+        for callback in self._registered_handlers:
+            try:
+                self.client.remove_event_handler(callback)
+            except Exception as e:
+                logger.debug(f"Could not remove event handler: {type(e).__name__}")
+        self._registered_handlers = []
+
     async def run(self) -> None:
         """
         Run the listener until stopped.
@@ -1506,6 +1569,10 @@ class TelegramListener:
         """
         logger.info("Stopping listener...")
         self._running = False
+
+        # Detach handlers first: a shared client outlives this listener, and a
+        # stopped listener must stop receiving events.
+        self._remove_handlers()
 
         # Only disconnect if we own the client
         if self.client and self._owns_client and self.client.is_connected():

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -428,17 +428,24 @@ async def download_and_shard_media(
             shutil.copy2(shared_file_path, file_path)
         return shared_file_path, content_hash
 
-    # First time seeing this file — download to unique .part then shard
+    # First time seeing this file — download to a unique .part name and KEEP the
+    # blob there until it reaches its final home. It must never be readable under
+    # the plain shared name in between: a concurrent ingest of the same document
+    # resolves that name, symlinks its chat dir to it, and is left with a
+    # permanently dangling link the moment we move the blob into its bucket.
+    # ``.part`` is private by construction — resolve_shared_file_path only looks
+    # up the plain name and the sharding migration skips ``.part`` entries.
     task_id = id(asyncio.current_task()) if asyncio.current_task() else 0
     tmp_shared_file_path = os.path.join(shared_dir, f"{file_name}.{os.getpid()}.{task_id}.part")
     if os.path.exists(tmp_shared_file_path):
         os.remove(tmp_shared_file_path)
 
     actual_path = await download_coro(tmp_shared_file_path)
+    # Collect whatever Telethon wrote back under the SAME private .part name.
     tmp_shared_file_path = finalize_atomic_download(
         actual_path if isinstance(actual_path, str) else None,
         tmp_shared_file_path,
-        os.path.join(shared_dir, file_name),
+        tmp_shared_file_path,
     )
     if not tmp_shared_file_path or not os.path.exists(tmp_shared_file_path):
         logger.warning("Media download did not produce a file")
@@ -448,10 +455,12 @@ async def download_and_shard_media(
     # Content-hash dedup: check if identical content already exists
     tmp_shared_file_path, content_hash, reused = await deduplicate_shared_file(db, tmp_shared_file_path, shared_dir)
 
-    # Move to sharded location if we own this file (not reused)
-    if not reused and content_hash:
-        actual_name = os.path.basename(tmp_shared_file_path)
-        final_shared = get_shared_file_path(shared_dir, actual_name, content_hash)
+    # Publish the blob if we own it (not reused): ONE rename from the private
+    # .part name straight to its final path, under the clean ``file_name``. With
+    # no hash there is no bucket, so that final path is the flat one — still
+    # final, nothing moves it afterwards.
+    if not reused:
+        final_shared = get_shared_file_path(shared_dir, file_name, content_hash)
         os.makedirs(os.path.dirname(final_shared), exist_ok=True)
         if tmp_shared_file_path != final_shared:
             os.replace(tmp_shared_file_path, final_shared)

--- a/src/migrate_shared_media.py
+++ b/src/migrate_shared_media.py
@@ -31,7 +31,11 @@ def _compute_hash(filepath: str) -> str | None:
 def migrate_shared_media(media_path: str) -> int:
     """Migrate flat _shared/ files into hash-prefix sharded subdirectories.
 
-    Returns the number of files migrated.
+    Returns the number of files migrated. Per-entry filesystem errors are
+    contained and counted as deferred — this runs before the scheduler and the
+    listener start, so one unreadable file must never keep the archiver from
+    running. The idempotency marker is withheld while anything is deferred, so
+    the leftovers are retried on the next start instead of being abandoned.
     """
     shared_dir = os.path.join(media_path, "_shared")
     if not os.path.isdir(shared_dir):
@@ -67,34 +71,71 @@ def migrate_shared_media(media_path: str) -> int:
         chat_dirs = []
 
     migrated = 0
+    deferred = 0
     for entry in flat_files:
         src_path = entry.path
 
-        content_hash = _compute_hash(src_path)
-        if not content_hash:
-            continue
+        try:
+            content_hash = _compute_hash(src_path)
+            if not content_hash:
+                # Unreadable — e.g. a symlink whose target is not mounted yet.
+                # Leave it flat and retry on a later start.
+                deferred += 1
+                continue
 
-        bucket = content_hash[:2]
-        dest_dir = os.path.join(shared_dir, bucket)
-        os.makedirs(dest_dir, exist_ok=True)
-        dest_path = os.path.join(dest_dir, entry.name)
+            bucket = content_hash[:2]
+            dest_dir = os.path.join(shared_dir, bucket)
+            os.makedirs(dest_dir, exist_ok=True)
+            dest_path = os.path.join(dest_dir, entry.name)
 
-        if os.path.lexists(dest_path):
-            # Already exists in shard — remove flat duplicate
-            if os.path.isfile(dest_path):
-                os.remove(src_path)
-            continue
+            if os.path.lexists(dest_path):
+                # Already exists in shard — remove flat duplicate
+                if os.path.isfile(dest_path):
+                    os.remove(src_path)
+                else:
+                    # Destination is not usable content (e.g. a dangling link);
+                    # the flat copy stays, so this entry is still outstanding.
+                    deferred += 1
+                continue
 
-        # Relink symlinks BEFORE moving: if crash occurs between relink and move,
-        # symlinks are dangling but file is still in flat_files on restart → full retry.
-        _relink_chat_symlinks(media_path, shared_dir, entry.name, dest_path, chat_dirs)
+            # Relink symlinks BEFORE moving: if crash occurs between relink and move,
+            # symlinks are dangling but file is still in flat_files on restart → full retry.
+            _relink_chat_symlinks(media_path, shared_dir, entry.name, dest_path, chat_dirs)
 
-        os.replace(src_path, dest_path)
-        migrated += 1
+            _relocate_into_bucket(shared_dir, src_path, dest_path, entry.is_symlink())
+            migrated += 1
+        except OSError:
+            # One bad file must not abort the migration, and must not propagate:
+            # the caller exits the process on any exception, before the scheduler
+            # and listener are started.
+            deferred += 1
 
-    _write_marker(marker)
+    if deferred:
+        # Count only: a media path carries the chat-id folder.
+        logger.warning(f"Sharding migration deferred {deferred} entries; will retry on next start")
+    else:
+        _write_marker(marker)
     logger.info(f"Migration complete: {migrated} files moved to sharded layout")
     return migrated
+
+
+def _relocate_into_bucket(shared_dir: str, src_path: str, dest_path: str, is_symlink: bool) -> None:
+    """Move one flat _shared/ entry into its shard bucket.
+
+    A symlink cannot be moved verbatim: a RELATIVE target is resolved against the
+    link's own directory, so relocating the link one level deeper re-points it one
+    directory too high and it dangles for good. Recreate it with the target
+    rewritten against the bucket directory instead. Absolute targets move as-is.
+    """
+    if is_symlink:
+        target = os.readlink(src_path)
+        if not os.path.isabs(target):
+            target = os.path.relpath(os.path.join(shared_dir, target), os.path.dirname(dest_path))
+        os.symlink(target, dest_path)
+        os.unlink(src_path)
+        return
+
+    os.replace(src_path, dest_path)
 
 
 def _relink_chat_symlinks(

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -17,6 +17,7 @@ from datetime import UTC, datetime, timedelta
 
 from telethon import TelegramClient
 from telethon.errors import (
+    AuthKeyError,
     ChannelPrivateError,
     ChatForbiddenError,
     ChatIdInvalidError,
@@ -25,6 +26,7 @@ from telethon.errors import (
     FloodWaitError,
     PeerIdInvalidError,
     RPCError,
+    UnauthorizedError,
     UserBannedInChannelError,
 )
 from telethon.tl.types import (
@@ -325,6 +327,10 @@ async def call_with_flood_retry(
             # If it is a FloodWaitError, FileReferenceExpiredError, or terminal RPC error,
             # raise it to let the prior except block or the calling scope catch it specifically
             # without wasting retries.
+            # UnauthorizedError (session revoked/expired, account deactivated) and
+            # AuthKeyError (key duplicated/unregistered) are process-wide and permanent:
+            # Telegram returns them identically forever, and the transport is still up so
+            # reconnecting cannot help. Retrying burns ~65s of backoff per call for nothing.
             if isinstance(
                 exc,
                 (
@@ -334,6 +340,8 @@ async def call_with_flood_retry(
                     ChatForbiddenError,
                     ChatIdInvalidError,
                     PeerIdInvalidError,
+                    UnauthorizedError,
+                    AuthKeyError,
                     UserBannedInChannelError,
                 ),
             ):
@@ -949,7 +957,9 @@ class TelegramBackup:
                         seen_chat_ids.add(cid)
                         logger.info("  → Fetched chat")
                     except Exception as e:
-                        logger.warning(f"  → Could not fetch chat: {e}")
+                        # Type only: Telethon's peer-resolution ValueError spells the id out
+                        # ("Could not find the input entity for PeerUser(user_id=...)").
+                        logger.warning(f"  → Could not fetch chat: {e.__class__.__name__}")
                         unresolved.add(cid)
 
                 # Fallback for unresolved entries (#234): a bare positive user id
@@ -1188,7 +1198,7 @@ class TelegramBackup:
                                 f"  → Added chat{' [in archive]' if is_in_archive else ' [not in any dialog list]'}"
                             )
                         except Exception as e:
-                            logger.warning(f"  → Could not fetch included chat: {e}")
+                            logger.warning(f"  → Could not fetch included chat: {e.__class__.__name__}")
 
                 # Delete only explicitly excluded chats from database
                 if explicitly_excluded_chat_ids:
@@ -1334,7 +1344,9 @@ class TelegramBackup:
                         await self._backup_forum_topics(chat_id, entity)
                     except Exception as e:
                         # Don't let a topic-fetch failure abort folders/stats below.
-                        logger.warning(f"End-of-run forum-topic fetch failed (will retry next run): {e}")
+                        logger.warning(
+                            f"End-of-run forum-topic fetch failed (will retry next run): {e.__class__.__name__}"
+                        )
 
             # v6.2.0: Backup user's chat folders
             logger.info("Backing up chat folders...")
@@ -1500,7 +1512,7 @@ class TelegramBackup:
                 try:
                     messages = await call_with_flood_retry(self.client.get_messages, chat_id, ids=message_ids)
                 except Exception as e:
-                    logger.warning(f"Cannot access chat for media verification: {e}")
+                    logger.warning(f"Cannot access chat for media verification: {e.__class__.__name__}")
                     failed += len(records)
                     continue
 
@@ -1605,7 +1617,7 @@ class TelegramBackup:
                 try:
                     messages = await call_with_flood_retry(self.client.get_messages, chat_id, ids=message_ids)
                 except Exception as e:
-                    logger.warning(f"Cannot access chat for pending media retry: {e}")
+                    logger.warning(f"Cannot access chat for pending media retry: {e.__class__.__name__}")
                     failed += len(records)
                     continue
 
@@ -1679,7 +1691,9 @@ class TelegramBackup:
             try:
                 await self._backup_forum_topics(chat_id, entity)
             except Exception as e:
-                logger.warning(f"Early forum-topic fetch failed for chat (will retry at end of run): {e}")
+                logger.warning(
+                    f"Early forum-topic fetch failed for chat (will retry at end of run): {e.__class__.__name__}"
+                )
 
         # Clean up existing media if this chat is in the skip list (once per session)
         if (
@@ -1712,15 +1726,30 @@ class TelegramBackup:
         uncheckpointed_count = 0
         batches_since_checkpoint = 0
         running_max_id = last_message_id
+        # One unprocessable message must never abort the dialog, and the cursor must
+        # never move past it: the message stays retryable on the next run instead of
+        # being silently skipped forever. Messages arrive oldest-first, so freezing
+        # the cursor at the first failure is enough to keep it behind that id.
+        failed_messages = 0
+        cursor_frozen = False
 
         async for message in iter_messages_with_flood_retry(self.client, entity, min_id=last_message_id, reverse=True):
-            running_max_id = max(running_max_id, message.id)
-
             # Skip messages belonging to excluded forum topics
             if self.config.should_skip_topic(chat_id, extract_topic_id(message)):
+                if not cursor_frozen:
+                    running_max_id = max(running_max_id, message.id)
                 continue
 
-            msg_data = await self._process_message(message, chat_id)
+            try:
+                msg_data = await self._process_message(message, chat_id)
+            except Exception as e:
+                failed_messages += 1
+                cursor_frozen = True
+                logger.debug(f"Message could not be processed: {type(e).__name__}")
+                continue
+
+            if not cursor_frozen:
+                running_max_id = max(running_max_id, message.id)
             batch_data.append(msg_data)
 
             if len(batch_data) >= batch_size:
@@ -1744,6 +1773,12 @@ class TelegramBackup:
             count = len(batch_data)
             grand_total += count
             uncheckpointed_count += count
+
+        if failed_messages:
+            logger.warning(
+                f"  → {failed_messages} message(s) could not be processed; "
+                f"the sync cursor stays behind them so they are retried next run"
+            )
 
         # Final checkpoint: persist when there are un-checkpointed messages OR
         # when the cursor advanced purely from skipped (topic-filtered) messages
@@ -1800,6 +1835,10 @@ class TelegramBackup:
         batch_data: list[dict] = []
         batch_size = self.config.batch_size
         recovered = 0
+        # Same per-message isolation as _backup_dialog: one unprocessable message must
+        # not abandon the rest of the gap. Gap-fill keeps no cursor, so a failed message
+        # is simply left in the gap and re-attempted on the next scan.
+        failed_messages = 0
 
         async for message in iter_messages_with_flood_retry(
             self.client, entity, min_id=gap_start, max_id=gap_end, reverse=True
@@ -1808,7 +1847,13 @@ class TelegramBackup:
             if self.config.should_skip_topic(chat_id, extract_topic_id(message)):
                 continue
 
-            msg_data = await self._process_message(message, chat_id)
+            try:
+                msg_data = await self._process_message(message, chat_id)
+            except Exception as e:
+                failed_messages += 1
+                logger.debug(f"Gap-fill: message could not be processed: {type(e).__name__}")
+                continue
+
             batch_data.append(msg_data)
 
             if len(batch_data) >= batch_size:
@@ -1820,6 +1865,9 @@ class TelegramBackup:
         if batch_data:
             await self._commit_batch(batch_data, chat_id)
             recovered += len(batch_data)
+
+        if failed_messages:
+            logger.warning(f"    → {failed_messages} message(s) in this gap could not be processed")
 
         return recovered
 
@@ -1875,7 +1923,7 @@ class TelegramBackup:
                 logger.warning(f"Gap-fill: skipping chat (no access): {e.__class__.__name__}")
                 continue
             except Exception as e:
-                logger.error(f"Gap-fill: failed to get entity for chat: {e}")
+                logger.error(f"Gap-fill: failed to get entity for chat: {e.__class__.__name__}")
                 summary["errors"] += 1
                 continue
 
@@ -1903,7 +1951,7 @@ class TelegramBackup:
                     chat_recovered += recovered
                     logger.info(f"    Recovered {recovered} messages")
                 except Exception as e:
-                    logger.error(f"    Error filling gap (size {gap_size}): {e}")
+                    logger.error(f"    Error filling gap (size {gap_size}): {type(e).__name__}")
                     summary["errors"] += 1
 
             summary["total_gaps"] += len(gaps)
@@ -3391,12 +3439,12 @@ class TelegramBackup:
                 # run continues from here.
                 if topics_count > 0:
                     logger.warning(
-                        f"GetForumTopicsRequest failed mid-pagination ({e.__class__.__name__}: {e}); "
+                        f"GetForumTopicsRequest failed mid-pagination ({e.__class__.__name__}); "
                         f"keeping {topics_count} topics fetched so far"
                     )
                     return topics_count
                 logger.warning(
-                    f"GetForumTopicsRequest failed ({e.__class__.__name__}: {e}), falling back to message inference"
+                    f"GetForumTopicsRequest failed ({e.__class__.__name__}), falling back to message inference"
                 )
                 # Fall through to inference method
         except ImportError:
@@ -3445,7 +3493,7 @@ class TelegramBackup:
             return topics_count
 
         except Exception as e:
-            logger.warning(f"  → Failed to infer forum topics: {e}")
+            logger.warning(f"  → Failed to infer forum topics: {e.__class__.__name__}")
             return 0
 
     def _resolve_peer_ids(self, peers, own_id: int | None = None) -> set[int]:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -149,9 +149,20 @@ def _is_non_retryable_media_op(exc: BaseException) -> bool:
     return is_media_location_error(exc) or isinstance(exc, TimeoutError)
 
 
+# Peak decode memory is set by pixel count, not compressed size, so the byte
+# gate in _pre_generate_thumbnail cannot bound it: a 12000x8000 flat-colour PNG
+# is well under 1 MB on disk and still costs ~370 MB to decode inside the
+# backup process. Image.MAX_IMAGE_PIXELS is no help either -- Pillow only
+# refuses above TWICE that value, so everything up to 100 MP proceeds after a
+# warning nobody reads. Mirrors _MAX_SOURCE_PIXELS in src/web/thumbnails.py;
+# keep the two in step.
+_MAX_SOURCE_PIXELS = 25_000_000
+
+
 def _pre_generate_thumbnail(source_path: str, media_root: str) -> None:
     """Pre-generate 200px WebP thumbnail for gallery grid view."""
     try:
+        import tempfile
         from pathlib import Path
 
         from PIL import Image
@@ -188,8 +199,28 @@ def _pre_generate_thumbnail(source_path: str, media_root: str) -> None:
 
         dest.parent.mkdir(parents=True, exist_ok=True)
         with Image.open(source) as img:
+            # Image.open() parses only the header, so the dimensions are known
+            # before a single pixel is decoded -- refuse pixel bombs here, not
+            # after. JPEG is exempt: img.thumbnail() drafts JPEGs to decode at
+            # up to 1/8 scale so their cost stays bounded, and Image.open()
+            # itself refuses anything past twice Image.MAX_IMAGE_PIXELS.
+            pixels = img.size[0] * img.size[1]
+            if img.format != "JPEG" and pixels > _MAX_SOURCE_PIXELS:
+                logger.debug("Thumbnail pre-generation refused oversized source (%d pixels)", pixels)
+                return
             img.thumbnail((200, 200), Image.LANCZOS)
-            img.save(dest, "WEBP", quality=WEBP_QUALITY)
+            # The viewer treats dest.exists() as "complete", so saving straight
+            # to dest would let a concurrent reader see -- and cache -- a
+            # half-written file. Write to a unique temp file in the same
+            # directory and os.replace() it: dest only ever appears whole.
+            fd, tmp_name = tempfile.mkstemp(dir=dest.parent, prefix=".thumb-", suffix=".tmp")
+            os.close(fd)
+            tmp = Path(tmp_name)
+            try:
+                img.save(tmp, "WEBP", quality=WEBP_QUALITY)
+                os.replace(tmp, dest)
+            finally:
+                tmp.unlink(missing_ok=True)
     except Exception as e:
         logger.debug("Thumbnail pre-generation failed: %s", describe_exception(e))
 

--- a/tests/test_media_symlink_integrity.py
+++ b/tests/test_media_symlink_integrity.py
@@ -1,0 +1,278 @@
+"""Media symlinks must always resolve to real bytes.
+
+Two ways an archived attachment used to become permanently unopenable:
+
+* concurrent ingest of the same document published the blob under the plain
+  ``_shared/<name>`` before moving it into its shard bucket, so a second task
+  could symlink its chat dir to a name that was about to disappear;
+* the flat-to-sharded migration moved a symlink one directory deeper without
+  rewriting its relative target, and sealed its marker anyway.
+"""
+
+import asyncio
+import hashlib
+import logging
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import AsyncMock, patch
+
+from src.message_utils import download_and_shard_media, resolve_shared_file_path
+from src.migrate_shared_media import SHARD_MARKER, migrate_shared_media
+
+logger = logging.getLogger(__name__)
+
+
+@unittest.skipIf(os.name == "nt", "Symlinks require administrator privileges on Windows")
+class TestSharedStorePublishIsAtomic(unittest.TestCase):
+    """download_and_shard_media must never expose an intermediate blob name."""
+
+    FILE_NAME = "999_holiday.jpg"
+    CONTENT = b"holiday photo bytes"
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.media_path = os.path.join(self.tmpdir, "media")
+        self.shared_dir = os.path.join(self.media_path, "_shared")
+        os.makedirs(self.shared_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def _chat_dir(self, chat_id):
+        chat_dir = os.path.join(self.media_path, str(chat_id))
+        os.makedirs(chat_dir, exist_ok=True)
+        return chat_dir
+
+    async def _download(self, tmp_path):
+        with open(tmp_path, "wb") as f:
+            f.write(self.CONTENT)
+        return tmp_path
+
+    def _ingest(self, db, chat_dir):
+        return download_and_shard_media(
+            db=db,
+            download_coro=self._download,
+            shared_dir=self.shared_dir,
+            chat_media_dir=chat_dir,
+            file_name=self.FILE_NAME,
+            file_path=os.path.join(chat_dir, self.FILE_NAME),
+            logger=logger,
+        )
+
+    def _flat_entries(self):
+        return sorted(name for name in os.listdir(self.shared_dir) if not name.endswith(".part"))
+
+    def test_blob_is_not_discoverable_before_it_is_final(self):
+        observed = {}
+
+        async def _observe(content_hash):
+            # Runs at the dedup await — exactly where a competing ingest gets to
+            # look at the shared store while this download is still in flight.
+            observed["resolved"] = resolve_shared_file_path(self.shared_dir, self.FILE_NAME, None)
+            observed["flat_entries"] = self._flat_entries()
+            return None
+
+        db = AsyncMock()
+        db.find_media_by_content_hash = AsyncMock(side_effect=_observe)
+        chat_dir = self._chat_dir(100)
+
+        shared_file_path, content_hash = self._run(self._ingest(db, chat_dir))
+
+        assert observed["resolved"] is None, "in-flight blob was discoverable under its plain shared name"
+        assert observed["flat_entries"] == [], "in-flight blob was published into the shared store root"
+        assert content_hash == hashlib.sha256(self.CONTENT).hexdigest()
+        assert shared_file_path == os.path.join(self.shared_dir, content_hash[:2], self.FILE_NAME)
+        assert os.path.exists(shared_file_path)
+
+    def test_concurrent_ingest_leaves_no_dangling_chat_symlink(self):
+        first_at_dedup = asyncio.Event()
+        second_done = asyncio.Event()
+
+        async def _park(content_hash):
+            first_at_dedup.set()
+            await second_done.wait()
+            return None
+
+        db_first = AsyncMock()
+        db_first.find_media_by_content_hash = AsyncMock(side_effect=_park)
+        db_second = AsyncMock()
+        db_second.find_media_by_content_hash = AsyncMock(return_value=None)
+
+        chat_first = self._chat_dir(100)
+        chat_second = self._chat_dir(200)
+
+        async def scenario():
+            first = asyncio.create_task(self._ingest(db_first, chat_first))
+            await first_at_dedup.wait()
+            # The second consumer runs start-to-finish while the first is parked
+            # mid-ingest — the window in which the transient name was visible.
+            second_result = await self._ingest(db_second, chat_second)
+            second_done.set()
+            return await first, second_result
+
+        (first_path, _), (second_path, second_hash) = self._run(scenario())
+
+        second_link = os.path.join(chat_second, self.FILE_NAME)
+        assert os.path.islink(second_link)
+        assert os.path.exists(second_link), "second consumer's chat symlink dangles"
+        with open(second_link, "rb") as f:
+            assert f.read() == self.CONTENT
+        assert second_hash == hashlib.sha256(self.CONTENT).hexdigest()
+        assert os.path.exists(second_path)
+        # And the first consumer's own link survived the second's publish.
+        assert os.path.exists(os.path.join(chat_first, self.FILE_NAME))
+        assert os.path.exists(first_path)
+
+    def test_unhashable_download_is_published_under_the_clean_name(self):
+        # Hashing can fail (transient read error) — the blob must still land on a
+        # clean name, never keep the private ".part" one (#175).
+        db = AsyncMock()
+        db.find_media_by_content_hash = AsyncMock(return_value=None)
+        chat_dir = self._chat_dir(100)
+
+        with patch("src.message_utils.compute_file_hash", return_value=None):
+            shared_file_path, content_hash = self._run(self._ingest(db, chat_dir))
+
+        assert content_hash is None
+        assert shared_file_path == os.path.join(self.shared_dir, self.FILE_NAME)
+        assert self._flat_entries() == [self.FILE_NAME]
+        assert os.listdir(self.shared_dir) == [self.FILE_NAME]
+        assert os.path.exists(os.path.join(chat_dir, self.FILE_NAME))
+
+
+class TestMigrationKeepsSymlinksResolvable(unittest.TestCase):
+    """Sharding migration must not break the media it relocates."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.media_path = os.path.join(self.tmpdir, "media")
+        self.shared_dir = os.path.join(self.media_path, "_shared")
+        os.makedirs(self.shared_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _create_file(self, path, content):
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            f.write(content)
+        return path
+
+    def _bucket_path(self, content, name):
+        digest = hashlib.sha256(content.encode()).hexdigest()
+        return os.path.join(self.shared_dir, digest[:2], name)
+
+    @unittest.skipIf(os.name == "nt", "Symlinks require administrator privileges on Windows")
+    def test_relative_symlink_still_resolves_after_migration(self):
+        # git-annex shape: the shared entry is a relative link out of the tree.
+        content = "annex object data"
+        blob = self._create_file(os.path.join(self.tmpdir, "annexstore", "obj"), content)
+        link_path = os.path.join(self.shared_dir, "annexed.jpg")
+        os.symlink(os.path.relpath(blob, self.shared_dir), link_path)
+
+        chat_dir = os.path.join(self.media_path, "-1001234")
+        os.makedirs(chat_dir)
+        chat_link = os.path.join(chat_dir, "annexed.jpg")
+        os.symlink(os.path.relpath(link_path, chat_dir), chat_link)
+
+        count = migrate_shared_media(self.media_path)
+
+        assert count == 1
+        sharded = self._bucket_path(content, "annexed.jpg")
+        assert os.path.islink(sharded)
+        assert os.path.exists(sharded), "relocated shared symlink no longer resolves"
+        assert os.path.exists(chat_link), "chat symlink no longer resolves"
+        with open(chat_link) as f:
+            assert f.read() == content
+
+    @unittest.skipIf(os.name == "nt", "Symlinks require administrator privileges on Windows")
+    def test_absolute_symlink_still_resolves_after_migration(self):
+        content = "absolute target data"
+        blob = self._create_file(os.path.join(self.tmpdir, "elsewhere", "obj"), content)
+        link_path = os.path.join(self.shared_dir, "external.jpg")
+        os.symlink(blob, link_path)
+
+        count = migrate_shared_media(self.media_path)
+
+        assert count == 1
+        sharded = self._bucket_path(content, "external.jpg")
+        assert os.path.islink(sharded)
+        assert os.path.exists(sharded)
+        assert os.readlink(sharded) == blob
+
+    def test_plain_file_still_resolves_after_migration(self):
+        content = "plain blob"
+        flat = self._create_file(os.path.join(self.shared_dir, "photo.jpg"), content)
+
+        count = migrate_shared_media(self.media_path)
+
+        assert count == 1
+        assert not os.path.lexists(flat)
+        sharded = self._bucket_path(content, "photo.jpg")
+        assert os.path.isfile(sharded)
+        with open(sharded) as f:
+            assert f.read() == content
+
+
+class TestMigrationContainsFilesystemErrors(unittest.TestCase):
+    """A failing file must not abort startup, and must be retried later."""
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.media_path = os.path.join(self.tmpdir, "media")
+        self.shared_dir = os.path.join(self.media_path, "_shared")
+        os.makedirs(self.shared_dir)
+        self.marker = os.path.join(self.shared_dir, SHARD_MARKER)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir, ignore_errors=True)
+
+    def _create_file(self, name, content):
+        path = os.path.join(self.shared_dir, name)
+        with open(path, "w") as f:
+            f.write(content)
+        return path
+
+    def test_oserror_on_one_file_does_not_abort_the_others(self):
+        good = self._create_file("good.jpg", "good data")
+        bad = self._create_file("bad.jpg", "bad data")
+        real_replace = os.replace
+
+        def _replace(src, dst):
+            if os.path.basename(src) == "bad.jpg":
+                raise PermissionError(13, "Permission denied")
+            return real_replace(src, dst)
+
+        with patch("src.migrate_shared_media.os.replace", side_effect=_replace):
+            count = migrate_shared_media(self.media_path)
+
+        assert count == 1
+        assert not os.path.lexists(good)
+        assert os.path.isfile(bad), "the failing file must be left where it was"
+        assert not os.path.exists(self.marker), "marker sealed a migration that left work behind"
+
+        # Next start (failure gone) picks the leftover up and seals the marker.
+        count2 = migrate_shared_media(self.media_path)
+        assert count2 == 1
+        assert not os.path.lexists(bad)
+        assert os.path.exists(self.marker)
+
+    @unittest.skipIf(os.name == "nt", "Symlinks require administrator privileges on Windows")
+    def test_unhashable_entry_withholds_the_marker(self):
+        link_path = os.path.join(self.shared_dir, "broken.jpg")
+        os.symlink("../../nowhere/missing.bin", link_path)
+
+        count = migrate_shared_media(self.media_path)
+
+        assert count == 0
+        assert os.path.islink(link_path)
+        assert not os.path.exists(self.marker), "unreadable entry was abandoned instead of retried"

--- a/tests/test_poison_message_isolation.py
+++ b/tests/test_poison_message_isolation.py
@@ -18,10 +18,16 @@ for one attempt only while never leaving a ``.part`` file behind.
 import asyncio
 import os
 import shutil
+import struct
 import tempfile
 import unittest
+import warnings
+import zlib
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from PIL import Image as PILImage
+from PIL import ImageFile
 from telethon.errors import (
     AuthKeyDuplicatedError,
     FloodWaitError,
@@ -30,7 +36,12 @@ from telethon.errors import (
 from telethon.tl.types import DocumentEmpty, MessageMediaDocument, MessageMediaPhoto
 
 from src.listener import TelegramListener
-from src.telegram_backup import TelegramBackup, call_with_flood_retry
+from src.telegram_backup import (
+    _MAX_SOURCE_PIXELS,
+    TelegramBackup,
+    _pre_generate_thumbnail,
+    call_with_flood_retry,
+)
 
 # Telethon's peer-resolution ValueError spells the id out in its message; the
 # fake below is the exact template (telethon/client/users.py).
@@ -537,6 +548,177 @@ class TestListenerMediaDownloadDiscipline(unittest.TestCase):
         self.assertEqual(samples["attempt"], [60, 60, 60])
         self.assertEqual(samples["sleep"], [0, 0])
         self.assertEqual(listener.client.flood_sleep_threshold, 0)
+
+
+class TestThumbnailPreGenerationHardening(unittest.TestCase):
+    """The archiver-side thumbnail pass must survive hostile media it just fetched.
+
+    ``_pre_generate_thumbnail`` runs inside the backup process right after a
+    media download, so a poisoned attachment reaches it before the viewer ever
+    sees the file. Its only size guard used to be the 50 MB byte gate, but
+    decode memory is set by pixel count, not compressed size: a 12000x8000
+    flat PNG is under 1 MB on disk and cost ~370 MB RSS to decode. The final
+    save also streamed straight into the cache path, so a concurrent viewer --
+    for which ``dest.exists()`` means "complete" -- could read and cache a torn
+    file. These tests are the attack: the pixel bomb must be refused from the
+    header alone, a large JPEG (draft-decoded at up to 1/8 scale) must keep its
+    thumbnail, and the destination must never exist half-written.
+    """
+
+    @staticmethod
+    def _write_flat_png(path: Path, width: int, height: int) -> None:
+        """A fully valid flat-black RGB PNG, streamed through zlib so the test
+        itself never allocates width*height*3 bytes. Under 4 MB on disk even at
+        96 MP -- comfortably inside the byte gate, which is exactly the attack.
+        """
+
+        def chunk(tag: bytes, payload: bytes) -> bytes:
+            crc = zlib.crc32(tag + payload) & 0xFFFFFFFF
+            return len(payload).to_bytes(4, "big") + tag + payload + crc.to_bytes(4, "big")
+
+        ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+        compressor = zlib.compressobj(1)
+        row = b"\x00" * (1 + width * 3)  # filter byte + RGB pixels
+        idat = bytearray()
+        for _ in range(height):
+            idat += compressor.compress(row)
+        idat += compressor.flush()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        png = b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IDAT", bytes(idat)) + chunk(b"IEND", b"")
+        path.write_bytes(png)
+
+    def test_png_pixel_bomb_is_refused_without_decoding(self):
+        """The reviewer's 96 MP flat PNG: refused from the header, zero pixels decoded."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            source = media_root / "chat1" / "bomb.png"
+            self._write_flat_png(source, 12000, 8000)
+            self.assertGreater(12000 * 8000, _MAX_SOURCE_PIXELS)
+            self.assertLess(source.stat().st_size, 4 * 1024 * 1024)  # the byte gate cannot see it
+
+            decoded = []
+            real_load = ImageFile.ImageFile.load
+
+            def spying_load(img_self):
+                decoded.append(img_self.size)
+                return real_load(img_self)
+
+            # 96 MP is past Image.MAX_IMAGE_PIXELS (50 MP), so open() itself
+            # warns before our gate runs; silence it so the refusal behaves
+            # identically under any warnings configuration.
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", PILImage.DecompressionBombWarning)
+                with patch.object(ImageFile.ImageFile, "load", spying_load):
+                    _pre_generate_thumbnail(str(source), str(media_root))
+
+            self.assertFalse((media_root / ".thumbs" / "200" / "chat1" / "bomb.webp").exists())
+            self.assertEqual(decoded, [])
+
+    def test_pixel_bomb_under_pillows_own_limit_is_still_refused(self):
+        """The gate must hold at the viewer's threshold, not at Pillow's.
+
+        32 MP sits under ``Image.MAX_IMAGE_PIXELS`` (50 MP), so Pillow neither
+        warns nor raises -- only the header gate stands between this file and a
+        ~100 MB decode per poisoned message inside the backup process.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            source = media_root / "chat1" / "bomb.png"
+            self._write_flat_png(source, 8000, 4000)
+            self.assertGreater(8000 * 4000, _MAX_SOURCE_PIXELS)
+
+            _pre_generate_thumbnail(str(source), str(media_root))
+
+            self.assertFalse((media_root / ".thumbs" / "200" / "chat1" / "bomb.webp").exists())
+
+    def test_normal_photo_still_gets_a_complete_thumbnail(self):
+        """An ordinary photo passes the gate and comes out whole via os.replace()."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            source = media_root / "chat1" / "photo.png"
+            source.parent.mkdir(parents=True)
+            PILImage.new("RGB", (640, 480), "blue").save(source)
+            self.assertLess(640 * 480, _MAX_SOURCE_PIXELS)
+
+            _pre_generate_thumbnail(str(source), str(media_root))
+
+            dest = media_root / ".thumbs" / "200" / "chat1" / "photo.webp"
+            self.assertTrue(dest.exists())
+            with PILImage.open(dest) as thumb:
+                self.assertEqual(thumb.format, "WEBP")
+                self.assertLessEqual(thumb.width, 200)
+                self.assertLessEqual(thumb.height, 200)
+            self.assertEqual(list(dest.parent.glob(".thumb-*.tmp")), [])
+
+    def test_oversized_jpeg_keeps_its_thumbnail(self):
+        """The gate is format-aware: a 26 MP camera JPEG is over the pixel
+        threshold but safe, because ``img.thumbnail()`` drafts JPEG decoding
+        down to 1/8 scale. Refusing it would silently strip thumbnails from
+        every full-resolution camera upload.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            source = media_root / "chat1" / "camera.jpg"
+            source.parent.mkdir(parents=True)
+            self.assertGreater(6000 * 4400, _MAX_SOURCE_PIXELS)
+            PILImage.new("RGB", (6000, 4400), "green").save(source, "JPEG", quality=50)
+
+            _pre_generate_thumbnail(str(source), str(media_root))
+
+            dest = media_root / ".thumbs" / "200" / "chat1" / "camera.webp"
+            self.assertTrue(dest.exists())
+            with PILImage.open(dest) as thumb:
+                self.assertEqual(thumb.format, "WEBP")
+
+    def test_thumbnail_is_written_via_temp_file_and_atomic_replace(self):
+        """Pillow must never stream into the final cache path directly."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            source = media_root / "chat1" / "photo.png"
+            source.parent.mkdir(parents=True)
+            PILImage.new("RGB", (300, 200), "red").save(source)
+
+            saved_to = []
+            real_save = PILImage.Image.save
+
+            def recording_save(img_self, fp, *args, **kwargs):
+                saved_to.append(Path(fp))
+                return real_save(img_self, fp, *args, **kwargs)
+
+            with patch.object(PILImage.Image, "save", recording_save):
+                _pre_generate_thumbnail(str(source), str(media_root))
+
+            dest = media_root / ".thumbs" / "200" / "chat1" / "photo.webp"
+            self.assertEqual(len(saved_to), 1)
+            self.assertNotEqual(saved_to[0], dest)
+            self.assertEqual(saved_to[0].parent, dest.parent)  # same dir, so os.replace() is atomic
+            self.assertTrue(saved_to[0].name.startswith(".thumb-"))
+            self.assertTrue(dest.exists())
+            self.assertEqual(list(dest.parent.glob(".thumb-*.tmp")), [])
+
+    def test_interrupted_write_never_leaves_a_visible_thumbnail(self):
+        """A save that dies mid-write must not leave dest half-written.
+
+        The viewer's only completeness check is ``dest.exists()``, and it
+        serves thumbnails with a long-lived cache header -- a torn file would
+        be cached by every client that raced the write.
+        """
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            source = media_root / "chat1" / "photo.png"
+            source.parent.mkdir(parents=True)
+            PILImage.new("RGB", (300, 200), "red").save(source)
+
+            def torn_save(img_self, fp, *args, **kwargs):
+                Path(fp).write_bytes(b"RIFF\x00\x00")  # half a WEBP header...
+                raise OSError(28, "No space left on device")  # ...then the disk fills
+
+            with patch.object(PILImage.Image, "save", torn_save):
+                _pre_generate_thumbnail(str(source), str(media_root))
+
+            dest = media_root / ".thumbs" / "200" / "chat1" / "photo.webp"
+            self.assertFalse(dest.exists())
+            self.assertEqual(list(dest.parent.glob("*")), [])  # and no torn temp left behind
 
 
 if __name__ == "__main__":

--- a/tests/test_poison_message_isolation.py
+++ b/tests/test_poison_message_isolation.py
@@ -7,16 +7,43 @@ dialog in the sweep and drop the message outright in the listener -- and because
 sync cursor is checkpointed before the offending message, every later run resumed at
 the same message and failed the same way, so that chat never advanced again.
 
-These tests pin the defensive probe in every copy of the pattern.
+These tests pin the defensive probe in every copy of the pattern, plus the
+per-message isolation that keeps ANY future shape drift from wedging a chat the
+same way, and the neighbouring capture-path guarantees audited alongside it:
+peer-resolution errors never reaching the logs, terminal auth errors failing
+fast, and the listener's media download holding the client-wide flood threshold
+for one attempt only while never leaving a ``.part`` file behind.
 """
 
+import asyncio
+import os
+import shutil
+import tempfile
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
-from telethon.tl.types import DocumentEmpty, MessageMediaDocument
+from telethon.errors import (
+    AuthKeyDuplicatedError,
+    FloodWaitError,
+    SessionRevokedError,
+)
+from telethon.tl.types import DocumentEmpty, MessageMediaDocument, MessageMediaPhoto
 
 from src.listener import TelegramListener
-from src.telegram_backup import TelegramBackup
+from src.telegram_backup import TelegramBackup, call_with_flood_retry
+
+# Telethon's peer-resolution ValueError spells the id out in its message; the
+# fake below is the exact template (telethon/client/users.py).
+PEER_ERROR_TEXT = "Could not find the input entity for PeerUser(user_id=555000111)"
+PEER_ID_IN_TEXT = "555000111"
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
 
 
 def _poison_media():
@@ -73,6 +100,443 @@ class TestDocumentEmptyIsNotFatal(unittest.TestCase):
         media.document = document
         self.assertEqual(self.backup._get_media_type(media), "document")
         self.assertEqual(self.listener._get_media_type(media), "document")
+
+
+class TestOneBadMessageCannotWedgeAChat(unittest.TestCase):
+    """Per-message isolation in the sweep and in gap-fill.
+
+    The probe above fixes the shape we know about. This pins the property that
+    matters for the ones we don't: a message _process_message cannot handle must
+    not abort the dialog, and the sync cursor must never move past it -- if it
+    did, the message would be skipped forever instead of retried.
+    """
+
+    CHAT_ID = 100
+    POISON_ID = 3
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+        self.config = MagicMock()
+        self.config.batch_size = 2
+        self.config.checkpoint_interval = 1
+        self.config.skip_media_chat_ids = set()
+        self.config.skip_media_delete_existing = False
+        self.config.sync_deletions_edits = False
+        self.config.reaction_resweep_days = 0
+        self.config.should_skip_topic = MagicMock(return_value=False)
+        self.config.media_path = os.path.join(self.temp_dir, "media")
+
+        self.db = AsyncMock()
+        self.db.get_last_message_id.return_value = 0
+
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.config = self.config
+        self.backup.db = self.db
+        self.backup.client = MagicMock()
+        self.backup._cleaned_media_chats = set()
+        self.backup._get_marked_id = MagicMock(return_value=self.CHAT_ID)
+        self.backup._extract_chat_data = MagicMock(return_value={"id": self.CHAT_ID})
+        self.backup._ensure_profile_photo = AsyncMock()
+        self.backup._sync_pinned_messages = AsyncMock()
+
+        self.committed: list[int] = []
+
+        async def commit(batch, chat_id):
+            self.committed.extend(m["id"] for m in batch)
+
+        self.backup._commit_batch = AsyncMock(side_effect=commit)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _make_message(self, msg_id):
+        msg = MagicMock()
+        msg.id = msg_id
+        # MagicMock truthiness would otherwise make every message look like a
+        # forum reply and be topic-filtered.
+        msg.reply_to = None
+        msg.action = None
+        return msg
+
+    def _feed(self, ids):
+        messages = [self._make_message(i) for i in ids]
+
+        async def fake_iter(*args, **kwargs):
+            for message in messages:
+                yield message
+
+        self.backup.client.iter_messages = fake_iter
+
+    def _poison_processor(self):
+        async def process(message, chat_id):
+            if message.id == self.POISON_ID:
+                raise AttributeError("'DocumentEmpty' object has no attribute 'attributes'")
+            return {"id": message.id, "chat_id": chat_id}
+
+        return AsyncMock(side_effect=process)
+
+    def _cursor_ids(self):
+        return [call.args[1] for call in self.db.update_sync_status.await_args_list]
+
+    def test_dialog_survives_one_unprocessable_message(self):
+        """Every other message in the chat is still archived."""
+        self._feed([1, 2, 3, 4, 5])
+        self.backup._process_message = self._poison_processor()
+
+        result = _run(self.backup._backup_dialog(MagicMock()))
+
+        self.assertEqual(result, 4)
+        self.assertEqual(self.committed, [1, 2, 4, 5])
+
+    def test_cursor_never_moves_past_the_failed_message(self):
+        """The poison message stays retryable instead of being skipped forever."""
+        self._feed([1, 2, 3, 4, 5])
+        self.backup._process_message = self._poison_processor()
+
+        _run(self.backup._backup_dialog(MagicMock()))
+
+        self.assertTrue(self._cursor_ids(), "the dialog must still checkpoint what it did archive")
+        for cursor_id in self._cursor_ids():
+            self.assertLess(cursor_id, self.POISON_ID)
+
+    def test_failure_is_surfaced_as_a_count_with_no_identifiers(self):
+        self._feed([1, 2, 3, 4, 5])
+        self.backup._process_message = self._poison_processor()
+
+        with self.assertLogs("src.telegram_backup", level="WARNING") as cm:
+            _run(self.backup._backup_dialog(MagicMock()))
+
+        warnings = [r.getMessage() for r in cm.records if "could not be processed" in r.getMessage()]
+        self.assertEqual(len(warnings), 1)
+        self.assertIn("1 message(s)", warnings[0])
+        self.assertNotIn(str(self.POISON_ID), warnings[0])
+        self.assertNotIn(str(self.CHAT_ID), warnings[0])
+
+    def test_clean_dialog_still_advances_the_cursor(self):
+        """Positive control: nothing freezes when nothing fails."""
+        self._feed([1, 2, 3, 4])
+        self.backup._process_message = AsyncMock(side_effect=lambda m, c: {"id": m.id, "chat_id": c})
+
+        result = _run(self.backup._backup_dialog(MagicMock()))
+
+        self.assertEqual(result, 4)
+        self.assertEqual(self._cursor_ids()[-1], 4)
+
+    def test_topic_skipped_messages_still_advance_the_cursor(self):
+        """Skipping is not failing: a filtered chat must not re-scan forever."""
+        self._feed([1, 2, 3, 4])
+        self.config.should_skip_topic = MagicMock(return_value=True)
+        self.backup._process_message = AsyncMock()
+
+        result = _run(self.backup._backup_dialog(MagicMock()))
+
+        self.assertEqual(result, 0)
+        self.backup._process_message.assert_not_awaited()
+        self.assertEqual(self._cursor_ids(), [4])
+
+    def test_gap_fill_isolates_one_unprocessable_message(self):
+        """_fill_gap_range must recover the rest of the gap, not abandon it."""
+        self._feed([1, 2, 3, 4])
+        self.backup._process_message = self._poison_processor()
+
+        recovered = _run(self.backup._fill_gap_range(MagicMock(), self.CHAT_ID, 0, 5))
+
+        self.assertEqual(recovered, 3)
+        self.assertEqual(self.committed, [1, 2, 4])
+
+
+class TestPeerResolutionErrorsNeverReachTheLogs(unittest.TestCase):
+    """Telethon's exception text carries the chat id; only the type may be logged.
+
+    These sites predate the #274 sweep's AST scanner, which is blind to ``{e}``.
+    """
+
+    def setUp(self):
+        self.config = MagicMock()
+        self.config.skip_media_chat_ids = set()
+        self.config.gap_threshold = 5
+        self.config.get_max_media_size_bytes = MagicMock(return_value=50 * 1024 * 1024)
+        self.config.max_media_download_attempts = 3
+
+        self.db = AsyncMock()
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.config = self.config
+        self.backup.db = self.db
+        self.backup.client = MagicMock()
+
+    def _assert_no_peer_id(self, records):
+        messages = [r.getMessage() for r in records if r.levelname in ("WARNING", "ERROR")]
+        self.assertTrue(messages, "the failure must still be reported")
+        for message in messages:
+            self.assertNotIn(PEER_ID_IN_TEXT, message)
+            self.assertNotIn("PeerUser", message)
+
+    def test_gap_fill_entity_failure_logs_the_type_only(self):
+        self.backup.client.get_entity = AsyncMock(side_effect=ValueError(PEER_ERROR_TEXT))
+
+        with self.assertLogs("src.telegram_backup", level="WARNING") as cm:
+            summary = _run(self.backup._fill_gaps(chat_id=-1001234567890))
+
+        self.assertEqual(summary["errors"], 1)
+        self._assert_no_peer_id(cm.records)
+
+    def test_media_verification_access_failure_logs_the_type_only(self):
+        self.db.get_media_for_verification.return_value = [
+            {"file_path": "/nonexistent/photo.jpg", "file_size": 100, "chat_id": -1001234567890, "message_id": 10}
+        ]
+        self.backup.client.get_messages = AsyncMock(side_effect=ValueError(PEER_ERROR_TEXT))
+
+        with self.assertLogs("src.telegram_backup", level="WARNING") as cm:
+            _run(self.backup._verify_and_redownload_media())
+
+        self._assert_no_peer_id(cm.records)
+
+    def test_pending_media_retry_access_failure_logs_the_type_only(self):
+        self.db.get_pending_media_downloads.return_value = [
+            {"id": 1, "chat_id": -1001234567890, "message_id": 10, "file_path": "/nonexistent/photo.jpg"}
+        ]
+        self.db.count_capped_media_downloads.return_value = 0
+        self.backup.client.get_messages = AsyncMock(side_effect=ValueError(PEER_ERROR_TEXT))
+
+        with self.assertLogs("src.telegram_backup", level="WARNING") as cm:
+            _run(self.backup._retry_pending_media_downloads())
+
+        self._assert_no_peer_id(cm.records)
+
+
+class TestTerminalAuthErrorsFailFast(unittest.TestCase):
+    """A revoked or duplicated session is permanent: retrying it is pure delay."""
+
+    def _call_counting(self, exc):
+        calls = []
+
+        async def boom():
+            calls.append(1)
+            raise exc
+
+        return boom, calls
+
+    def _drive(self, exc):
+        boom, calls = self._call_counting(exc)
+        with patch("src.telegram_backup.asyncio.sleep", new=AsyncMock()) as slept, self.assertRaises(type(exc)):
+            _run(call_with_flood_retry(boom))
+        return calls, slept
+
+    def test_session_revoked_raises_on_the_first_attempt(self):
+        calls, slept = self._drive(SessionRevokedError(request=None))
+        self.assertEqual(len(calls), 1)
+        slept.assert_not_awaited()
+
+    def test_auth_key_duplicated_raises_on_the_first_attempt(self):
+        calls, slept = self._drive(AuthKeyDuplicatedError(request=None))
+        self.assertEqual(len(calls), 1)
+        slept.assert_not_awaited()
+
+    def test_connection_errors_are_still_retried(self):
+        """Positive control: the harness can tell 'retried' from 'not retried'."""
+        calls, slept = self._drive(ConnectionError("transport dropped"))
+        self.assertGreater(len(calls), 1)
+        slept.assert_awaited()
+
+
+class _FakeEventClient:
+    """Telethon's add_event_handler only ever appends; so does this."""
+
+    def __init__(self):
+        self.handlers = []
+        self.flood_sleep_threshold = 0
+
+    def on(self, event):
+        def decorator(callback):
+            self.handlers.append((event, callback))
+            return callback
+
+        return decorator
+
+    def remove_event_handler(self, callback):
+        before = len(self.handlers)
+        self.handlers = [(e, cb) for e, cb in self.handlers if cb is not callback]
+        return before - len(self.handlers)
+
+    def is_connected(self):
+        return False
+
+
+def _listener_config(**overrides):
+    config = MagicMock()
+    config.validate_credentials = MagicMock()
+    config.listen_edits = True
+    config.listen_deletions = False
+    config.listen_new_messages = True
+    config.listen_new_messages_media = True
+    config.listen_reactions = False
+    config.listen_chat_actions = True
+    config.skip_topic_ids = {}
+    config.should_skip_topic = MagicMock(return_value=False)
+    config.mass_operation_threshold = 100
+    config.mass_operation_window_seconds = 30
+    config.mass_operation_buffer_delay = 2.0
+    config.max_filename_bytes = 255
+    config.deduplicate_media = True
+    config.get_max_media_size_bytes = MagicMock(return_value=50 * 1024 * 1024)
+    config.should_download_media_for_chat = MagicMock(return_value=True)
+    config.media_flood_sleep_threshold = 60
+    for key, value in overrides.items():
+        setattr(config, key, value)
+    return config
+
+
+class TestListenerDetachesItsHandlers(unittest.TestCase):
+    """A stopped listener must stop receiving events.
+
+    The scheduler builds a NEW listener on the SAME shared client after every
+    network blip, so a listener that never detaches leaves one more live
+    instance behind on each restart: duplicate writes, duplicate viewer
+    broadcasts, duplicate media downloads.
+    """
+
+    def _make_listener(self, client):
+        return TelegramListener(_listener_config(), AsyncMock(), client=client)
+
+    def test_stop_detaches_every_handler_it_registered(self):
+        client = _FakeEventClient()
+        listener = self._make_listener(client)
+        listener._register_handlers()
+        registered = len(client.handlers)
+        self.assertGreater(registered, 0)
+
+        _run(listener.stop())
+
+        self.assertEqual(client.handlers, [])
+        self.assertEqual(listener._registered_handlers, [])
+
+    def test_restart_does_not_double_the_handlers_on_a_shared_client(self):
+        client = _FakeEventClient()
+        first = self._make_listener(client)
+        first._register_handlers()
+        registered = len(client.handlers)
+
+        _run(first.stop())
+        second = self._make_listener(client)
+        second._register_handlers()
+
+        self.assertEqual(len(client.handlers), registered)
+
+
+class TestListenerMediaDownloadDiscipline(unittest.TestCase):
+    """Two guarantees on the live download path, both already true in the sweep."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.chat_id = -1001234567890
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _make_listener(self, **overrides):
+        config = _listener_config(media_path=self.temp_dir, **overrides)
+        listener = TelegramListener(config, AsyncMock())
+        listener.db.find_media_by_content_hash = AsyncMock(return_value=None)
+        listener.client = MagicMock()
+        listener.client.flood_sleep_threshold = 0
+        return listener
+
+    def _photo_message(self):
+        message = MagicMock()
+        message.id = 4242
+        message.reply_to = None
+        media = MagicMock(spec=MessageMediaPhoto)
+        media.photo = MagicMock()
+        media.photo.id = 123
+        media.photo.sizes = []
+        message.media = media
+        return message
+
+    def _part_files(self):
+        found = []
+        for root, _dirs, files in os.walk(self.temp_dir):
+            found.extend(os.path.join(root, f) for f in files if f.endswith(".part"))
+        return found
+
+    def _failing_download(self, listener):
+        """Write a partial file, then fail the way a real transfer fails."""
+
+        async def fake_download(message, path):
+            with open(path, "wb") as handle:
+                handle.write(b"partial bytes")
+            # Above MAX_FLOOD_WAIT_SECONDS, so call_with_flood_retry gives up at once.
+            raise FloodWaitError(request=None, capture=7200)
+
+        listener.client.download_media = AsyncMock(side_effect=fake_download)
+
+    def test_failed_dedup_download_leaves_no_part_file(self):
+        listener = self._make_listener(deduplicate_media=True)
+        self._failing_download(listener)
+
+        result = _run(listener._download_media(self._photo_message(), self.chat_id))
+
+        self.assertIsNone(result)
+        self.assertEqual(self._part_files(), [])
+
+    def test_failed_direct_download_leaves_no_part_file(self):
+        listener = self._make_listener(deduplicate_media=False)
+        self._failing_download(listener)
+
+        result = _run(listener._download_media(self._photo_message(), self.chat_id))
+
+        self.assertIsNone(result)
+        self.assertEqual(self._part_files(), [])
+
+    def _drive_flood_retries(self, listener):
+        """Two floods then a success, sampling the client-wide threshold throughout."""
+        samples = {"attempt": [], "sleep": []}
+        floods = {"left": 2}
+
+        async def fake_download(message, path):
+            samples["attempt"].append(listener.client.flood_sleep_threshold)
+            if floods["left"]:
+                floods["left"] -= 1
+                raise FloodWaitError(request=None, capture=5)
+            with open(path, "wb") as handle:
+                handle.write(b"done")
+            return path
+
+        listener.client.download_media = AsyncMock(side_effect=fake_download)
+
+        async def fake_sleep(_seconds):
+            samples["sleep"].append(listener.client.flood_sleep_threshold)
+
+        with patch("src.telegram_backup.asyncio.sleep", new=fake_sleep):
+            result = _run(listener._download_media(self._photo_message(), self.chat_id))
+
+        self.assertIsNotNone(result)
+        return samples
+
+    def test_flood_threshold_is_released_between_retry_sleeps(self):
+        """absorb_media_floods is client-wide: it may cover one attempt, not the ladder.
+
+        Holding it across call_with_flood_retry's sleeps leaves every other
+        coroutine on the shared client silently sleeping inside Telethon for as
+        long as the retry ladder lasts.
+        """
+        listener = self._make_listener(deduplicate_media=False)
+
+        samples = self._drive_flood_retries(listener)
+
+        self.assertEqual(samples["attempt"], [60, 60, 60])
+        self.assertEqual(samples["sleep"], [0, 0])
+        self.assertEqual(listener.client.flood_sleep_threshold, 0)
+
+    def test_flood_threshold_is_released_between_retry_sleeps_when_deduplicating(self):
+        """Same ordering on the dedup path -- the default, and the other copy."""
+        listener = self._make_listener(deduplicate_media=True)
+
+        samples = self._drive_flood_retries(listener)
+
+        self.assertEqual(samples["attempt"], [60, 60, 60])
+        self.assertEqual(samples["sleep"], [0, 0])
+        self.assertEqual(listener.client.flood_sleep_threshold, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## The problem

Three capture-side reliability gaps from the full audit, all of the "correct on the path you tested, missing on the mirror" kind.

**One bad message could still wedge a chat.** The `DocumentEmpty` crash was fixed in #283, but the deeper shape remained: any single message that failed to process aborted the *whole dialog*, and because the sync cursor was checkpointed before it, the next run resumed at the same message and failed again. That chat never advanced. The same failures leaked identifiers — several peer-scoped Telethon calls interpolate their exception text into the log, and Telethon spells the chat/user id out in that text.

**Shared-media symlinks could be silently broken.** Concurrent ingest published a transient flat name into the dedup store, so a chat symlink could point at a name that no longer existed — an archived attachment you can never open again. The sharding migration moved relative symlinks a directory deeper without rewriting their targets, breaking every one it touched, and a single unreadable file aborted the migration and with it container startup.

**A decompression bomb hit the archiver first.** The pre-generated thumbnail path had only a byte-size gate, so a ~300 KB / 96 MP image ballooned memory *inside the backup process* — measured at ~367 MB — and the thumbnail was written non-atomically.

## The fix

- **Per-message isolation:** a failed message is contained and counted, and `running_max_id` freezes at the first failure so the cursor can never checkpoint past unprocessed work — it stays retryable instead of being skipped forever. Topic-skips still advance normally.
- **PII:** peer-scoped call sites log the exception *type*, not the interpolated message.
- Terminal auth errors fail fast; the listener's flood nesting matches the backup path; no orphaned `.part` files; the listener detaches handlers on stop so a restart leaves one listener, not N+1.
- Atomic shared-media publish; symlink targets rewritten during re-sharding; per-file migration errors contained.
- Archiver thumbnails gated on decoded pixels (format-aware, so valid JPEGs still work) and written via atomic replace.

## Verification

- Full suite: **2763 passed**, 171 subtests, 0 failures (baseline 2725).
- Every new test proven able to go red before being trusted — including the cursor-freeze test (the cursor sails past the poison message without it) and the PII tests (the raw id appears in the log line without it).
- The archiver bomb re-run against an **unpatched shadow tree**: thumbnail written with ~367 MB RSS there, refused here.
- `ruff` check and format clean under the pinned version.