### PR TITLE
fix: a media path over 500 chars fails on PostgreSQL, and nothing tested PostgreSQL at all

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,10 +14,39 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+
+    # PostgreSQL is a first-class supported backend, so the gate runs against a
+    # real server. Without this the "postgres" tests were mock assertions that
+    # never compiled the SQL they claimed to check.
+    services:
+      postgres:
+        # Same pin as docker-compose.yml. Never :latest.
+        image: postgres:18-alpine
+        env:
+          POSTGRES_USER: telegram
+          POSTGRES_PASSWORD: ci-not-a-secret
+          POSTGRES_DB: telegram_archive_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U telegram -d telegram_archive_ci"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      # Deliberately not DATABASE_URL. src/db/base.py, alembic/env.py and
+      # scripts/entrypoint.sh all treat DATABASE_URL as "the archive", so
+      # exporting it job-wide would silently repoint every test that builds a
+      # bare DatabaseManager() at PostgreSQL — where init() does not create
+      # tables. This variable is read only by the real-engine fixtures in
+      # tests/conftest.py, which never touch the database named here: they
+      # create their own telegram_archive_pytest / _parity_* databases on it.
+      TEST_POSTGRES_URL: postgresql://telegram:ci-not-a-secret@localhost:5432/telegram_archive_ci
+
     steps:
       - uses: actions/checkout@v7
-      
+
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
@@ -33,9 +62,26 @@ jobs:
       - name: Install dependencies
         run: uv sync --locked --extra dev --no-install-project
 
+      # -rs prints skip reasons, which the next step reads. pipefail keeps a
+      # pytest failure from being swallowed by tee.
       - name: Run tests
         run: |
