### PR TITLE
fix: make a link in a message navigate to the host it displays

### DIFF
--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -5612,23 +5612,33 @@
                     return div.innerHTML
                 }
 
+                // Map a RAW url into href="..." in ONE pass: & escaped for attribute
+                // context, and the characters that must never sit raw inside the
+                // attribute percent-encoded. One pass is the whole point. The previous
+                // shape escaped the entire message and then decoded &amp; back to & while
+                // building the href, so message text could smuggle an entity through that
+                // second decode: `https://good.example&#x40;evil.example/` displayed
+                // good.example but the parser turned &#x40; into @ and the link navigated
+                // to evil.example.
+                const escapeUrlForAttr = (url) => {
+                    const replacements = { '&': '&amp;', '<': '%3C', '>': '%3E', '"': '%22', "'": '%27' }
+                    return [...url].map((char) => replacements[char] || char).join('')
+                }
+
                 const linkifyText = (text) => {
                     if (!text) return ''
-                    const escaped = escapeHtml(text)
-                    const urlRegex = /(https?:\/\/[^\s<]+)/g
-                    return escaped.replace(urlRegex, (match) => {
-                        // Build a safe href: decode HTML entities back to raw URL,
-                        // then percent-encode characters that break href="..." context.
-                        // Note: escapeHtml (textContent/innerHTML) does NOT encode " or '
-                        // so we must handle raw quotes directly, not just entities.
-                        const href = match
-                            .replace(/&amp;/g, '&')
-                            .replace(/&lt;/g, '%3C')
-                            .replace(/&gt;/g, '%3E')
-                            .replace(/"/g, '%22')
-                            .replace(/'/g, '%27')
-                        return `<a href="${href}" target="_blank" rel="noopener noreferrer">${match}</a>`
-                    })
+                    // Split the RAW text on the url pattern. The capture group keeps the
+                    // urls in the result, so even entries are plain text and odd entries
+                    // are urls, and each piece is escaped exactly once for the single
+                    // context it lands in — never escaped and then decoded again.
+                    // \S+ (not [^\s<]+) keeps the matched spans identical to the escaped
+                    // string the old regex ran against, where < could never appear.
+                    return String(text)
+                        .split(/(https?:\/\/\S+)/)
+                        .map((part, index) => (index % 2 === 0
+                            ? escapeHtml(part)
+                            : `<a href="${escapeUrlForAttr(part)}" target="_blank" rel="noopener noreferrer">${escapeHtml(part)}</a>`))
+                        .join('')
                 }
 
                 // Resolve the rendered row for a message id via its data-msg-id attribute.

--- a/tests/test_linkify_escaping.py
+++ b/tests/test_linkify_escaping.py
@@ -1,0 +1,327 @@
+"""Executable regressions for the viewer's message linkifier.
+
+``linkifyText`` turns fully attacker-controlled text — anything anyone can send
+to the archived account — into markup that the SPA renders through ``v-html``.
+It used to HTML-escape the whole message and then decode ``&amp;`` back to ``&``
+while building each href. That decode was a hole: the HTML parser decodes the
+attribute a *second* time, so a message could smuggle an entity through it and
+send the link somewhere its own visible text never showed. A message reading
+``https://good.example&#x40;evil.example/`` navigated to ``evil.example``,
+because ``&#x40;`` came back as ``@`` and turned the visible host into userinfo.
+
+The tests below execute the real helpers lifted verbatim out of the shipped
+template and parse what they emit with an HTML parser, so they pin behaviour
+rather than source text.
+"""
+
+import json
+import shutil
+import subprocess
+import tempfile
+from functools import cache
+from html.parser import HTMLParser
+from pathlib import Path
+from urllib.parse import urlsplit
+
+import pytest
+
+INDEX_HTML = Path(__file__).resolve().parents[1] / "src" / "web" / "templates" / "index.html"
+
+# ``escapeHtml`` round-trips through the DOM (``div.textContent`` in,
+# ``div.innerHTML`` out). This stub reproduces the HTML fragment serializer for
+# a text node: ``&``, ``<``, ``>`` and U+00A0 are escaped and nothing else is —
+# quotes in particular stay raw, which is precisely why an href needs its own
+# encoding rather than the text escaper. Checked against jsdom's serializer.
+_DOCUMENT_STUB = r"""
+const document = {
+    createElement: () => ({
+        set textContent(value) { this.value = String(value) },
+        get innerHTML() {
+            return this.value
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/ /g, '&nbsp;')
+        },
+    }),
+}
+"""
+
+# Every payload is one message body containing exactly one link. Hosts are
+# reserved ``.example`` names, so nothing here resolves anywhere real.
+PAYLOADS = {
+    "plain_url_with_query": "see https://good.example/a?x=1&y=2 ok",
+    "http_scheme": "http://good.example/x",
+    "raw_double_quote": 'https://good.example/"onmouseover="alert(1)',
+    "raw_single_quote": "https://good.example/'onmouseover='alert(1)",
+    "raw_angle_brackets": "https://good.example/<img/src=x/onerror=alert(1)>",
+    "entity_quote_breakout": "https://good.example/&quot;onmouseover=&quot;alert(1)",
+    "entity_tag_injection": "https://good.example/&quot;&gt;&lt;img/src=x/onerror=alert(1)&gt;",
+    "double_entity_tag_injection": (
+        "https://good.example/&amp;quot;&amp;gt;&amp;lt;script&amp;gt;alert(1)&amp;lt;/script&amp;gt;"
+    ),
+    "hex_entity_userinfo": "https://good.example&#x40;evil.example/",
+    "decimal_entity_userinfo": "https://good.example&#64;evil.example/",
+    "named_entity_userinfo": "https://good.example&commat;evil.example/",
+    "entity_userinfo_in_a_sentence": "Sign in at https://good.example&#x40;evil.example/ now",
+    "entity_userinfo_with_colon": "https://good.example&#x3A;x&#x40;evil.example/",
+    "entity_newline_in_host": "https://good.example&#10;evil.example/",
+    "entity_tab_in_path": "https://good.example/&#9;x",
+    "entity_slashes": "https://good.example&#47;&#47;evil.example/",
+    "legacy_entity_without_semicolon": "https://good.example/&quot",
+    "already_escaped_ampersand": "https://good.example/?a=1&amp;b=2",
+    "trailing_punctuation": "visit https://good.example/page. now",
+    "unicode_idn": "https://münchen.example/straße?q=ü",
+    "non_breaking_space": "https://good.example/ next",
+    "very_long_url": "https://good.example/" + "a" * 5000,
+}
+
+# The four characters that cannot sit raw inside href="..." and are therefore
+# percent-encoded on the way in. Everything else must reach the href untouched.
+HREF_PERCENT_ENCODED = {"<": "%3C", ">": "%3E", '"': "%22", "'": "%27"}
+
+
+def _expected_href(link_text: str) -> str:
+    """The only href the viewer may produce for a link showing ``link_text``.
+
+    The destination is the text the reader can see, with just the four
+    unrepresentable characters percent-encoded — nothing decoded, nothing added.
+    """
+    return "".join(HREF_PERCENT_ENCODED.get(char, char) for char in link_text)
+
+
+def _setup_slice(html: str, declaration: str) -> str:
+    """Return one setup-scope ``const`` body, lifted verbatim from the template.
+
+    Setup-scope declarations sit at 16 spaces of indentation, so the next such
+    line ends the current one; anything nested is indented deeper.
+    """
+    start = html.index(declaration)
+    return html[start : html.index("\n                const ", start + len(declaration))]
+
+
+@cache
+def _rendered() -> dict[str, str]:
+    """Run the template's real linkifier over every payload and return its markup."""
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node executable is not installed")
+
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    program = "\n".join(
+        [
+            '"use strict";',
+            _DOCUMENT_STUB,
+            _setup_slice(html, "const escapeHtml = (text) =>"),
+            _setup_slice(html, "const escapeUrlForAttr = (url) =>"),
+            _setup_slice(html, "const linkifyText = (text) =>"),
+            f"const payloads = {json.dumps(PAYLOADS)};",
+            "const rendered = {};",
+            "for (const name of Object.keys(payloads)) rendered[name] = linkifyText(payloads[name]);",
+            "console.log(JSON.stringify(rendered));",
+        ]
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        script = Path(tmp) / "linkify.js"
+        script.write_text(program, encoding="utf-8")
+        # SECURITY-REVIEW: the executable path is resolved locally and no
+        # untrusted input is ever passed to a shell.
+        result = subprocess.run([node, str(script)], capture_output=True, text=True, timeout=60)
+
+    assert result.returncode == 0, result.stderr + "\n----\n" + program
+    return json.loads(result.stdout)
+
+
+class _Markup(HTMLParser):
+    """Read linkified markup the way a browser would, using only the stdlib."""
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.tags: list[str] = []
+        self.attributes: list[tuple[str, str | None]] = []
+        self.anchors: list[tuple[dict[str, str | None], str]] = []
+        self._text: list[str] = []
+        self._open_anchor: tuple[dict[str, str | None], list[str]] | None = None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        self.tags.append(tag)
+        self.attributes.extend(attrs)
+        if tag == "a":
+            self._open_anchor = (dict(attrs), [])
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "a" and self._open_anchor is not None:
+            attributes, chunks = self._open_anchor
+            self.anchors.append((attributes, "".join(chunks)))
+            self._open_anchor = None
+
+    def handle_data(self, data: str) -> None:
+        self._text.append(data)
+        if self._open_anchor is not None:
+            self._open_anchor[1].append(data)
+
+    @property
+    def text(self) -> str:
+        return "".join(self._text)
+
+
+def _parse(markup: str) -> _Markup:
+    parser = _Markup()
+    parser.feed(markup)
+    parser.close()
+    return parser
+
+
+def _only_anchor(name: str) -> tuple[dict[str, str | None], str]:
+    """Return the single anchor a payload produces, as (attributes, link text)."""
+    parsed = _parse(_rendered()[name])
+    assert len(parsed.anchors) == 1, f"{name} produced {len(parsed.anchors)} anchors"
+    return parsed.anchors[0]
+
+
+@pytest.mark.parametrize("name", sorted(PAYLOADS))
+def test_href_is_the_visible_link_text_and_nothing_else(name: str) -> None:
+    """No entity may be decoded on the way into the href.
+
+    This is the double-escaping regression itself: escape-then-decode let the
+    parser resolve a smuggled entity inside the attribute, so the href stopped
+    matching the text the reader was shown.
+    """
+    attributes, link_text = _only_anchor(name)
+
+    assert attributes["href"] == _expected_href(link_text)
+
+
+@pytest.mark.parametrize("name", sorted(PAYLOADS))
+def test_link_navigates_to_the_host_it_displays(name: str) -> None:
+    """The host the browser resolves must be the host printed on the page."""
+    attributes, link_text = _only_anchor(name)
+
+    assert urlsplit(attributes["href"] or "").netloc == urlsplit(link_text).netloc
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "hex_entity_userinfo",
+        "decimal_entity_userinfo",
+        "named_entity_userinfo",
+        "entity_userinfo_in_a_sentence",
+        "entity_userinfo_with_colon",
+        "entity_newline_in_host",
+        "entity_slashes",
+    ],
+    ids=lambda name: name,
+)
+def test_entity_smuggling_cannot_retarget_a_link(name: str) -> None:
+    """An ``@``/newline entity must not turn the displayed host into userinfo.
+
+    Each payload reads as a link to ``good.example``; the second decode used to
+    resolve its entity and hand the whole visible host to ``evil.example`` as
+    userinfo, so the click landed on the attacker's site.
+    """
+    attributes, link_text = _only_anchor(name)
+    href = attributes["href"] or ""
+
+    assert link_text.startswith("https://good.example")
+    assert urlsplit(href).hostname != "evil.example", href
+
+
+@pytest.mark.parametrize("name", sorted(PAYLOADS))
+def test_payloads_render_as_an_inert_anchor(name: str) -> None:
+    """Nothing but the anchor itself may survive into the DOM."""
+    markup = _rendered()[name]
+    parsed = _parse(markup)
+
+    assert parsed.tags == ["a"]
+    assert {attribute for attribute, _ in parsed.attributes} == {"href", "target", "rel"}
+    assert not any(attribute.startswith("on") for attribute, _ in parsed.attributes)
+    assert "<script" not in markup.lower()
+    assert "javascript:" not in markup.lower()
+
+
+@pytest.mark.parametrize("name", sorted(PAYLOADS))
+def test_href_keeps_an_http_scheme(name: str) -> None:
+    """A link's scheme comes from the matched url and can never be swapped."""
+    attributes, _ = _only_anchor(name)
+
+    assert urlsplit(attributes["href"] or "").scheme in {"http", "https"}
+
+
+@pytest.mark.parametrize("name", sorted(PAYLOADS))
+def test_rendered_text_is_the_message_verbatim(name: str) -> None:
+    """Escaping happens exactly once, so the reader sees the message unchanged."""
+    parsed = _parse(_rendered()[name])
+
+    assert parsed.text == PAYLOADS[name]
+
+
+def test_ordinary_link_resolves_exactly_as_before() -> None:
+    """The everyday case — one url with an ``&`` query — still resolves the same.
+
+    The emitted markup does change here: a query ``&`` is now written ``&amp;``
+    instead of leaning on the parser's recovery for a bare ``&``. What the
+    browser ends up with — href, link text, target, rel — is identical.
+    """
+    assert _rendered()["plain_url_with_query"] == (
+        "see "
+        '<a href="https://good.example/a?x=1&amp;y=2" target="_blank" rel="noopener noreferrer">'
+        "https://good.example/a?x=1&amp;y=2</a>"
+        " ok"
+    )
+    attributes, _ = _only_anchor("plain_url_with_query")
+    assert attributes["href"] == "https://good.example/a?x=1&y=2"
+    assert attributes["target"] == "_blank"
+    assert attributes["rel"] == "noopener noreferrer"
+
+
+def test_message_without_a_url_is_plain_escaped_text() -> None:
+    """Text outside a url is escaped once and linked to nothing."""
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node executable is not installed")
+
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    program = "\n".join(
+        [
+            '"use strict";',
+            _DOCUMENT_STUB,
+            _setup_slice(html, "const escapeHtml = (text) =>"),
+            _setup_slice(html, "const escapeUrlForAttr = (url) =>"),
+            _setup_slice(html, "const linkifyText = (text) =>"),
+            "console.log(JSON.stringify(["
+            "linkifyText('a <b>bold</b> & \"quoted\" claim'),"
+            "linkifyText(''),"
+            "linkifyText(null),"
+            "]));",
+        ]
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        script = Path(tmp) / "linkify.js"
+        script.write_text(program, encoding="utf-8")
+        # SECURITY-REVIEW: the executable path is resolved locally and no
+        # untrusted input is ever passed to a shell.
+        result = subprocess.run([node, str(script)], capture_output=True, text=True, timeout=60)
+    assert result.returncode == 0, result.stderr
+    plain, empty, missing = json.loads(result.stdout)
+
+    assert plain == 'a &lt;b&gt;bold&lt;/b&gt; &amp; "quoted" claim'
+    assert _parse(plain).tags == []
+    assert _parse(plain).text == 'a <b>bold</b> & "quoted" claim'
+    assert empty == ""
+    assert missing == ""
+
+
+def test_linkifier_never_decodes_what_it_escaped() -> None:
+    """Guard the shape CodeQL flags: escaping must not be partially undone."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    linkify = _setup_slice(html, "const linkifyText = (text) =>")
+    encode = _setup_slice(html, "const escapeUrlForAttr = (url) =>")
+
+    for source in (linkify, encode):
+        assert "&amp;/g, '&'" not in source
+        assert "&lt;/g" not in source
+        assert "&gt;/g" not in source
+    assert "escapeUrlForAttr(part)" in linkify
+    assert "escapeHtml(part)" in linkify


### PR DESCRIPTION
## The problem

A link in an archived message could **display one host and navigate to another**.

`linkifyText` escaped the message text, then decoded `&amp;` back to `&` inside the matched URL to build the `href`. The browser then decodes that href a *second* time — so a character reference typed into a Telegram message became a real character in the link target.

A message containing:

```
https://good.example&#x40;evil.example/
```

rendered as a link reading `https://good.example…` while resolving to host **`evil.example`**, because `&#x40;` became `@` and demoted the visible host into userinfo. Anyone who can message the archived account could plant one.

Verified in a real DOM (jsdom + parse5) across 36 payloads. `&#64;`, `&#X40;`, `&#0000064;`, `&commat;`, the semicolon-less legacy forms, and `&colon;`+`&commat;` all behave the same; `&#10;`/`&Tab;` similarly corrupt the host.

**It is not XSS, and the report says so.** A literal quote or angle bracket can never reach the markup — raw quotes survive `escapeHtml` but are then percent-encoded, and the `&amp;` decode can only ever produce `&`. The URL pattern only matches `http(s)`, so `javascript:`/`data:` is unreachable. Across all 36 payloads the output was always exactly one `<a>` carrying only `href`, `target`, `rel` — never an extra tag, never an `on*` attribute. So: real finding, honestly scoped — a phishing primitive, not code execution. `rel="noopener noreferrer"` means the damage is the navigation itself.

## The fix

The escape-then-decode round trip is **removed**, not patched. The raw text is split on the URL pattern and each piece is escaped exactly once for the context it lands in: text segments for text, and for each URL a separate attribute-escaped `href` and an HTML-escaped visible label. There is no decode step left to exploit — which is also what closes the CodeQL `js/double-escaping` alert that surfaced this.

## Verification

- 120 regression cases execute the **real helpers lifted verbatim from the shipped template** under node, then parse the emitted markup with the stdlib `HTMLParser`, asserting on genuinely parsed hrefs and link text — no new dependency.
- Pinned invariants: href matches the visible text, the navigated host equals the displayed host, no payload resolves to `evil.example`, output is one inert anchor, scheme stays `http(s)`.
- **Positive control:** restoring the old algorithm turns 27 assertions red across 5 test functions; a full revert to main turns all 120 red. The test cannot silently pass against the old code.
- Ordinary links are byte-identical: same spans detected, same visible text, same `target`/`rel`, same resolved href, diffed old-vs-new over all 36 payloads.
- Full suite: **2975 passed**, 171 subtests, 0 failures. `ruff` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link handling to prevent URL and HTML entity injection.
  * Preserved visible message text and displayed link destinations accurately.
  * Ensured HTTP links, query parameters, and host resolution continue working correctly.
  * Rendered messages without links as safely escaped plain text.
  * Prevented malicious link attributes from becoming active or redirecting elsewhere.

* **Tests**
  * Added regression coverage for link rendering, URL escaping, inert attributes, and empty or null messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->