### PR TITLE
fix: stop a crafted attachment exhausting viewer memory, and unblock push fan-out

### DIFF
--- a/src/web/push.py
+++ b/src/web/push.py
@@ -7,6 +7,7 @@ This module handles:
 - Sending push notifications to subscribed clients
 """
 
+import asyncio
 import ipaddress
 import json
 import logging
@@ -24,6 +25,19 @@ from ..message_utils import utcnow_naive
 logger = logging.getLogger(__name__)
 
 _LOCAL_HOSTNAME_SUFFIXES = (".local", ".internal")
+
+# webpush() is pywebpush's synchronous requests.post, and it always forwards its
+# own timeout argument -- so leaving it out means requests.post(timeout=None),
+# i.e. no timeout at all. One blackholed push endpoint would then hold a thread
+# until the OS gives up on the TCP connection. Note requests applies this value
+# per socket operation (the connect, then each read), not to the request as a
+# whole: a fully silent endpoint is cut off after one interval, but an endpoint
+# that keeps trickling bytes can hold its thread longer than this value.
+_PUSH_TIMEOUT_SECONDS = 10
+# Sends run on the loop's default thread executor, which thumbnail generation
+# also uses. Cap the fan-out so a large subscriber list cannot occupy every
+# worker thread for the length of a timeout.
+_PUSH_CONCURRENCY = 8
 
 
 def validate_push_endpoint(endpoint: str) -> bool:
@@ -344,35 +358,48 @@ class PushNotificationManager:
             "timestamp": utcnow_naive().isoformat(),
         }
 
-        sent = 0
-        failed_endpoints = []
+        semaphore = asyncio.Semaphore(_PUSH_CONCURRENCY)
 
-        for sub in subscriptions:
+        async def deliver(sub: dict[str, Any]) -> tuple[bool, str | None]:
+            """Send one notification. Returns (sent, endpoint to prune)."""
             try:
                 # Extract origin from endpoint for VAPID audience claim
-                from urllib.parse import urlparse
-
                 endpoint_url = urlparse(sub["endpoint"])
                 audience = f"{endpoint_url.scheme}://{endpoint_url.netloc}"
 
                 # Generate VAPID headers using py_vapid
                 vapid_headers = self._vapid.sign({"sub": self.config.vapid_contact, "aud": audience})
 
-                webpush(subscription_info=sub, data=json.dumps(payload), headers=vapid_headers)
-                sent += 1
+                async with semaphore:
+                    # webpush() blocks: run it off the event loop and bound it,
+                    # or one slow push service stalls the whole viewer.
+                    await asyncio.to_thread(
+                        webpush,
+                        subscription_info=sub,
+                        data=json.dumps(payload),
+                        headers=vapid_headers,
+                        timeout=_PUSH_TIMEOUT_SECONDS,
+                    )
+                return True, None
             except WebPushException as e:
                 if e.response and e.response.status_code in (404, 410):
                     # Subscription expired or unsubscribed
-                    failed_endpoints.append(sub["endpoint"])
                     logger.debug(f"Push subscription expired: {sub['endpoint'][:50]}...")
-                elif e.response and e.response.status_code == 403:
+                    return False, sub["endpoint"]
+                if e.response and e.response.status_code == 403:
                     # Permission denied - user blocked notifications
-                    failed_endpoints.append(sub["endpoint"])
                     logger.info(f"Push blocked by user (403): {sub['endpoint'][:50]}...")
-                else:
-                    logger.warning(f"Push notification failed: {e}")
+                    return False, sub["endpoint"]
+                logger.warning(f"Push notification failed: {e}")
+                return False, None
             except Exception as e:
                 logger.warning(f"Push notification error: {e}")
+                return False, None
+
+        results = await asyncio.gather(*(deliver(sub) for sub in subscriptions))
+
+        sent = sum(1 for delivered, _ in results if delivered)
+        failed_endpoints = [endpoint for _, endpoint in results if endpoint]
 
         # Clean up expired subscriptions
         for endpoint in failed_endpoints:

--- a/src/web/thumbnails.py
+++ b/src/web/thumbnails.py
@@ -14,6 +14,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 
 from PIL import Image
@@ -29,16 +30,83 @@ Image.MAX_IMAGE_PIXELS = 50_000_000
 ALLOWED_SIZES: set[int] = {200, 400}
 WEBP_QUALITY = 80
 _MAX_SOURCE_BYTES = 50 * 1024 * 1024  # 50 MB
+# Peak decode memory is set by pixel count, not by compressed size, so the byte
+# gate above cannot bound it: a 12000x8000 PNG of flat colour is under 300 KB on
+# disk and still costs ~390 MB to decode (Pillow holds ~4 bytes per pixel while
+# resizing). Image.MAX_IMAGE_PIXELS is no help either -- Pillow only raises above
+# TWICE that value, so everything up to 100 MP proceeds after a warning nobody
+# reads. 25 MP caps what a single decode may cost, and the Semaphore(8) below
+# caps how many decodes run at once, so peak thumbnail memory stays a small
+# multiple of one capped decode instead of growing with request count -- and
+# the cap still covers every Telegram-compressed photo and ordinary camera
+# image. The image lane compares this against the size Pillow will actually
+# decode (after draft(), see _generate_sync); the video lane passes it to
+# ffmpeg as -max_pixels so the decoder itself refuses an oversized frame.
+_MAX_SOURCE_PIXELS = 25_000_000
 
 _IMAGE_EXTENSIONS: set[str] = {f".{ext}" for ext in IMAGE_EXTENSIONS}
 _VIDEO_EXTENSIONS: set[str] = {f".{ext}" for ext in VIDEO_EXTENSIONS}
 
-# Limit concurrent thumbnail generations to cap peak memory (~15MB per decode)
+# Limit concurrent thumbnail generations to cap peak memory (see _MAX_SOURCE_PIXELS)
 _generation_semaphore = asyncio.Semaphore(8)
 # Video thumbnails are heavier (ffmpeg subprocess) — lower concurrency limit
 _video_semaphore = asyncio.Semaphore(2)
 
 _DEFAULT_CACHE_DIR = "/tmp/telegram-archive-thumbs"
+
+# Remember recent generation failures. Nothing is written when generation fails,
+# so without this an undecodable video re-runs ffmpeg (up to two 15s subprocess
+# attempts, holding one of only two video slots) on every single request, for
+# every viewer, forever. Time-bounded rather than permanent so a truncated
+# download that later completes -- or a media volume that was briefly away --
+# recovers on its own.
+_FAILURE_TTL_SECONDS = 300.0
+_MAX_FAILURE_ENTRIES = 1024
+_recent_failures: dict[tuple[int, str], float] = {}
+
+
+def _failure_cached(key: tuple[int, str]) -> bool:
+    """True when this (size, source) failed recently enough to skip retrying."""
+    expires_at = _recent_failures.get(key)
+    if expires_at is None:
+        return False
+    if expires_at <= time.monotonic():
+        _recent_failures.pop(key, None)
+        return False
+    return True
+
+
+def _record_failure(key: tuple[int, str]) -> None:
+    """Remember a failed generation for _FAILURE_TTL_SECONDS."""
+    now = time.monotonic()
+    if len(_recent_failures) >= _MAX_FAILURE_ENTRIES:
+        for stale in [k for k, expires_at in _recent_failures.items() if expires_at <= now]:
+            del _recent_failures[stale]
+        if len(_recent_failures) >= _MAX_FAILURE_ENTRIES:
+            # Dropping entries only costs a regeneration, never correctness.
+            _recent_failures.clear()
+    _recent_failures[key] = now + _FAILURE_TTL_SECONDS
+
+
+def _save_webp_atomic(img: Image.Image, dest: Path) -> None:
+    """Write the WebP through a temp file in dest's directory, then os.replace().
+
+    Pillow streams straight into whatever path it is given, so writing to the
+    cache path directly makes a half-written file visible to any concurrent
+    request -- dest.exists() is the only completeness check there is, and the
+    truncated result is then served with a 24h Cache-Control. os.replace() is
+    atomic, so the cache path only ever appears fully written.
+    """
+    # Short fixed prefix: media names are already near the filesystem's
+    # per-component byte budget, so embedding one here could overflow it.
+    fd, tmp_name = tempfile.mkstemp(dir=dest.parent, prefix=".thumb-", suffix=".tmp")
+    os.close(fd)
+    tmp_path = Path(tmp_name)
+    try:
+        img.save(tmp_path, "WEBP", quality=WEBP_QUALITY)
+        os.replace(tmp_path, dest)
+    finally:
+        tmp_path.unlink(missing_ok=True)
 
 
 def resolve_cache_dir(media_root: Path | None) -> Path:
@@ -105,6 +173,17 @@ def _generate_video_sync(source: Path, dest: Path, size: int) -> bool:
                     [
                         "ffmpeg",
                         "-y",
+                        # The lane is chosen by the sender-controlled filename
+                        # extension, and the byte gate above cannot see pixel
+                        # cost, so a 96 MP still renamed .mp4 would otherwise
+                        # drive ffmpeg's decoder to allocate a ~675 MB frame.
+                        # -max_pixels makes the decoder refuse any frame over
+                        # the cap (exit non-zero at ~16 MB, handled below),
+                        # which bounds the child for both crafted stills and
+                        # genuinely oversized video streams; ordinary videos
+                        # decode normally.
+                        "-max_pixels",
+                        str(_MAX_SOURCE_PIXELS),
                         "-ss",
                         seek_time,
                         "-i",
@@ -123,7 +202,7 @@ def _generate_video_sync(source: Path, dest: Path, size: int) -> bool:
             else:
                 return False
             with Image.open(tmp_path) as img:
-                img.save(dest, "WEBP", quality=WEBP_QUALITY)
+                _save_webp_atomic(img, dest)
             return True
         finally:
             Path(tmp_path).unlink(missing_ok=True)
@@ -145,8 +224,20 @@ def _generate_sync(source: Path, dest: Path, size: int) -> bool:
             return False
         dest.parent.mkdir(parents=True, exist_ok=True)
         with Image.open(source) as img:
+            # Image.open() parses only the header, so nothing is decoded yet.
+            # draft() next: formats that support it (JPEG) decode thumbnails at
+            # a reduced scale -- size * 2 asks for the same reduction that
+            # thumbnail()'s reducing_gap would -- so a 96 MP JPEG really costs
+            # ~1.5 MP and must not be refused for pixels it never decodes.
+            # Formats without draft support (PNG, BMP) keep their full size
+            # here, and those are exactly the decode bombs the gate is for.
+            img.draft(None, (size * 2, size * 2))
+            pixels = img.size[0] * img.size[1]
+            if pixels > _MAX_SOURCE_PIXELS:
+                logger.warning("Source too large for thumbnail (%d pixels)", pixels)
+                return False
             img.thumbnail((size, size), Image.LANCZOS)
-            img.save(dest, "WEBP", quality=WEBP_QUALITY)
+            _save_webp_atomic(img, dest)
         return True
     except Exception as e:
         logger.warning("Thumbnail generation failed: %s", describe_exception(e))
@@ -213,9 +304,16 @@ async def ensure_thumbnail(
         if not found:
             return None
 
+    failure_key = (size, str(source))
+    if _failure_cached(failure_key):
+        return None
+
     sem = _video_semaphore if is_vid else _generation_semaphore
     async with sem:
         loop = asyncio.get_running_loop()
         gen_fn = _generate_video_sync if is_vid else _generate_sync
         ok = await loop.run_in_executor(None, gen_fn, source, dest, size)
-    return (dest, resolved_folder) if ok else None
+    if not ok:
+        _record_failure(failure_key)
+        return None
+    return dest, resolved_folder

--- a/tests/test_media_and_push_hardening.py
+++ b/tests/test_media_and_push_hardening.py
@@ -544,18 +544,27 @@ class TestVideoLaneAgainstRealTools(unittest.TestCase):
 # Runs _generate_sync in a fresh interpreter and reports its peak RSS. A child
 # process is the only honest gauge here: ru_maxrss is a high-water mark, so in
 # the test process the source image we just created would mask the decode.
+# The decode size is reported instead of ru_maxrss. On Linux a forked child
+# inherits the parent's ru_maxrss high-water mark, so the number would describe
+# the pytest process (suite + coverage + the source image built above) rather
+# than the decode: measured 609 MB for a child that really used 10 MB. The
+# post-draft dimensions are the mechanism that bounds the memory, and they are
+# deterministic on every platform, so they are what this asserts.
 _CHILD_DECODE_SCRIPT = """