-          uv run --no-sync python -m pytest tests/ -v --tb=short --cov=src --cov-report=term-missing --cov-report=xml
+          set -o pipefail
+          uv run --no-sync python -m pytest tests/ -v --tb=short -rs \
+            --cov=src --cov-report=term-missing --cov-report=xml | tee pytest-output.log
+
+      # The dual-backend fixtures skip the PostgreSQL leg when no server
+      # answers, so a broken service container would turn this job green while
+      # testing half of what it claims to. Skipping is correct on a laptop
+      # without Docker; in CI it is a failure.
+      - name: Fail if the PostgreSQL leg was skipped
+        run: |
+          if grep -q "no PostgreSQL server reachable" pytest-output.log; then
+            echo "::error::PostgreSQL tests were skipped - the service container was not reachable."
+            echo "PostgreSQL is a first-class backend; this job must exercise it."
+            exit 1
+          fi
+          echo "PostgreSQL leg ran."
 
       - name: Upload coverage reports
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/alembic/versions/20260815_021_align_schema_with_orm.py
+++ b/alembic/versions/20260815_021_align_schema_with_orm.py
@@ -1,0 +1,493 @@
+"""Make ``alembic upgrade head`` produce exactly the schema in models.py.
+
+Until now this project had two schema authors that nothing compared:
+``Base.metadata.create_all`` (SQLite only, from ``src/db/base.py``) and this
+migration chain (the only author PostgreSQL ever had). They had drifted to 54
+structural differences on SQLite and 50 on PostgreSQL. This migration removes
+every one of them, and ``tests/test_schema_parity.py`` keeps them removed: its
+allow-list is empty, so any new divergence between the two authors fails CI on
+both backends.
+
+What it changes, and why each is safe:
+
+* **NOT NULL on 35 columns.** The ORM has always marked them non-optional; the
+  migrations never said so, so a PostgreSQL install accepted NULLs that the
+  SQLite install of the same version rejected. Every column is backfilled with
+  the ORM's own default *before* it is tightened, so a database holding NULLs
+  converges instead of crash-looping on ``SET NOT NULL``.
+* **Server defaults.** ``created_at``/``updated_at`` gain the ``func.now()``
+  default the ORM declares. ``messages.is_pinned``/``is_outgoing`` and
+  ``media.downloaded`` lose the literal ``0`` the ORM does not declare (their
+  value is always supplied Python-side). ``chats.id``/``users.id`` lose the
+  ``BIGSERIAL`` sequence migration 001 gave them by accident — those ids come
+  from Telegram and were never generated.
+* **``media.file_path`` VARCHAR(500) -> TEXT on PostgreSQL.** This one is a live
+  bug: models.py widened it to Text in v6.0.0 for long paths, no migration
+  followed, so a path over 500 characters raises StringDataRightTruncation on
+  PostgreSQL and inserts fine on SQLite.
+* **INTEGER -> BIGINT on eight SQLite columns** that migration 005's
+  hand-written rebuild declared narrower than the ORM. Cosmetic on SQLite
+  (both are 8-byte), but it is the same declaration that produced the
+  VARCHAR(500) above, and leaving it makes the gate impossible to satisfy.
+* **``fk_reaction_message``.** The ORM constrains a reaction to its message; no
+  migration ever created it, so an Alembic-built install has orphanable
+  reaction rows. Orphans are deleted first or the constraint cannot be added.
+* **``_messages_media_backup``.** Migration 005 creates this rollback table and
+  drops it only in its downgrade, so every Alembic-built install carries a copy
+  forever. It is dropped ONLY when empty: on a database that really did upgrade
+  through v6.0.0 with legacy media rows it still holds the pre-normalization
+  pointers, and this migration will not delete those.
+
+Idempotency: every step reads the live schema first and does nothing when the
+object is already in its target shape, so this runs clean against a database
+provisioned by ``create_all`` (where most of it is already true), against one
+built by this chain, and against a re-run of itself.
+
+One difference is deliberately left alone. A SQLite database created by the
+``create_all`` of a release before this one carries the reactions -> users
+foreign key unnamed, because models.py only started naming it
+``fk_reactions_user`` here. SQLite never enforces that constraint (nothing in
+this project sets ``PRAGMA foreign_keys=ON``) and never exposes its name, so
+relabelling it would mean rebuilding a table of the user's data for a label
+nothing can observe. Every freshly built schema on either backend agrees, which
+is what the parity gate checks.
+
+Revision ID: 021
+Revises: 020
+Create Date: 2026-08-15
+"""
+
+import logging
+import re
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "021"
+down_revision: str | None = "020"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+BACKUP_TABLE = "_messages_media_backup"
+
+# Columns the ORM declares non-optional, with the value used to backfill any
+# existing NULL. "now" is the dialect's current timestamp; anything else is a
+# numeric literal. Ordering is irrelevant - each table is handled independently.
+NOT_NULL_COLUMNS: dict[str, dict[str, str]] = {
+    "app_settings": {"updated_at": "now"},
+    "chat_folders": {"created_at": "now", "sort_order": "0", "updated_at": "now"},
+    "chats": {
+        "created_at": "now",
+        "is_archived": "0",
+        "is_forum": "0",
+        "last_synced_message_id": "0",
+        "updated_at": "now",
+    },
+    "forum_topics": {
+        "created_at": "now",
+        "is_closed": "0",
+        "is_hidden": "0",
+        "is_pinned": "0",
+        "updated_at": "now",
+    },
+    "media": {"created_at": "now", "downloaded": "0"},
+    "messages": {"created_at": "now", "is_outgoing": "0"},
+    "reactions": {"count": "1", "created_at": "now"},
+    "sync_status": {"last_message_id": "0", "last_sync_date": "now", "message_count": "0"},
+    "users": {"created_at": "now", "is_bot": "0", "updated_at": "now"},
+    "viewer_accounts": {"created_at": "now", "no_download": "0", "updated_at": "now"},
+    "viewer_audit_log": {"created_at": "now"},
+    "viewer_sessions": {"no_download": "0"},
+    "viewer_tokens": {
+        "created_at": "now",
+        "is_revoked": "0",
+        "no_download": "0",
+        "use_count": "0",
+    },
+}
+
+# Columns whose ORM definition carries server_default=func.now().
+TIMESTAMP_DEFAULT_COLUMNS: dict[str, tuple[str, ...]] = {
+    "chats": ("created_at", "updated_at"),
+    "media": ("created_at",),
+    "messages": ("created_at",),
+    "reactions": ("created_at",),
+    "sync_status": ("last_sync_date",),
+    "users": ("created_at", "updated_at"),
+}
+
+# Columns the migrations gave a literal default the ORM does not declare. The
+# value is always supplied by the ORM's Python-side default on insert.
+DROP_DEFAULT_COLUMNS: dict[str, tuple[str, ...]] = {
+    "media": ("downloaded",),
+    "messages": ("is_outgoing", "is_pinned"),
+}
+
+# BigInteger in the ORM, INTEGER in migration 005's hand-written SQLite DDL.
+SQLITE_BIGINT_COLUMNS: dict[str, tuple[str, ...]] = {
+    "media": ("chat_id", "file_size", "message_id"),
+    "messages": ("chat_id", "forward_from_id", "id", "reply_to_msg_id", "sender_id"),
+}
+
+# PostgreSQL BIGSERIAL primary keys the ORM declares as autoincrement=False.
+PG_UNWANTED_SEQUENCES: tuple[tuple[str, str], ...] = (("chats", "id"), ("users", "id"))
+
+
+def _now_sql(dialect: str) -> str:
+    return "now()" if dialect == "postgresql" else "CURRENT_TIMESTAMP"
+
+
+def _columns(inspector: sa.Inspector, table: str) -> dict[str, dict]:
+    """Reflected columns of ``table``, or ``{}`` when the table is absent."""
+    if table not in inspector.get_table_names():
+        return {}
+    return {column["name"]: column for column in inspector.get_columns(table)}
+
+
+def _fk_to_table_exists(inspector: sa.Inspector, table: str, referred_table: str) -> bool:
+    """True if ``table`` already has any FK referencing ``referred_table``.
+
+    Name-agnostic on purpose, exactly as migration 005 does it: a
+    create_all()-provisioned database names its constraints differently, and
+    "already constrained" is the question that matters, not "named like this".
+    """
+    if table not in inspector.get_table_names():
+        return False
+    return any(fk.get("referred_table") == referred_table for fk in inspector.get_foreign_keys(table))
+
+
+def _backfill_nulls(conn: sa.Connection, dialect: str, table: str, column: str, fill: str) -> None:
+    """Replace NULLs so the column can be tightened without failing."""
+    value = _now_sql(dialect) if fill == "now" else fill
+    # Identifiers come from the module-level constants above, never from input.
+    conn.execute(sa.text(f'UPDATE "{table}" SET "{column}" = {value} WHERE "{column}" IS NULL'))
+
+
+def _pending_not_null(inspector: sa.Inspector, table: str) -> dict[str, str]:
+    """Columns of ``table`` that are still nullable and should not be."""
+    present = _columns(inspector, table)
+    return {
+        column: fill
+        for column, fill in NOT_NULL_COLUMNS.get(table, {}).items()
+        if column in present and present[column]["nullable"]
+    }
+
+
+def _pending_default_changes(inspector: sa.Inspector, table: str) -> tuple[set[str], set[str]]:
+    """(columns needing a now() default, columns needing their default dropped)."""
+    present = _columns(inspector, table)
+    add = {
+        column
+        for column in TIMESTAMP_DEFAULT_COLUMNS.get(table, ())
+        if column in present and present[column].get("default") is None
+    }
+    drop = {
+        column
+        for column in DROP_DEFAULT_COLUMNS.get(table, ())
+        if column in present and present[column].get("default") is not None
+    }
+    return add, drop
+
+
+def _pending_sqlite_bigint(inspector: sa.Inspector, table: str) -> set[str]:
+    present = _columns(inspector, table)
+    return {
+        column
+        for column in SQLITE_BIGINT_COLUMNS.get(table, ())
+        if column in present and str(present[column]["type"]).upper() != "BIGINT"
+    }
+
+
+def _delete_orphan_reactions(conn: sa.Connection, inspector: sa.Inspector) -> None:
+    """Remove reactions whose message is gone, so the FK can be added.
+
+    Migration 019 already deletes child reactions before deleting a phantom
+    message, and both delete paths in the adapter do the same, so this only
+    finds rows left behind by the eras before those fixes. Counts only in the
+    log - never a chat id or a message id.
+    """
+    tables = inspector.get_table_names()
+    if "reactions" not in tables or "messages" not in tables:
+        return
+    result = conn.execute(
+        sa.text(
+            "DELETE FROM reactions WHERE NOT EXISTS ("
+            " SELECT 1 FROM messages m"
+            " WHERE m.id = reactions.message_id AND m.chat_id = reactions.chat_id)"
+        )
+    )
+    if result.rowcount:
+        logger.info("021: deleted %d orphan reaction row(s) with no surviving message", result.rowcount)
+
+
+def _drop_empty_backup_table(conn: sa.Connection, inspector: sa.Inspector) -> None:
+    """Drop migration 005's rollback table, but only when it holds no rows."""
+    if BACKUP_TABLE not in inspector.get_table_names():
+        return
+    rows = conn.execute(sa.text(f"SELECT COUNT(*) FROM {BACKUP_TABLE}")).scalar() or 0
+    if rows:
+        logger.info(
+            "021: keeping %s - it still holds %d pre-normalization row(s) and is this database's only copy of them",
+            BACKUP_TABLE,
+            rows,
+        )
+        return
+    op.drop_table(BACKUP_TABLE)
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL
+# ---------------------------------------------------------------------------
+
+
+def _upgrade_postgresql(conn: sa.Connection) -> None:
+    inspector = sa.inspect(conn)
+
+    for table in sorted(set(NOT_NULL_COLUMNS) | set(TIMESTAMP_DEFAULT_COLUMNS) | set(DROP_DEFAULT_COLUMNS)):
+        present = _columns(inspector, table)
+        if not present:
+            continue
+
+        for column, fill in _pending_not_null(inspector, table).items():
+            _backfill_nulls(conn, "postgresql", table, column, fill)
+            op.alter_column(table, column, existing_type=present[column]["type"], nullable=False)
+
+        add_default, drop_default = _pending_default_changes(inspector, table)
+        for column in sorted(add_default):
+            op.alter_column(
+                table,
+                column,
+                existing_type=present[column]["type"],
+                server_default=sa.text("now()"),
+            )
+        for column in sorted(drop_default):
+            op.alter_column(table, column, existing_type=present[column]["type"], server_default=None)
+
+    # media.file_path: VARCHAR(500) -> TEXT. Binary-coercible, so PostgreSQL
+    # does not rewrite the table.
+    media_columns = _columns(inspector, "media")
+    if "file_path" in media_columns and str(media_columns["file_path"]["type"]).upper() != "TEXT":
+        op.alter_column("media", "file_path", existing_type=media_columns["file_path"]["type"], type_=sa.Text())
+
+    # Retire the BIGSERIAL sequences migration 001 created for Telegram-supplied
+    # primary keys. DROP DEFAULT must come first or the sequence is still
+    # depended upon. The sequence name is read out of the column's own default
+    # rather than assumed, and left in place if it does not parse.
+    for table, column in PG_UNWANTED_SEQUENCES:
+        present = _columns(inspector, table)
+        if column not in present or present[column].get("default") is None:
+            continue
+        sequence = re.search(r"nextval\('([A-Za-z_][A-Za-z0-9_.]*)'", str(present[column]["default"]))
+        op.alter_column(table, column, existing_type=present[column]["type"], server_default=None)
+        if sequence:
+            op.execute(f"DROP SEQUENCE IF EXISTS {sequence.group(1)}")
+
+    inspector = sa.inspect(conn)
+    if "reactions" in inspector.get_table_names() and not _fk_to_table_exists(inspector, "reactions", "messages"):
+        _delete_orphan_reactions(conn, inspector)
+        op.create_foreign_key(
+            "fk_reaction_message",
+            "reactions",
+            "messages",
+            ["message_id", "chat_id"],
+            ["id", "chat_id"],
+        )
+
+    _drop_empty_backup_table(conn, sa.inspect(conn))
+
+
+# ---------------------------------------------------------------------------
+# SQLite
+# ---------------------------------------------------------------------------
+
+
+def _named_fk_exists(inspector: sa.Inspector, table: str, referred_table: str, name: str) -> bool:
+    if table not in inspector.get_table_names():
+        return False
+    return any(
+        fk.get("referred_table") == referred_table and fk.get("name") == name
+        for fk in inspector.get_foreign_keys(table)
+    )
+
+
+def _sqlite_table_needs_rebuild(inspector: sa.Inspector, table: str) -> bool:
+    """True when this table's shape still differs from what the ORM builds.
+
+    SQLite cannot alter a column in place, so every change here costs a full
+    table copy. Asking per table keeps that cost off the databases that do not
+    need it — a schema provisioned by ``create_all`` is already in the target
+    shape for the big tables, so ``messages`` and ``media`` are not touched.
+    """
+    add_default, drop_default = _pending_default_changes(inspector, table)
+    if _pending_not_null(inspector, table) or add_default or drop_default:
+        return True
+    if _pending_sqlite_bigint(inspector, table):
+        return True
+    if table == "media" and not _named_fk_exists(inspector, "media", "messages", "fk_media_message"):
+        return True
+    if table == "reactions" and not (
+        _fk_to_table_exists(inspector, "reactions", "messages") and _fk_to_table_exists(inspector, "reactions", "users")
+    ):
+        return True
+    return False
+
+
+def _sqlite_media_copy_from(conn: sa.Connection) -> sa.Table:
+    """Reflect ``media`` with its messages FK given the name the ORM uses.
+
+    Migration 005's raw ``CREATE TABLE`` left that constraint unnamed on SQLite,
+    and an unnamed constraint cannot be dropped by name. Handing the rebuild a
+    reflected definition with the name filled in renames it without a line of
+    hand-written DDL that could drift from models.py again.
+    """
+    reflected = sa.Table("media", sa.MetaData(), autoload_with=conn)
+    for constraint in reflected.foreign_key_constraints:
+        if constraint.name is None and constraint.elements[0].target_fullname.startswith("messages."):
+            constraint.name = "fk_media_message"
+    return reflected
+
+
+def _repair_sqlite_desc_index(conn: sa.Connection) -> None:
+    """Restore ``idx_messages_chat_date_desc``'s DESC ordering after a rebuild.
+
+    SQLite reflection reports an index's columns but not their sort order, so
+    any table rebuild that goes through reflection recreates this one as plain
+    ASC. models.py declares it ``(chat_id, date DESC)`` for the page read
+    ``WHERE chat_id = ? ORDER BY date DESC``, and the parity gate compares
+    column names only - it would not catch the loss.
+    """
+    ddl = conn.execute(
+        sa.text("SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_messages_chat_date_desc'")
+    ).scalar()
+    # Only the column list may be inspected for DESC: the index's own name ends
+    # in "_desc", so testing the whole statement always reports a match.
+    columns_clause = ddl[ddl.index("(") :].upper() if ddl and "(" in ddl else ""
+    if not columns_clause or "DESC" in columns_clause:
+        return
+    op.drop_index("idx_messages_chat_date_desc", table_name="messages")
+    op.create_index("idx_messages_chat_date_desc", "messages", ["chat_id", sa.text("date DESC")])
+
+
+def _upgrade_sqlite(conn: sa.Connection) -> None:
+    inspector = sa.inspect(conn)
+    candidates = sorted(
+        set(NOT_NULL_COLUMNS) | set(TIMESTAMP_DEFAULT_COLUMNS) | set(DROP_DEFAULT_COLUMNS) | set(SQLITE_BIGINT_COLUMNS)
+    )
+
+    # A reaction whose message is gone would survive the rebuild and then break
+    # the FK the rebuild adds, so clean first.
+    if "reactions" in inspector.get_table_names() and not _fk_to_table_exists(inspector, "reactions", "messages"):
+        _delete_orphan_reactions(conn, inspector)
+
+    for table in candidates:
+        present = _columns(inspector, table)
+        if not present or not _sqlite_table_needs_rebuild(inspector, table):
+            continue
+
+        pending_null = _pending_not_null(inspector, table)
+        for column, fill in pending_null.items():
+            _backfill_nulls(conn, "sqlite", table, column, fill)
+
+        add_default, drop_default = _pending_default_changes(inspector, table)
+        widen = _pending_sqlite_bigint(inspector, table)
+
+        # SQLite cannot alter a column in place; batch_alter_table copies the
+        # table through a temporary one. Renaming over a table that other
+        # tables reference makes modern SQLite re-validate and rewrite those
+        # references, so the legacy rename is used for the duration - exactly
+        # the shape migration 005 already ships for this table set.
+        # recreate="always": this block is only entered when the table really
+        # does need rebuilding, and for `media` the only change can be a
+        # constraint rename, which produces no alter_column op for batch mode to
+        # trigger on.
+        batch_kwargs: dict = {"recreate": "always"}
+        if table == "media":
+            batch_kwargs["copy_from"] = _sqlite_media_copy_from(conn)
+
+        conn.exec_driver_sql("PRAGMA legacy_alter_table=ON")
+        try:
+            with op.batch_alter_table(table, **batch_kwargs) as batch_op:
+                for column in sorted(set(pending_null) | add_default | drop_default | widen):
+                    kwargs: dict = {"existing_type": present[column]["type"]}
+                    if column in pending_null:
+                        kwargs["nullable"] = False
+                    if column in widen:
+                        kwargs["type_"] = sa.BigInteger()
+                    if column in add_default:
+                        kwargs["server_default"] = sa.text("CURRENT_TIMESTAMP")
+                    elif column in drop_default:
+                        kwargs["server_default"] = None
+                    batch_op.alter_column(column, **kwargs)
+
+                if table == "media" and not _fk_to_table_exists(inspector, "media", "messages"):
+                    batch_op.create_foreign_key(
+                        "fk_media_message", "messages", ["message_id", "chat_id"], ["id", "chat_id"], ondelete="CASCADE"
+                    )
+                if table == "reactions":
+                    if not _fk_to_table_exists(inspector, "reactions", "messages"):
+                        batch_op.create_foreign_key(
+                            "fk_reaction_message", "messages", ["message_id", "chat_id"], ["id", "chat_id"]
+                        )
+                    if not _fk_to_table_exists(inspector, "reactions", "users"):
+                        batch_op.create_foreign_key(
+                            "fk_reactions_user", "users", ["user_id"], ["id"], ondelete="SET NULL"
+                        )
+        finally:
+            conn.exec_driver_sql("PRAGMA legacy_alter_table=OFF")
+
+        if table == "messages":
+            _repair_sqlite_desc_index(conn)
+
+        inspector = sa.inspect(conn)
+
+    _drop_empty_backup_table(conn, sa.inspect(conn))
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name == "postgresql":
+        _upgrade_postgresql(conn)
+    else:
+        _upgrade_sqlite(conn)
+
+
+def downgrade() -> None:
+    """Loosen the tightened columns again.
+
+    The dropped ``_messages_media_backup`` table is not recreated: it only ever
+    held a copy of columns migration 005 had already moved into ``media``, and
+    it is dropped above only when empty.
+    """
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+    inspector = sa.inspect(conn)
+
+    if dialect == "postgresql":
+        for table, columns in NOT_NULL_COLUMNS.items():
+            present = _columns(inspector, table)
+            for column in sorted(columns):
+                if column in present and not present[column]["nullable"]:
+                    op.alter_column(table, column, existing_type=present[column]["type"], nullable=True)
+        # Name-based, like migration 005's downgrade: only undo the constraint
+        # this migration created, never one that arrived some other way.
+        if _named_fk_exists(inspector, "reactions", "messages", "fk_reaction_message"):
+            op.drop_constraint("fk_reaction_message", "reactions", type_="foreignkey")
+        return
+
+    for table, columns in NOT_NULL_COLUMNS.items():
+        present = _columns(inspector, table)
+        targets = [column for column in sorted(columns) if column in present and not present[column]["nullable"]]
+        if not targets:
+            continue
+        conn.exec_driver_sql("PRAGMA legacy_alter_table=ON")
+        try:
+            with op.batch_alter_table(table) as batch_op:
+                for column in targets:
+                    batch_op.alter_column(column, existing_type=present[column]["type"], nullable=True)
+        finally:
+            conn.exec_driver_sql("PRAGMA legacy_alter_table=OFF")
+        inspector = sa.inspect(conn)

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -292,6 +292,11 @@ if has_tables and not has_alembic:
     # Migration 019 is a data-only cleanup with no detectable schema artifact.
     # A schema with the 020 column was created from current ORM metadata, but it
     # must still stamp at 018 so Alembic runs 019 before guarded/idempotent 020.
