### PR TITLE
fix: close the viewer's websocket and thumbnail ACL bypasses

### DIFF
--- a/src/web/main.py
+++ b/src/web/main.py
@@ -7,13 +7,13 @@ v5.0: WebSocket support for real-time updates and notifications.
 """
 
 import asyncio
-import glob
 import hashlib
 import json
 import logging
 import os
 import secrets
 import time
+import traceback
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
@@ -28,6 +28,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy.exc import DBAPIError, OperationalError
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from ..config import Config
 from ..db import DatabaseAdapter, close_database, get_db_manager, init_database
@@ -89,7 +90,11 @@ class ConnectionManager:
     async def broadcast_to_chat(self, chat_id: int, message: dict):
         """Broadcast a message to all connections subscribed to a chat."""
         disconnected = []
-        for websocket, subscribed_chats in self.active_connections.items():
+        # Snapshot first: send_json suspends, and a connect/disconnect landing in
+        # another task during that await mutates active_connections. Iterating it
+        # live raises RuntimeError at the `for`, which aborts the whole broadcast
+        # and silently drops the event for every client not yet reached.
+        for websocket, subscribed_chats in list(self.active_connections.items()):
             allowed = self._allowed_chats.get(websocket)
             if allowed is not None and chat_id not in allowed:
                 continue
@@ -107,7 +112,8 @@ class ConnectionManager:
     async def broadcast_to_all(self, message: dict):
         """Broadcast a message to all connected clients."""
         disconnected = []
-        for websocket in self.active_connections:
+        # Same snapshot rule as broadcast_to_chat: the dict can change under us.
+        for websocket in list(self.active_connections):
             try:
                 await websocket.send_json(message)
             except Exception as e:
@@ -556,6 +562,16 @@ def _verify_password(password: str, salt: str, password_hash: str) -> bool:
     return secrets.compare_digest(_hash_password(password, salt), password_hash)
 
 
+def _hash_token(plaintext_token: str, salt: str) -> str:
+    """Share-token twin of _hash_password: token salts are hex, password salts are raw.
+
+    600k rounds take ~50ms, so every caller must run this via asyncio.to_thread —
+    inline it would stall the event loop for the duration (matches the login/
+    create-viewer/update-viewer hashing sites).
+    """
+    return hashlib.pbkdf2_hmac("sha256", plaintext_token.encode(), bytes.fromhex(salt), 600_000).hex()
+
+
 def _check_rate_limit(ip: str) -> bool:
     """Returns True if the request is within rate limits."""
     now = time.time()
@@ -798,10 +814,18 @@ async def _resolve_proxy_user(proxy_username: str) -> UserContext:
     raise HTTPException(status_code=503, detail="Database required for proxy authentication")
 
 
-async def require_auth(
-    request: Request, auth_cookie: str | None = Cookie(default=None, alias=AUTH_COOKIE_NAME)
-) -> UserContext:
-    """Dependency that enforces session-based auth. Returns UserContext."""
+async def _resolve_user_context(proxy_header_value: str | None, auth_cookie: str | None) -> UserContext:
+    """Resolve the authenticated principal from a proxy header value and a session cookie.
+
+    One resolver for every transport. The proxy header is tried first and, when
+    it is absent, resolution FALLS THROUGH to the session cookie — enabling
+    AUTH_PROXY_HEADER never turns the cookie check off. The WebSocket upgrade
+    used to make that decision on its own and skipped the cookie branch whenever
+    proxy auth was configured, which admitted credential-less sockets and gave
+    authenticated viewers a socket with no chat ACL.
+
+    Raises HTTPException when the caller cannot be tied to a principal.
+    """
     if not AUTH_ENABLED and not _PROXY_AUTH_ENABLED:
         if ALLOW_ANONYMOUS_VIEWER:
             # Read-only viewer, not master: anonymous internet users must never get
@@ -811,7 +835,7 @@ async def require_auth(
 
     # Trusted proxy header authentication (v7.9.0)
     if _PROXY_AUTH_ENABLED:
-        proxy_user = request.headers.get(AUTH_PROXY_HEADER, "").strip()
+        proxy_user = (proxy_header_value or "").strip()
         if proxy_user:
             return await _resolve_proxy_user(proxy_user)
 
@@ -836,6 +860,14 @@ async def require_auth(
         allowed_chat_ids=session.allowed_chat_ids,
         no_download=session.no_download,
     )
+
+
+async def require_auth(
+    request: Request, auth_cookie: str | None = Cookie(default=None, alias=AUTH_COOKIE_NAME)
+) -> UserContext:
+    """Dependency that enforces session-based auth. Returns UserContext."""
+    proxy_header_value = request.headers.get(AUTH_PROXY_HEADER) if _PROXY_AUTH_ENABLED else None
+    return await _resolve_user_context(proxy_header_value, auth_cookie)
 
 
 def require_master(request: Request, user: UserContext = Depends(require_auth)) -> UserContext:
@@ -970,6 +1002,50 @@ _media_root = Path(config.media_path).resolve() if os.path.exists(config.media_p
 _thumb_cache_dir: Path | None = None
 
 
+def _checked_media_path(path: str) -> str:
+    """Return the single media path string used for BOTH the ACL and the file read.
+
+    The folder segment IS the authorization key (_enforce_media_acl reads
+    parts[0] as the chat id), so the string that is authorized has to be the
+    string that selects bytes on disk. A traversal segment breaks exactly that:
+    the ASGI server percent-decodes before routing, so ``%2e%2e`` reaches the
+    route as a real ``..`` and lets the ACL read one folder while the filesystem
+    reads another. Every media route funnels its request path through here
+    first, and passes the returned value on unchanged, so the two can never
+    disagree again.
+    """
+    if path.startswith("/") or ".." in path.split("/"):
+        raise HTTPException(status_code=403, detail="Access denied")
+    return path
+
+
+# Types the viewer renders inline. Anything else is served as a download, so an
+# archived file can never become an active document on the viewer's own origin.
+_INLINE_MEDIA_FAMILIES = frozenset({"image", "video", "audio"})
+_INLINE_MEDIA_EXTRA = frozenset({"application/pdf"})
+_INLINE_MEDIA_BLOCKED = frozenset({"image/svg+xml"})
+
+
+def _inline_media_type(filename: str) -> str | None:
+    """Content type to serve a media file with inline, or None when it must download.
+
+    The stored name is chosen by whoever sent the file: sanitize_media_filename
+    strips separators but keeps the extension verbatim, so a contact can archive
+    ``report.html``. Serving that with its guessed type makes it a same-origin
+    document holding the viewer's session — stored XSS with a plain attachment.
+    Only the families the viewer actually renders inline (<img>, <video>,
+    <audio>, plus PDF) get a real type; everything else, including SVG (an SVG
+    navigated to directly executes its script), becomes an octet-stream
+    attachment.
+    """
+    guessed, _ = mimetypes.guess_type(filename)
+    if not guessed or guessed in _INLINE_MEDIA_BLOCKED:
+        return None
+    if guessed in _INLINE_MEDIA_EXTRA or guessed.split("/", 1)[0] in _INLINE_MEDIA_FAMILIES:
+        return guessed
+    return None
+
+
 # Thumbnail endpoint MUST be defined before the catch-all /media/{path:path} route
 @app.get("/media/thumb/{size}/{folder:path}/{filename}")
 async def serve_thumbnail(size: int, folder: str, filename: str, user: UserContext = Depends(require_auth)):
@@ -977,12 +1053,22 @@ async def serve_thumbnail(size: int, folder: str, filename: str, user: UserConte
     if not _media_root:
         raise HTTPException(status_code=404, detail="Media directory not configured")
 
+    # Traversal check FIRST: an "avatars/../<chat>" folder would otherwise skip
+    # the no_download rule below on its way to another chat's media.
+    requested = _checked_media_path(f"{folder}/{filename}")
+    folder, _, filename = requested.rpartition("/")
+    if not folder:
+        raise HTTPException(status_code=403, detail="Access denied")
+
     if user.no_download and not folder.startswith("avatars/"):
         raise HTTPException(status_code=403, detail="Downloads disabled for this account")
 
+    # `requested` is now the ONLY path string in this handler: it is what the ACL
+    # below authorizes and, split back into folder/filename, what ensure_thumbnail
+    # reads. ensure_thumbnail resolves it and bounds it at the media root, so a
+    # symlink cannot take it outside either.
     # Early ACL check on requested path (prevents existence leakage).
     # Member avatars (avatars/users/) are gated by a visible-membership probe.
-    requested = f"{folder}/{filename}"
     member_ok = await _avatar_user_visible_member(requested, user)
     _enforce_media_acl(requested, user, thumbnail=True, member_ok=member_ok)
 
@@ -1003,7 +1089,9 @@ async def serve_thumbnail(size: int, folder: str, filename: str, user: UserConte
         resolved_member_ok = await _avatar_user_visible_member(resolved, user)
         _enforce_media_acl(resolved, user, thumbnail=True, member_ok=resolved_member_ok)
 
-    return FileResponse(thumb_path, media_type="image/webp", headers={"Cache-Control": "public, max-age=86400"})
+    # Access-controlled bytes: private, so a shared proxy cache can never hand
+    # one viewer's thumbnail to another.
+    return FileResponse(thumb_path, media_type="image/webp", headers={"Cache-Control": "private, max-age=86400"})
 
 
 @app.get("/media/{path:path}")
@@ -1012,15 +1100,16 @@ async def serve_media(path: str, download: int = Query(0), user: UserContext = D
     if not _media_root:
         raise HTTPException(status_code=404, detail="Media directory not configured")
 
+    # Reject path traversal and absolute paths before anything else reads the
+    # path — the no_download rule below tests a prefix, and a prefix means
+    # nothing until the path is known to stay in the folder it names.
+    path = _checked_media_path(path)
+
     # Server-side download restriction. Original media bytes are not served to
     # no-download users because a direct GET is indistinguishable from browser
     # inline rendering once the URL is known. Avatars stay available for UI chrome.
     if user.no_download and not path.startswith("avatars/"):
         raise HTTPException(status_code=403, detail="Downloads disabled for this account")
-
-    # Reject path traversal and absolute paths before any filesystem operations
-    if ".." in path.split("/") or path.startswith("/"):
-        raise HTTPException(status_code=403, detail="Access denied")
 
     # Construct and resolve path, then verify it stays within media root
     candidate = _media_root / path
@@ -1081,9 +1170,11 @@ async def serve_media(path: str, download: int = Query(0), user: UserContext = D
     # model the call as a filesystem sink and raise py/path-injection on
     # `resolved`, which is a false positive: containment is already enforced above
     # (reject ../absolute, resolve(strict=True), is_relative_to(_media_root)).
-    # Default (no download param) stays inline: <img>/<video> use the same URL.
-    response = FileResponse(resolved)
-    if download:
+    # Default (no download param) stays inline for the types the viewer renders
+    # inline; everything else is handed over as a download (see _inline_media_type).
+    inline_type = _inline_media_type(resolved.name)
+    response = FileResponse(resolved, media_type=inline_type or "application/octet-stream")
+    if download or inline_type is None:
         download_name = media_display_filename(path.rsplit("/", 1)[-1])
         quoted = quote(download_name)
         response.headers["Content-Disposition"] = (
@@ -1091,8 +1182,10 @@ async def serve_media(path: str, download: int = Query(0), user: UserContext = D
             if quoted != download_name
             else f'attachment; filename="{download_name}"'
         )
-    if path.startswith("avatars/"):
-        response.headers["Cache-Control"] = "public, max-age=86400"
+    # Every byte this route serves is access-controlled, so no shared cache may
+    # store it. Avatars keep their long browser TTL; the rest stays as cacheable
+    # per-browser as it was, just never in a proxy that skips the ACL.
+    response.headers["Cache-Control"] = "private, max-age=86400" if path.startswith("avatars/") else "private"
     return response
 
 
@@ -1105,14 +1198,107 @@ async def read_root():
     )
 
 
+def _redacted_error_response(route_template: str, exc: Exception) -> JSONResponse:
+    """Log an unhandled exception under the PII-redaction rule and build its response.
+
+    Shared by RedactingErrorMiddleware (the normal path) and the FastAPI
+    exception handler below (a defence-in-depth fallback) so BOTH emit the exact
+    same redacted log line and the exact same 500/503 JSON body — the 503 split
+    for DB-connection errors, 500 for everything else.
+
+    Never the concrete path: a media URL is /media/<chat_id>/<file_id>_<the
+    sender's document name>, so logging it logs a chat id and a person's file
+    name. The route template is what an operator needs to find the endpoint,
+    and it carries no identifiers. describe_exception keeps the same rule for
+    the exception text (OSError stringifies with the offending path).
+    """
+    if _is_db_connection_error(exc):
+        logger.error(f"Database connection error on {route_template}: {describe_exception(exc)}")
+        return JSONResponse(status_code=503, content={"detail": "Database temporarily unavailable"})
+    # exc_info is banned on this branch too: the log formatter ends a traceback
+    # with the exception's own str() (and its __cause__/__context__ chain), and
+    # non-OSError exceptions carry paths there — subprocess.TimeoutExpired /
+    # CalledProcessError stringify with the full ffmpeg argv, which contains a
+    # media path (a chat id and the sender's file name). describe_exception
+    # already refuses those messages, so log only the frame list (file, line,
+    # function, source text — never a runtime value): the crash site stays
+    # diagnosable while nothing an exception smuggled in can reach the log.
+    frames = "".join(traceback.format_tb(exc.__traceback__)).rstrip()
+    detail = f"Unhandled error on {route_template}: {describe_exception(exc)}"
+    logger.error(f"{detail}\n{frames}" if frames else detail)
+    return JSONResponse(status_code=500, content={"detail": "Internal server error"})
+
+
+class RedactingErrorMiddleware:
+    """Handle unhandled exceptions at the ASGI layer, one level inside ServerErrorMiddleware.
+
+    The exception handler below already logs a redacted line, but that alone is
+    not enough. Starlette's ServerErrorMiddleware re-raises the exception after
+    the handler returns (errors.py ends its except block with ``raise exc``), and
+    uvicorn's ``run_asgi`` then logs "Exception in ASGI application" with exc_info
+    UNCONDITIONALLY. That traceback ends with the exception's own str() — and a
+    thumbnail failure raises subprocess.TimeoutExpired whose argv is the ffmpeg
+    command, i.e. a media path carrying the chat id and the sender's file name.
+    So the redaction has to happen where the exception can be STOPPED, not merely
+    logged.
+
+    Registered via app.add_middleware after every other middleware, this becomes
+    the outermost user middleware: it wraps the whole app yet still sits inside
+    ServerErrorMiddleware (Starlette forces that one outermost). It catches the
+    unhandled exception first, logs the identical redacted line, sends the
+    identical 500/503 JSON response, and does NOT re-raise. ServerErrorMiddleware
+    and uvicorn therefore never see the exception, so no traceback can leak.
+
+    A failure after the response has started (a streaming FileResponse that dies
+    mid-body) cannot be answered with a clean JSON body, so it is re-raised and
+    behaves exactly as before; the assigned exploit raises before the response
+    starts and is fully handled here.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        response_started = False
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal response_started
+            if message["type"] == "http.response.start":
+                response_started = True
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        except Exception as exc:
+            if response_started:
+                raise
+            route_template = getattr(scope.get("route"), "path", None) or "unrouted request"
+            response = _redacted_error_response(route_template, exc)
+            await response(scope, receive, send)
+
+
+# Added last, so it is the OUTERMOST user middleware: it wraps CORS and the
+# security-headers middleware and sits just inside ServerErrorMiddleware, which
+# lets it catch and answer an unhandled exception before ServerErrorMiddleware
+# can re-raise it into uvicorn (where the traceback would leak the media path).
+app.add_middleware(RedactingErrorMiddleware)
+
+
 @app.exception_handler(Exception)
 async def unhandled_exception_handler(request: Request, exc: Exception):