-import resource
 import sys
 from pathlib import Path
 
+from PIL import Image
+
 from src.web.thumbnails import _generate_sync
 
+# Mirror the draft() call _generate_sync makes, to observe what it decodes.
+with Image.open(sys.argv[1]) as probe:
+    probe.draft(None, (400, 400))
+    drafted = probe.size[0] * probe.size[1]
+
 ok = _generate_sync(Path(sys.argv[1]), Path(sys.argv[2]), 200)
-peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
-if sys.platform != "darwin":
-    peak *= 1024
-print(int(ok), peak)
+print(int(ok), drafted)
 """
 
 _REPO_ROOT = Path(thumbs.__file__).resolve().parents[2]
@@ -581,17 +590,20 @@ class TestDraftAwarePixelGate(unittest.TestCase):
                 env={**os.environ, "PYTHONPATH": str(_REPO_ROOT)},
             )
             self.assertEqual(child.returncode, 0, "decode child crashed")
-            ok_flag, peak = child.stdout.split()
+            ok_flag, drafted = child.stdout.split()
 
             self.assertEqual(int(ok_flag), 1, "a 96 MP JPEG was refused; the gate ignored draft()")
             self.assertTrue(dest.exists())
             with PILImage.open(dest) as img:
                 self.assertEqual(img.format, "WEBP")
                 self.assertLessEqual(max(img.size), 200)
+            # 96 MP on disk, but draft() hands the decoder a fraction of that.
+            # If draft() ever stops applying, this is what regresses first --
+            # and the gate would then refuse the file, failing the check above.
             self.assertLess(
-                int(peak),
-                250 * 1024 * 1024,
-                f"decode peaked at {int(peak)} bytes; draft() was not applied before decoding",
+                int(drafted),
+                thumbs._MAX_SOURCE_PIXELS,
+                f"draft() decoded {int(drafted)} pixels; it was not applied before decoding",
             )
 
     def test_decodable_png_bomb_of_the_same_size_is_still_refused(self):

--- a/tests/test_media_and_push_hardening.py
+++ b/tests/test_media_and_push_hardening.py
@@ -1,0 +1,631 @@
+"""Regression tests for thumbnail and push-fanout hardening.
+
+Covers four audit findings:
+- S5  push fan-out ran blocking HTTP with no timeout, sequentially, on the loop
+- S23 thumbnail generation was gated on file bytes, not decoded pixels
+- S26 thumbnails were written non-atomically into the live cache path
+- S28 failed thumbnail generation was never cached, so it re-ran per request
+
+And two residuals found against the S23 gate:
+- the video lane trusted the sender-chosen filename, so a 96 MP still image
+  renamed .mp4 bypassed the pixel gate and cost ffmpeg a full-size frame buffer
+- the gate read header pixels, refusing large JPEGs that draft() decodes
+  cheaply -- valid 96 MP JPEG documents 404ed for no memory benefit
+
+The push half depends on py_vapid/pywebpush, which may be missing locally; a
+module-level guard skips those tests gracefully (they run on CI).
+"""
+
+import asyncio
+import os
+import resource
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+import warnings
+import zlib
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from PIL import Image as PILImage
+
+import src.web.thumbnails as thumbs
+from src.web.thumbnails import _MAX_SOURCE_PIXELS, _generate_sync, _generate_video_sync, ensure_thumbnail
+
+try:
+    from src.web.push import PushNotificationManager
+
+    _PUSH_AVAILABLE = True
+except Exception:
+    _PUSH_AVAILABLE = False
+    PushNotificationManager = None  # type: ignore[assignment, misc]
+
+
+def _skip_unless_push(cls_or_fn):
+    """Skip test class/method when push module could not be imported."""
+    return unittest.skipUnless(_PUSH_AVAILABLE, "src.web.push import failed (missing py_vapid/pywebpush)")(cls_or_fn)
+
+
+def _make_enabled_manager():
+    """Helper: a PushNotificationManager with push enabled and _vapid stubbed."""
+    db = MagicMock()
+    cfg = MagicMock()
+    cfg.push_notifications = "full"
+    cfg.vapid_contact = "mailto:test@example.com"
+    mgr = PushNotificationManager(db, cfg)
+    mgr._vapid = MagicMock()
+    mgr._vapid.sign.return_value = {"Authorization": "vapid t=token"}
+    return mgr
+
+
+def _pixel_bomb_png(width: int, height: int) -> bytes:
+    """A tiny PNG whose IHDR claims huge dimensions.
+
+    This is the attack shape: a few dozen bytes on disk, ~4 bytes per claimed
+    pixel once decoded. Pillow reads the size from the header, so a gate that
+    runs before decoding sees the real cost.
+    """
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return struct.pack(">I", len(data)) + tag + data + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    return b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IDAT", zlib.compress(b"\x00")) + chunk(b"IEND", b"")
+
+
+def _write_png(path: Path, size: tuple[int, int], colour: str = "red") -> None:
+    img = PILImage.new("RGB", size, colour)
+    img.save(path, "PNG")
+
+
+_flat_png_cache: dict[tuple[int, int], bytes] = {}
+
+
+def _flat_png(width: int, height: int) -> bytes:
+    """A real, fully decodable flat-black PNG, built without a pixel buffer.
+
+    Unlike _pixel_bomb_png above, this file decodes cleanly end to end, so a
+    lane that ignores the header and just decodes (ffmpeg on a renamed file)
+    pays the full pixel cost -- ~280 KB on disk, 96 MP once decoded at the
+    default test size. Rows are streamed through one zlib compressor so the
+    test process never holds the raw pixels either.
+    """
+    cached = _flat_png_cache.get((width, height))
+    if cached is not None:
+        return cached
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        return struct.pack(">I", len(data)) + tag + data + struct.pack(">I", zlib.crc32(tag + data) & 0xFFFFFFFF)
+
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    comp = zlib.compressobj(9)
+    row = b"\x00" + b"\x00" * (width * 3)  # filter byte 0 + RGB zeros
+    idat = bytearray()
+    for _ in range(height):
+        idat += comp.compress(row)
+    idat += comp.flush()
+    data = b"\x89PNG\r\n\x1a\n" + chunk(b"IHDR", ihdr) + chunk(b"IDAT", bytes(idat)) + chunk(b"IEND", b"")
+    _flat_png_cache[(width, height)] = data
+    return data
+
+
+def _maxrss_bytes(raw: int) -> int:
+    """ru_maxrss is bytes on macOS and kibibytes on Linux."""
+    return raw if sys.platform == "darwin" else raw * 1024
+
+
+_REAL_FFMPEG = shutil.which("ffmpeg") is not None and shutil.which("ffprobe") is not None
+
+
+# ============================================================================
+# S23 - gate on decoded pixels, not on compressed bytes
+# ============================================================================
+
+
+class TestPixelBudget(unittest.TestCase):
+    """_generate_sync must refuse oversized images before decoding them."""
+
+    def test_pixel_bomb_is_refused_without_decoding_a_pixel(self):
+        """A 96 MP PNG of 66 bytes passes the byte gate and must still be refused."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "bomb.png"
+            source.write_bytes(_pixel_bomb_png(12000, 8000))
+            dest = Path(tmpdir) / "out.webp"
+
+            # Sanity: the existing byte gate cannot see this coming.
+            self.assertLess(source.stat().st_size, thumbs._MAX_SOURCE_BYTES)
+
+            decodes = []
+            real_load = PILImage.Image.load
+
+            def spy_load(self, *args, **kwargs):
+                decodes.append(1)
+                return real_load(self, *args, **kwargs)
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                with patch.object(PILImage.Image, "load", spy_load):
+                    ok = _generate_sync(source, dest, 200)
+
+            self.assertFalse(ok)
+            self.assertFalse(dest.exists())
+            self.assertEqual(decodes, [], "the pixel bomb was decoded before being refused")
+
+    def test_budget_is_below_pillows_effective_ceiling(self):
+        """Pillow only raises above 2x MAX_IMAGE_PIXELS, so our gate must be stricter."""
+        self.assertLess(_MAX_SOURCE_PIXELS, 2 * PILImage.MAX_IMAGE_PIXELS)
+        self.assertLess(_MAX_SOURCE_PIXELS, 12000 * 8000)
+
+    def test_ordinary_image_still_generates(self):
+        """The gate must not refuse a normal photo-sized source."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "photo.png"
+            _write_png(source, (300, 200))
+            dest = Path(tmpdir) / "thumbs" / "photo.webp"
+            dest.parent.mkdir()
+
+            self.assertTrue(_generate_sync(source, dest, 200))
+            with PILImage.open(dest) as img:
+                self.assertEqual(img.format, "WEBP")
+
+    def test_source_just_over_the_budget_is_refused(self):
+        """The gate fires on pixel count alone, at whatever budget is configured."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "wide.png"
+            _write_png(source, (100, 100))
+            dest = Path(tmpdir) / "wide.webp"
+
+            with patch.object(thumbs, "_MAX_SOURCE_PIXELS", 9999):
+                self.assertFalse(_generate_sync(source, dest, 200))
+            self.assertFalse(dest.exists())
+
+
+# ============================================================================
+# S26 - the cache path is either absent or complete
+# ============================================================================
+
+
+class TestAtomicThumbnailWrite(unittest.TestCase):
+    """A concurrent reader must never observe a partially written thumbnail."""
+
+    def _crash_midway(self, partial: bytes = b"RIFF-truncated"):
+        """A save() that writes some bytes and then dies, as a full disk would."""
+        real_save = PILImage.Image.save
+
+        def failing_save(img_self, fp, *args, **kwargs):
+            Path(fp).write_bytes(partial)
+            raise OSError("no space left on device")
+
+        return real_save, failing_save
+
+    def test_crash_midway_leaves_no_truncated_file_in_the_cache(self):
+        """An interrupted image write must not leave a servable, cacheable stub."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "photo.png"
+            _write_png(source, (300, 200))
+            dest = Path(tmpdir) / "thumbs" / "photo.webp"
+
+            _real, failing_save = self._crash_midway()
+            with patch.object(PILImage.Image, "save", failing_save):
+                ok = _generate_sync(source, dest, 200)
+
+            self.assertFalse(ok)
+            self.assertFalse(dest.exists(), "a truncated thumbnail was left in the cache path")
+
+    def test_video_crash_midway_leaves_no_truncated_file(self):
+        """Same guarantee on the video path, which writes through the same helper."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "clip.mp4"
+            source.write_bytes(b"\x00" * 128)
+            dest = Path(tmpdir) / "thumbs" / "clip.webp"
+            frame = Path(tmpdir) / "frame.jpg"
+            _write_png(frame, (64, 64))  # Pillow picks the format from the data, not the name
+
+            def fake_ffmpeg(cmd, **kwargs):
+                Path(cmd[-1]).write_bytes(frame.read_bytes())
+                return MagicMock(returncode=0)
+
+            _real, failing_save = self._crash_midway()
+            with (
+                patch.object(thumbs, "_check_ffmpeg", return_value=True),
+                patch.object(thumbs.subprocess, "run", fake_ffmpeg),
+                patch.object(PILImage.Image, "save", failing_save),
+            ):
+                ok = _generate_video_sync(source, dest, 200)
+
+            self.assertFalse(ok)
+            self.assertFalse(dest.exists(), "a truncated video thumbnail was left in the cache path")
+
+    def test_cache_path_never_exists_while_the_write_is_in_flight(self):
+        """dest.exists() is the only completeness check callers have; keep it honest."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "photo.png"
+            _write_png(source, (300, 200))
+            dest = Path(tmpdir) / "thumbs" / "photo.webp"
+
+            observed = []
+            written_to = []
+            real_save = PILImage.Image.save
+
+            def spy_save(img_self, fp, *args, **kwargs):
+                result = real_save(img_self, fp, *args, **kwargs)
+                # What a concurrent request would see at this instant.
+                written_to.append(Path(fp))
+                observed.append(dest.exists())
+                return result
+
+            with patch.object(PILImage.Image, "save", spy_save):
+                ok = _generate_sync(source, dest, 200)
+
+            self.assertTrue(ok)
+            self.assertEqual(observed, [False], "the cache path was visible before the write finished")
+            self.assertNotIn(dest, written_to, "Pillow wrote straight into the live cache path")
+            self.assertTrue(dest.exists())
+            with PILImage.open(dest) as img:
+                self.assertEqual(img.format, "WEBP")
+
+    def test_no_temp_files_are_left_behind(self):
+        """Success and failure both clean up the temp file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "photo.png"
+            _write_png(source, (300, 200))
+            dest = Path(tmpdir) / "thumbs" / "photo.webp"
+
+            self.assertTrue(_generate_sync(source, dest, 200))
+            self.assertEqual([p.name for p in dest.parent.iterdir()], ["photo.webp"])
+
+            _real, failing_save = self._crash_midway()
+            with patch.object(PILImage.Image, "save", failing_save):
+                _generate_sync(source, dest.parent / "other.webp", 200)
+            self.assertEqual([p.name for p in dest.parent.iterdir()], ["photo.webp"])
+
+
+# ============================================================================
+# S28 - failures are cached too, so broken media costs one attempt, not one per request
+# ============================================================================
+
+
+class TestFailedGenerationIsNotRepeated(unittest.IsolatedAsyncioTestCase):
+    """ensure_thumbnail must not re-run an expensive generation that just failed."""
+
+    def setUp(self):
+        thumbs._recent_failures.clear()
+
+    def tearDown(self):
+        thumbs._recent_failures.clear()
+
+    async def _request_three_times(self, filename: str, gen_name: str):
+        calls = []
+
+        def failing_generator(source, dest, size):
+            calls.append(1)
+            return False
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            (media_root / "chat1").mkdir()
+            (media_root / "chat1" / filename).write_bytes(b"\x00" * 64)
+
+            with patch.object(thumbs, gen_name, failing_generator):
+                for _ in range(3):
+                    self.assertIsNone(await ensure_thumbnail(media_root, 200, "chat1", filename))
+        return calls
+
+    async def test_undecodable_video_runs_ffmpeg_once_not_per_request(self):
+        """The expensive path (two 15s ffmpeg attempts) must not repeat per request."""
+        calls = await self._request_three_times("clip.mp4", "_generate_video_sync")
+        self.assertEqual(len(calls), 1, "video thumbnail generation re-ran for a known-bad file")
+
+    async def test_undecodable_image_is_also_only_attempted_once(self):
+        """Same guarantee on the image path — one failure, one attempt."""
+        calls = await self._request_three_times("broken.png", "_generate_sync")
+        self.assertEqual(len(calls), 1, "image thumbnail generation re-ran for a known-bad file")
+
+    async def test_negative_result_expires_so_a_repaired_file_recovers(self):
+        """A truncated download that later completes must not stay 404 forever."""
+        calls = []
+
+        def failing_generator(source, dest, size):
+            calls.append(1)
+            return False
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            (media_root / "chat1").mkdir()
+            (media_root / "chat1" / "clip.mp4").write_bytes(b"\x00" * 64)
+
+            with patch.object(thumbs, "_generate_video_sync", failing_generator):
+                await ensure_thumbnail(media_root, 200, "chat1", "clip.mp4")
+                # Age the recorded failure past its TTL.
+                for key in list(thumbs._recent_failures):
+                    thumbs._recent_failures[key] = time.monotonic() - 1
+                await ensure_thumbnail(media_root, 200, "chat1", "clip.mp4")
+
+        self.assertEqual(len(calls), 2, "an expired negative result was not retried")
+
+    async def test_failure_cache_is_bounded(self):
+        """The negative cache must not grow without limit."""
+        for index in range(thumbs._MAX_FAILURE_ENTRIES + 50):
+            thumbs._record_failure((200, f"/media/chat1/file{index}.mp4"))
+        self.assertLessEqual(len(thumbs._recent_failures), thumbs._MAX_FAILURE_ENTRIES)
+
+
+# ============================================================================
+# S5 - push fan-out is bounded, off the event loop, and concurrent
+# ============================================================================
+
+
+@_skip_unless_push
+class TestPushFanout(unittest.IsolatedAsyncioTestCase):
+    """One unreachable push endpoint must not stall the viewer."""
+
+    def _subs(self, count: int):
+        return [
+            {"endpoint": f"https://push.example.com/sub{i}", "keys": {"p256dh": "k", "auth": "a"}} for i in range(count)
+        ]
+
+    async def test_webpush_is_given_a_timeout(self):
+        """pywebpush forwards timeout to requests.post; omitting it means no timeout at all."""
+        mgr = _make_enabled_manager()
+        mgr.get_subscriptions = AsyncMock(return_value=self._subs(1))
+
+        with patch("src.web.push.webpush") as mock_webpush:
+            await mgr.send_notification("Title", "Body", chat_id=1)
+
+        timeout = mock_webpush.call_args.kwargs.get("timeout")
+        self.assertIsNotNone(timeout, "webpush was called without a timeout")
+        self.assertGreater(timeout, 0)
+
+    async def test_slow_endpoints_neither_block_the_loop_nor_serialize(self):
+        """A hung push service must not freeze the event loop or the other sends."""
+        mgr = _make_enabled_manager()
+        mgr.get_subscriptions = AsyncMock(return_value=self._subs(4))
+
+        ticks = 0
+
+        async def heartbeat():
+            nonlocal ticks
+            while True:
+                await asyncio.sleep(0.01)
+                ticks += 1
+
+        def slow_webpush(**kwargs):
+            time.sleep(0.15)
+
+        beat = asyncio.create_task(heartbeat())
+        try:
+            with patch("src.web.push.webpush", slow_webpush):
+                started = time.monotonic()
+                sent = await mgr.send_notification("Title", "Body", chat_id=1)
+                elapsed = time.monotonic() - started
+        finally:
+            beat.cancel()
+
+        self.assertEqual(sent, 4)
+        # Sequential on-loop sends would be 4 x 0.15s = 0.6s with zero heartbeats.
+        self.assertLess(elapsed, 0.45, f"sends did not run concurrently (took {elapsed:.2f}s)")
+        self.assertGreater(ticks, 0, "the event loop was blocked for the whole fan-out")
+
+    async def test_one_failing_endpoint_does_not_stop_the_others(self):
+        """Delivery to healthy subscribers survives a broken one."""
+        mgr = _make_enabled_manager()
+        mgr.get_subscriptions = AsyncMock(return_value=self._subs(3))
+        mgr.unsubscribe = AsyncMock()
+
+        calls = []
+
+        def flaky_webpush(**kwargs):
+            calls.append(kwargs["subscription_info"]["endpoint"])
+            if kwargs["subscription_info"]["endpoint"].endswith("sub1"):
+                raise OSError("connection reset")
+
+        with patch("src.web.push.webpush", flaky_webpush):
+            sent = await mgr.send_notification("Title", "Body", chat_id=1)
+
+        self.assertEqual(sent, 2)
+        self.assertEqual(len(calls), 3)
+
+
+# ============================================================================
+# Residual 1 - the video lane is routed by the sender-chosen filename, so a
+# still image renamed .mp4 reaches ffmpeg's decoder; -max_pixels bounds it
+# ============================================================================
+
+
+class TestVideoDecodeIsBounded(unittest.TestCase):
+    """_generate_video_sync must cap ffmpeg's decode at the pixel budget."""
+
+    def test_ffmpeg_command_carries_the_pixel_cap(self):
+        """The bound lives in the ffmpeg argv: -max_pixels == the pixel budget.
+
+        Without it, ffmpeg sizes its frame buffer from whatever dimensions the
+        bytes declare, so a 96 MP still renamed .mp4 allocates ~675 MB. This is
+        the deterministic half of the proof; the real-tool test below shows the
+        flag actually refusing the bomb at ~16 MB.
+        """
+        commands = []
+
+        def fake_ffmpeg(cmd, **kwargs):
+            commands.append(cmd)
+            PILImage.new("RGB", (64, 64), "blue").save(cmd[-1], "JPEG")
+            return MagicMock(returncode=0)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "clip.mp4"
+            source.write_bytes(b"\x00" * 128)
+            dest = Path(tmpdir) / "thumbs" / "clip.webp"
+            with (
+                patch.object(thumbs, "_check_ffmpeg", return_value=True),
+                patch.object(thumbs.subprocess, "run", fake_ffmpeg),
+            ):
+                ok = _generate_video_sync(source, dest, 200)
+
+        self.assertTrue(ok)
+        self.assertTrue(commands, "ffmpeg was never invoked")
+        for cmd in commands:
+            self.assertIn("-max_pixels", cmd, "ffmpeg was invoked without a pixel cap")
+            idx = cmd.index("-max_pixels")
+            self.assertEqual(
+                int(cmd[idx + 1]),
+                thumbs._MAX_SOURCE_PIXELS,
+                "the ffmpeg pixel cap does not match the configured budget",
+            )
+            # The cap must precede -i so it constrains the decoder that reads it.
+            self.assertLess(idx, cmd.index("-i"), "-max_pixels came after the input; ffmpeg ignores it there")
+
+
+@unittest.skipUnless(_REAL_FFMPEG, "needs real ffmpeg on PATH")
+class TestVideoLaneAgainstRealTools(unittest.TestCase):
+    """The measured attack, end to end: the same 96 MP flat PNG, renamed .mp4."""
+
+    def test_renamed_pixel_bomb_is_refused_without_a_large_decode(self):
+        """The ~280 KB / 96 MP PNG behind a .mp4 name cost ffmpeg ~675 MB RSS;
+        -max_pixels now makes the decoder refuse the frame at a small cost, so
+        no thumbnail is produced and no large buffer is ever allocated."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "bomb.mp4"  # sender-chosen name routes to the video lane
+            source.write_bytes(_flat_png(12000, 8000))
+            dest = Path(tmpdir) / "thumbs" / "bomb.webp"
+
+            children_before = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+            ok = _generate_video_sync(source, dest, 200)
+            children_after = resource.getrusage(resource.RUSAGE_CHILDREN).ru_maxrss
+
+            self.assertFalse(ok, "the renamed pixel bomb produced a video thumbnail")
+            self.assertFalse(dest.exists())
+            child_growth = _maxrss_bytes(children_after) - _maxrss_bytes(children_before)
+            self.assertLess(
+                child_growth,
+                300 * 1024 * 1024,
+                f"a decode child peaked {child_growth} bytes above the previous high-water mark "
+                "(the ~675 MB frame buffer was allocated)",
+            )
+
+    def test_genuine_small_video_still_thumbnails(self):
+        """The bound must not cost real, in-budget videos their thumbnails."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "clip.mp4"
+            created = subprocess.run(
+                [
+                    "ffmpeg",
+                    "-y",
+                    "-f",
+                    "lavfi",
+                    "-i",
+                    "testsrc=duration=2:size=64x64:rate=10",
+                    "-c:v",
+                    "mpeg4",
+                    "-q:v",
+                    "5",
+                    str(source),
+                ],
+                capture_output=True,
+                timeout=60,
+            )
+            if created.returncode != 0 or not source.exists():
+                self.skipTest("local ffmpeg cannot synthesize a test video")
+
+            dest = Path(tmpdir) / "thumbs" / "clip.webp"
+            self.assertTrue(_generate_video_sync(source, dest, 200))
+            with PILImage.open(dest) as img:
+                self.assertEqual(img.format, "WEBP")
+                self.assertLessEqual(max(img.size), 200)
+
+
+# ============================================================================
+# Residual 2 - the pixel gate must measure what Pillow will decode (draft()),
+# not what the header declares, or large valid JPEGs 404 for no benefit
+# ============================================================================
+
+# Runs _generate_sync in a fresh interpreter and reports its peak RSS. A child
+# process is the only honest gauge here: ru_maxrss is a high-water mark, so in
+# the test process the source image we just created would mask the decode.
+_CHILD_DECODE_SCRIPT = """
+import resource
+import sys
+from pathlib import Path
+
+from src.web.thumbnails import _generate_sync
+
+ok = _generate_sync(Path(sys.argv[1]), Path(sys.argv[2]), 200)
+peak = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+if sys.platform != "darwin":
+    peak *= 1024
+print(int(ok), peak)
+"""
+
+_REPO_ROOT = Path(thumbs.__file__).resolve().parents[2]
+
+
+class TestDraftAwarePixelGate(unittest.TestCase):
+    """96 MP JPEG -> thumbnail (draft decodes ~1.5 MP); 96 MP PNG -> refused."""
+
+    def test_large_valid_jpeg_still_thumbnails_in_bounded_memory(self):
+        """A 96 MP JPEG drafts down to a ~1.5 MP decode and must not 404."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "document.jpg"
+            page = PILImage.new("RGB", (12000, 8000), (40, 90, 130))
+            page.save(source, "JPEG", quality=60)
+            del page
+            dest = Path(tmpdir) / "thumbs" / "document.webp"
+
+            child = subprocess.run(
+                [sys.executable, "-c", _CHILD_DECODE_SCRIPT, str(source), str(dest)],
+                capture_output=True,
+                timeout=120,
+                cwd=_REPO_ROOT,
+                env={**os.environ, "PYTHONPATH": str(_REPO_ROOT)},
+            )
+            self.assertEqual(child.returncode, 0, "decode child crashed")
+            ok_flag, peak = child.stdout.split()
+
+            self.assertEqual(int(ok_flag), 1, "a 96 MP JPEG was refused; the gate ignored draft()")
+            self.assertTrue(dest.exists())
+            with PILImage.open(dest) as img:
+                self.assertEqual(img.format, "WEBP")
+                self.assertLessEqual(max(img.size), 200)
+            self.assertLess(
+                int(peak),
+                250 * 1024 * 1024,
+                f"decode peaked at {int(peak)} bytes; draft() was not applied before decoding",
+            )
+
+    def test_decodable_png_bomb_of_the_same_size_is_still_refused(self):
+        """The same 96 MP as a real PNG has no draft path and stays refused,
+        without decoding a pixel."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "bomb.png"
+            source.write_bytes(_flat_png(12000, 8000))
+            dest = Path(tmpdir) / "out.webp"
+
+            decodes = []
+            real_load = PILImage.Image.load
+
+            def spy_load(img_self, *args, **kwargs):
+                decodes.append(1)
+                return real_load(img_self, *args, **kwargs)
+
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                with patch.object(PILImage.Image, "load", spy_load):
+                    ok = _generate_sync(source, dest, 200)
+
+            self.assertFalse(ok, "a fully decodable 96 MP PNG got past the pixel gate")
+            self.assertFalse(dest.exists())
+            self.assertEqual(decodes, [], "the PNG bomb was decoded before being refused")
+
+    def test_small_jpeg_is_unaffected_by_the_draft_pass(self):
+        """draft() on an already-small JPEG is a no-op; output stays correct."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            source = Path(tmpdir) / "photo.jpg"
+            PILImage.new("RGB", (300, 200), (200, 30, 30)).save(source, "JPEG")
+            dest = Path(tmpdir) / "thumbs" / "photo.webp"
+
+            self.assertTrue(_generate_sync(source, dest, 200))
+            with PILImage.open(dest) as img:
+                self.assertEqual(img.format, "WEBP")
+                self.assertEqual(img.size, (200, 133))


### PR DESCRIPTION
## The problem

Thumbnail generation was gated on **file bytes, not decoded pixels**. A ~300 KB image that decodes to 96 megapixels — a decompression bomb any Telegram contact can send you — sailed through the size gate and cost hundreds of MB of RAM per request.

Worse, the guard that *was* added only covered the image lane. Routing to the video lane is by **filename extension**, and the sender controls the filename: the same bomb renamed `bomb.mp4` reached the video path, which only checked file size. Measured: `ok=True` in 0.75s with **~675 MB of ffmpeg child RSS**.

Two more issues on the same surface:
- Concurrent requests wrote the **same thumbnail file non-atomically**, so a reader could cache a truncated image essentially forever. Failed video thumbnails were never cached, so a broken video re-paid the cost on every request.
- The web-push fan-out ran **blocking HTTP with no timeout on the event loop**, sequentially over every subscription — one unreachable push endpoint stalled the entire viewer for every user until the OS TCP timeout.

## The fix

- Gate on **decoded pixel count**, and cover the video lane too so a renamed file cannot bypass it.
- The gate is **format-aware**: Pillow applies a JPEG `draft()` downscale during decode, so large JPEGs were never the bomb — measured 11 MB, not 372 MB. Refusing them would have 404'd valid documents for zero benefit, so JPEGs still thumbnail while PNG/BMP-class bombs are refused.
- Thumbnails write to a unique temp file and `os.replace()` atomically; failed video thumbnails cache the negative result.
- Push fan-out runs off the event loop, concurrently, with a real timeout.

## Verification

- Both exploits re-run against an **unpatched shadow tree** and confirmed still-live there, then confirmed dead here: the renamed `.mp4` bomb went from ~675 MB child RSS to refused; a 96 MP JPEG still produces a thumbnail.
- Every new test proven able to go red before being trusted.
- Full suite: **2752 passed**, 171 subtests, 0 failures. `ruff` check + format clean.

Behaviour note: an image whose header declares more than the pixel cap gets no gallery thumbnail (the tile falls back), while the full-size media still serves normally.