+    # 021 deliberately adds no rung either: its artifacts (NOT NULL, server
+    # defaults, the reactions FK) are exactly what an ORM-provisioned schema
+    # already has, so detecting them could only push the stamp past data-only
+    # 019. It reads the live schema per column and does nothing where the
+    # target shape is already in place, so re-running it here is a no-op.
     if has_018_reaction_removed_at and has_017_chat_id_id_index and has_016_download_attempts and has_015_message_versions and has_014_soft_delete:
         stamp_version = '018'
     elif has_017_chat_id_id_index and has_016_download_attempts and has_015_message_versions and has_014_soft_delete:
@@ -356,9 +361,17 @@ print('Migrations complete.')
       DB_PATH="${DATABASE_URL#sqlite:///}"
     fi
 
+    # Alembic is the schema authority on both backends, so it runs whether or not
+    # the file exists yet. On a fresh install this creates the database at head
+    # with alembic_version already written, instead of leaving create_all() to
+    # build an unstamped schema whose revision the next start has to guess.
+    mkdir -p "$(dirname "$DB_PATH")"
     if [ -f "$DB_PATH" ]; then
       echo "SQLite database found at $DB_PATH - running migrations..."
-      python -c "
+    else
+      echo "No SQLite database at $DB_PATH yet - creating it with Alembic..."
+    fi
+    python -c "
 from alembic.config import Config
 from alembic import command
 import os
