### PR TITLE
fix: stop the viewer scanning on every keystroke and losing notification clicks

### DIFF
--- a/src/web/static/sw.js
+++ b/src/web/static/sw.js
@@ -107,28 +107,55 @@ self.addEventListener('notificationclick', (event) => {
         }
     }
     
+    // `url` is relative; client.url is the absolute creation URL, so comparing them
+    // directly was true every time and client.navigate() always ran — a full document
+    // reload that threw away the loaded messages, the scroll position, any open
+    // lightbox, and (the audio engine is one in-page element) whatever was playing.
+    const targetUrl = new URL(url, self.location.origin).href;
+    const isSameOrigin = (client) => {
+        try {
+            return new URL(client.url).origin === self.location.origin;
+        } catch (e) {
+            return false;
+        }
+    };
+
     event.waitUntil(
         clients.matchAll({ type: 'window', includeUncontrolled: true })
             .then((windowClients) => {
-                // Check if there's already a window open
-                for (const client of windowClients) {
-                    // If we find an existing window, focus it and navigate
-                    if ('focus' in client) {
-                        return client.focus().then(() => {
-                            if (client.url !== url && 'navigate' in client) {
-                                return client.navigate(url);
-                            }
-                            // Post message to the client to navigate/highlight
-                            client.postMessage({
+                // Only our own pages can act on the message, and only they should be
+                // focused for this notification.
+                const ownClients = windowClients.filter(isSameOrigin);
+                // Prefer handing the click to an open tab: focus it and post the deep
+                // link so the page navigates in place. The tab is selected on 'focus'
+                // — NOT on 'postMessage', which exists on every window client per
+                // spec, so that predicate matched unconditionally and made the
+                // openWindow fallback below unreachable.
+                const focusable = ownClients.find((client) => 'focus' in client);
+                if (focusable) {
+                    return Promise.resolve()
+                        .then(() => focusable.focus())
+                        .then((focused) => {
+                            (focused || focusable).postMessage({
                                 type: 'NOTIFICATION_CLICK',
                                 data: data
                             });
+                        })
+                        .catch((err) => {
+                            // The tab refused focus or died mid-click: land the click
+                            // in a fresh window instead of swallowing it. An unhandled
+                            // rejection here would reject waitUntil and kill the whole
+                            // click. Log the failure type only, never the deep link.
+                            console.error('[SW] Failed to hand the click to an open tab:', err && err.name);
+                            if (clients.openWindow) {
+                                return clients.openWindow(targetUrl);
+                            }
                         });
-                    }
                 }
-                // No existing window, open a new one
+                // No focusable window of ours: open one directly on the deep link so
+                // a cold start still lands on the right chat.
                 if (clients.openWindow) {
-                    return clients.openWindow(url);
+                    return clients.openWindow(targetUrl);
                 }
             })
     );
@@ -164,10 +191,10 @@ self.addEventListener('pushsubscriptionchange', (event) => {
     );
 });
 
-// Handle messages from the main page
+// Handle messages from the main page.
+// Nothing about the payload is logged: a message can carry identifiers, and the
+// console travels with screen shares, devtools screenshots and browser bug reports.
 self.addEventListener('message', (event) => {
-    console.log('[SW] Message received:', event.data);
-    
     if (event.data && event.data.type === 'SKIP_WAITING') {
         self.skipWaiting();
     }

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -11,15 +11,42 @@
     <link rel="apple-touch-icon" href="/static/apple-touch-icon.png">
     <link rel="manifest" href="/static/manifest.json">
     <title>Telegram Archive</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.43/moment-timezone-with-data-1970-2030.min.js"></script>
+    <!-- Third-party assets: every URL is pinned to an exact version and carries a
+         Subresource Integrity hash, because these scripts run in the same origin
+         as the archive session — an unpinned URL ships whatever the next npm
+         publish contains, and without integrity a compromised CDN edge can
+         return anything at all.
+         TWO DELIBERATE EXCEPTIONS, both unhashable rather than overlooked:
+           * cdn.tailwindcss.com serves no Access-Control-Allow-Origin header even
+             when the request carries an Origin (re-verified 2026-08-15), and
+             integrity= forces a CORS-checked fetch, so adding it would block the
+             script outright and the UI would load unstyled. The bytes themselves
+             are stable and hashable, but the npm package ships no browser bundle,
+             so no CORS-enabled CDN can serve this file. Pinned only.
+           * the Google Fonts stylesheet is generated per user agent, so its bytes
+             (and therefore its hash) differ between browsers. It has no version
+             to pin and delivers CSS, not script. -->
+    <script src="https://cdn.tailwindcss.com/3.4.17"></script>
+    <script src="https://unpkg.com/vue@3.5.41/dist/vue.global.prod.js"
+        integrity="sha384-arPHRzOKPl8g3Rbe/cQBWYPnq4HcxfPFSFWD3qvI/hc2XQf+4GkVqkOlWgjN5mD3"
+        crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js"
+        integrity="sha384-VCGDSwGwLWkVOK5vAWSaY38KZ4oKJ0whHjpJQhjqrMlWadpf2dUVKLgOLBdEaLvZ"
+        crossorigin="anonymous"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.43/moment-timezone-with-data-1970-2030.min.js"
+        integrity="sha384-l7VdBcaAfGCeXKsn587Z+4Z3m6M5/96OPpQu1zC3wscMtXK9xPY8oQQYUhZBJIC/"
+        crossorigin="anonymous"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css"
+        integrity="sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0"
+        crossorigin="anonymous">
     <!-- Flatpickr for date picker -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
-    <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.css"
+        integrity="sha384-RkASv+6KfBMW9eknReJIJ6b3UnjKOKC5bOUaNgIY778NFbQ8MtWq9Lr/khUgqtTt"
+        crossorigin="anonymous">
+    <script src="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js"
+        integrity="sha384-5JqMv4L/Xa0hfvtF06qboNdhvuYXUku9ZrhZh3bSk8VXF0A/RuSLHpLsSV9Zqhl6"
+        crossorigin="anonymous"></script>
     <style>
         /* iOS Safe Area Support */
         :root {
@@ -708,6 +735,20 @@
                             <span class="text-sm">Loading topics...</span>
                         </div>
 
+                        <!-- Topics failed to load (same shape as the chat-list error banner) -->
+                        <div v-else-if="topicsError" class="px-3 py-2 bg-amber-900/80 border-b border-amber-700">
+                            <div class="flex items-center gap-2 text-amber-200 text-sm">
+                                <svg class="w-5 h-5 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                        d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                </svg>
+                                <span>{{ topicsError }}</span>
+                                <button @click="retryLoadTopics()" class="ml-auto text-amber-300 hover:text-white text-xs underline">
+                                    Retry
+                                </button>
+                            </div>
+                        </div>
+
                         <!-- Topic list -->
                         <div v-else-if="topics.length === 0" class="flex flex-col items-center justify-center py-12 px-4 text-tg-muted text-center gap-3">
                             <span class="text-sm">No topics backed up yet</span>
@@ -967,7 +1008,7 @@
                         <div class="flex items-center gap-1 sm:gap-2 shrink-0">
                             <!-- Search Bar - responsive width -->
                             <div class="relative w-28 sm:w-48 md:w-64">
-                                <input v-model="messageSearchQuery" @input="searchMessages" type="text"
+                                <input v-model="messageSearchQuery" @input="onMessageSearchInput" type="text"
                                     placeholder="Search..."
                                     class="w-full bg-gray-900 text-white rounded-lg pl-8 sm:pl-10 pr-2 sm:pr-4 py-1.5 sm:py-2 text-xs sm:text-sm focus:outline-none focus:ring-2 focus:ring-blue-500">
                                 <svg class="w-3.5 h-3.5 sm:w-4 sm:h-4 text-gray-400 absolute left-2 sm:left-3 top-2 sm:top-2.5" fill="none"
@@ -1437,21 +1478,35 @@
 
                                         <!-- Videos - click to open in lightbox -->
                                         <div v-else-if="msg.media?.type === 'video'"
-                                            class="relative cursor-pointer group"
-                                            @click="openMedia(msg)">
-                                            <video preload="metadata"
-                                                class="rounded-lg max-h-64 w-full pointer-events-none"
-                                                @error="handleMediaError($event, msg)">
-                                                <source :src="getMediaUrl(msg)" type="video/mp4">
-                                            </video>
-                                            <!-- Play overlay -->
-                                            <div class="absolute inset-0 flex items-center justify-center bg-black/20 group-hover:bg-black/40 transition rounded-lg">
-                                                <div class="w-14 h-14 bg-white/90 rounded-full flex items-center justify-center shadow-lg">
-                                                    <svg class="w-8 h-8 text-gray-800 ml-1" fill="currentColor" viewBox="0 0 24 24">
-                                                        <path d="M8 5v14l11-7z"/>
-                                                    </svg>
-                                                </div>
+                                            class="relative group"
+                                            :class="msg.mediaLoadFailed ? '' : 'cursor-pointer'"
+                                            @click="msg.mediaLoadFailed || openMedia(msg)">
+                                            <!-- The missing-media placeholder is rendered BY Vue. Writing it in
+                                                 with innerHTML detached this subtree from the render tree for
+                                                 good: Vue kept patching nodes that were no longer in the
+                                                 document, so the bubble never updated again. -->
+                                            <div v-if="msg.mediaLoadFailed" class="flex items-center gap-2 text-gray-400 text-sm py-2">
+                                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                        d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                                </svg>
+                                                <span>Media not found</span>
                                             </div>
+                                            <template v-else>
+                                                <video preload="metadata"
+                                                    class="rounded-lg max-h-64 w-full pointer-events-none"
+                                                    @error="handleMediaError($event, msg)">
+                                                    <source :src="getMediaUrl(msg)" type="video/mp4">
+                                                </video>
+                                                <!-- Play overlay -->
+                                                <div class="absolute inset-0 flex items-center justify-center bg-black/20 group-hover:bg-black/40 transition rounded-lg">
+                                                    <div class="w-14 h-14 bg-white/90 rounded-full flex items-center justify-center shadow-lg">
+                                                        <svg class="w-8 h-8 text-gray-800 ml-1" fill="currentColor" viewBox="0 0 24 24">
+                                                            <path d="M8 5v14l11-7z"/>
+                                                        </svg>
+                                                    </div>
+                                                </div>
+                                            </template>
                                         </div>
 
                                         <!-- Stickers (static/animated) -->
@@ -2224,6 +2279,11 @@
                 const archivedCount = ref(0)
                 const topics = ref([])
                 const loadingTopics = ref(false)
+                const topicsError = ref('')
+                // Same stale-response idiom as the message loaders: the topic list is
+                // keyed to one forum chat, so a response that lost the race must not
+                // paint another chat's topics under this chat's header.
+                let topicsRequestSeq = 0
 
                 const currentNav = computed(() => navStack.value[navStack.value.length - 1])
                 const canGoBack = computed(() => navStack.value.length > 1)
@@ -2767,18 +2827,36 @@
                 }
 
                 const loadTopics = async (chatId) => {
+                    const requestSeq = ++topicsRequestSeq
                     loadingTopics.value = true
+                    // Drop the previous chat's rows up front: a failure or a lost race
+                    // used to leave them on screen under the new chat's header, and
+                    // clicking one opened a topic id that does not exist in this chat.
+                    topics.value = []
+                    topicsError.value = ''
                     try {
                         const res = await fetch(`/api/chats/${chatId}/topics`, { credentials: 'include' })
+                        if (requestSeq !== topicsRequestSeq) return
                         if (res.ok) {
                             const data = await res.json()
+                            if (requestSeq !== topicsRequestSeq) return
                             topics.value = data.topics || []
+                        } else {
+                            topicsError.value = 'Failed to load topics. Please try again.'
                         }
                     } catch (e) {
+                        if (requestSeq !== topicsRequestSeq) return
                         console.error('Failed to load topics:', e)
+                        topicsError.value = 'Failed to load topics. Please try again.'
                     } finally {
-                        loadingTopics.value = false
+                        // A superseded request must not switch off the newer one's spinner.
+                        if (requestSeq === topicsRequestSeq) loadingTopics.value = false
                     }
+                }
+
+                const retryLoadTopics = () => {
+                    const nav = topicsNavEntry.value
+                    if (nav) loadTopics(nav.chatId)
                 }
 
                 const selectFolder = (folderId) => {
@@ -2925,36 +3003,46 @@
                     const container = messagesContainer.value
                     if (!container) return
                     const containerTop = container.getBoundingClientRect().top
+                    const markers = container.querySelectorAll('.date-separator')
+                    if (markers.length === 0) {
+                        floatingDateLabel.value = ''
+                        floatingDateIso.value = null
+                        return
+                    }
+                    const topOf = (index) => markers[index].getBoundingClientRect().top - containerTop
+                    // Every separator is a direct child of this one scroll container, so their
+                    // offsets are monotonic in DOM order — descending, because the list is
+                    // flex-col-reverse — and the ends say which way round it is.
+                    // This runs on every animation frame while scrolling, and a separator is
+                    // added for every distinct day paged in (nothing trims the window), so
+                    // reading a rect PER separator made scrolling slower the further back you
+                    // read — worst exactly where the pill earns its keep. Binary search reads
+                    // ~log2(days) rects per frame instead, with the same answer.
+                    const last = markers.length - 1
+                    const descending = topOf(0) > topOf(last)
+                    const nth = (rank) => (descending ? last - rank : rank)
                     // A separator sits directly ABOVE its own day's messages, so the day the
-                    // viewport is inside is the separator closest above the trip line.
-                    // One rect read per day (tens at most), never per message.
+                    // viewport is inside is the separator closest above the trip line: the
+                    // highest rank still at or above it.
                     let best = null
-                    let bestTop = -Infinity
+                    let lo = 0
+                    let hi = last
+                    while (lo <= hi) {
+                        const mid = (lo + hi) >> 1
+                        if (topOf(nth(mid)) <= FLOATING_DATE_TRIP_PX) {
+                            best = markers[nth(mid)]
+                            lo = mid + 1
+                        } else {
+                            hi = mid - 1
+                        }
+                    }
                     // Only reached when the viewport is above EVERY separator, i.e. at the
                     // very start of history: then the day on screen is the one whose
                     // separator is first BELOW the line (the oldest loaded day). Resolving
                     // that case to "newest message" would show today's date while reading
                     // the oldest day — the same wrong-date symptom, moved to the top edge.
-                    let firstBelow = null
-                    let firstBelowTop = Infinity
-                    for (const marker of container.querySelectorAll('.date-separator')) {
-                        const top = marker.getBoundingClientRect().top - containerTop
-                        if (top <= FLOATING_DATE_TRIP_PX) {
-                            if (top > bestTop) {
-                                bestTop = top
-                                best = marker
-                            }
-                        } else if (top < firstBelowTop) {
-                            firstBelowTop = top
-                            firstBelow = marker
-                        }
-                    }
+                    const firstBelow = best ? null : markers[nth(0)]
                     best = best || firstBelow
-                    if (!best) {
-                        floatingDateLabel.value = ''
-                        floatingDateIso.value = null
-                        return
-                    }
                     floatingDateLabel.value = best.dataset.dateLabel || ''
                     floatingDateIso.value = best.dataset.dateIso || null
                 }
@@ -3073,8 +3161,89 @@
                     loadingStats.value = false
                 }
 
+                // Resolve the chat a notification points at. The sidebar holds one page of
+                // 50 NON-archived chats, so looking the id up there alone silently fails
+                // for every archived chat (a notification is fired for those too) and for
+                // anything past the first page. Fall back to one wider lookup — no
+                // archived filter, so archived chats are included — before giving up.
+                const resolveChatById = async (chatId) => {
+                    const known = chats.value.find(c => c.id === chatId)
+                    if (known) return known
+                    try {
+                        const res = await fetch('/api/chats?limit=1000', { credentials: 'include' })
+                        if (res.ok) {
+                            const data = await res.json()
+                            return (data.chats || []).find(c => c.id === chatId) || null
+                        }
+                    } catch (e) {
+                        // No identifiers in the message: the chat id is PII.
+                        console.error('Failed to resolve the notification target chat')
+                    }
+                    return null
+                }
+
+                // Open what a notification points at, or say so instead of doing nothing.
+                // Returns whether the chat was opened, so the caller can decide to keep a
+                // deep link in the URL and let a refresh retry it.
+                const openNotificationTarget = async (chatId, messageId) => {
+                    const targetChat = await resolveChatById(chatId)
+                    if (!targetChat) {
+                        showToast('Could not open that chat')
+                        return false
+                    }
+                    await selectChat(targetChat)
+                    if (messageId) {
+                        await nextTick()
+                        scrollToMessage(messageId)
+                    }
+                    return true
+                }
+
+                // A notification click can arrive before initialization has loaded the
+                // chat list (the listener is registered before the first await below,
+                // so it hears clicks from the very start). Until the app can act on a
+                // click it is parked here, then replayed exactly once — never dropped.
+                let pendingNotificationClick = null
+                let notificationClickReady = false
+                const flushPendingNotificationClick = async () => {
+                    notificationClickReady = true
+                    if (!pendingNotificationClick) return
+                    const { chatId, messageId } = pendingNotificationClick
+                    pendingNotificationClick = null
+                    await openNotificationTarget(chatId, messageId)
+                }
+
                 // Auth check on mount
                 onMounted(async () => {
+                    // Listen for notification clicks when app is already open.
+                    // Registered synchronously, before the first await: the service
+                    // worker hands clicks to the page with postMessage, so a listener
+                    // attached only after auth + chats + stats had loaded left a
+                    // seconds-wide window where a click was focused but never acted on.
+                    // NOT gated on navigator.serviceWorker.controller: on the first load
+                    // after registration the worker has not taken control yet, so that
+                    // gate left the page with no receiver for the very clicks it exists
+                    // to handle.
+                    const onServiceWorkerMessage = async (event) => {
+                        if (event.data?.type !== 'NOTIFICATION_CLICK') return
+                        const { chat_id, message_id } = event.data.data || {}
+                        if (!chat_id) return
+                        // No identifiers in the log line: chat and message ids are PII.
+                        console.log('[Notification] Click received')
+                        if (!notificationClickReady) {
+                            pendingNotificationClick = { chatId: chat_id, messageId: message_id }
+                            return
+                        }
+                        await openNotificationTarget(chat_id, message_id)
+                    }
+                    if ('serviceWorker' in navigator) {
+                        navigator.serviceWorker.addEventListener('message', onServiceWorkerMessage)
+                        // addEventListener alone does not start delivery — only an
+                        // onmessage= assignment or startMessages() does — so without
+                        // this call a click posted during page load sat queued forever.
+                        navigator.serviceWorker.startMessages?.()
+                    }
+
                     try {
                         const res = await fetch('/api/auth/check', {
                             credentials: 'include'
@@ -3134,19 +3303,16 @@
 
                                 if (chatIdParam) {
                                     const chatId = parseInt(chatIdParam)
-                                    const targetChat = chats.value.find(c => c.id === chatId)
-                                    if (targetChat) {
-                                        console.log('[Notification] Deep linking to chat:', chatId)
-                                        await selectChat(targetChat)
-                                        if (msgIdParam) {
-                                            const msgId = parseInt(msgIdParam)
-                                            console.log('[Notification] Scrolling to message:', msgId)
-                                            await nextTick()
-                                            scrollToMessage(msgId)
-                                        }
+                                    const msgId = msgIdParam ? parseInt(msgIdParam) : null
+                                    // No identifiers in the log line: chat and message ids are PII.
+                                    console.log('[Notification] Deep linking to a chat')
+                                    const opened = await openNotificationTarget(chatId, msgId)
+                                    // Clean URL without reload to prevent re-navigation on refresh —
+                                    // but only once the link actually opened, so a failed one stays
+                                    // retryable by refresh instead of being scrubbed away.
+                                    if (opened) {
+                                        window.history.replaceState({}, '', '/')
                                     }
-                                    // Clean URL without reload to prevent re-navigation on refresh
-                                    window.history.replaceState({}, '', '/')
                                 }
                             }
                         } else {
@@ -3168,26 +3334,9 @@
                     await initNotifications()
                     initWebSocket()
 
-                    // Listen for notification clicks when app is already open
-                    if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {
-                        navigator.serviceWorker.addEventListener('message', async (event) => {
-                            if (event.data?.type === 'NOTIFICATION_CLICK') {
-                                const { chat_id, message_id } = event.data.data || {}
-                                if (chat_id) {
-                                    console.log('[Notification] Click received for chat:', chat_id)
-                                    const targetChat = chats.value.find(c => c.id === chat_id)
-                                    if (targetChat) {
-                                        await selectChat(targetChat)
-                                        if (message_id) {
-                                            console.log('[Notification] Scrolling to message:', message_id)
-                                            await nextTick()
-                                            scrollToMessage(message_id)
-                                        }
-                                    }
-                                }
-                            }
-                        })
-                    }
+                    // Initialization is far enough along to act on notification clicks:
+                    // replay any click that arrived while the app was still loading.
+                    await flushPendingNotificationClick()
 
                     // Mark secondary initialization complete
                     finishInitialization()
@@ -3347,10 +3496,12 @@
                             break
 
                         case 'subscribed':
-                            console.log('[WS] Subscribed to chat:', data.chat_id)
+                            // Keep the event, drop the chat id: it is PII, and the console
+                            // buffer leaves the device in screenshots and bug reports.
+                            console.log('[WS] Subscribed to a chat')
                             break
                         case 'subscribe_denied':
-                            console.warn('[WS] Subscription denied for chat:', data.chat_id)
+                            console.warn('[WS] Subscription denied for a chat')
                             break
                     }
                 }
@@ -3699,9 +3850,22 @@
                 }
 
                 // Media Gallery methods (v7.10.0)
+                let mediaGalleryRequestSeq = 0
                 const loadMediaGallery = async (append = false) => {
                     if (!selectedChat.value) return
-                    if (mediaGalleryLoading.value) return
+                    // Take a ticket rather than refuse to start. Refusing dropped the newly
+                    // selected tab's load while the previous tab's response still landed in
+                    // the (already cleared) list, so the grid filled with the wrong type's
+                    // items and stayed that way: both the skeleton and the empty state only
+                    // render while the list is empty, and no request for the visible tab was
+                    // ever issued. The chat id and tab are pinned too, because a response can
+                    // also outlive the view it was requested for.
+                    const requestSeq = ++mediaGalleryRequestSeq
+                    const requestChatId = selectedChat.value.id
+                    const requestTab = mediaGalleryTab.value
+                    const stillCurrent = () => requestSeq === mediaGalleryRequestSeq &&
+                        selectedChat.value?.id === requestChatId &&
+                        mediaGalleryTab.value === requestTab
                     mediaGalleryLoading.value = true
                     try {
                         const typeMap = {
@@ -3719,11 +3883,13 @@
                         })
                         if (lastItem) params.set('before_id', lastItem.id)
 
-                        const res = await fetch(`/api/chats/${selectedChat.value.id}/media?${params}`, {
+                        const res = await fetch(`/api/chats/${requestChatId}/media?${params}`, {
                             credentials: 'include'
                         })
+                        if (!stillCurrent()) return
                         if (!res.ok) throw new Error('Failed to load media')
                         const data = await res.json()
+                        if (!stillCurrent()) return
                         if (append) {
                             mediaGalleryItems.value.push(...data.items)
                         } else {
@@ -3731,20 +3897,30 @@
                         }
                         mediaGalleryHasMore.value = data.has_more
                     } catch (e) {
+                        if (!stillCurrent()) return
                         console.error('Failed to load media gallery:', e)
+                        // Say so: the catch used to leave the previous view's rows on screen
+                        // (or an empty grid claiming "No media") with no sign of a failure.
+                        showToast('Failed to load media')
                     } finally {
-                        mediaGalleryLoading.value = false
+                        // A superseded request must not clear the current one's spinner.
+                        if (requestSeq === mediaGalleryRequestSeq) mediaGalleryLoading.value = false
                     }
                 }
 
                 const loadMediaCounts = async () => {
                     if (!selectedChat.value) return
+                    // Same staleness as the item list: these counts are the tab badges, so a
+                    // response that outlived its chat would label this chat's tabs with the
+                    // previous chat's numbers.
+                    const requestChatId = selectedChat.value.id
                     try {
-                        const res = await fetch(`/api/chats/${selectedChat.value.id}/media/counts`, {
+                        const res = await fetch(`/api/chats/${requestChatId}/media/counts`, {
                             credentials: 'include'
                         })
                         if (res.ok) {
                             const data = await res.json()
+                            if (selectedChat.value?.id !== requestChatId) return
                             mediaGalleryCounts.value = {
                                 photos: (data.photo || 0) + (data.video || 0) + (data.animation || 0),
                                 voice: (data.voice || 0) + (data.audio || 0),
@@ -3933,6 +4109,12 @@
                             scrollTop: messagesContainer.value ? messagesContainer.value.scrollTop : 0,
                             focusElement: document.activeElement instanceof HTMLElement ? document.activeElement : null
                         }
+                        // Opening is the one chokepoint for a chat change: nothing else clears
+                        // these, so the grid and the tab badges used to show the PREVIOUS
+                        // chat's media for the whole fetch (and for good if it failed).
+                        mediaGalleryItems.value = []
+                        mediaGalleryCounts.value = {}
+                        mediaGalleryHasMore.value = true
                         loadMediaGallery()
                         loadMediaCounts()
                     } else {
@@ -4514,6 +4696,28 @@
                     messages.value = []
                     resetMessagePagination()
                     await loadMessages()
+                }
+
+                // Every keystroke used to run searchMessages directly, and it defeats
+                // loadMessages' own in-flight gate by design, so a 10-character query issued
+                // 10 unindexed full-chat LIKE scans and blanked the pane on each one. Debounce
+                // it like the sidebar search (onSearchInput), and let the chatVersion bump
+                // inside searchMessages discard whatever request the last one superseded.
+                let messageSearchDebounceTimer = null
+                const onMessageSearchInput = () => {
+                    if (messageSearchDebounceTimer) {
+                        clearTimeout(messageSearchDebounceTimer)
+                    }
+                    const queryAtInput = messageSearchQuery.value
+                    const chatIdAtInput = selectedChat.value?.id ?? null
+                    messageSearchDebounceTimer = setTimeout(() => {
+                        messageSearchDebounceTimer = null
+                        // A chat/topic switch clears the box and rebuilds the pane while the
+                        // timer is pending; running the old query then would wipe the new view.
+                        if ((selectedChat.value?.id ?? null) !== chatIdAtInput) return
+                        if (messageSearchQuery.value !== queryAtInput) return
+                        searchMessages()
+                    }, 300) // 300ms debounce, same as the sidebar search
                 }
 
                 const handleScroll = (e) => {
@@ -5329,8 +5533,11 @@
                 }
 
                 const handleImageError = (event, msg) => {
-                    // Log the error for debugging (real 404s should be investigated)
-                    console.error('Failed to load image:', getMediaUrl(msg))
+                    // Log the event, never the URL: it is /media/<chat id>/<file id>_<the
+                    // sender's own filename>, i.e. exactly the identifiers the project
+                    // keeps out of logs, and the console buffer travels in screenshots,
+                    // screen shares and browser bug reports.
+                    console.error('Failed to load image')
                     // Show placeholder instead of broken image
                     const img = event.target
                     img.onerror = null  // Prevent infinite loop
@@ -5346,21 +5553,14 @@
                 }
 
                 const handleMediaError = (event, msg) => {
-                    // Log the error for debugging (real 404s should be investigated)
-                    console.error('Failed to load media:', getMediaUrl(msg))
-                    // Replace with placeholder
-                    const media = event.target
-                    const parent = media.parentElement
-                    if (parent) {
-                        parent.innerHTML = `
-                            <div class="flex items-center gap-2 text-gray-400 text-sm py-2">
-                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                                </svg>
-                                <span>Media not found</span>
-                            </div>
-                        `
-                    }
+                    // Same rule as handleImageError: the media URL carries the chat id and
+                    // the sender's original filename, so log the event only.
+                    console.error('Failed to load media')
+                    // Flag the row and let the template swap in the placeholder. Writing
+                    // the placeholder in with innerHTML destroyed the <video>, its <source>
+                    // and the play overlay that Vue still held vnode.el pointers to, so the
+                    // bubble stayed detached from the render tree for the rest of its life.
+                    msg.mediaLoadFailed = true
                 }
 
                 const openMedia = (msg) => {
@@ -6887,6 +7087,7 @@
                     loadMessagesAroundId,
                     viewingPinnedWindow,
                     searchMessages,
+                    onMessageSearchInput,
                     isOwnMessage,
                     getSenderName,
                     getCurrentSenderName,
@@ -7095,6 +7296,8 @@
                     archivedCount,
                     topics,
                     loadingTopics,
+                    topicsError,
+                    retryLoadTopics,
                     selectFolder,
                     showArchived,
                     showAllChats,

--- a/tests/test_frontend_audit_fixes.py
+++ b/tests/test_frontend_audit_fixes.py
@@ -1,0 +1,1054 @@
+"""Executable regressions for the frontend audit findings (S16-S18, S22/S30, S38-S43).
+
+The viewer ships as one 7k-line template, so these tests lift the real functions
+out of it and RUN them under node: a string assertion cannot tell a debounce that
+works from one that was deleted, and every finding here is about behaviour under
+a race, a failure, or a hostile CDN.
+"""
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+INDEX_HTML = Path(__file__).resolve().parents[1] / "src" / "web" / "templates" / "index.html"
+SERVICE_WORKER = Path(__file__).resolve().parents[1] / "src" / "web" / "static" / "sw.js"
+
+
+def _matching_closing_brace(source: str, opening_brace: int) -> int:
+    """Find a JavaScript block's closing brace while ignoring strings and comments."""
+    depth = 0
+    state = "code"
+    index = opening_brace
+
+    while index < len(source):
+        char = source[index]
+        following = source[index + 1] if index + 1 < len(source) else ""
+
+        if state == "code":
+            if char == "/" and following == "/":
+                state = "line_comment"
+                index += 2
+                continue
+            if char == "/" and following == "*":
+                state = "block_comment"
+                index += 2
+                continue
+            if char in {"'", '"', "`"}:
+                state = char
+            elif char == "{":
+                depth += 1
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    return index
+        elif state == "line_comment":
+            if char == "\n":
+                state = "code"
+        elif state == "block_comment":
+            if char == "*" and following == "/":
+                state = "code"
+                index += 2
+                continue
+        elif char == "\\":
+            index += 2
+            continue
+        elif char == state:
+            state = "code"
+
+        index += 1
+
+    raise ValueError("JavaScript function has no balanced closing brace")
+
+
+def _extract_const_arrow_function(html: str, name: str, *, asynchronous: bool) -> str:
+    """Extract a named block-bodied const arrow function from the shipped template."""
+    async_prefix = r"async\s+" if asynchronous else ""
+    declaration = re.compile(rf"\bconst\s+{re.escape(name)}\s*=\s*{async_prefix}\([^)]*\)\s*=>\s*\{{")
+    match = declaration.search(html)
+    if match is None:
+        function_kind = "async " if asynchronous else ""
+        raise ValueError(f"Could not find const {name} = {function_kind}(...) => {{...}}")
+
+    opening_brace = match.end() - 1
+    closing_brace = _matching_closing_brace(html, opening_brace)
+    return html[match.start() : closing_brace + 1]
+
+
+def _run_node(script: str) -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node executable is not installed")
+
+    # SECURITY-REVIEW: The executable path is resolved locally and untrusted input is never passed to a shell.
+    result = subprocess.run(
+        [node, "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"Node behavior test failed with exit code {result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+def _without_comments(source: str) -> str:
+    """Drop ``//`` comments so an assertion reads the code, not the note explaining it."""
+    return re.sub(r"//[^\n]*", "", source)
+
+
+def _console_call_lines(source: str) -> list[str]:
+    """Every line that writes to the browser console."""
+    return [line for line in source.splitlines() if re.search(r"\bconsole\.(log|warn|error|info|debug)\(", line)]
+
+
+# --------------------------------------------------------------------------------------
+# S17 — the chat-header search ran an unindexed full-chat LIKE scan on every keystroke
+# --------------------------------------------------------------------------------------
+
+
+def test_chat_search_input_is_debounced_not_fired_per_keystroke() -> None:
+    """A 10-character query must cost one search, not ten.
+
+    ``searchMessages`` deliberately defeats ``loadMessages``' in-flight gate (it
+    resets ``loading`` and bumps ``chatVersion``), so binding it straight to
+    ``@input`` really did issue one full-chat ``ILIKE '%...%'`` per keystroke and
+    blank the message pane in between.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    # The box must go through the debounce, never straight to the loader.
+    assert '@input="onMessageSearchInput"' in html
+    assert '@input="searchMessages"' not in html
+
+    script = "\n".join(
+        [
+            '"use strict";',
+            "const assert = require('node:assert/strict');",
+            """
+const ref = value => ({ value });
+const messageSearchQuery = ref('');
+const selectedChat = ref({ id: 42 });
+let messageSearchDebounceTimer = null;
+let searchCalls = 0;
+const searchMessages = async () => { searchCalls += 1; };
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+""",
+            _extract_const_arrow_function(html, "onMessageSearchInput", asynchronous=False),
+            """
+(async () => {
+    for (const char of 'birthday22') {
+        messageSearchQuery.value += char;
+        onMessageSearchInput();
+    }
+    assert.equal(searchCalls, 0, 'typing must not search before the pause');
+    await sleep(450);
+    assert.equal(searchCalls, 1, `10 keystrokes issued ${searchCalls} searches`);
+
+    // A chat switch clears the box and rebuilds the pane; the pending timer must
+    // not then run the previous chat's query over the new view.
+    messageSearchQuery.value = 'holiday';
+    onMessageSearchInput();
+    selectedChat.value = { id: 99 };
+    messageSearchQuery.value = '';
+    await sleep(450);
+    assert.equal(searchCalls, 1, 'a superseded query ran after the chat changed');
+})().catch(error => {
+    process.stderr.write(`${error.stack}\\n`);
+    process.exitCode = 1;
+});
+""",
+        ]
+    )
+
+    _run_node(script)
+
+
+# --------------------------------------------------------------------------------------
+# S18 — switching media tabs mid-flight painted the old tab's items under the new tab
+# --------------------------------------------------------------------------------------
+
+
+def test_media_gallery_tab_switch_supersedes_the_in_flight_page() -> None:
+    """Clicking Files while the Photos page is in flight must load Files.
+
+    The old gate (``if (mediaGalleryLoading.value) return``) refused to start the
+    new tab's request, and the photos response then landed in the cleared list —
+    so the Files tab rendered photos, terminally, because the skeleton and the
+    empty state only render while the list is empty.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    script = "\n".join(
+        [
+            '"use strict";',
+            "const assert = require('node:assert/strict');",
+            """
+const ref = value => ({ value });
+const selectedChat = ref({ id: 7 });
+const mediaGalleryTab = ref('photos');
+const mediaGalleryItems = ref([]);
+const mediaGalleryLoading = ref(false);
+const mediaGalleryHasMore = ref(true);
+const mediaGalleryCounts = ref({});
+let mediaGalleryRequestSeq = 0;
+const toasts = [];
+const showToast = message => { toasts.push(message); };
+const console = { error: () => {} };
+const requests = [];
+const fetch = async url => {
+    let settle;
+    const body = new Promise(resolve => { settle = resolve; });
+    requests.push({ url, settle });
+    return body;
+};
+""",
+            _extract_const_arrow_function(html, "loadMediaGallery", asynchronous=True),
+            _extract_const_arrow_function(html, "switchMediaTab", asynchronous=False),
+            """
+const flush = () => new Promise(resolve => setImmediate(resolve));
+const respond = (index, items) => requests[index].settle({
+    ok: true,
+    json: async () => ({ items, has_more: false }),
+});
+(async () => {
+    loadMediaGallery();
+    await flush();
+    assert.equal(requests.length, 1);
+    assert.ok(requests[0].url.includes('types=photo%2Cvideo%2Canimation'), requests[0].url);
+
+    // Switch tabs while the photos page is still in flight.
+    switchMediaTab('files');
+    await flush();
+    assert.equal(requests.length, 2, 'the new tab never issued its own request');
+    assert.ok(requests[1].url.includes('types=document'), requests[1].url);
+
+    // The superseded photos page lands first and must be discarded.
+    respond(0, [{ id: 'photo-1', type: 'photo' }]);
+    await flush();
+    assert.deepEqual(mediaGalleryItems.value, [], 'the old tab painted into the new tab');
+
+    respond(1, [{ id: 'doc-1', type: 'document' }]);
+    await flush();
+    assert.deepEqual(mediaGalleryItems.value.map(item => item.id), ['doc-1']);
+    assert.equal(mediaGalleryTab.value, 'files');
+    assert.equal(mediaGalleryLoading.value, false);
+})().catch(error => {
+    process.stderr.write(`${error.stack}\\n`);
+    process.exitCode = 1;
+});
+""",
+        ]
+    )
+
+    _run_node(script)
+
+
+def test_media_gallery_response_that_outlived_its_chat_is_discarded() -> None:
+    """A page requested for one chat must never be painted into another."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    script = "\n".join(
+        [
+            '"use strict";',
+            "const assert = require('node:assert/strict');",
+            """
+const ref = value => ({ value });
+const selectedChat = ref({ id: 111 });
+const mediaGalleryTab = ref('photos');
+const mediaGalleryItems = ref([]);
+const mediaGalleryLoading = ref(false);
+const mediaGalleryHasMore = ref(true);
+const mediaGalleryCounts = ref({});
+let mediaGalleryRequestSeq = 0;
+const showToast = () => {};
+const console = { error: () => {} };
+const requests = [];
+const fetch = async url => {
+    let settle;
+    const body = new Promise(resolve => { settle = resolve; });
+    requests.push({ url, settle });
+    return body;
+};
+""",
+            _extract_const_arrow_function(html, "loadMediaGallery", asynchronous=True),
+            """
+const flush = () => new Promise(resolve => setImmediate(resolve));
+(async () => {
+    loadMediaGallery();
+    await flush();
+    assert.ok(requests[0].url.startsWith('/api/chats/111/media?'), requests[0].url);
+
+    selectedChat.value = { id: 222 };
+    requests[0].settle({ ok: true, json: async () => ({ items: [{ id: 'from-111' }], has_more: true }) });
+    await flush();
+    assert.deepEqual(mediaGalleryItems.value, [], "chat 111's media landed in chat 222");
+})().catch(error => {
+    process.stderr.write(`${error.stack}\\n`);
+    process.exitCode = 1;
+});
+""",
+        ]
+    )
+
+    _run_node(script)
+
+
+# --------------------------------------------------------------------------------------
+# S16 — the push deep link silently did nothing outside the first 50 non-archived chats
+# --------------------------------------------------------------------------------------
+
+
+def test_notification_deep_link_resolves_a_chat_outside_the_loaded_page() -> None:
+    """Archived chats are never in the sidebar page, and they still fire notifications.
+
+    The old code looked the id up in ``chats.value`` (one page of 50, ``archived=false``)
+    and, on a miss, fell through with no error — after scrubbing the URL, so a refresh
+    could not retry either.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    script = "\n".join(
+        [
+            '"use strict";',
+            "const assert = require('node:assert/strict');",
+            """
+const ref = value => ({ value });
+// The sidebar page: 50 non-archived chats, none of them the notification's target.
+const chats = ref(Array.from({ length: 50 }, (_, index) => ({ id: 1000 + index, title: 'chat' })));
+const archived = { id: -1009999, title: 'archived chat', is_archived: true };
+const opened = [];
+const scrolled = [];
+const toasts = [];
+const selectChat = async chat => { opened.push(chat.id); };
+const scrollToMessage = id => { scrolled.push(id); };
+const nextTick = async () => {};
+const showToast = message => { toasts.push(message); };
+const console = { error: () => {}, log: () => {} };
+const requested = [];
+const fetch = async url => {
+    requested.push(url);
+    return { ok: true, json: async () => ({ chats: [archived] }) };
+};
+""",
+            _extract_const_arrow_function(html, "resolveChatById", asynchronous=True),
+            _extract_const_arrow_function(html, "openNotificationTarget", asynchronous=True),
+            """
+(async () => {
+    const wasOpened = await openNotificationTarget(-1009999, 4242);
+    assert.equal(wasOpened, true, 'the deep link silently failed');
+    assert.deepEqual(opened, [-1009999]);
+    assert.deepEqual(scrolled, [4242]);
+    assert.deepEqual(toasts, []);
+    assert.equal(requested.length, 1, 'no wider lookup was issued');
+    assert.ok(requested[0].startsWith('/api/chats?'), requested[0]);
+    // No archived=false filter: an archived chat must be resolvable.
+    assert.equal(requested[0].includes('archived=false'), false, requested[0]);
+
+    // A chat in the loaded page needs no request at all.
+    requested.length = 0;
+    assert.equal(await openNotificationTarget(1003, null), true);
+    assert.deepEqual(requested, []);
+    assert.deepEqual(scrolled, [4242]);
+
+    // Genuinely unresolvable: say so instead of doing nothing.
+    const missing = await openNotificationTarget(-1, 7);
+    assert.equal(missing, false);
+    assert.equal(toasts.length, 1, 'a failed deep link stayed silent');
+    assert.deepEqual(opened, [-1009999, 1003]);
+})().catch(error => {
+    process.stderr.write(`${error.stack}\\n`);
+    process.exitCode = 1;
+});
+""",
+        ]
+    )
+
+    _run_node(script)
+
+
+def test_failed_deep_link_keeps_the_url_so_a_refresh_retries() -> None:
+    """The URL is scrubbed only once the chat actually opened."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    start = html.index("const chatIdParam = urlParams.get('chat')")
+    block = html[start : html.index("window.history.replaceState({}, '', '/')", start) + 80]
+
+    assert "const opened = await openNotificationTarget(chatId, msgId)" in block
+    assert "if (opened) {" in block
+    assert block.index("if (opened) {") < block.index("window.history.replaceState({}, '', '/')")
+
+
+def test_notification_click_listener_is_not_gated_on_an_active_controller() -> None:
+    """On the first load after registration there is no controller yet.
+
+    The service worker now hands clicks to the open tab with ``postMessage``, so a
+    listener that is only attached when ``navigator.serviceWorker.controller`` is
+    already set would miss exactly the clicks it exists for.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    assert "if ('serviceWorker' in navigator && navigator.serviceWorker.controller) {" not in html
+    listener_start = html.index("// Listen for notification clicks when app is already open")
+    listener_body = _without_comments(html[listener_start : html.index("finishInitialization()", listener_start)])
+    assert "if ('serviceWorker' in navigator) {" in listener_body
+    assert "navigator.serviceWorker.controller" not in listener_body
+    assert "await openNotificationTarget(chat_id, message_id)" in listener_body
+
+
+# --------------------------------------------------------------------------------------
+# S38 — loadTopics kept the previous forum chat's topics on screen
+# --------------------------------------------------------------------------------------
+
+
+def test_load_topics_clears_stale_rows_and_surfaces_a_failure() -> None:
+    """A 503 must not leave another chat's topics under this chat's header."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    script = "\n".join(
+        [
+            '"use strict";',
+            "const assert = require('node:assert/strict');",
+            """
+const ref = value => ({ value });
+const topics = ref([{ id: 77, title: 'chat A topic' }]);
+const loadingTopics = ref(false);
+const topicsError = ref('');
+let topicsRequestSeq = 0;
+const console = { error: () => {} };
+const fetch = async () => ({ ok: false, status: 503, json: async () => ({}) });
+""",
+            _extract_const_arrow_function(html, "loadTopics", asynchronous=True),
+            """
+(async () => {
+    await loadTopics(-100222);
+    assert.deepEqual(topics.value, [], "the previous chat's topics stayed on screen");
+    assert.notEqual(topicsError.value, '', 'the failure was swallowed silently');
+    assert.equal(loadingTopics.value, false);
+})().catch(error => {
+    process.stderr.write(`${error.stack}\\n`);
+    process.exitCode = 1;
+});
+""",
+        ]
+    )
+
+    _run_node(script)
+
+
+def test_load_topics_ignores_a_response_that_lost_the_race() -> None:
+    """Open forum A then forum B fast: B's list must win even if A answers last."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    script = "\n".join(
+        [
+            '"use strict";',
+            "const assert = require('node:assert/strict');",
+            """
+const ref = value => ({ value });
+const topics = ref([]);
+const loadingTopics = ref(false);
+const topicsError = ref('');
+let topicsRequestSeq = 0;
+const console = { error: () => {} };
+const pending = [];
+const fetch = async url => {
+    let settle;
+    const body = new Promise(resolve => { settle = resolve; });
+    pending.push({ url, settle });
+    return body;
+};
+""",
+            _extract_const_arrow_function(html, "loadTopics", asynchronous=True),
+            """
+const flush = () => new Promise(resolve => setImmediate(resolve));
+const rows = (label) => ({ ok: true, json: async () => ({ topics: [{ id: 1, title: label }] }) });
+(async () => {
+    loadTopics(-100111);   // chat A, slow
+    await flush();
+    loadTopics(-100222);   // chat B, fast
+    await flush();
+    assert.equal(pending.length, 2);
+
+    pending[1].settle(rows('chat B topic'));
+    await flush();
+    pending[0].settle(rows('chat A topic'));
+    await flush();
+
+    assert.deepEqual(topics.value.map(topic => topic.title), ['chat B topic']);
+    assert.equal(loadingTopics.value, false, 'the spinner never cleared');
+})().catch(error => {
+    process.stderr.write(`${error.stack}\\n`);
+    process.exitCode = 1;
+});
+""",
+        ]
+    )
+
+    _run_node(script)
+
+
+# --------------------------------------------------------------------------------------
+# S39 — a notification click hard-reloaded an open app, and could be a silent no-op:
+# the tab was selected with `'postMessage' in client`, which is true of EVERY window
+# client per spec, so the openWindow fallback was unreachable dead code
+# --------------------------------------------------------------------------------------
+
+
+def _service_worker_click_script(body: str) -> str:
+    """Load the REAL sw.js into a stubbed worker global and drive notificationclick."""
+    return "\n".join(
+        [
+            '"use strict";',
+            "const assert = require('node:assert/strict');",
+            "const fs = require('node:fs');",
+            "const vm = require('node:vm');",
+            f"const SW_PATH = {str(SERVICE_WORKER)!r};",
+            """
+const handlers = {};
+const calls = [];
+let windowClients = [];
+globalThis.self = {
+    addEventListener: (type, handler) => { handlers[type] = handler; },
+    location: { origin: 'https://archive.example' },
+    skipWaiting: () => {},
+    clients: { claim: () => {} },
+    registration: { showNotification: async () => {} },
+};
+globalThis.clients = {
+    matchAll: async () => windowClients,
+    openWindow: async url => { calls.push(['openWindow', url]); return {}; },
+};
+globalThis.caches = { keys: async () => [], delete: async () => {} };
+const originalConsole = console;
+globalThis.console = { log: () => {}, warn: () => {}, error: () => {} };
+vm.runInThisContext(fs.readFileSync(SW_PATH, 'utf8'), { filename: 'sw.js' });
+
+const appTab = () => ({
+    url: 'https://archive.example/',
+    focus: async function () { calls.push(['focus']); return this; },
+    postMessage: message => { calls.push(['postMessage', message.type, message.data]); },
+    navigate: async url => { calls.push(['navigate', url]); return {}; },
+});
+const click = async (data) => {
+    calls.length = 0;
+    const waited = [];
+    await handlers.notificationclick({
+        notification: { data, close: () => {} },
+        waitUntil: promise => { waited.push(promise); },
+    });
+    await Promise.all(waited);
+};
+""",
+            body,
+        ]
+    )
+
+
+def test_notification_click_talks_to_an_open_tab_instead_of_reloading_it() -> None:
+    """``client.url`` is absolute and ``url`` was relative, so navigate() always ran.
+
+    A navigate() is a full document load: it throws away the loaded message window,
+    the scroll position and whatever the single in-page audio element was playing.
+    """
+    _run_node(
+        _service_worker_click_script(
+            """
+(async () => {
+    windowClients = [appTab()];
+    await click({ chat_id: -100123, message_id: 55, url: '/?chat=-100123&msg=55' });
+
+    const kinds = calls.map(entry => entry[0]);
+    assert.ok(kinds.includes('focus'), 'the open tab was not focused');
+    assert.ok(kinds.includes('postMessage'), 'the in-place path is still unreachable');
+    assert.equal(kinds.includes('navigate'), false, 'the click still hard-reloads the app');
+    assert.equal(kinds.includes('openWindow'), false);
+    const message = calls.find(entry => entry[0] === 'postMessage');
+    assert.equal(message[1], 'NOTIFICATION_CLICK');
+    assert.deepEqual(message[2], { chat_id: -100123, message_id: 55, url: '/?chat=-100123&msg=55' });
+})().catch(error => {
+    originalConsole.error(error.stack);
+    process.exitCode = 1;
+});
+"""
+        )
+    )
+
+
+def test_notification_click_opens_an_absolute_url_when_no_tab_is_open() -> None:
+    """With no window of our own, the relative URL must be resolved against the origin."""
+    _run_node(
+        _service_worker_click_script(
+            """
+(async () => {
+    windowClients = [];
+    await click({ chat_id: -100123, url: '/?chat=-100123' });
+    assert.deepEqual(calls, [['openWindow', 'https://archive.example/?chat=-100123']]);
+
+    // A window belonging to some other origin is not ours to focus or message.
+    windowClients = [{ url: 'https://elsewhere.example/', focus: async () => {}, postMessage: () => {
+        throw new Error('messaged a cross-origin client');
+    } }];
+    await click({ url: '/' });
+    assert.deepEqual(calls, [['openWindow', 'https://archive.example/']]);
+})().catch(error => {
+    originalConsole.error(error.stack);
+    process.exitCode = 1;
+});
+"""
+        )
+    )
+
+
+def test_notification_click_selects_tabs_on_focus_not_postmessage() -> None:
+    """The click handler's tab selector must be a predicate that can actually miss.
+
+    ``'postMessage' in client`` is true of every window client the spec can hand
+    back, so the old selector matched unconditionally: a tab whose listener was not
+    attached yet swallowed the deep link, and openWindow could never run.
+    """
+    source = _without_comments(SERVICE_WORKER.read_text(encoding="utf-8"))
+
+    assert "'postMessage' in client" not in source, "the always-true selector is back"
+    assert '"postMessage" in client' not in source, "the always-true selector is back"
+
+    click_handler = source[source.index("'notificationclick'") :]
+    assert "'focus' in client" in click_handler
+    # Both misses land the click in a window: no focusable tab, and a focus() that fails.
+    assert click_handler.count("clients.openWindow(targetUrl)") >= 2
+
+
+def test_notification_click_opens_a_window_when_no_tab_is_focusable() -> None:
+    """An own tab that cannot be focused must fall through to openWindow.
+
+    This exact shape was the silent no-op: the old ``'postMessage' in client``
+    selector matched it, posted a message no listener necessarily received, and
+    never reached the fallback.
+    """
+    _run_node(
+        _service_worker_click_script(
+            """
+(async () => {
+    windowClients = [{
+        url: 'https://archive.example/',
+        postMessage: () => { calls.push(['postMessage']); },
+    }];
+    await click({ chat_id: -100123, message_id: 55, url: '/?chat=-100123&msg=55' });
+    assert.deepEqual(calls, [['openWindow', 'https://archive.example/?chat=-100123&msg=55']],
+        'an unfocusable tab still swallowed the click');
+})().catch(error => {
+    originalConsole.error(error.stack);
+    process.exitCode = 1;
+});
+"""
+        )
+    )
+
+
+def test_notification_click_focus_failure_still_lands_the_click() -> None:
+    """A tab that refuses focus() must not swallow the click.
+
+    The rejection also must not escape into event.waitUntil unhandled — the click
+    promise still resolves, and the deep link lands in a fresh window instead.
+    """
+    _run_node(
+        _service_worker_click_script(
+            """
+(async () => {
+    windowClients = [{
+        url: 'https://archive.example/',
+        focus: async () => { throw new Error('focus rejected'); },
+        postMessage: () => { calls.push(['postMessage']); },
+    }];
+    await click({ chat_id: -100123, url: '/?chat=-100123' });   // resolves, or this test throws
+    assert.deepEqual(calls, [['openWindow', 'https://archive.example/?chat=-100123']],
+        'a refused focus() left the click a silent no-op');
+})().catch(error => {
+    originalConsole.error(error.stack);
+    process.exitCode = 1;
+});
+"""
+        )
+    )
+
+
+def test_notification_click_listener_attaches_before_initialization_awaits() -> None:
+    """The page half of the same no-op: the listener must exist when the click lands.
+
+    It was attached at the END of onMounted, after auth + chats + stats + folders
+    had all been awaited — seconds on a slow link — so the worker focused the tab,
+    posted the deep link, and nobody was listening. It must be registered before
+    the first await, and delivery must be started explicitly: addEventListener
+    alone never drains the browser's queue of messages posted during page load.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    mounted = html[html.index("onMounted(async () => {") :]
+    registration = mounted.index("navigator.serviceWorker.addEventListener('message'")
+    start_messages = mounted.index("navigator.serviceWorker.startMessages?.()")
+    first_await = mounted.index("await fetch('/api/auth/check'")
+    assert registration < first_await, "the listener is attached only after initialization awaits"
+    assert start_messages < first_await, "queued messages are never released to the listener"
+
+
+def test_notification_click_during_startup_is_parked_and_replayed_once() -> None:
+    """A click that arrives before the chat list exists must be replayed, not dropped."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    script = "\n".join(
+        [
+            '"use strict";',
+            "const assert = require('node:assert/strict');",
+            """
+let pendingNotificationClick = null;
+let notificationClickReady = false;
+const opened = [];
+const openNotificationTarget = async (chatId, messageId) => { opened.push([chatId, messageId]); return true; };
+const console = { log: () => {} };
+""",
+            _extract_const_arrow_function(html, "flushPendingNotificationClick", asynchronous=True),
+            _extract_const_arrow_function(html, "onServiceWorkerMessage", asynchronous=True),
+            """
+(async () => {
+    // Before initialization is done: the click is parked, not acted on and not lost.
+    await onServiceWorkerMessage({ data: { type: 'NOTIFICATION_CLICK', data: { chat_id: -100123, message_id: 55 } } });
+    assert.deepEqual(opened, [], 'acted on a click before the app could open a chat');
+
+    // Non-clicks and payloads without a chat must not park anything.
+    await onServiceWorkerMessage({ data: { type: 'SOMETHING_ELSE' } });
+    await onServiceWorkerMessage({ data: { type: 'NOTIFICATION_CLICK', data: {} } });
+    await onServiceWorkerMessage({});
+
+    // Initialization finishes: the parked click replays exactly once.
+    await flushPendingNotificationClick();
+    assert.deepEqual(opened, [[-100123, 55]], 'the parked click was dropped');
+    await flushPendingNotificationClick();
+    assert.deepEqual(opened, [[-100123, 55]], 'the parked click replayed twice');
+
+    // From now on clicks are handled directly.
+    await onServiceWorkerMessage({ data: { type: 'NOTIFICATION_CLICK', data: { chat_id: 7 } } });
+    assert.deepEqual(opened, [[-100123, 55], [7, undefined]]);
+})().catch(error => {
+    process.stderr.write(`${error.stack}\\n`);
+    process.exitCode = 1;
+});
+""",
+        ]
+    )
+
+    _run_node(script)
+
+
+# --------------------------------------------------------------------------------------
+# S40 — the floating day pill read one rect per loaded date separator, every frame
+# --------------------------------------------------------------------------------------
+
+
+def test_floating_day_pill_costs_log_rect_reads_not_one_per_day() -> None:
+    """Per-frame scroll work must not grow with how much history is loaded.
+
+    Nothing trims the message window, so a separator accumulates for every distinct
+    day paged in. The answer is unchanged — it is checked here against a straight
+    linear scan at 40 scroll positions, in both layout directions.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    script = "\n".join(
+        [
+            '"use strict";',
+            "const assert = require('node:assert/strict');",
+            """
+const ref = value => ({ value });
+const FLOATING_DATE_TRIP_PX = 12;
+const floatingDateLabel = ref('');
+const floatingDateIso = ref(null);
+let rectReads = 0;
+let markers = [];
+const container = {
+    getBoundingClientRect: () => ({ top: 0 }),
+    querySelectorAll: selector => {
+        assert.equal(selector, '.date-separator');
+        return markers;
+    },
+};
+const messagesContainer = ref(container);
+
+const DAYS = 400;
+// One separator per loaded day, 800px apart. `reversed` is the shipped layout:
+// flex-col-reverse puts the newest day (DOM index 0) at the bottom.
+const buildMarkers = (scrollOffset, reversed) => {
+    const built = [];
+    for (let day = 0; day < DAYS; day++) {
+        const top = day * 800 - scrollOffset;
+        built.push({
+            top,
+            dataset: { dateLabel: `day-${day}`, dateIso: `2026-01-${day}` },
+            getBoundingClientRect() { rectReads += 1; return { top: this.top }; },
+        });
+    }
+    return reversed ? built.reverse() : built;
+};
+
+// The behaviour being preserved, written out plainly.
+const linearAnswer = () => {
+    let best = null;
+    let bestTop = -Infinity;
+    let firstBelow = null;
+    let firstBelowTop = Infinity;
+    for (const marker of markers) {
+        const top = marker.top;
+        if (top <= FLOATING_DATE_TRIP_PX) {
+            if (top > bestTop) { bestTop = top; best = marker; }
+        } else if (top < firstBelowTop) { firstBelowTop = top; firstBelow = marker; }
+    }
+    best = best || firstBelow;
+    return best ? best.dataset.dateLabel : '';
+};
+""",
+            _extract_const_arrow_function(html, "updateFloatingDate", asynchronous=False),
+            """
+let worstReads = 0;
+for (const reversed of [true, false]) {
+    for (let step = 0; step < 40; step++) {
+        const scrollOffset = step * 8000;
+        markers = buildMarkers(scrollOffset, reversed);
+        const expected = linearAnswer();
+        rectReads = 0;
+        updateFloatingDate();
+        assert.equal(floatingDateLabel.value, expected,
+            `wrong day at offset ${scrollOffset} (reversed=${reversed})`);
+        worstReads = Math.max(worstReads, rectReads);
+    }
+}
+// A linear scan would read all 400 every frame; a binary search reads ~log2(400).
+assert.equal(markers.length, 400);
+assert.ok(worstReads <= 20, `read ${worstReads} rects per frame for ${markers.length} separators`);
+
+// Boundaries: an empty list clears the pill, one separator still resolves.
+floatingDateLabel.value = 'stale';
+markers = [];
+updateFloatingDate();
+assert.equal(floatingDateLabel.value, '');
+// One separator, and it sits below the trip line: the top-of-history branch.
+markers = buildMarkers(0, true).slice(0, 1);
+updateFloatingDate();
+assert.equal(floatingDateLabel.value, 'day-399');
+""",
+        ]
+    )
+
+    _run_node(script)
+
+
+# --------------------------------------------------------------------------------------
+# S42 — chat ids and full media paths were written to the browser console
+# --------------------------------------------------------------------------------------
+
+
+def test_no_identifiers_are_written_to_the_browser_console() -> None:
+    """The project's logging rule covers the client too.
+
+    ``getMediaUrl`` is ``/media/<chat id>/<file id>_<the sender's own filename>``, and
+    the console buffer is what a screen share, a devtools screenshot and a browser
+    bug report carry off the device.
+    """
+    forbidden = ("chat_id", "chatId", "message_id", "messageId", "msgId", "topic_id", "topicId", "getMediaUrl")
+
+    for source_file in (INDEX_HTML, SERVICE_WORKER):
+        source = source_file.read_text(encoding="utf-8")
+        for line in _console_call_lines(source):
+            for identifier in forbidden:
+                assert identifier not in line, f"{source_file.name} logs {identifier}: {line.strip()}"
+
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    assert "console.error('Failed to load image:', getMediaUrl(msg))" not in html
+    assert "console.error('Failed to load media:', getMediaUrl(msg))" not in html
+    assert "console.log('[WS] Subscribed to chat:', data.chat_id)" not in html
+    assert "console.warn('[WS] Subscription denied for chat:', data.chat_id)" not in html
+
+
+def test_console_never_carries_a_whole_message_payload() -> None:
+    """``console.log('...', event.data)`` prints the entire payload object.
+
+    For a notification message that is the chat id, the message id and whatever
+    else the sender attached — the identifier ban is defeated in one line if the
+    object itself is logged instead of a field.
+    """
+    for source_file in (INDEX_HTML, SERVICE_WORKER):
+        source = source_file.read_text(encoding="utf-8")
+        for line in _console_call_lines(source):
+            assert "event.data" not in line, f"{source_file.name} logs a message payload: {line.strip()}"
+
+
+def test_media_error_handlers_log_the_event_without_the_media_url() -> None:
+    """Run both handlers and read what they actually wrote."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    script = "\n".join(
+        [
+            '"use strict";',
+            "const assert = require('node:assert/strict');",
+            """
+const logged = [];
+const console = { error: (...args) => { logged.push(args.join(' ')); } };
+const getMediaUrl = () => { throw new Error('the handler built the media URL'); };
+const msg = { id: 5, chat_id: -1001234567890, media: { type: 'video' } };
+const img = { onerror: () => {}, style: {}, onclick: () => {} };
+const video = { parentElement: { set innerHTML(value) { throw new Error('wrote innerHTML'); } } };
+""",
+            _extract_const_arrow_function(html, "handleImageError", asynchronous=False),
+            _extract_const_arrow_function(html, "handleMediaError", asynchronous=False),
+            """
+handleImageError({ target: img }, msg);
+handleMediaError({ target: video }, msg);
+assert.equal(logged.length, 2);
+for (const line of logged) {
+    assert.equal(/\\d/.test(line), false, `console line carries an identifier: ${line}`);
+    assert.equal(line.includes('/media/'), false, line);
+}
+""",
+        ]
+    )
+
+    _run_node(script)
+
+
+# --------------------------------------------------------------------------------------
+# S43 — handleMediaError overwrote Vue-owned DOM with innerHTML
+# --------------------------------------------------------------------------------------
+
+
+def test_media_error_placeholder_is_rendered_by_vue_not_written_into_the_dom() -> None:
+    """Assigning innerHTML to the parent destroyed nodes Vue still held el pointers to.
+
+    The bubble then stayed detached for the life of the row: Vue kept patching nodes
+    that were no longer in the document, so nothing about that message updated again.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    handler = _extract_const_arrow_function(html, "handleMediaError", asynchronous=False)
+    assert "innerHTML" not in _without_comments(handler)
+    assert "msg.mediaLoadFailed = true" in handler
+
+    # ...and the placeholder is a real branch of the template.
+    video_block = html[html.index("<!-- Videos - click to open in lightbox -->") :]
+    video_block = video_block[: video_block.index("<!-- Stickers")]
+    assert 'v-if="msg.mediaLoadFailed"' in video_block
+    assert "<template v-else>" in video_block
+    assert video_block.index('v-if="msg.mediaLoadFailed"') < video_block.index("<video")
+
+    # The handler must flag the row and touch nothing else (the stub throws on a write).
+    script = "\n".join(
+        [
+            '"use strict";',
+            "const assert = require('node:assert/strict');",
+            """
+const console = { error: () => {} };
+const msg = { id: 9, chat_id: -100, media: { type: 'video' } };
+const parent = { set innerHTML(value) { throw new Error('handleMediaError wrote innerHTML'); } };
+""",
+            _extract_const_arrow_function(html, "handleMediaError", asynchronous=False),
+            """
+handleMediaError({ target: { parentElement: parent } }, msg);
+assert.equal(msg.mediaLoadFailed, true, 'the row was not flagged, so Vue cannot render the placeholder');
+""",
+        ]
+    )
+
+    _run_node(script)
+
+
+# --------------------------------------------------------------------------------------
+# S22 / S30 — CDN assets had no Subresource Integrity and two were unpinned
+# --------------------------------------------------------------------------------------
+
+# Fetched from each CDN and hashed; a wrong value here silently breaks the whole page,
+# so these are the bytes actually served for these exact URLs.
+EXPECTED_SUBRESOURCES = {
+    "https://unpkg.com/vue@3.5.41/dist/vue.global.prod.js": (
+        "sha384-arPHRzOKPl8g3Rbe/cQBWYPnq4HcxfPFSFWD3qvI/hc2XQf+4GkVqkOlWgjN5mD3"
+    ),
+    "https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.29.4/moment.min.js": (
+        "sha384-VCGDSwGwLWkVOK5vAWSaY38KZ4oKJ0whHjpJQhjqrMlWadpf2dUVKLgOLBdEaLvZ"
+    ),
+    "https://cdnjs.cloudflare.com/ajax/libs/moment-timezone/0.5.43/moment-timezone-with-data-1970-2030.min.js": (
+        "sha384-l7VdBcaAfGCeXKsn587Z+4Z3m6M5/96OPpQu1zC3wscMtXK9xPY8oQQYUhZBJIC/"
+    ),
+    "https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css": (
+        "sha384-iw3OoTErCYJJB9mCa8LNS2hbsQ7M3C0EpIsO/H5+EGAkPGc6rk+V8i04oW/K5xq0"
+    ),
+    "https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.css": (
+        "sha384-RkASv+6KfBMW9eknReJIJ6b3UnjKOKC5bOUaNgIY778NFbQ8MtWq9Lr/khUgqtTt"
+    ),
+    "https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js": (
+        "sha384-5JqMv4L/Xa0hfvtF06qboNdhvuYXUku9ZrhZh3bSk8VXF0A/RuSLHpLsSV9Zqhl6"
+    ),
+}
+
+# The two that cannot carry a hash, and why. Tailwind's CDN serves no
+# Access-Control-Allow-Origin, and integrity= forces a CORS fetch — adding it would
+# block the script and the UI would load unstyled. The Google Fonts stylesheet is
+# generated per user agent, so its bytes differ between browsers.
+UNHASHABLE_SUBRESOURCES = {
+    "https://cdn.tailwindcss.com/3.4.17",
+    "https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&display=swap",
+}
+
+_SUBRESOURCE_TAG = re.compile(r"<(?P<tag>script|link)\b(?P<attrs>[^>]*?)>", re.IGNORECASE | re.DOTALL)
+_URL_ATTR = re.compile(r'\b(?:src|href)="(?P<url>https://[^"]+)"')
+
+
+def _external_subresources(html: str) -> dict[str, str]:
+    """Map every externally loaded script/stylesheet URL to its tag's attributes."""
+    head = html[: html.index("</head>")]
+    found = {}
+    for match in _SUBRESOURCE_TAG.finditer(head):
+        attrs = match.group("attrs")
+        url_match = _URL_ATTR.search(attrs)
+        if url_match is None:
+            continue
+        found[url_match.group("url")] = attrs
+    return found
+
+
+def test_every_cdn_asset_is_version_pinned_and_integrity_checked() -> None:
+    """Third-party code runs in the origin that holds the archive session.
+
+    ``vue@3`` and a versionless ``/npm/flatpickr`` resolved to whatever was latest at
+    page load, and not one tag carried an integrity hash — so a malicious publish, or
+    one bad CDN edge, executed arbitrary JS against the viewer's own API.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    found = _external_subresources(html)
+
+    assert set(found) == set(EXPECTED_SUBRESOURCES) | UNHASHABLE_SUBRESOURCES, (
+        "an external asset was added, removed or re-pointed without updating this test"
+    )
+
+    for url, expected_hash in EXPECTED_SUBRESOURCES.items():
+        attrs = found[url]
+        assert f'integrity="{expected_hash}"' in attrs, f"{url} has no (or a changed) integrity hash"
+        assert 'crossorigin="anonymous"' in attrs, f"{url} needs crossorigin for integrity to be checked"
+
+    for url in UNHASHABLE_SUBRESOURCES:
+        assert "integrity=" not in found[url], f"{url} cannot be hashed; see the comment above it"
+
+    # No floating version may come back.
+    assert "https://unpkg.com/vue@3/" not in html
+    assert '<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>' not in html
+    assert "https://cdn.jsdelivr.net/npm/flatpickr/" not in html
+    assert '"https://cdn.tailwindcss.com"' not in html
+
+
+def test_the_unhashable_exceptions_are_documented_in_the_template() -> None:
+    """A missing integrity= must read as a decision, not an oversight."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    head = html[: html.index("</head>")]
+
+    assert "Access-Control-Allow-Origin" in head
+    assert "per user agent" in head


### PR DESCRIPTION
## The problem

- **The search box fired a full-chat scan on every keystroke.** `@input` called `searchMessages` directly, which cleared the message list, reset pagination and issued a fresh unindexed `LIKE` query per character — so the pane blanked as you typed and the server did the most expensive query it has, repeatedly.
- **Switching media-gallery tabs mid-load painted the wrong tab's results**, and opening the gallery in a new chat briefly showed the previous chat's thumbnails. A failed topic load left the *previous* forum chat's topics on screen with no error.
- **A notification click could do nothing at all.** The service worker picked its target with `'postMessage' in client` — true for every window client per spec — so the `openWindow` fallback was unreachable. And the page only registers its message listener late in `onMounted`, after several awaits, so a click often landed on a tab that was not listening yet: a silent no-op.
- **Third-party scripts loaded from CDNs with no Subresource Integrity**, so a CDN compromise executes arbitrary JS in the authenticated viewer origin.
- Chat ids and full media paths (chat id + the sender's original filename) were written to the **browser console**, and a whole message payload was logged by the service worker.

## The fix

- Search debounces and cancels superseded requests; gallery and topic loads carry a request token so a stale response can never paint.
- The service worker focuses an open tab when it can and otherwise opens the deep link, so a click is never a no-op.
- Third-party assets pinned with real SRI hashes — each fetched and hashed, not invented.
- Console PII removed.

## Verification

- The service-worker fix was re-verified by driving the **real `sw.js`** under a stubbed Service Worker global: no tabs → `openWindow(deep link)`; unfocusable tab → `openWindow`; `focus()` rejection → falls back rather than dying.
- SRI hashes verified by fetching each asset from the live CDN and recomputing.
- Full suite: **2753 passed**, 171 subtests, 0 failures — including the 145 existing frontend-bootstrap tests. `ruff` clean.