### PR TITLE
fix: give the frozen sync cursor a way out

### DIFF
--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -122,6 +122,16 @@ MEDIA_REFRESH_TIMEOUT_SECONDS = _get_int_env("MEDIA_REFRESH_TIMEOUT_SECONDS", 12
 # Hard wall-clock bound on the #234 whitelist dialog scan — the count limit alone
 # cannot prevent a wedged-connection hang, which is what #95 was about.
 WHITELIST_RESOLVE_SWEEP_TIMEOUT_SECONDS = 300
+# Bounded retry for a message _process_message cannot handle (#286 follow-up).
+# Holding the sync cursor behind a failure is right for a TRANSIENT one, but a
+# PERMANENT one would hold it there forever: every later run would re-fetch and
+# re-commit the entire tail of that chat — a window that keeps growing — and the
+# chat's recorded progress would never advance again. After this many separate
+# runs have failed on the SAME message the cursor is allowed past it.
+MESSAGE_MAX_PROCESS_ATTEMPTS = 2
+# Cap on the ids kept in a chat's give-up record so it cannot grow without bound.
+# The running total is stored separately and stays exact.
+MESSAGE_GIVE_UP_RECORD_LIMIT = 500
 
 
 def _media_retry_backoff_seconds(attempt: int) -> float:
@@ -1696,6 +1706,79 @@ class TelegramBackup:
             logger.info("Pending media retry: no actionable items")
         logger.info("=" * 60)
 
+    @staticmethod
+    def _message_failure_key(chat_id: int) -> str:
+        """Metadata KV key holding one chat's message-failure record."""
+        return f"message_failures_{chat_id}"
+
+    async def _load_message_failures(self, chat_id: int) -> dict:
+        """Load the durable per-chat message-failure record from the metadata KV.
+
+        Two independent facts live in it:
+
+        ``frozen_id``/``runs``
+            which message the sync cursor is currently parked behind, and how
+            many separate runs have already failed on it. This is what bounds
+            the retry: without a count that survives the process, a permanently
+            unprocessable message freezes the cursor forever.
+        ``given_up_total``/``given_up_ids``
+            the record of messages the cursor was eventually allowed past, so a
+            skip is never silent. ``detect_message_gaps`` cannot stand in for
+            it: it only reports holes larger than ``GAP_THRESHOLD`` (50), so a
+            single passed-over message is invisible to it by construction.
+
+        An id stays in the record even if a later run archives it successfully —
+        it is a log of what was given up on, not of what is missing now.
+
+        Never raises: a missing or malformed value degrades to "nothing recorded
+        yet", which costs one more retry and never skips anything early.
+        """
+        state: dict = {"frozen_id": 0, "runs": 0, "given_up_total": 0, "given_up_ids": set()}
+        try:
+            raw = await self.db.get_metadata(self._message_failure_key(chat_id))
+        except Exception as e:
+            logger.debug("Could not load the message-failure record (%s)", type(e).__name__)
+            return state
+        if not isinstance(raw, str) or not raw:
+            return state
+        try:
+            loaded = json.loads(raw)
+        except ValueError, TypeError:
+            logger.debug("Malformed message-failure record; starting a fresh one")
+            return state
+        if not isinstance(loaded, dict):
+            return state
+        for field in ("frozen_id", "runs", "given_up_total"):
+            value = loaded.get(field)
+            if isinstance(value, int) and value > 0:
+                state[field] = value
+        ids = loaded.get("given_up_ids")
+        if isinstance(ids, list):
+            state["given_up_ids"] = {i for i in ids if isinstance(i, int)}
+        return state
+
+    async def _save_message_failures(self, chat_id: int, state: dict) -> None:
+        """Persist one chat's message-failure record. Never raises.
+
+        Only the most recent ``MESSAGE_GIVE_UP_RECORD_LIMIT`` ids are kept (ids
+        grow over time, so the highest are the newest); ``given_up_total`` counts
+        every give-up regardless.
+        """
+        try:
+            await self.db.set_metadata(
+                self._message_failure_key(chat_id),
+                json.dumps(
+                    {
+                        "frozen_id": state["frozen_id"],
+                        "runs": state["runs"],
+                        "given_up_total": state["given_up_total"],
+                        "given_up_ids": sorted(state["given_up_ids"])[-MESSAGE_GIVE_UP_RECORD_LIMIT:],
+                    }
+                ),
+            )
+        except Exception as e:
+            logger.debug("Could not persist the message-failure record (%s)", type(e).__name__)
+
     async def _backup_dialog(self, dialog, is_archived: bool = False) -> int:
         """
         Backup a single dialog (chat).
@@ -1758,11 +1841,21 @@ class TelegramBackup:
         batches_since_checkpoint = 0
         running_max_id = last_message_id
         # One unprocessable message must never abort the dialog, and the cursor must
-        # never move past it: the message stays retryable on the next run instead of
-        # being silently skipped forever. Messages arrive oldest-first, so freezing
-        # the cursor at the first failure is enough to keep it behind that id.
+        # not move past it: the message stays retryable on the next run instead of
+        # being silently skipped. Messages arrive oldest-first, so freezing the
+        # cursor at the first failure is enough to keep it behind that id.
+        #
+        # That freeze needs a way out, or a PERMANENTLY unprocessable message parks
+        # the cursor forever and every run re-fetches the whole (ever-growing) tail
+        # behind it. So the failure is counted across runs in the metadata KV, and
+        # once the same message has failed MESSAGE_MAX_PROCESS_ATTEMPTS times the
+        # cursor is let past it and its id is recorded as given up on.
         failed_messages = 0
+        given_up_messages = 0
         cursor_frozen = False
+        cursor_passed_failure = False
+        # Loaded lazily: a dialog with no failures must not pay for a read.
+        failures: dict | None = None
 
         async for message in iter_messages_with_flood_retry(self.client, entity, min_id=last_message_id, reverse=True):
             # Skip messages belonging to excluded forum topics
@@ -1774,9 +1867,39 @@ class TelegramBackup:
             try:
                 msg_data = await self._process_message(message, chat_id)
             except Exception as e:
-                failed_messages += 1
-                cursor_frozen = True
                 logger.debug(f"Message could not be processed: {type(e).__name__}")
+                if failures is None:
+                    failures = await self._load_message_failures(chat_id)
+                # Only the message the cursor is parked behind carries a count;
+                # anything else is failing for the first time as far as we know.
+                prior_runs = failures["runs"] if failures["frozen_id"] == message.id else 0
+
+                if message.id in failures["given_up_ids"] or prior_runs + 1 >= MESSAGE_MAX_PROCESS_ATTEMPTS:
+                    # The exit from the freeze. Re-checking the recorded ids is what
+                    # makes it stick: if a previous run gave up here but died before
+                    # its checkpoint landed, this message would otherwise start its
+                    # count again and the chat would never get past it.
+                    given_up_messages += 1
+                    if message.id not in failures["given_up_ids"]:
+                        failures["given_up_ids"].add(message.id)
+                        failures["given_up_total"] += 1
+                    if failures["frozen_id"] == message.id:
+                        failures["frozen_id"] = 0
+                        failures["runs"] = 0
+                    if not cursor_frozen:
+                        running_max_id = max(running_max_id, message.id)
+                        cursor_passed_failure = True
+                    continue
+
+                failed_messages += 1
+                if not cursor_frozen:
+                    cursor_frozen = True
+                    # Persisted here rather than at the end of the dialog: this run
+                    # may not reach the end, and without the count on disk the next
+                    # run restarts the message at attempt one, forever.
+                    failures["frozen_id"] = message.id
+                    failures["runs"] = prior_runs + 1
+                    await self._save_message_failures(chat_id, failures)
                 continue
 
             if not cursor_frozen:
@@ -1811,10 +1934,24 @@ class TelegramBackup:
                 f"the sync cursor stays behind them so they are retried next run"
             )
 
-        # Final checkpoint: persist when there are un-checkpointed messages OR
-        # when the cursor advanced purely from skipped (topic-filtered) messages
-        # that were never counted in uncheckpointed_count.
-        if uncheckpointed_count > 0 or (grand_total == 0 and running_max_id > last_message_id):
+        if given_up_messages and failures is not None:
+            # Written before the checkpoint below, never after: if only one of the
+            # two lands it must be this one. A cursor that moved past a message
+            # with no record of which message is exactly the silent skip this
+            # whole mechanism exists to avoid.
+            await self._save_message_failures(chat_id, failures)
+            given_up_total = failures["given_up_total"]
+            logger.warning(
+                f"  → {given_up_messages} message(s) failed on {MESSAGE_MAX_PROCESS_ATTEMPTS} separate runs "
+                f"and were passed over so the chat can move on ({given_up_total} recorded for it in total); "
+                f"their ids are kept in the backup metadata"
+            )
+
+        # Final checkpoint: persist when there are un-checkpointed messages, when the
+        # cursor was let past a message given up on (otherwise the give-up is lost and
+        # the next run starts it over), OR when the cursor advanced purely from skipped
+        # (topic-filtered) messages that were never counted in uncheckpointed_count.
+        if uncheckpointed_count > 0 or cursor_passed_failure or (grand_total == 0 and running_max_id > last_message_id):
             await self.db.update_sync_status(chat_id, running_max_id, uncheckpointed_count)
 
         # Sync deletions and edits if enabled (expensive!)

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -1886,6 +1886,13 @@ class TelegramBackup:
                     if failures["frozen_id"] == message.id:
                         failures["frozen_id"] = 0
                         failures["runs"] = 0
+                    # Written before the cursor is allowed to move. A batch
+                    # checkpoint later in this run can commit a cursor past this
+                    # id, so persisting only at the end of the dialog leaves a
+                    # window where the process dies having skipped the message
+                    # with nothing on disk saying so — the silent skip this
+                    # whole mechanism exists to prevent.
+                    await self._save_message_failures(chat_id, failures)
                     if not cursor_frozen:
                         running_max_id = max(running_max_id, message.id)
                         cursor_passed_failure = True

--- a/tests/test_cursor_freeze_exit.py
+++ b/tests/test_cursor_freeze_exit.py
@@ -456,3 +456,58 @@ class TestTheExitIsBounded(CursorFreezeExitTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestTheRecordSurvivesACrashMidDialog(CursorFreezeExitTestCase):
+    """The give-up must be on disk before the cursor is allowed to move.
+
+    A batch checkpoint later in the same run can commit a cursor past the
+    message that was passed over. If the record were only written when the
+    dialog finishes, a process that dies in between would leave the cursor
+    beyond a message that nothing remembers skipping -- it would never be
+    retried and never be reported, which is the silent skip this whole
+    mechanism exists to prevent.
+    """
+
+    def _run_until_crash(self):
+        """A run that dies after the poison message, before the dialog ends."""
+        backup = self._make_backup()
+
+        async def commit_then_die(batch, chat_id):
+            self.db.committed.extend(m["id"] for m in batch)
+            raise RuntimeError("process died mid-dialog")
+
+        backup._commit_batch = AsyncMock(side_effect=commit_then_die)
+        with self.assertRaises(RuntimeError):
+            _run(backup._backup_dialog(MagicMock()))
+
+    def test_given_up_id_is_on_disk_even_if_the_run_dies_after_it(self):
+        self.available = list(range(1, 9))
+        self.poison_ids = {3}
+
+        # First run freezes on the poison message and records the attempt.
+        self._run_backup()
+        self.assertEqual(self.db.failure_record().get("frozen_id"), 3)
+
+        # Second run gives up on it, then the process dies before the dialog ends.
+        self._run_until_crash()
+
+        record = self.db.failure_record()
+        self.assertIn(3, record.get("given_up_ids", []), "the skip was not recorded before the crash")
+        self.assertEqual(record.get("given_up_total"), 1)
+
+    def test_a_crashed_run_does_not_leave_the_cursor_past_an_unrecorded_skip(self):
+        self.available = list(range(1, 9))
+        self.poison_ids = {3}
+
+        self._run_backup()
+        self._run_until_crash()
+
+        record = self.db.failure_record()
+        skipped = set(record.get("given_up_ids", []))
+        # Whatever the cursor reached, every id it moved past that failed must
+        # be accounted for on disk.
+        self.assertTrue(
+            self.db.cursor < 3 or 3 in skipped,
+            f"cursor {self.db.cursor} moved past message 3 with skipped={skipped}",
+        )

--- a/tests/test_cursor_freeze_exit.py
+++ b/tests/test_cursor_freeze_exit.py
@@ -1,0 +1,458 @@
+"""A frozen sync cursor must have a way out.
+
+#286 stopped one unprocessable message from aborting a whole dialog: the message
+is skipped, the rest of the chat is archived, and the sync cursor freezes just
+behind the failure so the message stays retryable instead of being lost. That is
+the right call for a TRANSIENT failure.
+
+For a PERMANENT one it was a state with no exit. The cursor never moved, so every
+later run resumed from the same ``last_message_id`` and re-fetched and re-committed
+the entire tail of that chat -- a window that grows with every message the chat
+receives -- while ``sync_status`` reported no progress at all. Nothing was corrupted
+(the re-commits are idempotent upserts), but the cost was unbounded and permanent.
+
+The exit is a bounded retry. The failure is counted across runs in the existing
+metadata KV -- no schema change, the same place ``followed_migrations``,
+``whitelist_unresolved_ids`` and ``reaction_resweep_cycle_done`` already keep
+cross-run state -- and once the SAME message has failed
+``MESSAGE_MAX_PROCESS_ATTEMPTS`` separate runs, the cursor is allowed past it and
+its id is recorded as given up on. Gap detection cannot serve as that record:
+``detect_message_gaps`` only reports holes larger than ``GAP_THRESHOLD`` (50), so a
+single passed-over message is invisible to it by construction.
+
+These tests drive real consecutive runs against a fake database that keeps its
+cursor and its metadata between them, and pin both halves of the invariant: a
+permanently failing message must not cause unbounded repeated work, and it must
+never be passed over without a durable, operator-visible record. Plus the
+properties the exit must not cost: a transient failure still gets its retry, a
+clean dialog pays nothing, and a corrupt record degrades to retrying rather than
+to skipping.
+"""
+
+import asyncio
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.telegram_backup import (
+    MESSAGE_GIVE_UP_RECORD_LIMIT,
+    MESSAGE_MAX_PROCESS_ATTEMPTS,
+    TelegramBackup,
+)
+
+CHAT_ID = 100
+
+
+def _run(coro):
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(coro)
+    finally:
+        loop.close()
+
+
+class _FakeDb:
+    """Just enough database to survive between runs.
+
+    The sync cursor and the metadata KV are real state here; everything a run
+    writes is what the next run reads. That is the only way to test a bug whose
+    whole shape is "run N+1 repeats run N".
+    """
+
+    def __init__(self):
+        self.cursor = 0
+        self.metadata: dict[str, str] = {}
+        self.committed: list[int] = []
+        self.sync_writes: list[int] = []
+        self.metadata_reads: list[str] = []
+
+    async def upsert_chat(self, chat_data):
+        return None
+
+    async def get_last_message_id(self, chat_id):
+        return self.cursor
+
+    async def update_sync_status(self, chat_id, last_message_id, message_count):
+        self.cursor = last_message_id
+        self.sync_writes.append(last_message_id)
+
+    async def get_metadata(self, key):
+        self.metadata_reads.append(key)
+        return self.metadata.get(key)
+
+    async def set_metadata(self, key, value):
+        self.metadata[key] = value
+
+    def failure_record(self, chat_id=CHAT_ID):
+        raw = self.metadata.get(TelegramBackup._message_failure_key(chat_id))
+        return json.loads(raw) if raw else {}
+
+
+class CursorFreezeExitTestCase(unittest.TestCase):
+    """Shared harness: a chat that keeps growing, and a poison message in it."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.db = _FakeDb()
+        self.poison_ids: set[int] = set()
+        self.available: list[int] = []
+        self.fetched_per_run: list[int] = []
+        self.batch_size = 2
+        self.checkpoint_interval = 1
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _make_backup(self):
+        """A fresh archiver, as a new run would build it, on the shared database."""
+        config = MagicMock()
+        config.batch_size = self.batch_size
+        config.checkpoint_interval = self.checkpoint_interval
+        config.skip_media_chat_ids = set()
+        config.skip_media_delete_existing = False
+        config.sync_deletions_edits = False
+        config.reaction_resweep_days = 0
+        config.should_skip_topic = MagicMock(return_value=False)
+        config.media_path = os.path.join(self.temp_dir, "media")
+
+        backup = TelegramBackup.__new__(TelegramBackup)
+        backup.config = config
+        backup.db = self.db
+        backup.client = MagicMock()
+        backup._cleaned_media_chats = set()
+        backup._get_marked_id = MagicMock(return_value=CHAT_ID)
+        backup._extract_chat_data = MagicMock(return_value={"id": CHAT_ID})
+        backup._ensure_profile_photo = AsyncMock()
+        backup._sync_pinned_messages = AsyncMock()
+
+        fetched: list[int] = []
+
+        async def fake_iter(entity, *, min_id=0, **kwargs):
+            for msg_id in sorted(self.available):
+                if msg_id <= min_id:
+                    continue
+                fetched.append(msg_id)
+                message = MagicMock()
+                message.id = msg_id
+                # MagicMock truthiness would make every message look like a
+                # forum reply and be topic-filtered out.
+                message.reply_to = None
+                message.action = None
+                yield message
+
+        backup.client.iter_messages = fake_iter
+        self._fetched = fetched
+
+        async def process(message, chat_id):
+            if message.id in self.poison_ids:
+                raise AttributeError("'DocumentEmpty' object has no attribute 'attributes'")
+            return {"id": message.id, "chat_id": chat_id}
+
+        backup._process_message = AsyncMock(side_effect=process)
+
+        async def commit(batch, chat_id):
+            self.db.committed.extend(m["id"] for m in batch)
+
+        backup._commit_batch = AsyncMock(side_effect=commit)
+        return backup
+
+    def _run_backup(self):
+        """One archiver run over the chat as it currently stands."""
+        backup = self._make_backup()
+        result = _run(backup._backup_dialog(MagicMock()))
+        self.fetched_per_run.append(len(self._fetched))
+        return result
+
+    def _grow_chat(self, count):
+        """New messages arrive between runs, as they do in a live chat."""
+        start = max(self.available, default=0) + 1
+        self.available.extend(range(start, start + count))
+
+
+class TestPermanentFailureStopsCostingTheWholeTail(CursorFreezeExitTestCase):
+    """The unbounded-work half of the invariant."""
+
+    def test_repeated_runs_stop_re_fetching_the_tail(self):
+        """Two runs pay for the poison message; every run after it pays nothing.
+
+        Without the exit, run 3 and every run after it re-fetch from the poison
+        message to the tip of the chat, and that window grows forever.
+        """
+        self.available = list(range(1, 11))  # ids 1..10, poison at 5
+        self.poison_ids = {5}
+
+        self._run_backup()  # run 1: freeze behind 5
+        self.assertEqual(self.db.cursor, 4)
+
+        self._grow_chat(2)  # ids 11, 12
+        self._run_backup()  # run 2: second failure on 5 -> let the cursor past it
+        self.assertEqual(self.db.cursor, 12)
+
+        self._grow_chat(2)  # ids 13, 14
+        self._run_backup()
+        self._grow_chat(2)  # ids 15, 16
+        self._run_backup()
+
+        # Run 1 saw the whole chat, run 2 re-scanned from the poison message,
+        # and from then on each run fetches only what actually arrived.
+        self.assertEqual(self.fetched_per_run, [10, 8, 2, 2])
+        self.assertEqual(self.db.cursor, 16)
+
+    def test_every_message_except_the_poison_one_is_archived(self):
+        self.available = list(range(1, 11))
+        self.poison_ids = {5}
+
+        self._run_backup()
+        self._run_backup()
+
+        self.assertNotIn(5, self.db.committed)
+        self.assertEqual(set(self.db.committed), set(range(1, 11)) - {5})
+
+    def test_several_poison_messages_still_converge(self):
+        """Each one costs its own bounded retry, not a permanent stall."""
+        self.available = list(range(1, 13))
+        self.poison_ids = {3, 7, 11}
+
+        for _ in range(len(self.poison_ids) + 1):
+            self._run_backup()
+
+        self.assertEqual(self.db.cursor, 12)
+        self.assertEqual(set(self.db.committed), set(range(1, 13)) - self.poison_ids)
+        # And a further run has nothing left to do at all.
+        self._run_backup()
+        self.assertEqual(self.fetched_per_run[-1], 0)
+
+    def test_a_give_up_after_the_last_checkpoint_is_still_persisted(self):
+        """A give-up the batch checkpoints cannot carry must force its own write.
+
+        The final checkpoint used to fire only for un-checkpointed messages, or
+        for a cursor that moved purely on topic-filtered ones. Neither covers a
+        run that ends on a give-up: the batches before it were already
+        checkpointed, so the cursor would be left behind a message the run had
+        decided to stop retrying, and the next run would start from there again
+        -- give up again, write nothing again, forever.
+
+        The state here is the one that reaches that shape: a previous run
+        recorded the give-up and then died before its checkpoint landed, which is
+        precisely the ordering the record is written in.
+        """
+        self.db.cursor = 2
+        self.db.metadata[TelegramBackup._message_failure_key(CHAT_ID)] = json.dumps(
+            {"frozen_id": 0, "runs": 0, "given_up_total": 1, "given_up_ids": [7]}
+        )
+        self.available = [3, 4, 5, 6, 7]
+        self.poison_ids = {7}
+
+        self._run_backup()  # batches [3,4] and [5,6] checkpoint; then 7 is passed over
+
+        self.assertEqual(self.db.cursor, 7)
+        self.assertEqual(self.db.failure_record()["given_up_total"], 1)  # not counted twice
+
+
+class TestTheSkipIsNeverSilent(CursorFreezeExitTestCase):
+    """The durable-record half of the invariant."""
+
+    def test_the_given_up_id_is_recorded_durably(self):
+        self.available = list(range(1, 11))
+        self.poison_ids = {5}
+
+        self._run_backup()
+        record_after_freeze = self.db.failure_record()
+        self.assertEqual(record_after_freeze["frozen_id"], 5)
+        self.assertEqual(record_after_freeze["runs"], 1)
+        self.assertEqual(record_after_freeze["given_up_ids"], [])
+
+        self._run_backup()
+        record = self.db.failure_record()
+        self.assertEqual(record["given_up_ids"], [5])
+        self.assertEqual(record["given_up_total"], 1)
+        # The freeze is released with the same write that records the give-up.
+        self.assertEqual(record["frozen_id"], 0)
+        self.assertEqual(record["runs"], 0)
+
+    def test_the_record_survives_a_run_that_never_checkpointed(self):
+        """A crash between the two writes must not restart the count.
+
+        The give-up is written before the cursor checkpoint precisely so this
+        ordering is the survivable one. If the process dies in between, the next
+        run re-reads the id, recognises it, and passes over it immediately
+        instead of freezing on it again -- which would be a loop with no exit.
+        """
+        self.available = list(range(1, 11))
+        self.poison_ids = {5}
+
+        self._run_backup()  # freeze behind 5
+        cursor_before = self.db.cursor
+
+        self._run_backup()  # gives up on 5 and checkpoints past it...
+        self.assertEqual(self.db.failure_record()["given_up_ids"], [5])
+        self.db.cursor = cursor_before  # ...but the process died before that landed
+
+        self._run_backup()
+
+        self.assertGreater(self.db.cursor, 5)
+        self.assertEqual(self.db.failure_record()["given_up_total"], 1)  # counted once, not twice
+
+    def test_the_operator_warning_carries_counts_and_no_identifiers(self):
+        self.available = [1, 2, 4242, 4243]
+        self.poison_ids = {4242}
+        self.db.cursor = 0
+
+        backup = self._make_backup()
+        backup._get_marked_id = MagicMock(return_value=-1001234567890)
+        backup._extract_chat_data = MagicMock(return_value={"id": -1001234567890})
+        _run(backup._backup_dialog(MagicMock()))
+
+        backup = self._make_backup()
+        backup._get_marked_id = MagicMock(return_value=-1001234567890)
+        backup._extract_chat_data = MagicMock(return_value={"id": -1001234567890})
+        with self.assertLogs("src.telegram_backup", level="WARNING") as cm:
+            _run(backup._backup_dialog(MagicMock()))
+
+        passed_over = [r.getMessage() for r in cm.records if "passed over" in r.getMessage()]
+        self.assertEqual(len(passed_over), 1)
+        self.assertIn("1 message(s)", passed_over[0])
+        self.assertNotIn("4242", passed_over[0])
+        self.assertNotIn("1001234567890", passed_over[0])
+
+    def test_the_freeze_warning_is_not_claimed_for_a_message_passed_over(self):
+        """The two outcomes are opposite, so they must not share a count.
+
+        "the sync cursor stays behind them so they are retried next run" is
+        false for a message the run just decided to stop retrying.
+        """
+        self.available = [1, 2, 3]
+        self.poison_ids = {3}
+
+        self._run_backup()
+
+        backup = self._make_backup()
+        with self.assertLogs("src.telegram_backup", level="WARNING") as cm:
+            _run(backup._backup_dialog(MagicMock()))
+
+        messages = [r.getMessage() for r in cm.records]
+        self.assertEqual([m for m in messages if "could not be processed" in m], [])
+        self.assertEqual(len([m for m in messages if "passed over" in m]), 1)
+
+    def test_the_recorded_ids_are_capped_but_the_total_stays_exact(self):
+        """A chat that drifts wholesale must not grow one unbounded metadata row."""
+        backup = self._make_backup()
+        overflow = MESSAGE_GIVE_UP_RECORD_LIMIT + 100
+        state = {
+            "frozen_id": 0,
+            "runs": 0,
+            "given_up_total": overflow,
+            "given_up_ids": set(range(1, overflow + 1)),
+        }
+
+        _run(backup._save_message_failures(CHAT_ID, state))
+
+        record = self.db.failure_record()
+        self.assertEqual(len(record["given_up_ids"]), MESSAGE_GIVE_UP_RECORD_LIMIT)
+        self.assertEqual(record["given_up_ids"][-1], overflow)  # the newest are kept
+        self.assertEqual(record["given_up_total"], overflow)
+
+
+class TestTheRetryTheExitMustNotCost(CursorFreezeExitTestCase):
+    """#286's guarantee has to survive the exit being added."""
+
+    def test_the_first_failure_still_freezes_the_cursor(self):
+        self.available = list(range(1, 11))
+        self.poison_ids = {5}
+
+        self._run_backup()
+
+        self.assertEqual(self.db.cursor, 4)
+        self.assertNotIn(5, self.db.committed)
+        for written in self.db.sync_writes:
+            self.assertLess(written, 5)
+
+    def test_a_transient_failure_is_archived_on_its_retry(self):
+        """The whole reason the freeze exists: one bad run must not lose a message."""
+        self.available = list(range(1, 11))
+        self.poison_ids = {5}
+
+        self._run_backup()
+        self.poison_ids = set()  # whatever it was, it cleared
+        self._run_backup()
+
+        self.assertIn(5, self.db.committed)
+        self.assertEqual(self.db.cursor, 10)
+        self.assertEqual(self.db.failure_record()["given_up_total"], 0)
+
+    def test_a_failure_on_a_different_message_does_not_inherit_the_count(self):
+        """The count is per message, not per chat: only a repeat earns the exit."""
+        self.available = list(range(1, 11))
+        self.poison_ids = {5}
+
+        self._run_backup()  # freeze behind 5, runs=1
+        self.poison_ids = {8}  # 5 recovers, a different message fails now
+
+        self._run_backup()
+
+        self.assertIn(5, self.db.committed)
+        self.assertEqual(self.db.cursor, 7)  # frozen behind 8, not past it
+        record = self.db.failure_record()
+        self.assertEqual(record["frozen_id"], 8)
+        self.assertEqual(record["runs"], 1)
+        self.assertEqual(record["given_up_total"], 0)
+
+    def test_a_clean_dialog_never_touches_the_failure_record(self):
+        """Positive control on the lazy read: no failures, no cost."""
+        self.available = list(range(1, 11))
+
+        self._run_backup()
+
+        self.assertEqual(self.db.metadata_reads, [])
+        self.assertEqual(self.db.metadata, {})
+        self.assertEqual(self.db.cursor, 10)
+
+    def test_a_corrupt_record_degrades_to_retrying_not_to_skipping(self):
+        """Unreadable state must never be read as 'this already failed once'."""
+        self.available = list(range(1, 11))
+        self.poison_ids = {5}
+        self.db.metadata[TelegramBackup._message_failure_key(CHAT_ID)] = "{not json"
+
+        self._run_backup()
+
+        self.assertEqual(self.db.cursor, 4)  # frozen, not skipped
+        record = self.db.failure_record()
+        self.assertEqual(record["frozen_id"], 5)
+        self.assertEqual(record["runs"], 1)
+
+    def test_a_database_that_cannot_store_the_record_still_backs_up_the_chat(self):
+        """The record is a safety net, not a dependency of the capture path."""
+        self.available = list(range(1, 11))
+        self.poison_ids = {5}
+        self.db.set_metadata = AsyncMock(side_effect=RuntimeError("metadata write failed"))
+        self.db.get_metadata = AsyncMock(side_effect=RuntimeError("metadata read failed"))
+
+        result = self._run_backup()
+
+        self.assertEqual(result, 9)
+        self.assertEqual(self.db.cursor, 4)  # falls back to the freeze, exactly as before
+
+
+class TestTheExitIsBounded(CursorFreezeExitTestCase):
+    """The number of attempts is a stated constant, not an accident."""
+
+    def test_a_message_is_retried_on_more_than_one_run_before_it_is_passed_over(self):
+        self.assertGreaterEqual(MESSAGE_MAX_PROCESS_ATTEMPTS, 2)
+
+    def test_the_cursor_advances_after_exactly_that_many_failed_runs(self):
+        self.available = list(range(1, 11))
+        self.poison_ids = {5}
+
+        for attempt in range(1, MESSAGE_MAX_PROCESS_ATTEMPTS):
+            self._run_backup()
+            self.assertEqual(self.db.cursor, 4, f"still frozen after {attempt} failed run(s)")
+
+        self._run_backup()
+        self.assertEqual(self.db.cursor, 10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The problem

Per-message isolation (#286) holds the sync cursor behind the first message that fails to process, so a transient failure is retried next run instead of being silently skipped. That part was right — but **the state had no exit**.

A message that can never be processed pinned the cursor forever, and every later run re-fetched and re-committed that chat's entire tail. Measured over six consecutive runs of one chat with a permanently failing message, adding two new messages between runs:

| run | messages fetched | cursor after | rows written (cumulative) |
|----|----|----|----|
| 1 | 10 | 4 | 9 |
| 2 | 8 | 4 | 16 |
| 3 | 10 | 4 | 25 |
| 4 | 12 | 4 | 36 |
| 5 | 14 | 4 | 49 |
| 6 | 16 | 4 | 64 |

The work per run grows without bound while the cursor never moves, and `sync_status` permanently misreports progress. No corruption — the re-commits are idempotent upserts — but unbounded waste and a stalled cursor.

## The fix

A message is passed over once it has failed on **two separate runs**, and the ids passed over are recorded durably so the skip is never silent. The first failure behaves exactly as before, so a transient error still gets its retry — that guarantee is pinned by its own test.

**No schema change.** The record lives in the existing metadata table, one row per chat that has ever had a failure. Reading it is lazy, so a dialog that processes cleanly makes zero extra database calls. Every failure mode of that record — missing, malformed, or a database that cannot store it — degrades to the previous freeze behaviour rather than to an early skip.

Deliberately no migration: two workstreams are rewriting the schema for 8.0 right now, and a migration from here would collide with both.

## Verification

- **The reviewer built an independent harness from scratch** rather than reusing the implementation's tests, and drove both a pristine pre-fix tree and the patched one.
- Unpatched: 304 fetches over 15 runs, per-run cost growing, cursor pinned forever. Patched: **44 fetches, constant 2 per run from run 3 on** — a one-time overhead of 6 over a clean baseline, not a growing one.
- **Positive control:** three separate reverts, each disabling one part of the fix; the whole-exit revert produced `AssertionError: 4 != 10` — the cursor stuck where it used to stick — across 11 failing tests.
- Full suite: **2872 passed**, 171 subtests, 0 failures. `ruff` clean.

Operator-visible: a warning reports how many messages were passed over and that their ids are in the backup metadata — counts only, no ids in logs, per the project's PII rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added bounded retries for messages that repeatedly fail during backup.
  - Failed messages are retried across runs before being skipped, preventing the sync process from stalling indefinitely.
  - Progress is now saved when a message is ultimately skipped, preventing silent data omissions.
  - Added durable tracking and capped history for skipped messages.
  - Improved handling of temporary failures and incomplete metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->