@@ -370,7 +383,21 @@ if database_url.startswith('sqlite+aiosqlite:///'):
 elif database_url.startswith('sqlite:///'):
     db_path = database_url.removeprefix('sqlite:///')
 else:
-    db_path = os.getenv('DB_PATH', os.getenv('DATABASE_PATH', os.path.join(os.getenv('BACKUP_PATH', '/data/backups'), 'telegram_backup.db')))
+    # Same precedence as src/db/base.py and alembic/env.py. DATABASE_DIR was
+    # missing here, so a DATABASE_DIR-only install had its schema inspected at
+    # one path and migrated at another - the stamping ladder then read an empty
+    # database and skipped, and Alembic re-ran migration 001 against the real
+    # one. Keep these three resolution chains identical.
+    db_path = os.getenv('DATABASE_PATH', '')
+    if not db_path:
+        db_dir = os.getenv('DATABASE_DIR', '')
+        if db_dir:
+            db_path = os.path.join(db_dir, 'telegram_backup.db')
+    if not db_path:
+        db_path = os.getenv('DB_PATH', '')
+    if not db_path:
+        db_path = os.path.join(os.getenv('BACKUP_PATH', '/data/backups'), 'telegram_backup.db')
+    db_path = os.path.abspath(db_path)
 
 # Check if this is a pre-Alembic database that needs stamping
 conn = sqlite3.connect(db_path)
@@ -478,6 +505,11 @@ if has_tables and not has_alembic:
     # Determine which version to stamp based on existing schema
     # Even when the 020 artifact exists, cap the stamp at 018 so migration 019
     # runs before guarded/idempotent migration 020.
+    # 021 adds no rung for the same reason: its artifacts (NOT NULL, server
+    # defaults, the reactions FK) are what an ORM-provisioned schema already
+    # has, so detecting them could only push the stamp past data-only 019. It
+    # inspects the live schema per column and rebuilds only the tables that
+    # still differ, so re-running it against such a database does nothing.
     if has_018_reaction_removed_at and has_017_chat_id_id_index and has_016_download_attempts and has_015_message_versions and has_014_soft_delete:
         stamp_version = '018'
     elif has_017_chat_id_id_index and has_016_download_attempts and has_015_message_versions and has_014_soft_delete:
@@ -526,9 +558,6 @@ config = Config('/app/alembic.ini')
 command.upgrade(config, 'head')
 print('SQLite migrations complete.')
 "
-    else
-      echo "No database found yet - skipping migrations (will be created automatically)"
-    fi
   fi
 fi
 

--- a/src/db/base.py
+++ b/src/db/base.py
@@ -141,9 +141,15 @@ class DatabaseManager:
             expire_on_commit=False,
         )
 
-        # Only use create_all for SQLite — Alembic manages PostgreSQL schema
-        # via entrypoint.sh, so running create_all concurrently would race with
-        # Alembic migrations and cause deadlocks.
+        # Alembic is the schema authority on both backends: scripts/entrypoint.sh
+        # runs `upgrade head` before this process starts, on SQLite whether or not
+        # the file existed. This create_all is only a fallback for a process that
+        # never passes through that entrypoint — the viewer image, which ships no
+        # alembic/ directory, or a direct `python -m src` run — and it is limited
+        # to SQLite because on PostgreSQL it would race a concurrently migrating
+        # container into a deadlock. tests/test_schema_parity.py builds both
+        # schemas on both backends and fails on any difference, so the fallback
+        # cannot quietly produce a different schema from the authority again.
         if self._is_sqlite:
             try:
                 async with self.engine.begin() as conn:

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -250,7 +250,12 @@ class Reaction(Base):
     message_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
     chat_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
     emoji: Mapped[str] = mapped_column(String(50), nullable=False)
-    user_id: Mapped[int | None] = mapped_column(BigInteger, ForeignKey("users.id", ondelete="SET NULL"))
+    # Named explicitly: migration 005 created this constraint as fk_reactions_user,
+    # and an unnamed ForeignKey() leaves PostgreSQL to invent reactions_user_id_fkey
+    # instead — the same constraint under two names on the two schema paths.
+    user_id: Mapped[int | None] = mapped_column(
+        BigInteger, ForeignKey("users.id", ondelete="SET NULL", name="fk_reactions_user")
+    )
     count: Mapped[int] = mapped_column(Integer, default=1)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
     # v7.23.0 (#219): retain-on-removal tombstone. When a reaction is no longer

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,214 @@
+"""Shared pytest fixtures.
+
+The point of this file is ``real_adapter``: a genuine :class:`DatabaseAdapter`
+bound to a genuine engine, parameterised over SQLite *and* PostgreSQL.
+
+Why it exists
+-------------
+Most adapter tests build a ``MagicMock`` DatabaseManager and assert that
+``session.execute`` was awaited. That proves the Python branch was taken; it
+does not prove the statement compiles, and it certainly does not prove the
+database accepts it. Every dialect-specific branch in ``src/db/adapter.py``
+(``sqlite_insert`` vs ``pg_insert``, ``SELECT ... FOR UPDATE`` vs the SQLite
+no-op-write lock, ``ilike`` escaping) is therefore untested against the backend
+it exists for. A test that cannot go red is not a test.
+
+Using it
+--------
+Request ``real_adapter`` (or ``real_db`` for the manager itself) and the test
+runs twice: once on a throwaway SQLite file, once on PostgreSQL. The PostgreSQL
+leg skips cleanly when no server is reachable, so a laptop without Docker still
+gets a green suite — it just gets half the coverage, and says so.
+
+Pointing it at a server
+-----------------------
+``TEST_POSTGRES_URL`` (preferred) or ``DATABASE_URL``. Either way the suite
+connects to the *server* in that URL but never reads or writes the database
+named in it: it creates and uses a dedicated ``telegram_archive_pytest``
+database, whose ``public`` schema is dropped and rebuilt once per session.
+"""
+
+import os
+from urllib.parse import urlsplit, urlunsplit
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import text
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Base
+
+# Backends every ``real_adapter`` test runs against. PostgreSQL is a
+# first-class supported backend, so it is in this list unconditionally and is
+# skipped only when no server answers.
+REAL_BACKENDS = ("sqlite", "postgresql")
+
+# The suite owns this database entirely and recreates its schema each session.
+# It is never the database named in TEST_POSTGRES_URL/DATABASE_URL.
+POSTGRES_TEST_DB = "telegram_archive_pytest"
+
+_POSTGRES_SCHEMES = ("postgresql", "postgres")
+
+# Skip reason for the PostgreSQL leg. .github/workflows/tests.yml greps pytest's
+# `-rs` output for this exact string and fails the job if it appears: in CI a
+# skipped PostgreSQL leg is a broken service container, not a valid outcome.
+# Change it here and there together.
+NO_POSTGRES_REASON = "no PostgreSQL server reachable — set TEST_POSTGRES_URL or DATABASE_URL"
+
+
+def rewrite_url(url: str, *, driver: str | None = None, database: str | None = None) -> str:
+    """Return ``url`` with its DBAPI driver and/or database name replaced.
+
+    ``postgres://`` is normalised to ``postgresql://`` because SQLAlchemy 2.x
+    rejects the legacy scheme outright.
+    """
+    parts = urlsplit(url)
+    backend = parts.scheme.split("+", 1)[0]
+    if backend == "postgres":
+        backend = "postgresql"
+    scheme = f"{backend}+{driver}" if driver else backend
+    path = f"/{database}" if database is not None else parts.path
+    return urlunsplit((scheme, parts.netloc, path, parts.query, parts.fragment))
+
+
+def _configured_postgres_url() -> str | None:
+    """Read the PostgreSQL URL the developer or CI supplied, if any."""
+    for var in ("TEST_POSTGRES_URL", "DATABASE_URL"):
+        raw = (os.getenv(var) or "").strip()
+        if raw and urlsplit(raw).scheme.split("+", 1)[0] in _POSTGRES_SCHEMES:
+            return raw
+    return None
+
+
+@pytest.fixture(scope="session")
+def postgres_server_url() -> str | None:
+    """A reachable PostgreSQL server URL, or ``None``.
+
+    Probing here (once per session) is what lets the PostgreSQL leg skip
+    cleanly instead of erroring on every test that wants it.
+    """
+    url = _configured_postgres_url()
+    if not url:
+        return None
+    engine = sa.create_engine(rewrite_url(url, driver="psycopg2"), connect_args={"connect_timeout": 5})
+    try:
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+    except Exception as exc:  # pragma: no cover - depends on the environment
+        # Type name only: a connection error can carry the host and user.
+        print(f"PostgreSQL leg disabled: {type(exc).__name__} while probing the configured server")
+        return None
+    finally:
+        engine.dispose()
+    return url
+
+
+def create_postgres_database(server_url: str, database: str) -> str:
+    """Create ``database`` on ``server_url`` with an empty ``public`` schema.
+
+    Returns the asyncpg URL for it. Safe to call repeatedly: the database is
+    created only if missing, and its schema is always reset, so a run never
+    inherits objects from the previous one.
+    """
+    admin = sa.create_engine(
+        rewrite_url(server_url, driver="psycopg2"),
+        isolation_level="AUTOCOMMIT",
+        connect_args={"connect_timeout": 5},
+    )
+    try:
+        with admin.connect() as conn:
+            exists = conn.execute(text("SELECT 1 FROM pg_database WHERE datname = :name"), {"name": database}).scalar()
+            if not exists:
+                # Identifier is a module constant, never user input.
+                conn.execute(text(f'CREATE DATABASE "{database}"'))
+    finally:
+        admin.dispose()
+
+    target = sa.create_engine(
+        rewrite_url(server_url, driver="psycopg2", database=database),
+        connect_args={"connect_timeout": 5},
+    )
+    try:
+        with target.begin() as conn:
+            conn.execute(text("DROP SCHEMA IF EXISTS public CASCADE"))
+            conn.execute(text("CREATE SCHEMA public"))
+    finally:
+        target.dispose()
+
+    return rewrite_url(server_url, driver="asyncpg", database=database)
+
+
+@pytest.fixture
+def require_postgres(postgres_server_url: str | None) -> str:
+    """Skip the requesting test unless a PostgreSQL server is reachable."""
+    if not postgres_server_url:
+        pytest.skip(NO_POSTGRES_REASON)
+    return postgres_server_url
+
+
+@pytest.fixture(scope="session")
+def make_postgres_database(postgres_server_url: str | None):
+    """Factory: ``name -> (asyncpg url, psycopg2 url)`` for a clean database.
+
+    Used by the schema-parity harness, which needs two independent databases to
+    build the ORM schema and the Alembic schema side by side.
+    """
+
+    def factory(name: str) -> tuple[str, str]:
+        if not postgres_server_url:
+            raise RuntimeError("no PostgreSQL server reachable")
+        async_url = create_postgres_database(postgres_server_url, name)
+        return async_url, rewrite_url(async_url, driver="psycopg2")
+
+    return factory
+
+
+@pytest.fixture(scope="session")
+def postgres_test_url(postgres_server_url: str | None) -> str | None:
+    """asyncpg URL for a dedicated, ORM-provisioned PostgreSQL test database."""
+    if not postgres_server_url:
+        return None
+    async_url = create_postgres_database(postgres_server_url, POSTGRES_TEST_DB)
+    sync_engine = sa.create_engine(
+        rewrite_url(postgres_server_url, driver="psycopg2", database=POSTGRES_TEST_DB),
+        connect_args={"connect_timeout": 5},
+    )
+    try:
+        with sync_engine.begin() as conn:
+            Base.metadata.create_all(conn)
+    finally:
+        sync_engine.dispose()
+    return async_url
+
+
+async def _truncate_all(manager: DatabaseManager) -> None:
+    """Empty every ORM table so each test starts from a known state."""
+    tables = ", ".join(f'"{table.name}"' for table in Base.metadata.sorted_tables)
+    async with manager.engine.begin() as conn:
+        await conn.execute(text(f"TRUNCATE TABLE {tables} RESTART IDENTITY CASCADE"))
+
+
+@pytest.fixture(params=REAL_BACKENDS)
+async def real_db(request, postgres_test_url, tmp_path):
+    """An initialised :class:`DatabaseManager` on a real engine, per backend."""
+    if request.param == "postgresql":
+        if not postgres_test_url:
+            pytest.skip(NO_POSTGRES_REASON)
+        manager = DatabaseManager(postgres_test_url)
+        await manager.init()
+        await _truncate_all(manager)
+    else:
+        manager = DatabaseManager(f"sqlite+aiosqlite:///{tmp_path / 'archive.db'}")
+        await manager.init()
+
+    try:
+        yield manager
+    finally:
+        await manager.close()
+
+
+@pytest.fixture
+async def real_adapter(real_db):
+    """A :class:`DatabaseAdapter` whose SQL is really compiled and really run."""
+    return DatabaseAdapter(real_db)