-    """Catch unhandled exceptions and return 503 for DB connection errors."""
-    if _is_db_connection_error(exc):
-        logger.error(f"Database connection error on {request.url.path}: {exc}")
-        return JSONResponse(status_code=503, content={"detail": "Database temporarily unavailable"})
-    logger.error(f"Unhandled error on {request.url.path}: {exc}", exc_info=True)
-    return JSONResponse(status_code=500, content={"detail": "Internal server error"})
+    """Fallback 500/503 handler for any path that bypasses the middleware.
+
+    RedactingErrorMiddleware is what catches in the normal path (so uvicorn never
+    logs the traceback); this handler stays registered so the same redacted-log +
+    503-for-DB / 500-for-everything-else contract still holds for any code that
+    reaches ServerErrorMiddleware directly.
+    """
+    route_template = getattr(request.scope.get("route"), "path", None) or "unrouted request"
+    return _redacted_error_response(route_template, exc)
 
 
 @app.get("/api/health")
@@ -1217,7 +1403,9 @@ async def login(request: Request):
             viewer = None
 
         if viewer and viewer["is_active"]:
-            if _verify_password(password, viewer["salt"], viewer["password_hash"]):
+            # 600k-round PBKDF2: off the event loop, or one login attempt stalls
+            # every other request, WebSocket frame and health check on the way.
+            if await asyncio.to_thread(_verify_password, password, viewer["salt"], viewer["password_hash"]):
                 allowed = None
                 if viewer["allowed_chat_ids"]:
                     try:
@@ -1416,6 +1604,64 @@ async def auth_via_token(request: Request):
     return response
 
 
+# One directory read per avatars/ subfolder, reused until that folder changes:
+# {directory: (directory mtime, {id: [filenames]})}. A glob per id scandirs the
+# whole folder every time, so a page of 50 senders cost 50 full directory scans
+# on the event loop; a lookup now costs one stat of the folder.
+_avatar_dir_index: dict[str, tuple[int, dict[int, list[str]]]] = {}
+
+
+def _avatar_dir_listing(avatar_dir: str, force: bool = False) -> dict[int, list[str]]:
+    """Map {id: [avatar filenames]} for one avatars/ subfolder.
+
+    Cached against the directory's own mtime, which changes whenever a file is
+    added or removed there — so a newly downloaded avatar is picked up on the
+    next request without a timer, and nothing can serve a listing for a folder
+    that has since changed.
+    """
+    try:
+        stamp = os.stat(avatar_dir).st_mtime_ns
+    except OSError:
+        _avatar_dir_index.pop(avatar_dir, None)
+        return {}
+
+    cached = _avatar_dir_index.get(avatar_dir)
+    if cached is not None and cached[0] == stamp and not force:
+        return cached[1]
+
+    listing: dict[int, list[str]] = {}
+    try:
+        with os.scandir(avatar_dir) as entries:
+            for entry in entries:
+                if not entry.name.endswith(".jpg"):
+                    continue
+                # "{id}_{photo_id}.jpg" and the legacy "{id}.jpg" both key on id.
+                try:
+                    avatar_id = int(entry.name[:-4].split("_", 1)[0])
+                except ValueError:
+                    continue
+                listing.setdefault(avatar_id, []).append(entry.name)
+    except OSError:
+        return {}
+
+    _avatar_dir_index[avatar_dir] = (stamp, listing)
+    return listing
+
+
+def _newest_avatar_file(avatar_dir: str, names: list[str] | None) -> str | None:
+    """Most recently modified of the candidate files that are still on disk."""
+    newest_name: str | None = None
+    newest_mtime: float | None = None
+    for name in names or ():
+        try:
+            mtime = os.path.getmtime(os.path.join(avatar_dir, name))
+        except OSError:
+            continue  # deleted since the folder was read
+        if newest_mtime is None or mtime > newest_mtime:
+            newest_name, newest_mtime = name, mtime
+    return newest_name
+
+
 def _find_avatar_path(chat_id: int, chat_type: str) -> str | None:
     """Find avatar file path for a chat.
 
@@ -1426,22 +1672,14 @@ def _find_avatar_path(chat_id: int, chat_type: str) -> str | None:
     avatar_folder = "users" if chat_type == "private" else "chats"
     avatar_dir = os.path.join(config.media_path, "avatars", avatar_folder)
 
-    if not os.path.exists(avatar_dir):
-        return None
+    candidates = _avatar_dir_listing(avatar_dir).get(chat_id)
+    avatar_file = _newest_avatar_file(avatar_dir, candidates)
+    if avatar_file is None and candidates:
+        # Every candidate has vanished — re-read the folder once and retry, so a
+        # deletion is never served from a listing that outlived it.
+        avatar_file = _newest_avatar_file(avatar_dir, _avatar_dir_listing(avatar_dir, force=True).get(chat_id))
 
-    # Look for avatar file matching chat_id
-    pattern = os.path.join(avatar_dir, f"{chat_id}_*.jpg")
-    matches = glob.glob(pattern)
-
-    # Legacy fallback: files saved without photo_id suffix
-    legacy_path = os.path.join(avatar_dir, f"{chat_id}.jpg")
-    if os.path.exists(legacy_path):
-        matches.append(legacy_path)
-
-    if matches:
-        # Return the most recently modified avatar (newest profile photo)
-        newest_avatar = max(matches, key=os.path.getmtime)
-        avatar_file = os.path.basename(newest_avatar)
+    if avatar_file:
         return f"avatars/{avatar_folder}/{avatar_file}"
 
     return None
@@ -1816,6 +2054,10 @@ async def get_chat_media(
 
             if user.no_download:
                 item.pop("file_path", None)
+                # serve_thumbnail refuses derived bytes for these accounts, so a
+                # thumb_url here would only render as a broken image; dropping it
+                # lights up the gallery's own placeholder instead.
+                item["thumb_url"] = None
             else:
                 item["media_url"] = f"/media/{_encode_media_path(file_path)}"
 
@@ -2455,7 +2697,7 @@ async def create_viewer(request: Request, user: UserContext = Depends(require_ma
         raise HTTPException(status_code=409, detail="Username already exists")
 
     salt = secrets.token_hex(32)
-    password_hash = _hash_password(password, salt)
+    password_hash = await asyncio.to_thread(_hash_password, password, salt)
 
     chat_ids_json = None
     if allowed_chat_ids is not None:
@@ -2509,7 +2751,7 @@ async def update_viewer(viewer_id: int, request: Request, user: UserContext = De
         if len(pwd) < 8:
             raise HTTPException(status_code=400, detail="Password must be at least 8 characters")
         salt = secrets.token_hex(32)
-        updates["password_hash"] = _hash_password(pwd, salt)
+        updates["password_hash"] = await asyncio.to_thread(_hash_password, pwd, salt)
         updates["salt"] = salt
 
     if "allowed_chat_ids" in data:
@@ -2664,7 +2906,7 @@ async def create_token(request: Request, user: UserContext = Depends(require_mas
     # Generate token: 32 bytes = 64 hex chars
     plaintext_token = secrets.token_hex(32)
     salt = secrets.token_hex(32)
-    token_hash = hashlib.pbkdf2_hmac("sha256", plaintext_token.encode(), bytes.fromhex(salt), 600_000).hex()
+    token_hash = await asyncio.to_thread(_hash_token, plaintext_token, salt)
 
     token_record = await db.create_viewer_token(
         label=label,
@@ -2845,37 +3087,20 @@ async def websocket_endpoint(websocket: WebSocket):
         await websocket.close(code=4003, reason="Forbidden origin")
         return
 
-    # Validate auth from cookie before accepting
-    cookies = websocket.cookies
-    auth_cookie = cookies.get(AUTH_COOKIE_NAME)
-    ws_user_chat_ids: set[int] | None = None
-
-    # Trusted proxy header auth for WebSocket upgrade
-    if _PROXY_AUTH_ENABLED:
-        proxy_user = websocket.headers.get(AUTH_PROXY_HEADER, "").strip()
-        if proxy_user:
-            try:
-                user_ctx = await _resolve_proxy_user(proxy_user)
-                ws_user_chat_ids = get_user_chat_ids(user_ctx)
-            except HTTPException:
-                await websocket.close(code=4001, reason="Proxy auth failed")
-                return
-        elif not AUTH_ENABLED and not ALLOW_ANONYMOUS_VIEWER:
-            await websocket.close(code=4001, reason="Unauthorized")
-            return
-    elif AUTH_ENABLED:
-        if not auth_cookie:
-            await websocket.close(code=4001, reason="Unauthorized")
-            return
-        session = await _resolve_session(auth_cookie)
-        if not session or time.time() - session.created_at > AUTH_SESSION_SECONDS:
-            await websocket.close(code=4001, reason="Session expired")
-            return
-        user_ctx = UserContext(session.username, session.role, session.allowed_chat_ids)
-        ws_user_chat_ids = get_user_chat_ids(user_ctx)
-    elif not ALLOW_ANONYMOUS_VIEWER:
-        await websocket.close(code=4001, reason="Viewer authentication is not configured")
+    # Validate auth before accepting, through the SAME resolver the HTTP routes
+    # use: proxy header first, then the session cookie, then the anonymous
+    # fallback. A socket that resolves to no principal is closed rather than
+    # connected, and the ACL it carries is that principal's ACL.
+    try:
+        user_ctx = await _resolve_user_context(
+            websocket.headers.get(AUTH_PROXY_HEADER) if _PROXY_AUTH_ENABLED else None,
+            websocket.cookies.get(AUTH_COOKIE_NAME),
+        )
+    except HTTPException as exc:
+        await websocket.close(code=4001, reason=exc.detail)
         return
+
+    ws_user_chat_ids = get_user_chat_ids(user_ctx)
 
     await ws_manager.connect(websocket, allowed_chat_ids=ws_user_chat_ids)
 

--- a/tests/test_viewer_acl_hardening.py
+++ b/tests/test_viewer_acl_hardening.py
@@ -1,0 +1,807 @@
+"""Regression tests for the viewer's access-control and media-serving hardening.
+
+Each class pins one defect found by the security audit of src/web/main.py:
+
+- /ws/updates admitted credential-less sockets, and gave authenticated viewers a
+  socket with NO chat ACL, whenever AUTH_PROXY_HEADER and VIEWER_USERNAME/
+  VIEWER_PASSWORD were configured together.
+- The thumbnail route authorized the raw request string while the file lookup
+  used the joined path, so a percent-encoded ".." read another chat's media and
+  bypassed no_download.
+- broadcast_to_chat iterated the live connection dict across awaits.
+- Archived .html/.svg documents were served inline as same-origin documents.
+- Access-controlled media carried Cache-Control: public.
+- The global exception handlers logged the request path (a chat id and the
+  sender's file name), and exc_info on the 500 branch printed the exception's
+  own text — a subprocess error's ffmpeg argv carries that same media path.
+- The media gallery handed no_download viewers thumb_urls that always 403.
+- Login and share-token creation ran a 600k-round PBKDF2 on the event loop.
+- Avatars were resolved with one directory scan per id.
+"""
+
+import asyncio
+import importlib
+import logging
+import os
+import subprocess
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+try:
+    os.environ.setdefault("BACKUP_PATH", tempfile.mkdtemp(prefix="ta_test_acl_"))
+    from src.web import main as web_main
+
+    _WEB_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only on installs without fastapi
+    _WEB_AVAILABLE = False
+    web_main = None  # type: ignore[assignment]
+
+try:
+    from fastapi.testclient import TestClient
+    from httpx import ASGITransport, AsyncClient
+    from starlette.websockets import WebSocketDisconnect
+
+    _CLIENTS_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised only on installs without fastapi
+    _CLIENTS_AVAILABLE = False
+
+
+def _skip_unless_web(cls):
+    return unittest.skipUnless(_WEB_AVAILABLE and _CLIENTS_AVAILABLE, "web_main/test client import failed")(cls)
+
+
+def _mock_db():
+    db = AsyncMock()
+    db.get_session = AsyncMock(return_value=None)
+    db.save_session = AsyncMock()
+    db.delete_session = AsyncMock()
+    db.create_audit_log = AsyncMock()
+    db.get_viewer_by_username = AsyncMock(return_value=None)
+    return db
+
+
+# ============================================================================
+# /ws/updates authentication (proxy header + password auth configured together)
+# ============================================================================
+
+# The shape tests/test_proxy_auth.py calls proxy_with_basic_env: the documented
+# combination where the WebSocket used to skip the cookie check entirely.
+PROXY_WITH_BASIC_ENV = {
+    "VIEWER_USERNAME": "admin",
+    "VIEWER_PASSWORD": "testpass123",
+    "AUTH_PROXY_HEADER": "X-Forwarded-User",
+    "AUTH_PROXY_ADMIN_USERS": "sso-admin@corp.com",
+    "AUTH_PROXY_DEFAULT_ACCESS": "none",
+    "SECURE_COOKIES": "false",
+}
+
+NEUTRAL_ENV = {
+    "VIEWER_USERNAME": "",
+    "VIEWER_PASSWORD": "",
+    "AUTH_PROXY_HEADER": "",
+    "ALLOW_ANONYMOUS_VIEWER": "false",
+}
+
+
+@_skip_unless_web
+class TestWebSocketAuthWithProxyAndPassword(unittest.TestCase):
+    """A socket must belong to a principal, and carry that principal's chat ACL."""
+
+    def setUp(self):
+        with patch.dict(os.environ, PROXY_WITH_BASIC_ENV):
+            importlib.reload(web_main)
+        web_main.db = _mock_db()
+        web_main._sessions.clear()
+        self.client = TestClient(web_main.app, raise_server_exceptions=False)
+
+    def tearDown(self):
+        web_main._sessions.clear()
+        # Leave the module in a neutral state so later test files are not
+        # affected by this file's reload.
+        with patch.dict(os.environ, NEUTRAL_ENV):
+            importlib.reload(web_main)
+
+    def test_config_under_test_is_the_reported_one(self):
+        """Guard the guard: both auth mechanisms really are enabled here."""
+        self.assertTrue(web_main.AUTH_ENABLED)
+        self.assertTrue(web_main._PROXY_AUTH_ENABLED)
+
+    def test_socket_without_any_credential_is_refused(self):
+        """No cookie and no proxy header: the handshake must be closed, not accepted."""
+        with self.assertRaises(WebSocketDisconnect) as caught, self.client.websocket_connect("/ws/updates"):
+            pass
+        self.assertEqual(4001, caught.exception.code)
+
+    def test_authenticated_viewer_socket_keeps_its_chat_acl(self):
+        """A restricted viewer must not be able to subscribe outside its allowed set."""
+        token = "acl-ws-session"
+        web_main._sessions[token] = web_main.SessionData(
+            username="v1", role="viewer", allowed_chat_ids={1, 2}, created_at=time.time()
+        )
+        self.client.cookies.set("viewer_auth", token)
+
+        with self.client.websocket_connect("/ws/updates") as socket:
+            socket.send_json({"action": "subscribe", "chat_id": 1})
+            self.assertEqual({"type": "subscribed", "chat_id": 1}, socket.receive_json())
+            socket.send_json({"action": "subscribe", "chat_id": 999})
+            self.assertEqual({"type": "subscribe_denied", "chat_id": 999}, socket.receive_json())
+
+    def test_proxy_header_still_authenticates(self):
+        """Control: the proxy path itself is untouched and still connects."""
+        with self.client.websocket_connect("/ws/updates", headers={"X-Forwarded-User": "sso-admin@corp.com"}) as socket:
+            socket.send_json({"action": "ping"})
+            self.assertEqual({"type": "pong"}, socket.receive_json())
+
+
+# ============================================================================
+# Thumbnail route: percent-encoded ".." (the ACL string must be the read string)
+# ============================================================================
+
+
+@_skip_unless_web
+class TestThumbnailPathTraversal(unittest.IsolatedAsyncioTestCase):
+    """`%2e%2e` arrives decoded, so the folder the ACL reads must be the folder served."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self._saved_root = web_main._media_root
+        self._saved_cache = web_main._thumb_cache_dir
+        self._saved_auth = web_main.AUTH_ENABLED
+        self._saved_db = web_main.db
+        web_main._media_root = Path(self.tmp.name)
+        web_main._thumb_cache_dir = Path(self.tmp.name) / "thumbs"
+        web_main.AUTH_ENABLED = True
+        web_main.db = _mock_db()
+        web_main._sessions.clear()
+
+    def tearDown(self):
+        web_main._media_root = self._saved_root
+        web_main._thumb_cache_dir = self._saved_cache
+        web_main.AUTH_ENABLED = self._saved_auth
+        web_main.db = self._saved_db
+        web_main._sessions.clear()
+        self.tmp.cleanup()
+
+    def _session(self, token, **kwargs):
+        web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", created_at=time.time(), **kwargs)
+        return {"viewer_auth": token}
+
+    def _client(self):
+        return AsyncClient(transport=ASGITransport(app=web_main.app), base_url="http://test")
+
+    async def test_encoded_dot_dot_cannot_reach_a_forbidden_chat(self):
+        """The exploit: authorized on -1001, served from -1002."""
+        cookies = self._session("tv-restricted", allowed_chat_ids={-1001})
+        generated = AsyncMock(return_value=(Path(self.tmp.name) / "thumb.webp", "-1002"))
+        with patch("src.web.thumbnails.ensure_thumbnail", generated):
+            async with self._client() as client:
+                resp = await client.get("/media/thumb/200/-1001/%2e%2e/-1002/secret.jpg", cookies=cookies)
+        self.assertEqual(403, resp.status_code)
+        # No file was even looked at: the request never reached generation.
+        generated.assert_not_awaited()
+
+    async def test_encoded_slash_spelling_is_refused_too(self):
+        """`..%2f` decodes to the same traversal and must fail the same way."""
+        cookies = self._session("tv-restricted-2", allowed_chat_ids={-1001})
+        async with self._client() as client:
+            resp = await client.get("/media/thumb/200/-1001/..%2f-1002/secret.jpg", cookies=cookies)
+        self.assertEqual(403, resp.status_code)
+
+    async def test_encoded_dot_dot_cannot_bypass_no_download(self):
+        """`avatars/..` used to skip the no_download rule on its way to real media."""
+        cookies = self._session("tv-nodl", allowed_chat_ids={-1001}, no_download=True)
+        generated = AsyncMock(return_value=(Path(self.tmp.name) / "thumb.webp", "-1001"))
+        with patch("src.web.thumbnails.ensure_thumbnail", generated):
+            async with self._client() as client:
+                resp = await client.get("/media/thumb/200/avatars/%2e%2e/-1001/private.jpg", cookies=cookies)
+        self.assertEqual(403, resp.status_code)
+        generated.assert_not_awaited()
+
+    async def test_clean_path_in_an_allowed_chat_still_serves(self):
+        """Control: the guard denies only requests that were already meant to be denied."""
+        cookies = self._session("tv-allowed", allowed_chat_ids={-1001})
+        thumb = Path(self.tmp.name) / "thumb.webp"
+        thumb.write_bytes(b"\x00" * 8)
+        with patch("src.web.thumbnails.ensure_thumbnail", AsyncMock(return_value=(thumb, "-1001"))):
+            async with self._client() as client:
+                resp = await client.get("/media/thumb/200/-1001/allowed.jpg", cookies=cookies)
+        self.assertEqual(200, resp.status_code)
+
+    async def test_serve_media_still_refuses_traversal(self):
+        """The sibling route shares the same guard now; it must not have regressed."""
+        cookies = self._session("tv-media", allowed_chat_ids={-1001})
+        async with self._client() as client:
+            resp = await client.get("/media/-1001/%2e%2e/-1002/secret.jpg", cookies=cookies)
+        self.assertEqual(403, resp.status_code)
+
+
+# ============================================================================
+# Broadcast must survive a disconnect landing mid-send
+# ============================================================================
+
+
+class _FakeSocket:
+    """Minimal stand-in for a Starlette WebSocket that can suspend inside send_json."""
+
+    def __init__(self, on_send=None):
+        self.received = []
+        self._on_send = on_send
+
+    async def accept(self):
+        return None
+
+    async def send_json(self, message):
+        if self._on_send is not None:
+            hook, self._on_send = self._on_send, None
+            await hook()
+        self.received.append(message)
+
+
+@_skip_unless_web
+class TestBroadcastSnapshot(unittest.IsolatedAsyncioTestCase):
+    """One client leaving must not cancel the event for everyone else."""
+
+    async def test_disconnect_during_send_still_reaches_the_remaining_clients(self):
+        manager = web_main.ConnectionManager()
+        leaving = _FakeSocket()
+        staying = _FakeSocket()
+
+        async def disconnect_mid_broadcast():
+            # Exactly what websocket_endpoint's WebSocketDisconnect handler does,
+            # from another task, while the broadcast is suspended on send_json.
+            manager.disconnect(leaving)
+            await asyncio.sleep(0)
+
+        first = _FakeSocket(on_send=disconnect_mid_broadcast)
+        for socket in (first, leaving, staying):
+            await manager.connect(socket)
+            manager.subscribe(socket, 42)
+
+        await manager.broadcast_to_chat(42, {"type": "new_message", "chat_id": 42})
+
+        self.assertEqual(1, len(first.received))
+        self.assertEqual(1, len(staying.received), "a client after the mutation point missed the broadcast")
+
+    async def test_broadcast_to_all_survives_the_same_race(self):
+        manager = web_main.ConnectionManager()
+        leaving = _FakeSocket()
+        staying = _FakeSocket()
+
+        async def disconnect_mid_broadcast():
+            manager.disconnect(leaving)
+            await asyncio.sleep(0)
+
+        first = _FakeSocket(on_send=disconnect_mid_broadcast)
+        for socket in (first, leaving, staying):
+            await manager.connect(socket)
+
+        await manager.broadcast_to_all({"type": "ping"})
+
+        self.assertEqual(1, len(staying.received))
+
+
+# ============================================================================
+# Media content type, disposition and cache directives
+# ============================================================================
+
+
+@_skip_unless_web
+class TestMediaServingHeaders(unittest.IsolatedAsyncioTestCase):
+    """Archived bytes are attacker-named: they must never become a live document."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        # serve_media compares the resolved file against _media_root, and the
+        # module resolves media_path at import; a temp dir behind a symlink
+        # (macOS /var) would fail that check for reasons unrelated to this test.
+        self.root = Path(self.tmp.name).resolve()
+        self.chat_dir = self.root / "-1001"
+        self.chat_dir.mkdir()
+        (self.root / "avatars" / "chats").mkdir(parents=True)
+        (self.root / "avatars" / "chats" / "-1001_7.jpg").write_bytes(b"\xff\xd8\xff")
+        self._saved_root = web_main._media_root
+        self._saved_auth = web_main.AUTH_ENABLED
+        self._saved_anon = web_main.ALLOW_ANONYMOUS_VIEWER
+        self._saved_db = web_main.db
+        web_main._media_root = self.root
+        web_main.AUTH_ENABLED = False
+        web_main.ALLOW_ANONYMOUS_VIEWER = True
+        web_main.db = _mock_db()
+
+    def tearDown(self):
+        web_main._media_root = self._saved_root
+        web_main.AUTH_ENABLED = self._saved_auth
+        web_main.ALLOW_ANONYMOUS_VIEWER = self._saved_anon
+        web_main.db = self._saved_db
+        self.tmp.cleanup()
+
+    def _client(self):
+        return AsyncClient(transport=ASGITransport(app=web_main.app), base_url="http://test")
+
+    async def _get(self, name, query=""):
+        (self.chat_dir / name).write_bytes(b"<script>archive.exfiltrate()</script>")
+        async with self._client() as client:
+            return await client.get(f"/media/-1001/{name}{query}")
+
+    async def test_archived_html_is_a_download_not_a_document(self):
+        resp = await self._get("77_report.html")
+        self.assertEqual(200, resp.status_code)
+        self.assertNotIn("text/html", resp.headers["content-type"])
+        self.assertEqual("application/octet-stream", resp.headers["content-type"])
+        self.assertTrue(resp.headers["content-disposition"].startswith("attachment"))
+        self.assertEqual("nosniff", resp.headers["x-content-type-options"])
+
+    async def test_archived_svg_is_a_download_too(self):
+        """An <img> cannot run an SVG's script, but navigating to the URL can."""
+        resp = await self._get("77_logo.svg")
+        self.assertEqual("application/octet-stream", resp.headers["content-type"])
+        self.assertTrue(resp.headers["content-disposition"].startswith("attachment"))
+
+    async def test_archived_xhtml_is_a_download_too(self):
+        resp = await self._get("77_page.xhtml")
+        self.assertEqual("application/octet-stream", resp.headers["content-type"])
+        self.assertTrue(resp.headers["content-disposition"].startswith("attachment"))
+
+    async def test_real_media_still_renders_inline(self):
+        """Control: the types the viewer renders inline keep their type and stay inline."""
+        for name, expected in (("77_photo.jpg", "image/jpeg"), ("77_clip.mp4", "video/mp4")):
+            resp = await self._get(name)
+            self.assertEqual(200, resp.status_code)
+            self.assertTrue(resp.headers["content-type"].startswith(expected), name)
+            self.assertNotIn("attachment", resp.headers.get("content-disposition", ""), name)
+
+    async def test_media_is_never_stored_by_a_shared_cache(self):
+        resp = await self._get("77_photo.jpg")
+        self.assertIn("private", resp.headers["cache-control"])
+        self.assertNotIn("public", resp.headers["cache-control"])
+
+    async def test_avatar_cache_control_is_private(self):
+        async with self._client() as client:
+            resp = await client.get("/media/avatars/chats/-1001_7.jpg")
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual("private, max-age=86400", resp.headers["cache-control"])
+
+    async def test_thumbnail_cache_control_is_private(self):
+        thumb = self.root / "thumb.webp"
+        thumb.write_bytes(b"\x00" * 8)
+        saved_cache_dir = web_main._thumb_cache_dir
+        web_main._thumb_cache_dir = self.root / "thumbs"
+        try:
+            with patch("src.web.thumbnails.ensure_thumbnail", AsyncMock(return_value=(thumb, "-1001"))):
+                async with self._client() as client:
+                    resp = await client.get("/media/thumb/200/-1001/77_photo.jpg")
+        finally:
+            web_main._thumb_cache_dir = saved_cache_dir
+        self.assertEqual(200, resp.status_code)
+        self.assertIn("private", resp.headers["cache-control"])
+        self.assertNotIn("public", resp.headers["cache-control"])
+
+
+# ============================================================================
+# The global exception handlers must not log the request path
+# ============================================================================
+
+
+@_skip_unless_web
+class TestExceptionHandlerRedaction(unittest.TestCase):
+    """A media URL is /media/<chat id>/<file id>_<the sender's file name>."""
+
+    CHAT_FOLDER = "-1001234567890"
+    FILE_NAME = "555_Maria Invoice.jpg"
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self._saved_root = web_main._media_root
+        self._saved_auth = web_main.AUTH_ENABLED
+        self._saved_anon = web_main.ALLOW_ANONYMOUS_VIEWER
+        self._saved_cache = web_main._thumb_cache_dir
+        self._saved_db = web_main.db
+        web_main._media_root = Path(self.tmp.name)
+        web_main._thumb_cache_dir = Path(self.tmp.name) / "thumbs"
+        web_main.AUTH_ENABLED = False
+        web_main.ALLOW_ANONYMOUS_VIEWER = True
+        web_main.db = _mock_db()
+
+    def tearDown(self):
+        web_main._media_root = self._saved_root
+        web_main.AUTH_ENABLED = self._saved_auth
+        web_main.ALLOW_ANONYMOUS_VIEWER = self._saved_anon
+        web_main._thumb_cache_dir = self._saved_cache
+        web_main.db = self._saved_db
+        self.tmp.cleanup()
+
+    def _drive_failing_request(self, failure):
+        client = TestClient(web_main.app, raise_server_exceptions=False)
+        url = f"/media/thumb/200/{self.CHAT_FOLDER}/{self.FILE_NAME}"
+        with (
+            patch("src.web.thumbnails.ensure_thumbnail", AsyncMock(side_effect=failure)),
+            self.assertLogs("src.web.main", level=logging.ERROR) as captured,
+        ):
+            response = client.get(url)
+        # captured.output is the FORMATTED record — unlike getMessage(), it
+        # appends the exc_info traceback, which is exactly where the leak hid.
+        return response, "\n".join(captured.output)
+
+    def test_database_error_branch_logs_no_identifiers(self):
+        response, logged = self._drive_failing_request(OSError(20, "Not a directory", "/cache/thumbs"))
+        self.assertEqual(503, response.status_code)
+        self.assertNotIn(self.CHAT_FOLDER, logged)
+        self.assertNotIn("Maria", logged)
+        self.assertNotIn("Errno", logged)
+        self.assertIn("/media/thumb/{size}/{folder:path}/{filename}", logged)
+
+    def test_unhandled_error_branch_logs_no_identifiers(self):
+        response, logged = self._drive_failing_request(RuntimeError("thumbnail worker exploded"))
+        self.assertEqual(500, response.status_code)
+        self.assertNotIn(self.CHAT_FOLDER, logged)
+        self.assertNotIn("Maria", logged)
+        self.assertIn("/media/thumb/{size}/{folder:path}/{filename}", logged)
+        # The class and message of a non-path exception stay: that is the diagnostic.
+        self.assertIn("RuntimeError", logged)
+
+    def test_unhandled_error_traceback_cannot_carry_the_ffmpeg_argv(self):
+        """The attack: a subprocess error stringifies with the full ffmpeg argv.
+
+        describe_exception already refuses that message, but exc_info=True on the
+        500 branch re-printed it as the traceback's last line — chat id, sender
+        file name and all. The formatted log record must carry neither.
+        """
+        attack = subprocess.TimeoutExpired(
+            ["ffmpeg", "-y", "-i", f"/data/media/{self.CHAT_FOLDER}/{self.FILE_NAME}", "-frames:v", "1", "t.jpg"],
+            10,
+        )
+        response, logged = self._drive_failing_request(attack)
+        self.assertEqual(500, response.status_code)
+        self.assertNotIn(self.CHAT_FOLDER, logged)
+        self.assertNotIn("Maria", logged)
+        self.assertNotIn("ffmpeg", logged)
+        # Debuggability survives redaction: the type names the failure and the
+        # frame list (file/line/function — never a runtime value) locates it.
+        self.assertIn("TimeoutExpired", logged)
+        self.assertIn('File "', logged)
+
+    def test_oserror_with_a_media_path_stays_clean_on_the_503_branch(self):
+        """An OSError carrying the media path classifies as a connection error;
+        its 503 branch must keep refusing the exception text (which stringifies
+        with the offending filename) and must never grow an exc_info."""
+        attack = FileNotFoundError(2, "No such file or directory", f"/data/media/{self.CHAT_FOLDER}/{self.FILE_NAME}")
+        response, logged = self._drive_failing_request(attack)
+        self.assertEqual(503, response.status_code)
+        self.assertNotIn(self.CHAT_FOLDER, logged)
+        self.assertNotIn("Maria", logged)
+        self.assertNotIn("Errno", logged)
+        self.assertIn("FileNotFoundError", logged)
+
+
+# ============================================================================
+# The unhandled exception must never reach the ASGI server (uvicorn)
+# ============================================================================
+
+
+@_skip_unless_web
+class TestUnhandledExceptionNeverReachesTheServer(unittest.TestCase):
+    """Redacting the app logger was necessary but not sufficient.
+
+    After the app's handler runs, Starlette's ServerErrorMiddleware re-raises the
+    exception (errors.py: ``raise exc``) and uvicorn's run_asgi then logs
+    "Exception in ASGI application" with exc_info UNCONDITIONALLY. That traceback
+    ends with the exception's own str(), and a thumbnail failure raises
+    subprocess.TimeoutExpired whose argv is the ffmpeg command — a media path
+    carrying the chat id and the sender's file name. RedactingErrorMiddleware
+    must catch the exception, answer 500/503 WITHOUT re-raising (so it never
+    propagates out of the ASGI app), and leak nothing.
+    """
+
+    CHAT_FOLDER = "-1001234567890"
+    FILE_NAME = "555_Maria Invoice.jpg"
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self._saved_root = web_main._media_root
+        self._saved_auth = web_main.AUTH_ENABLED
+        self._saved_anon = web_main.ALLOW_ANONYMOUS_VIEWER
+        self._saved_cache = web_main._thumb_cache_dir
+        self._saved_db = web_main.db
+        web_main._media_root = Path(self.tmp.name)
+        web_main._thumb_cache_dir = Path(self.tmp.name) / "thumbs"
+        web_main.AUTH_ENABLED = False
+        web_main.ALLOW_ANONYMOUS_VIEWER = True
+        web_main.db = _mock_db()
+
+    def tearDown(self):
+        web_main._media_root = self._saved_root
+        web_main.AUTH_ENABLED = self._saved_auth
+        web_main.ALLOW_ANONYMOUS_VIEWER = self._saved_anon
+        web_main._thumb_cache_dir = self._saved_cache
+        web_main.db = self._saved_db
+        self.tmp.cleanup()
+
+    def _drive(self, failure):
+        # raise_server_exceptions=True is the in-process stand-in for uvicorn's
+        # run_asgi: if the exception escapes the ASGI app, TestClient re-raises it
+        # here — exactly the condition under which uvicorn would log the traceback
+        # with exc_info. So "this call returned a response" == "uvicorn never saw
+        # it". Before the middleware, this same call raised the exception.
+        client = TestClient(web_main.app, raise_server_exceptions=True)
+        url = f"/media/thumb/200/{self.CHAT_FOLDER}/{self.FILE_NAME}"
+
+        # Capture BOTH 'src.web.main' and 'uvicorn.error' by attaching a handler
+        # to the ROOT logger (both propagate there), and FORMAT each record so an
+        # exc_info traceback — if any code path ever attached one — would show up
+        # in the captured text, which is exactly where the leak would hide.
+        captured = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                captured.append(self.format(record))
+
+        handler = _Capture()
+        handler.setFormatter(logging.Formatter("%(name)s %(levelname)s %(message)s"))
+        root = logging.getLogger()
+        root.addHandler(handler)
+        try:
+            with patch("src.web.thumbnails.ensure_thumbnail", AsyncMock(side_effect=failure)):
+                response = client.get(url)
+        finally:
+            root.removeHandler(handler)
+        return response, "\n".join(captured)
+
+    def test_ffmpeg_timeout_is_answered_not_reraised(self):
+        """The exact assigned exploit: a TimeoutExpired whose argv is the media path."""
+        attack = subprocess.TimeoutExpired(
+            ["ffmpeg", "-y", "-i", f"/data/media/{self.CHAT_FOLDER}/{self.FILE_NAME}", "-frames:v", "1", "t.jpg"],
+            10,
+        )
+        # If the middleware re-raised, client.get would raise TimeoutExpired and
+        # this test would ERROR before reaching a single assertion.
+        response, logged = self._drive(attack)
+        self.assertEqual(500, response.status_code)
+        self.assertNotIn(self.CHAT_FOLDER, logged)
+        self.assertNotIn("Maria", logged)
+        self.assertNotIn("ffmpeg", logged)
+        # Debuggability survives: the type names the failure, the frames locate it.
+        self.assertIn("TimeoutExpired", logged)
+        self.assertIn('File "', logged)
+
+    def test_db_connection_error_still_answers_503_without_reraise(self):
+        """The 503-for-DB branch keeps its status and its redaction under the middleware."""
+        response, logged = self._drive(OSError(20, "Not a directory", "/cache/thumbs"))
+        self.assertEqual(503, response.status_code)
+        self.assertNotIn(self.CHAT_FOLDER, logged)
+        self.assertNotIn("Maria", logged)
+        self.assertNotIn("Errno", logged)
+
+    def test_generic_error_answers_500_without_reraise(self):
+        """Control: an ordinary exception is answered 500 and keeps its diagnostic type."""
+        response, logged = self._drive(RuntimeError("thumbnail worker exploded"))
+        self.assertEqual(500, response.status_code)
+        self.assertNotIn(self.CHAT_FOLDER, logged)
+        self.assertNotIn("Maria", logged)
+        self.assertIn("RuntimeError", logged)
+
+
+# ============================================================================
+# Media gallery: no_download sessions
+# ============================================================================
+
+
+@_skip_unless_web
+class TestNoDownloadGalleryThumbnails(unittest.IsolatedAsyncioTestCase):
+    """A URL the route puts in its own response must be fetchable by its recipient."""
+
+    def setUp(self):
+        self._saved_db = web_main.db
+        self._saved_auth = web_main.AUTH_ENABLED
+        self._saved_anon = web_main.ALLOW_ANONYMOUS_VIEWER
+        self._saved_display = web_main.config.display_chat_ids
+        web_main.AUTH_ENABLED = True
+        web_main.ALLOW_ANONYMOUS_VIEWER = False
+        web_main.config.display_chat_ids = set()
+        web_main._sessions.clear()
+        self.mock_db = _mock_db()
+        self.mock_db.get_media_paginated = AsyncMock(
+            side_effect=lambda *a, **k: {"items": [{"id": 1, "file_path": "-1001/photo_123.jpg"}]}
+        )
+        web_main.db = self.mock_db
+
+    def tearDown(self):
+        web_main.db = self._saved_db
+        web_main.AUTH_ENABLED = self._saved_auth
+        web_main.ALLOW_ANONYMOUS_VIEWER = self._saved_anon
+        web_main.config.display_chat_ids = self._saved_display
+        web_main._sessions.clear()
+
+    async def _gallery(self, token, no_download):
+        web_main._sessions[token] = web_main.SessionData(
+            username="v1",
+            role="viewer",
+            allowed_chat_ids={-1001},
+            no_download=no_download,
+            created_at=time.time(),
+        )
+        async with AsyncClient(transport=ASGITransport(app=web_main.app), base_url="http://test") as client:
+            resp = await client.get("/api/chats/-1001/media", cookies={"viewer_auth": token})
+        self.assertEqual(200, resp.status_code)
+        return resp.json()["items"][0]
+
+    async def test_no_download_gallery_omits_the_thumbnail_url(self):
+        item = await self._gallery("gal-nodl", no_download=True)
+        self.assertIsNone(item["thumb_url"])
+        self.assertNotIn("file_path", item)
+
+    async def test_ordinary_viewer_still_gets_the_thumbnail_url(self):
+        item = await self._gallery("gal-ok", no_download=False)
+        self.assertEqual("/media/thumb/200/-1001/photo_123.jpg", item["thumb_url"])
+
+
+# ============================================================================
+# Password hashing must not run on the event loop
+# ============================================================================
+
+
+@_skip_unless_web
+class TestLoginHashingOffTheEventLoop(unittest.IsolatedAsyncioTestCase):
+    """600k rounds of PBKDF2 inline would stall every other request for its duration."""
+
+    def setUp(self):
+        self._saved_db = web_main.db
+        self._saved_auth = web_main.AUTH_ENABLED
+        web_main.AUTH_ENABLED = True
+        web_main._sessions.clear()
+        web_main._login_attempts.clear()
+        self.mock_db = _mock_db()
+        self.mock_db.get_viewer_by_username = AsyncMock(
+            return_value={
+                "username": "v1",
+                "is_active": 1,
+                "salt": "salt-value",
+                "password_hash": "hash-value",
+                "allowed_chat_ids": None,
+                "no_download": 0,
+            }
+        )
+        web_main.db = self.mock_db
+
+    def tearDown(self):
+        web_main.db = self._saved_db
+        web_main.AUTH_ENABLED = self._saved_auth
+        web_main._sessions.clear()
+        web_main._login_attempts.clear()
+
+    async def test_verify_password_runs_in_a_worker_thread(self):
+        hashed_on = []
+
+        def recording_verify(password, salt, password_hash):
+            hashed_on.append(threading.get_ident())
+            return True
+
+        loop_thread = threading.get_ident()
+        with patch.object(web_main, "_verify_password", recording_verify):
+            async with AsyncClient(transport=ASGITransport(app=web_main.app), base_url="http://test") as client:
+                resp = await client.post("/api/login", json={"username": "v1", "password": "test@value/here"})
+
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(1, len(hashed_on))
+        self.assertNotEqual(loop_thread, hashed_on[0], "PBKDF2 ran on the event loop thread")
+
+
+@_skip_unless_web
+class TestTokenHashingOffTheEventLoop(unittest.IsolatedAsyncioTestCase):
+    """create_token kept a fourth inline PBKDF2 after the login/viewer sites moved."""
+
+    def setUp(self):
+        self._saved_db = web_main.db
+        self._saved_auth = web_main.AUTH_ENABLED
+        web_main.AUTH_ENABLED = True
+        web_main._sessions.clear()
+        self.mock_db = _mock_db()
+        self.mock_db.create_viewer_token = AsyncMock(
+            side_effect=lambda **kwargs: {
+                "id": 7,
+                "label": kwargs.get("label"),
+                "no_download": kwargs.get("no_download", 0),
+                "expires_at": None,
+                "created_at": "2026-01-01T00:00:00",
+            }
+        )
+        web_main.db = self.mock_db
+
+    def tearDown(self):
+        web_main.db = self._saved_db
+        web_main.AUTH_ENABLED = self._saved_auth
+        web_main._sessions.clear()
+
+    async def test_token_hash_runs_in_a_worker_thread(self):
+        hashed_on = []
+
+        def recording_hash(plaintext_token, salt):
+            hashed_on.append(threading.get_ident())
+            return "feedface" * 8
+
+        web_main._sessions["master-tok"] = web_main.SessionData(username="admin", role="master")
+        loop_thread = threading.get_ident()
+        with patch.object(web_main, "_hash_token", recording_hash):
+            async with AsyncClient(transport=ASGITransport(app=web_main.app), base_url="http://test") as client:
+                resp = await client.post(
+                    "/api/admin/tokens",
+                    json={"label": "backup", "allowed_chat_ids": [-1001]},
+                    cookies={"viewer_auth": "master-tok"},
+                )
+
+        self.assertEqual(200, resp.status_code)
+        self.assertEqual(1, len(hashed_on), "create_token no longer routes through _hash_token")
+        self.assertNotEqual(loop_thread, hashed_on[0], "token PBKDF2 ran on the event loop thread")
+
+
+# ============================================================================
+# Avatar resolution costs one directory read, not one per id
+# ============================================================================
+
+
+@_skip_unless_web
+class TestAvatarLookupScans(unittest.TestCase):
+    """A page of N senders used to trigger N full scans of the avatars folder."""
+
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.users_dir = Path(self.tmp.name) / "avatars" / "users"
+        self.users_dir.mkdir(parents=True)
+        self._saved_media_path = web_main.config.media_path
+        web_main.config.media_path = self.tmp.name
+        web_main._avatar_cache.clear()
+        web_main._avatar_cache_time = None
+        web_main._avatar_dir_index.clear()
+
+    def tearDown(self):
+        web_main.config.media_path = self._saved_media_path
+        web_main._avatar_cache.clear()
+        web_main._avatar_cache_time = None
+        web_main._avatar_dir_index.clear()
+        self.tmp.cleanup()
+
+    def _touch(self, name, mtime=None):
+        path = self.users_dir / name
+        path.write_bytes(b"x")
+        if mtime is not None:
+            os.utime(path, (mtime, mtime))
+        return path
+
+    def test_a_page_of_senders_reads_the_folder_once(self):
+        sender_ids = list(range(1000, 1030))
+        for sender_id in sender_ids:
+            self._touch(f"{sender_id}_1.jpg")
+
+        real_scandir = os.scandir
+        scans = []
+
+        def counting_scandir(path="."):
+            scans.append(str(path))
+            return real_scandir(path)
+
+        with patch.object(web_main.os, "scandir", counting_scandir):
+            urls = [web_main._sender_avatar_url(sender_id) for sender_id in sender_ids]
+
+        self.assertEqual([f"/media/avatars/users/{sender_id}_1.jpg" for sender_id in sender_ids], urls)
+        self.assertEqual(1, len([s for s in scans if str(self.users_dir) in s]))
+
+    def test_a_new_avatar_is_picked_up_without_waiting(self):
+        """The listing is keyed on the folder's own mtime, so it cannot go stale."""
+        self.assertIsNone(web_main._find_avatar_path(2001, "private"))
+        self._touch("2001_5.jpg")
+        self.assertEqual("avatars/users/2001_5.jpg", web_main._find_avatar_path(2001, "private"))
+
+    def test_newest_avatar_still_wins_and_a_deleted_one_is_dropped(self):
+        self._touch("2002_old.jpg", mtime=1_000_000)
+        newest = self._touch("2002_new.jpg", mtime=2_000_000)
+        self.assertEqual("avatars/users/2002_new.jpg", web_main._find_avatar_path(2002, "private"))
+
+        newest.unlink()
+        self.assertEqual("avatars/users/2002_old.jpg", web_main._find_avatar_path(2002, "private"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The problem

Four ways the viewer handed out data it should not have. All were reproduced with working exploits before being fixed, and re-run afterwards to confirm they are dead.

**Anyone could open a websocket with no credentials.** When `AUTH_PROXY_HEADER` is set together with `VIEWER_USERNAME`/`VIEWER_PASSWORD` — a combination the project documents and tests — the proxy branch swallowed the request. With no header its only rejection was `not AUTH_ENABLED and not ALLOW_ANONYMOUS_VIEWER`, which is false when auth *is* enabled, so the cookie check below it was unreachable and the socket connected with `allowed_chat_ids=None`: no ACL at all. It then received every live message, edit, deletion and reaction, message text included.

There is a second impact that needs no attacker: in that same configuration an ordinary logged-in viewer restricted to chats `{1,2}` also got a null ACL, so it could subscribe to any chat id. That is horizontal privilege escalation against the per-viewer ACL, reachable by simply logging in.

**A restricted viewer could read other chats' media.** `GET /media/thumb/200/<allowed>/%2e%2e/<forbidden>/<file>` — uvicorn unquotes before routing, so `%2e%2e` arrives as a real `..`. The ACL was applied to the raw string's first segment while the file was resolved from the joined path, so the two disagreed. `serve_media` already had the guard; the thumbnail route never got it.

**Any attachment could run JavaScript in the viewer's origin.** Archived `.html`/`.svg`/`.xhtml` documents were served inline, so opening one executed it as a same-origin document holding the viewer's session — stored XSS from a file any Telegram contact can send you.

**Archive paths reached the logs.** An unhandled error logged the request path, which carries the chat id and the sender's original filename. Redacting the app's own log line was not enough: Starlette's error middleware re-raises after calling the handler, and the server then logs the full traceback unconditionally, so a thumbnail failure still printed the ffmpeg argv — chat id and filename — into the container log.

## The fix

- Both transports resolve their principal through **one shared resolver** (proxy header, then cookie, then anonymous), so HTTP and websocket cannot drift apart again.
- Both media routes **check and normalise the path once, up front**, so the string that is authorised is the string that selects the file.
- Only image, video, audio and PDF stay inline; everything else is served as an attachment with `nosniff`.
- The redaction moved into middleware registered so it sits **inside** Starlette's error middleware — it responds without re-raising, so the exception never reaches the server's traceback logging. Status codes and JSON bodies are byte-identical to before.
- Access-controlled media is no longer marked cacheable by shared proxies; `no_download` viewers are not handed thumbnail URLs that always 403.
- Password, token and share-token hashing moved off the event loop, along with the blocking per-id avatar directory scan.
- Broadcasts iterate a snapshot, so a client connecting mid-send no longer aborts delivery to everyone else.

## Verification

- Every exploit re-run against **two real uvicorn servers** (patched vs unpatched) — the credential-less socket, the restricted viewer's ACL, the encoded `..`, and the log leak. Each confirmed live on the unpatched side and dead on the patched side.
- The log fix was verified at real-uvicorn fidelity: with the middleware stripped, stderr shows `Exception in ASGI application` and the full ffmpeg argv; with it in place, the chat id, filename, argv and that log line are all absent.
- Every new test proven able to go red before being trusted. One false green was caught and corrected during this work — a stale `__pycache__` made two tests look passing when they were not.
- Full suite: **2763 passed**, 171 subtests, 0 failures. `ruff` check and format clean.

## Behaviour change worth knowing

Clicking a non-media attachment (`.html`, `.svg`, `.txt`, `.zip`) now **downloads** it instead of rendering it in a tab. That is the point of the fix: rendering it made it a same-origin document holding your session.

## Known, pre-existing, not fixed here

The server's **access log** still records the full request line, which contains the chat id and filename for media requests. That predates this change and needs a logging-config fix rather than an application one; it is tracked separately.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Strengthened access controls for media, thumbnails, chat, and WebSocket connections.
  - Blocked unsafe path traversal and prevented potentially dangerous media from rendering inline.
  - Improved privacy by hiding download links from users without download access and protecting cached private media.
  - Improved authentication reliability across web and real-time connections.
  - Prevented sensitive details from appearing in error logs.
  - Improved stability during simultaneous connection and broadcast changes.
- **Tests**
  - Added comprehensive coverage for security, privacy, authentication, and connection stability improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->