--- a/tests/test_db_adapter_real_engine.py
+++ b/tests/test_db_adapter_real_engine.py
@@ -1,0 +1,158 @@
+"""Adapter tests that run against a real engine on both supported backends.
+
+``tests/test_db_adapter.py`` covers the adapter with a mocked DatabaseManager:
+fast, broad, and blind to anything the database itself decides. These tests are
+the counterweight. They use the ``real_adapter`` fixture from ``conftest.py``,
+so every one of them runs twice — once on SQLite, once on PostgreSQL — and the
+SQL is compiled and executed for real.
+
+Only the paths where the two backends genuinely diverge live here:
+
+* ``update_sync_status``  — ``sqlite_insert`` vs ``pg_insert`` upsert, and the
+  ``message_count + excluded.message_count`` accumulate on conflict.
+* ``insert_message``      — ``on_conflict_do_nothing`` plus, on the conflict
+  branch, ``SELECT ... FOR UPDATE`` (PostgreSQL) vs the no-op-write lock
+  (SQLite), and the message-version capture that hangs off it.
+* ``get_messages_paginated`` — the composite ``(date, id)`` cursor and the
+  ``ilike`` search with its ``\\`` escape, which PostgreSQL and SQLite treat
+  differently.
+
+The PostgreSQL leg skips when no server is reachable; see conftest.
+"""
+
+from datetime import datetime, timedelta
+
+from src.db.models import SyncStatus
+
+BASE_DATE = datetime(2026, 3, 1, 12, 0, 0)
+
+
+async def _seed_chat(adapter, chat_id: int) -> None:
+    """Insert the parent chat row messages and sync_status point at."""
+    await adapter.upsert_chat({"id": chat_id, "type": "group", "title": "fixture chat"})
+
+
+def _message(chat_id: int, message_id: int, *, text: str | None = None, offset_minutes: int = 0) -> dict:
+    return {
+        "id": message_id,
+        "chat_id": chat_id,
+        "sender_id": 4242,
+        "date": BASE_DATE + timedelta(minutes=offset_minutes),
+        "text": text,
+        "raw_data": {},
+    }
+
+
+class TestUpdateSyncStatusRealEngine:
+    """The sync cursor upsert, executed rather than mocked."""
+
+    async def test_insert_then_accumulate_on_conflict(self, real_adapter):
+        """First call inserts; the second updates the cursor and ADDS the count.
+
+        The mocked twin of this test asserts ``execute`` was awaited once. That
+        passes even if ``message_count`` were assigned instead of accumulated —
+        which is the one thing this method's ON CONFLICT clause is for.
+        """
+        await _seed_chat(real_adapter, 900001)
+
+        await real_adapter.update_sync_status(900001, 500, 50)
+        async with real_adapter.db_manager.async_session_factory() as session:
+            row = (await session.execute(SyncStatus.__table__.select())).mappings().one()
+        assert row["last_message_id"] == 500
+        assert row["message_count"] == 50
+
+        await real_adapter.update_sync_status(900001, 750, 25)
+        async with real_adapter.db_manager.async_session_factory() as session:
+            row = (await session.execute(SyncStatus.__table__.select())).mappings().one()
+        assert row["last_message_id"] == 750
+        assert row["message_count"] == 75
+
+    async def test_last_message_id_round_trips(self, real_adapter):
+        """get_last_message_id reads back what the upsert wrote."""
+        await _seed_chat(real_adapter, 900002)
+        assert await real_adapter.get_last_message_id(900002) == 0
+
+        await real_adapter.update_sync_status(900002, 1234, 7)
+        assert await real_adapter.get_last_message_id(900002) == 1234
+
+
+class TestMessageUpsertConflictRealEngine:
+    """insert_message's conflict branch on both dialects."""
+
+    async def test_reinserting_identical_message_is_a_no_op(self, real_adapter):
+        """A re-scan of an unchanged message must not duplicate or mutate it."""
+        await _seed_chat(real_adapter, 900003)
+        await real_adapter.insert_message(_message(900003, 10, text="hello"))
+        await real_adapter.insert_message(_message(900003, 10, text="hello"))
+
+        messages = await real_adapter.get_messages_paginated(900003, limit=10)
+        assert len(messages) == 1
+        assert messages[0]["text"] == "hello"
+        assert await real_adapter.get_message_versions(900003, 10) == []
+
+    async def test_edited_text_updates_row_and_records_a_version(self, real_adapter):
+        """The conflict path takes the row lock, updates, and snapshots the old text.
+
+        On PostgreSQL that lock is ``SELECT ... FOR UPDATE``; on SQLite it is a
+        no-op ``UPDATE`` that acquires the write lock. Both are exercised here.
+        """
+        await _seed_chat(real_adapter, 900004)
+        await real_adapter.insert_message(_message(900004, 11, text="first"))
+
+        edited = _message(900004, 11, text="second")
+        edited["edit_date"] = BASE_DATE + timedelta(minutes=5)
+        await real_adapter.insert_message(edited)
+
+        messages = await real_adapter.get_messages_paginated(900004, limit=10)
+        assert len(messages) == 1
+        assert messages[0]["text"] == "second"
+
+        versions = await real_adapter.get_message_versions(900004, 11)
+        assert [v["text"] for v in versions] == ["first"]
+
+    async def test_composite_primary_key_separates_chats(self, real_adapter):
+        """The same message id in two chats is two rows, not a conflict."""
+        await _seed_chat(real_adapter, 900005)
+        await _seed_chat(real_adapter, 900006)
+        await real_adapter.insert_message(_message(900005, 12, text="in chat A"))
+        await real_adapter.insert_message(_message(900006, 12, text="in chat B"))
+
+        assert (await real_adapter.get_messages_paginated(900005, limit=10))[0]["text"] == "in chat A"
+        assert (await real_adapter.get_messages_paginated(900006, limit=10))[0]["text"] == "in chat B"
+
+
+class TestPaginationRealEngine:
+    """get_messages_paginated against a real planner and a real collation."""
+
+    async def test_cursor_pagination_walks_the_chat_newest_first(self, real_adapter):
+        """The (date, id) cursor returns every row exactly once, in order."""
+        await _seed_chat(real_adapter, 900007)
+        for index in range(6):
+            await real_adapter.insert_message(_message(900007, 100 + index, text=f"m{index}", offset_minutes=index))
+
+        first = await real_adapter.get_messages_paginated(900007, limit=4)
+        assert [m["id"] for m in first] == [105, 104, 103, 102]
+
+        cursor = first[-1]
+        second = await real_adapter.get_messages_paginated(
+            900007, limit=4, before_date=cursor["date"], before_id=cursor["id"]
+        )
+        assert [m["id"] for m in second] == [101, 100]
+
+    async def test_search_escapes_sql_wildcards(self, real_adapter):
+        """A literal ``%`` in the query must not behave as a wildcard.
+
+        The escape is passed to ``ilike(..., escape="\\\\")``; whether the
+        backend honours it can only be settled by running the query.
+        """
+        await _seed_chat(real_adapter, 900008)
+        await real_adapter.insert_message(_message(900008, 200, text="100% done", offset_minutes=0))
+        await real_adapter.insert_message(_message(900008, 201, text="nothing here", offset_minutes=1))
+
+        hits = await real_adapter.get_messages_paginated(900008, limit=10, search="100%")
+        assert [m["id"] for m in hits] == [200]
+
+        # A bare "%" must match only the row that literally contains one.
+        # Unescaped it is the match-everything wildcard and would return both.
+        bare = await real_adapter.get_messages_paginated(900008, limit=10, search="%")
+        assert [m["id"] for m in bare] == [200]

--- a/tests/test_schema_parity.py
+++ b/tests/test_schema_parity.py
@@ -1,0 +1,418 @@
+"""Diff the two schemas this project can produce, on both supported backends.
+
+There are two ways this project can build a schema:
+
+* ``alembic upgrade head``     — ``scripts/entrypoint.sh`` runs this on both
+  backends before the app starts. It is the authority.
+* ``Base.metadata.create_all`` — ``src/db/base.py`` falls back to this on
+  SQLite for processes that never pass through that entrypoint (the viewer
+  image ships no ``alembic/``), and ``src/db/migrate.py`` uses it to provision
+  the target of a SQLite-to-PostgreSQL move.
+
+Nothing compared them until this module, and they had drifted to 54 structural
+differences on SQLite and 50 on PostgreSQL. It builds both, on each backend,
+and reports every structural difference: tables, columns, types, nullability,
+server defaults, indexes, unique constraints, primary keys and foreign keys.
+
+``KNOWN_DIFFERENCES`` is empty, so this is a strict parity gate: a new
+difference fails it, and so does an allow-list entry that no longer describes a
+real difference.
+
+The PostgreSQL leg skips when no server is reachable (see ``conftest.py``).
+Both tests are deliberately synchronous: Alembic's ``env.py`` calls
+``asyncio.run()``, which cannot be nested inside a running loop.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+from alembic import command
+from src.db.models import Base
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ALEMBIC_DIR = REPO_ROOT / "alembic"
+
+# Alembic's own bookkeeping table has no ORM counterpart by design.
+IGNORED_TABLES = {"alembic_version"}
+
+
+# ---------------------------------------------------------------------------
+# Known differences. Key -> why it is here. Delete an entry when it is fixed.
+# ---------------------------------------------------------------------------
+
+# Empty, and it stays empty. Migration 021 closed all 54 differences on SQLite
+# and all 50 on PostgreSQL, so the two schema authors now agree exactly and any
+# difference at all — a column added to models.py without a migration, or a
+# migration that lands somewhere the ORM does not — fails this gate on both
+# backends. Adding an entry here silences a real divergence: fix the schema
+# instead.
+KNOWN_DIFFERENCES: dict[str, dict[str, str]] = {
+    "sqlite": {},
+    "postgresql": {},
+}
+
+
+# ---------------------------------------------------------------------------
+# Schema capture
+# ---------------------------------------------------------------------------
+
+
+def _snapshot(sync_url: str) -> dict:
+    """Reflect a live schema into a plain comparable structure."""
+    engine = sa.create_engine(sync_url)
+    try:
+        inspector = sa.inspect(engine)
+        schema = {}
+        for table in sorted(inspector.get_table_names()):
+            if table in IGNORED_TABLES:
+                continue
+            schema[table] = {
+                "columns": {
+                    column["name"]: {
+                        "type": str(column["type"]),
+                        "nullable": bool(column["nullable"]),
+                        "server_default": None if column.get("default") is None else str(column["default"]),
+                    }
+                    for column in inspector.get_columns(table)
+                },
+                "indexes": {
+                    index["name"]: {
+                        "columns": list(index.get("column_names") or []),
+                        "unique": bool(index.get("unique")),
+                    }
+                    for index in inspector.get_indexes(table)
+                },
+                "unique_constraints": {
+                    constraint["name"]: sorted(constraint["column_names"])
+                    for constraint in inspector.get_unique_constraints(table)
+                },
+                "primary_key": sorted(inspector.get_pk_constraint(table).get("constrained_columns") or []),
+                # Keyed by what the constraint *does*, not by its name: an
+                # unnamed FK and a named one that constrain the same columns are
+                # the same constraint with a naming nit, and that is a much less
+                # interesting finding than a missing constraint.
+                "foreign_keys": {
+                    (
+                        f"{','.join(fk['constrained_columns'])}"
+                        f"->{fk['referred_table']}({','.join(fk['referred_columns'])})"
+                    ): fk.get("name")
+                    for fk in inspector.get_foreign_keys(table)
+                },
+            }
+        return schema
+    finally:
+        engine.dispose()
+
+
+def _diff(orm: dict, alembic: dict) -> dict[str, str]:
+    """Return ``{difference key: human-readable description}``."""
+    found: dict[str, str] = {}
+
+    for table in sorted(set(orm) - set(alembic)):
+        found[f"table-only-in-orm:{table}"] = f"table {table} exists only in the ORM schema"
+    for table in sorted(set(alembic) - set(orm)):
+        found[f"table-only-in-alembic:{table}"] = f"table {table} exists only in the Alembic schema"
+
+    for table in sorted(set(orm) & set(alembic)):
+        left, right = orm[table], alembic[table]
+
+        for column in sorted(set(left["columns"]) - set(right["columns"])):
+            found[f"column-only-in-orm:{table}.{column}"] = f"{table}.{column} exists only in the ORM schema"
+        for column in sorted(set(right["columns"]) - set(left["columns"])):
+            found[f"column-only-in-alembic:{table}.{column}"] = f"{table}.{column} exists only in the Alembic schema"
+
+        for column in sorted(set(left["columns"]) & set(right["columns"])):
+            lc, rc = left["columns"][column], right["columns"][column]
+            if lc["nullable"] != rc["nullable"]:
+                found[f"nullable:{table}.{column}"] = (
+                    f"{table}.{column} nullable: ORM={lc['nullable']} Alembic={rc['nullable']}"
+                )
+            if lc["type"] != rc["type"]:
+                found[f"type:{table}.{column}"] = f"{table}.{column} type: ORM={lc['type']} Alembic={rc['type']}"
+            if lc["server_default"] != rc["server_default"]:
+                found[f"server-default:{table}.{column}"] = (
+                    f"{table}.{column} server default: ORM={lc['server_default']} Alembic={rc['server_default']}"
+                )
+
+        for index in sorted(set(left["indexes"]) - set(right["indexes"])):
+            found[f"index-only-in-orm:{table}.{index}"] = (
+                f"index {index} on {left['indexes'][index]['columns']} exists only in the ORM schema"
+            )
+        for index in sorted(set(right["indexes"]) - set(left["indexes"])):
+            found[f"index-only-in-alembic:{table}.{index}"] = (
+                f"index {index} on {right['indexes'][index]['columns']} exists only in the Alembic schema"
+            )
+        for index in sorted(set(left["indexes"]) & set(right["indexes"])):
+            if left["indexes"][index] != right["indexes"][index]:
+                found[f"index-differs:{table}.{index}"] = (
+                    f"index {index}: ORM={left['indexes'][index]} Alembic={right['indexes'][index]}"
+                )
+
+        for name in sorted(set(left["unique_constraints"]) - set(right["unique_constraints"])):
+            found[f"unique-only-in-orm:{table}.{name}"] = f"unique constraint {name} exists only in the ORM schema"
+        for name in sorted(set(right["unique_constraints"]) - set(left["unique_constraints"])):
+            found[f"unique-only-in-alembic:{table}.{name}"] = (
+                f"unique constraint {name} exists only in the Alembic schema"
+            )
+        for name in sorted(set(left["unique_constraints"]) & set(right["unique_constraints"])):
+            if left["unique_constraints"][name] != right["unique_constraints"][name]:
+                found[f"unique-differs:{table}.{name}"] = (
+                    f"unique constraint {name}: ORM={left['unique_constraints'][name]} "
+                    f"Alembic={right['unique_constraints'][name]}"
+                )
+
+        if left["primary_key"] != right["primary_key"]:
+            found[f"primary-key:{table}"] = (
+                f"{table} primary key: ORM={left['primary_key']} Alembic={right['primary_key']}"
+            )
+
+        for fk in sorted(set(left["foreign_keys"]) - set(right["foreign_keys"])):
+            found[f"fk-only-in-orm:{table}:{fk}"] = f"{table} FK {fk} exists only in the ORM schema"
+        for fk in sorted(set(right["foreign_keys"]) - set(left["foreign_keys"])):
+            found[f"fk-only-in-alembic:{table}:{fk}"] = f"{table} FK {fk} exists only in the Alembic schema"
+        for fk in sorted(set(left["foreign_keys"]) & set(right["foreign_keys"])):
+            if left["foreign_keys"][fk] != right["foreign_keys"][fk]:
+                found[f"fk-name:{table}:{fk}"] = (
+                    f"{table} FK {fk} name: ORM={left['foreign_keys'][fk]} Alembic={right['foreign_keys'][fk]}"
+                )
+
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Schema construction
+# ---------------------------------------------------------------------------
+
+
+def _build_orm_schema(sync_url: str) -> None:
+    engine = sa.create_engine(sync_url)
+    try:
+        Base.metadata.create_all(engine)
+    finally:
+        engine.dispose()
+
+
+def _build_alembic_schema(async_url: str, target: str = "head") -> None:
+    """Run ``alembic upgrade`` against a database.
+
+    A ``Config`` with no ini file is deliberate: ``alembic/env.py`` only calls
+    ``fileConfig`` when ``config_file_name`` is set, and letting it run would
+    reconfigure pytest's logging. env.py reads the URL from ``DATABASE_URL``,
+    so that is what has to be set.
+    """
+    config = Config()
+    config.set_main_option("script_location", str(ALEMBIC_DIR))
+    config.set_main_option("sqlalchemy.url", async_url)
+
+    previous = os.environ.get("DATABASE_URL")
+    os.environ["DATABASE_URL"] = async_url
+    try:
+        command.upgrade(config, target)
+    finally:
+        if previous is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = previous
+
+
+def _assert_parity(backend: str, orm: dict, alembic: dict, allowed: dict[str, str]) -> None:
+    """Fail unless the ORM/Alembic diff is exactly ``allowed``.
+
+    ``allowed`` is passed in rather than looked up so the positive controls
+    below can exercise this function against a diff they control.
+    """
+    __tracebackhide__ = True  # the report is the message; the frame locals are noise
+    found = _diff(orm, alembic)
+
+    new = {key: text for key, text in found.items() if key not in allowed}
+    stale = sorted(key for key in allowed if key not in found)
+
+    if not new and not stale:
+        return
+
+    report = [f"ORM vs Alembic schema parity failed on {backend}.", ""]
+    if new:
+        report.append(f"{len(new)} NEW difference(s) — the two schema paths just drifted further apart:")
+        report += [f"  {key}\n      {text}" for key, text in sorted(new.items())]
+        report.append("")
+    if stale:
+        report.append(
+            f"{len(stale)} allow-listed difference(s) no longer exist. Delete them from "
+            f"KNOWN_DIFFERENCES['{backend}'] so the allow-list keeps shrinking:"
+        )
+        report += [f"  {key}" for key in stale]
+        report.append("")
+    report.append(f"Full diff on {backend} ({len(found)} difference(s) total):")
+    report += [f"  {key}\n      {text}" for key, text in sorted(found.items())]
+    raise AssertionError("\n".join(report))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_orm_and_alembic_schemas_agree_on_sqlite(tmp_path):
+    """A create_all SQLite install and a migrated one must be the same schema."""
+    orm_db = tmp_path / "orm.db"
+    alembic_db = tmp_path / "alembic.db"
+
+    _build_orm_schema(f"sqlite:///{orm_db}")
+    _build_alembic_schema(f"sqlite+aiosqlite:///{alembic_db}")
+
+    _assert_parity(
+        "sqlite",
+        _snapshot(f"sqlite:///{orm_db}"),
+        _snapshot(f"sqlite:///{alembic_db}"),
+        KNOWN_DIFFERENCES["sqlite"],
+    )
+
+
+def test_stepwise_upgrade_lands_where_a_jump_to_head_lands(tmp_path):
+    """One-revision-at-a-time must reach the same schema as a single jump.
+
+    The parity tests build the Alembic side with one ``upgrade head``. A real
+    long-lived install got there one migration at a time. If the two routes
+    diverged, the parity result would describe a schema nobody actually runs,
+    and a migration that only works when jumped over would go unnoticed.
+    """
+    stepwise = tmp_path / "stepwise.db"
+    jumped = tmp_path / "jumped.db"
+
+    _build_alembic_schema(f"sqlite+aiosqlite:///{jumped}")
+    revisions = list(reversed(list(ScriptDirectory(str(ALEMBIC_DIR)).walk_revisions())))
+    for revision in revisions:
+        _build_alembic_schema(f"sqlite+aiosqlite:///{stepwise}", revision.revision)
+
+    differences = _diff(_snapshot(f"sqlite:///{stepwise}"), _snapshot(f"sqlite:///{jumped}"))
+    assert not differences, "stepwise upgrade and `upgrade head` produced different schemas:\n" + "\n".join(
+        f"  {key}: {text}" for key, text in sorted(differences.items())
+    )
+
+
+def test_orm_and_alembic_schemas_agree_on_postgresql(require_postgres, make_postgres_database):
+    """Same check on PostgreSQL, where Alembic is the only schema author."""
+    _, orm_sync_url = make_postgres_database("telegram_archive_parity_orm")
+    alembic_async_url, alembic_sync_url = make_postgres_database("telegram_archive_parity_alembic")
+
+    _build_orm_schema(orm_sync_url)
+    _build_alembic_schema(alembic_async_url)
+
+    _assert_parity(
+        "postgresql",
+        _snapshot(orm_sync_url),
+        _snapshot(alembic_sync_url),
+        KNOWN_DIFFERENCES["postgresql"],
+    )
+
+
+class TestDiffCanGoRed:
+    """Positive controls: prove ``_diff`` actually detects each difference.
+
+    An empty diff is the pass condition of the two tests above, and an empty
+    diff is also what a broken comparator returns. These pin the comparator so
+    a silent pass cannot be mistaken for parity.
+    """
+
+    @staticmethod
+    def _base() -> dict:
+        return {
+            "t": {
+                "columns": {"c": {"type": "INTEGER", "nullable": False, "server_default": None}},
+                "indexes": {"ix_c": {"columns": ["c"], "unique": False}},
+                "unique_constraints": {"uq_c": ["c"]},
+                "primary_key": ["c"],
+                "foreign_keys": {"c->other(id)": "fk_c"},
+            }
+        }
+
+    def test_identical_schemas_produce_no_differences(self):
+        assert _diff(self._base(), self._base()) == {}
+
+    def test_detects_a_missing_table(self):
+        assert "table-only-in-orm:t" in _diff(self._base(), {})
+
+    def test_detects_an_extra_table(self):
+        assert "table-only-in-alembic:t" in _diff({}, self._base())
+
+    def test_detects_a_missing_column(self):
+        other = self._base()
+        other["t"]["columns"] = {}
+        assert "column-only-in-orm:t.c" in _diff(self._base(), other)
+
+    def test_detects_a_nullability_change(self):
+        other = self._base()
+        other["t"]["columns"]["c"]["nullable"] = True
+        assert "nullable:t.c" in _diff(self._base(), other)
+
+    def test_detects_a_type_change(self):
+        other = self._base()
+        other["t"]["columns"]["c"]["type"] = "BIGINT"
+        assert "type:t.c" in _diff(self._base(), other)
+
+    def test_detects_a_server_default_change(self):
+        other = self._base()
+        other["t"]["columns"]["c"]["server_default"] = "0"
+        assert "server-default:t.c" in _diff(self._base(), other)
+
+    def test_detects_a_missing_index(self):
+        other = self._base()
+        other["t"]["indexes"] = {}
+        assert "index-only-in-orm:t.ix_c" in _diff(self._base(), other)
+
+    def test_detects_a_changed_index(self):
+        other = self._base()
+        other["t"]["indexes"]["ix_c"]["unique"] = True
+        assert "index-differs:t.ix_c" in _diff(self._base(), other)
+
+    def test_detects_a_missing_unique_constraint(self):
+        other = self._base()
+        other["t"]["unique_constraints"] = {}
+        assert "unique-only-in-orm:t.uq_c" in _diff(self._base(), other)
+
+    def test_detects_a_changed_primary_key(self):
+        other = self._base()
+        other["t"]["primary_key"] = []
+        assert "primary-key:t" in _diff(self._base(), other)
+
+    def test_detects_a_missing_foreign_key(self):
+        other = self._base()
+        other["t"]["foreign_keys"] = {}
+        assert "fk-only-in-orm:t:c->other(id)" in _diff(self._base(), other)
+
+    def test_detects_a_renamed_foreign_key(self):
+        other = self._base()
+        other["t"]["foreign_keys"]["c->other(id)"] = None
+        assert "fk-name:t:c->other(id)" in _diff(self._base(), other)
+
+    def test_new_difference_fails_the_gate(self):
+        """An unlisted difference must fail, not be quietly tolerated."""
+        other = self._base()
+        other["t"]["columns"]["c"]["nullable"] = True
+        with pytest.raises(AssertionError) as excinfo:
+            _assert_parity("sqlite", self._base(), other, allowed={})
+        assert "NEW difference" in str(excinfo.value)
+        assert "nullable:t.c" in str(excinfo.value)
+
+    def test_allow_listed_difference_passes_the_gate(self):
+        """The listed difference is tolerated — that is what keeps this green."""
+        other = self._base()
+        other["t"]["columns"]["c"]["nullable"] = True
+        _assert_parity("sqlite", self._base(), other, allowed={"nullable:t.c": "known"})
+
+    def test_stale_allow_list_entry_fails_the_gate(self):
+        """A fixed difference must fail until its allow-list entry is removed."""
+        with pytest.raises(AssertionError) as excinfo:
+            _assert_parity("sqlite", self._base(), self._base(), allowed={"nullable:t.c": "already fixed"})
+        assert "no longer exist" in str(excinfo.value)
+
+    def test_every_allow_list_entry_carries_a_reason(self):
+        """An entry with no explanation is a silenced failure, not a decision."""
+        for backend, entries in KNOWN_DIFFERENCES.items():
+            for key, reason in entries.items():
+                assert reason.strip(), f"{backend}:{key} has no reason"


### PR DESCRIPTION
## The problem

PostgreSQL was never actually exercised. The test workflow had no database service, and every "postgres" test asserted on mock calls — `mock_session.execute.assert_awaited_once()` — so the SQL those paths generate was never compiled, let alone run. One mock helper is used ~145 times against a handful of real-SQLite tests. That is a check that cannot go red.

Meanwhile there were **two schema authorities**: SQLite built by `create_all`, PostgreSQL built only by Alembic. They drifted, and nothing could notice.

**Measured, not assumed: 54 differences on SQLite, 50 on PostgreSQL.**

One is a live bug rather than cosmetics:

```sql
INSERT INTO media (id, file_path) VALUES ('probe1', repeat('a', 600));
-- Alembic-built database: ERROR: value too long for type character varying(500)
-- ORM-built database:     INSERT 0 1
```

`media.file_path` is `VARCHAR(500)` on a real PostgreSQL install but `Text` in the models — the comment says "changed to Text for long paths" but no migration ever widened it. **A media path over 500 characters hard-fails on PostgreSQL and works on SQLite.**

Two more the audit had missed: the `reactions` table has **no foreign key to `messages`** in the migrated schema on either backend (so reaction rows are orphanable), and on SQLite migration 005's rebuild dropped its other foreign key too, leaving that table with none. PostgreSQL also carries two unused `nextval()` sequences from a `BIGSERIAL` the models explicitly disclaim.

One audit claim turned out **stale** and is reported as such: the audit-log indexes it flagged as missing are now declared — #288 added them. There is no index drift anywhere, on either backend.

## The fix

**Migration 021** aligns the migrated schema with the models on both backends: nullability on 35 columns (backfill, then tighten), the declared defaults, the `file_path` widening, the missing reaction foreign key, eight SQLite integer widths, and the empty rollback table migration 005 leaves behind on every fresh install.

Every step reads the live schema first and does nothing where the shape already matches — so an install provisioned by `create_all`, which is what most existing users have, **rebuilds nothing**. SQLite rebuilds go through `batch_alter_table` per table, only where that table still differs.

**CI now runs a real PostgreSQL service**, and a new fixture yields a real adapter on a real engine, parameterised over both backends, skipping cleanly when no server is reachable so a laptop without Docker still passes. The workflow **fails if the PostgreSQL leg skips** — a silently skipped backend is exactly how this drift survived.

**A schema-parity test** builds both schemas both ways on both backends and fails on any difference in tables, columns, types, nullability, defaults, indexes, unique constraints, primary keys or foreign keys.

Also fixes a pre-existing crash loop found while working in the entrypoint: its SQLite path chain omitted `DATABASE_DIR`, so such an install was inspected at one path and migrated at another, and Alembic then re-ran the initial migration against the real database.

## Two deletions, stated loudly

- `_messages_media_backup` is dropped **only when empty**; a copy holding a real pre-normalization row survives untouched (tested).
- Orphan reaction rows are deleted, but only on a database about to gain `fk_reaction_message`, because PostgreSQL refuses the constraint otherwise. A `create_all`-built database already declares that FK, so nothing is deleted there.

## Verification

- **Eight real upgrade shapes**, each "old" database built by `git archive origin/main`'s own models and migration chain — never the current tree — seeded with real rows and digested row-by-row, column-by-column, before and after. Fresh SQLite, fresh PostgreSQL, existing `create_all`-provisioned SQLite (the common real-user case; the shipped stamping ladder was **extracted verbatim** from `entrypoint.sh` and run, not reimplemented), existing PostgreSQL at the previous head, both backends from older revisions, and a re-run. Every row byte-identical where it should be.
- **The reviewer diffed deeper than the committed test and without any allow-list** — raw `sqlite_master` DDL text, and `pg_attribute`/`pg_constraint`/`pg_indexes`/`pg_sequences` directly. Zero differences after normalising cosmetic ordering.
- **The gate was proven able to go red**: four hand-injected drifts, all caught, including one that fails on the PostgreSQL leg only — proving that leg is genuinely independent rather than decorative.
- Full suite with a real PostgreSQL configured: **2889 passed**, 171 subtests, 0 failed, 0 skipped, and zero hits for the PostgreSQL skip reason. `ruff` clean.

## Known and deliberate

`create_all` stays as a fallback for the viewer image, which ships no `alembic/` and has no entrypoint, so it cannot migrate. It is limited to SQLite because on PostgreSQL it would race a concurrently migrating container. This is now two provably-equal paths rather than two drifting ones — the parity test fails if they diverge again. Making it literally one path means shipping Alembic into the viewer image, which is a bigger blast radius than this change warranted and is tracked separately.

No version bump: still 7.33.6. The single 8.0.0 bump comes at the end of the programme.
