### PR TITLE
fix: never let the viewer write schema into a database Alembic owns

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -200,6 +200,17 @@ services:
       - ALL
     security_opt:
       - no-new-privileges:true
+    # There is deliberately no ordering between this service and
+    # telegram-backup, and none is needed. telegram-backup owns the schema and
+    # migrates it on start; this image ships no alembic/ and cannot. It also no
+    # longer writes tables into a database that already has any (see
+    # _create_schema_if_absent in src/db/base.py), so starting it never
+    # corrupts a migration. The ordering that matters is enforced from the
+    # other side: a migration that rebuilds tables refuses to start while any
+    # other process holds the SQLite file, and proceeds once it is released.
+    # Do not add depends_on here expecting it to wait for migrations:
+    # depends_on waits for the container, not for the work it does, so it
+    # would only look like a guarantee.
     # Uncomment to use PostgreSQL
     # depends_on:
     #   postgres:

--- a/src/db/base.py
+++ b/src/db/base.py
@@ -10,7 +10,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from urllib.parse import quote_plus
 
-from sqlalchemy import event, text
+from sqlalchemy import event, inspect, text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import AsyncAdaptedQueuePool, NullPool
 
@@ -153,13 +153,62 @@ class DatabaseManager:
         if self._is_sqlite:
             try:
                 async with self.engine.begin() as conn:
-                    await conn.run_sync(lambda sync_conn: Base.metadata.create_all(sync_conn, checkfirst=True))
+                    created = await conn.run_sync(self._create_schema_if_absent)
+                if not created:
+                    logger.info("Existing schema found - leaving it to Alembic, no tables created")
             except Exception as e:
                 # Viewer containers may mount the database read-only — that's fine,
                 # the backup container is responsible for creating tables.
                 logger.warning(f"Could not create/verify tables (database may be read-only): {e}")
 
         logger.info(f"Database initialized successfully ({self._db_type()})")
+
+    @staticmethod
+    def _create_schema_if_absent(sync_conn) -> bool:
+        """Build the ORM schema, but only into a database that has none yet.
+
+        Returns True if the schema was created, False if one was already there.
+
+        The whole check-and-create runs on one connection inside ``init``'s
+        transaction, so this process cannot race itself.
+
+        Why the guard is not optional
+        -----------------------------
+        The viewer image ships no ``alembic/`` and has no ENTRYPOINT
+        (``Dockerfile.viewer``), so it never migrates — but it does reach this
+        line on every SQLite start, and ``docker compose up -d`` starts it
+        alongside the backup container that *is* migrating. Unguarded,
+        ``create_all(checkfirst=True)`` adds whole missing tables to a database
+        a migration is halfway through rebuilding: the migration's own
+        ``CREATE TABLE`` then dies with "table already exists" and the backup
+        container crash-loops, against what is usually the only copy of
+        someone's Telegram history.
+
+        Any table at all means this database is not ours to build.
+        ``alembic_version`` says so outright — Alembic owns this schema and is
+        the only thing allowed to change it. Any other table means a previous
+        run already provisioned it, and the entrypoint's stamping ladder is
+        about to read that shape to decide which revision it is; adding a table
+        underneath that read gets it stamped wrong, which is the same
+        crash-loop by a different route.
+
+        Skipping costs a viewer nothing: ``checkfirst=True`` only ever added
+        whole missing tables, never a column, so it could never have made an
+        older archive readable by a newer viewer anyway. A viewer against an
+        existing archive still opens it and still serves it — the reason this
+        fallback exists is the *fresh* database, and that case still works.
+
+        The fresh case is also the one narrow window left open: with no
+        database at all, the viewer may win the race and build the full ORM
+        schema unstamped. That is the shape ``scripts/entrypoint.sh`` already
+        detects and stamps, and that every migration is already required to
+        survive as a no-op, so it converges — and there is no history in an
+        empty database to lose while it does.
+        """
+        if inspect(sync_conn).get_table_names():
+            return False
+        Base.metadata.create_all(sync_conn, checkfirst=True)
+        return True
 
     def _setup_sqlite_pragmas(self) -> None:
         """Set up SQLite PRAGMA settings for optimal performance.

--- a/src/db/base.py
+++ b/src/db/base.py
@@ -10,7 +10,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from urllib.parse import quote_plus
 
-from sqlalchemy import event, inspect, text
+from sqlalchemy import Connection, event, inspect, text
 from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import AsyncAdaptedQueuePool, NullPool
 
@@ -164,7 +164,7 @@ class DatabaseManager:
         logger.info(f"Database initialized successfully ({self._db_type()})")
 
     @staticmethod
-    def _create_schema_if_absent(sync_conn) -> bool:
+    def _create_schema_if_absent(sync_conn: Connection) -> bool:
         """Build the ORM schema, but only into a database that has none yet.
 
         Returns True if the schema was created, False if one was already there.

--- a/tests/test_createall_race.py
+++ b/tests/test_createall_race.py
@@ -119,7 +119,7 @@ async def open_with_manager(db_path: Path) -> None:
     await manager.close()
 
 
-async def test_alembic_owned_database_gains_nothing(tmp_path):
+async def test_alembic_owned_database_gains_nothing(tmp_path: Path) -> None:
     """The gate: an 8.0 viewer against a 7.x file creates zero tables."""
     db_path = tmp_path / "archive.db"
     build_old_database(db_path, stamped=True)
@@ -132,7 +132,7 @@ async def test_alembic_owned_database_gains_nothing(tmp_path):
     assert not (table_names(db_path) & set(MISSING_IN_OLD_DB))
 
 
-async def test_alembic_version_is_left_exactly_as_it_was(tmp_path):
+async def test_alembic_version_is_left_exactly_as_it_was(tmp_path: Path) -> None:
     """The viewer must not stamp, re-stamp or clear the revision either."""
     db_path = tmp_path / "archive.db"
     build_old_database(db_path, stamped=True)
@@ -146,7 +146,7 @@ async def test_alembic_version_is_left_exactly_as_it_was(tmp_path):
         conn.close()
 
 
-async def test_pre_alembic_database_gains_nothing(tmp_path):
+async def test_pre_alembic_database_gains_nothing(tmp_path: Path) -> None:
     """A database with tables but no alembic_version is still not ours.
 
     The entrypoint stamps this shape by inspecting which schema objects exist.
@@ -163,7 +163,7 @@ async def test_pre_alembic_database_gains_nothing(tmp_path):
     assert after == before
 
 
-async def test_the_viewers_own_startup_path_creates_nothing(tmp_path):
+async def test_the_viewers_own_startup_path_creates_nothing(tmp_path: Path) -> None:
     """Same assertion through ``init_database()``, which is what the app calls.
 
     ``src/web/main.py`` builds its manager from the environment via
@@ -183,7 +183,7 @@ async def test_the_viewers_own_startup_path_creates_nothing(tmp_path):
     assert snapshot_schema(db_path) == before
 
 
-async def test_a_genuinely_fresh_database_is_still_built(tmp_path):
+async def test_a_genuinely_fresh_database_is_still_built(tmp_path: Path) -> None:
     """The reverse check: the fallback this guard narrows must still work.
 
     A fresh install with no entrypoint — the viewer image, or ``python -m src``
@@ -197,7 +197,7 @@ async def test_a_genuinely_fresh_database_is_still_built(tmp_path):
     assert table_names(db_path) == set(Base.metadata.tables)
 
 
-async def test_an_empty_file_that_already_exists_is_still_built(tmp_path):
+async def test_an_empty_file_that_already_exists_is_still_built(tmp_path: Path) -> None:
     """A zero-byte file is fresh too — an empty mount must not read as owned."""
     db_path = tmp_path / "archive.db"
     db_path.touch()
@@ -208,7 +208,7 @@ async def test_an_empty_file_that_already_exists_is_still_built(tmp_path):
     assert table_names(db_path) == set(Base.metadata.tables)
 
 
-async def test_removing_the_guard_puts_the_tables_back(tmp_path):
+async def test_removing_the_guard_puts_the_tables_back(tmp_path: Path) -> None:
     """POSITIVE CONTROL: with the guard gone, the assertions above go red.
 
     This is the pre-fix body of ``_create_schema_if_absent``. If this test ever
@@ -216,7 +216,7 @@ async def test_removing_the_guard_puts_the_tables_back(tmp_path):
     protects the database and something else is masking the bug.
     """
 
-    def unguarded(sync_conn) -> bool:
+    def unguarded(sync_conn: sa.Connection) -> bool:
         Base.metadata.create_all(sync_conn, checkfirst=True)
         return True
 
@@ -233,7 +233,7 @@ async def test_removing_the_guard_puts_the_tables_back(tmp_path):
 
 
 @pytest.mark.parametrize("stamped", [True, False])
-async def test_repeated_starts_stay_a_no_op(tmp_path, stamped):
+async def test_repeated_starts_stay_a_no_op(tmp_path: Path, stamped: bool) -> None:
     """Restart loops must not accumulate anything either."""
     db_path = tmp_path / "archive.db"
     build_old_database(db_path, stamped=stamped)

--- a/tests/test_createall_race.py
+++ b/tests/test_createall_race.py
@@ -1,0 +1,245 @@
+"""The viewer must never build tables into a database Alembic owns.
+
+The hazard
+----------
+``Dockerfile.viewer`` ships no ``alembic/`` and sets no ENTRYPOINT — it runs
+uvicorn directly — so the viewer container can never migrate. It does, however,
+reach ``Base.metadata.create_all(checkfirst=True)`` in ``src/db/base.py`` on
+every SQLite start, and ``docker-compose.yml`` starts it concurrently with the
+backup container, which *is* running ``alembic upgrade head`` on the same file.
+
+Unguarded, ``checkfirst=True`` adds whole missing tables. Land one of those
+inside a database a migration is halfway through rebuilding and the migration's
+own ``CREATE TABLE`` dies with "table already exists"; the backup container then
+crash-loops against what is usually the only copy of someone's Telegram history.
+
+What is asserted
+----------------
+An existing database gains **nothing**: not a table, not an index, not a
+trigger. ``sqlite_master`` is snapshotted before and after a real
+``DatabaseManager.init()`` and must come back byte-identical.
+
+Why the fixtures drop tables
+----------------------------
+A 7.x file is, to a newer viewer, exactly "a database Alembic owns that is
+missing tables the current ORM declares". Building that shape by dropping real
+tables reproduces it without pinning the test to whichever tables the next
+migration happens to add, and — unlike a same-version database, where
+``create_all`` is a no-op anyway — it gives the assertion something real to
+catch. ``test_removing_the_guard_puts_the_tables_back`` is the positive control:
+it defeats the guard and watches those same assertions go red.
+
+Which of these can go red
+-------------------------
+Deleting the guard line from ``src/db/base.py`` fails
+``test_alembic_owned_database_gains_nothing``,
+``test_pre_alembic_database_gains_nothing``,
+``test_the_viewers_own_startup_path_creates_nothing`` and both
+``test_repeated_starts_stay_a_no_op`` cases — measured, 5 failures. The other
+three are meant to survive it: the two fresh-database tests assert the fallback
+still works, which the guard does not change, and the alembic_version test
+guards a second invariant (nothing here ever stamps) that ``create_all`` was
+never going to break on its own.
+"""
+
+import os
+import sqlite3
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import sqlalchemy as sa
+
+from src.db.base import DatabaseManager, close_database, init_database
+from src.db.models import Base
+
+# Stand-ins for "a table the newer ORM declares and this file does not have".
+# Both are leaf tables (nothing references them), and both are asserted to
+# still exist in models.py before use, so a rename fails loudly here instead of
+# quietly turning this file into a test of nothing.
+MISSING_IN_OLD_DB = ("push_subscriptions", "viewer_sessions")
+
+# A revision well below head: the point is only that alembic_version is present
+# and untouched, never which revision it names.
+OLD_REVISION = "018"
+
+
+def snapshot_schema(db_path: Path) -> list[tuple[str, str, str | None]]:
+    """Every schema object SQLite knows about, read without SQLAlchemy.
+
+    Indexes and triggers are included deliberately: create_all makes those too,
+    and a gate that only counted tables would miss them.
+    """
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        return conn.execute(
+            "SELECT type, name, sql FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name"
+        ).fetchall()
+    finally:
+        conn.close()
+
+
+def table_names(db_path: Path) -> set[str]:
+    """Just the table names, for readable assertions."""
+    return {name for kind, name, _ in snapshot_schema(db_path) if kind == "table"}
+
+
+def build_old_database(db_path: Path, *, stamped: bool) -> None:
+    """Write a database that predates the current ORM.
+
+    ``stamped=True`` gives it an ``alembic_version`` row — every database a
+    recent release has ever started. ``stamped=False`` is the pre-Alembic shape
+    that ``scripts/entrypoint.sh`` stamps by inspecting the schema, which is the
+    read this guard must not disturb.
+    """
+    for table in MISSING_IN_OLD_DB:
+        assert table in Base.metadata.tables, f"{table} is no longer an ORM table — pick another stand-in"
+
+    engine = sa.create_engine(f"sqlite:///{db_path}")
+    try:
+        Base.metadata.create_all(engine)
+        with engine.begin() as conn:
+            for table in MISSING_IN_OLD_DB:
+                conn.execute(sa.text(f"DROP TABLE {table}"))
+            if stamped:
+                conn.execute(sa.text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)"))
+                conn.execute(sa.text("INSERT INTO alembic_version (version_num) VALUES (:rev)"), {"rev": OLD_REVISION})
+    finally:
+        engine.dispose()
+
+    present = table_names(db_path)
+    assert not (present & set(MISSING_IN_OLD_DB)), "fixture failed to remove the newer tables"
+    assert ("alembic_version" in present) is stamped
+
+
+async def open_with_manager(db_path: Path) -> None:
+    """Do exactly what the viewer does on startup, and nothing else."""
+    manager = DatabaseManager(f"sqlite+aiosqlite:///{db_path}")
+    await manager.init()
+    await manager.close()
+
+
+async def test_alembic_owned_database_gains_nothing(tmp_path):
+    """The gate: an 8.0 viewer against a 7.x file creates zero tables."""
+    db_path = tmp_path / "archive.db"
+    build_old_database(db_path, stamped=True)
+
+    before = snapshot_schema(db_path)
+    await open_with_manager(db_path)
+    after = snapshot_schema(db_path)
+
+    assert after == before
+    assert not (table_names(db_path) & set(MISSING_IN_OLD_DB))
+
+
+async def test_alembic_version_is_left_exactly_as_it_was(tmp_path):
+    """The viewer must not stamp, re-stamp or clear the revision either."""
+    db_path = tmp_path / "archive.db"
+    build_old_database(db_path, stamped=True)
+
+    await open_with_manager(db_path)
+
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        assert conn.execute("SELECT version_num FROM alembic_version").fetchall() == [(OLD_REVISION,)]
+    finally:
+        conn.close()
+
+
+async def test_pre_alembic_database_gains_nothing(tmp_path):
+    """A database with tables but no alembic_version is still not ours.
+
+    The entrypoint stamps this shape by inspecting which schema objects exist.
+    A table appearing between that inspection and the upgrade gets it stamped at
+    the wrong revision — the same crash-loop, reached a different way.
+    """
+    db_path = tmp_path / "archive.db"
+    build_old_database(db_path, stamped=False)
+
+    before = snapshot_schema(db_path)
+    await open_with_manager(db_path)
+    after = snapshot_schema(db_path)
+
+    assert after == before
+
+
+async def test_the_viewers_own_startup_path_creates_nothing(tmp_path):
+    """Same assertion through ``init_database()``, which is what the app calls.
+
+    ``src/web/main.py`` builds its manager from the environment via
+    ``init_database()``; testing only ``DatabaseManager`` would leave the real
+    entry point unproven.
+    """
+    db_path = tmp_path / "archive.db"
+    build_old_database(db_path, stamped=True)
+
+    before = snapshot_schema(db_path)
+    with patch.dict(os.environ, {"DB_PATH": str(db_path), "DATABASE_URL": "", "DB_TYPE": "sqlite"}):
+        try:
+            await init_database()
+        finally:
+            await close_database()
+
+    assert snapshot_schema(db_path) == before
+
+
+async def test_a_genuinely_fresh_database_is_still_built(tmp_path):
+    """The reverse check: the fallback this guard narrows must still work.
+
+    A fresh install with no entrypoint — the viewer image, or ``python -m src``
+    — has to be able to provision an empty file, and the whole ORM schema has to
+    land, not part of it.
+    """
+    db_path = tmp_path / "archive.db"
+
+    await open_with_manager(db_path)
+
+    assert table_names(db_path) == set(Base.metadata.tables)
+
+
+async def test_an_empty_file_that_already_exists_is_still_built(tmp_path):
+    """A zero-byte file is fresh too — an empty mount must not read as owned."""
+    db_path = tmp_path / "archive.db"
+    db_path.touch()
+    assert table_names(db_path) == set()
+
+    await open_with_manager(db_path)
+
+    assert table_names(db_path) == set(Base.metadata.tables)
+
+
+async def test_removing_the_guard_puts_the_tables_back(tmp_path):
+    """POSITIVE CONTROL: with the guard gone, the assertions above go red.
+
+    This is the pre-fix body of ``_create_schema_if_absent``. If this test ever
+    passes *and* the tests above also pass, the guard has stopped being what
+    protects the database and something else is masking the bug.
+    """
+
+    def unguarded(sync_conn) -> bool:
+        Base.metadata.create_all(sync_conn, checkfirst=True)
+        return True
+
+    db_path = tmp_path / "archive.db"
+    build_old_database(db_path, stamped=True)
+    before = snapshot_schema(db_path)
+
+    with patch.object(DatabaseManager, "_create_schema_if_absent", staticmethod(unguarded)):
+        await open_with_manager(db_path)
+
+    after = snapshot_schema(db_path)
+    assert after != before, "the guard was not what stopped create_all — this file proves nothing"
+    assert set(MISSING_IN_OLD_DB) <= table_names(db_path)
+
+
+@pytest.mark.parametrize("stamped", [True, False])
+async def test_repeated_starts_stay_a_no_op(tmp_path, stamped):
+    """Restart loops must not accumulate anything either."""
+    db_path = tmp_path / "archive.db"
+    build_old_database(db_path, stamped=stamped)
+
+    before = snapshot_schema(db_path)
+    for _ in range(3):
+        await open_with_manager(db_path)
+
+    assert snapshot_schema(db_path) == before


### PR DESCRIPTION
## The problem

The viewer image ships no `alembic/` and has no entrypoint, so it cannot migrate — but on every SQLite start it ran `create_all(checkfirst=True)` anyway. `docker compose up -d` starts it alongside the backup container that *is* migrating, so the viewer could add whole tables underneath a running migration, or underneath the entrypoint's stamping inspection — the documented crash-loop trap, aimed at what is usually the only copy of someone's Telegram history. Migration 021 survives that because it is fully guarded; the 8.0 key rebuild would not.

## The fix

`create_all` now runs only into a database with **no tables at all** (`_create_schema_if_absent`, check and create on one connection inside `init()`'s transaction). Any table means the database is not the viewer's to build: `alembic_version` says Alembic owns it, and any other table means the stamping ladder is about to read that shape and must not have it move underneath the read. Skipping costs a viewer nothing — `checkfirst=True` only ever added whole missing tables, never a column, so it could never make an older archive readable by a newer viewer anyway.

A side effect worth having: a viewer on a **read-only** mounted archive used to dump a full `CREATE TABLE` DDL warning on every start; it now logs one clean INFO line.

## Verification

- Nine tests in `tests/test_createall_race.py`: an Alembic-owned 7.x archive, a pre-Alembic archive, a genuinely fresh database, an existing zero-byte file, restart loops, `alembic_version` left byte-identical, and the viewer's own `init_database()` path.
- The same assertions were run against a **real image built from `Dockerfile.viewer`** (confirmed it ships no `/app/alembic`) serving a real 7.x archive: 43 schema objects before and after, chat still served.
- Every gate was watched **going red** with the guard deleted — unit level (5 tests fail), real app (43→50 objects), and real image (43→50). A permanent in-suite positive control (`test_removing_the_guard_puts_the_tables_back`) keeps the file falsifiable.
- Full suite with a real PostgreSQL leg: 3018 passed, 0 failed, 0 skipped. ruff check and format clean.

The compose change is a comment documenting why there is deliberately no `depends_on` ordering. No version bump: still 7.33.6.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented viewer startup from modifying existing database schemas managed by migrations.
  * Preserved migration revision information and existing database structures across restarts.
  * Ensured genuinely new or empty databases are initialized correctly.
  * Prevented repeated startups from making unnecessary schema changes.

* **Tests**
  * Added coverage for migration-managed, legacy, fresh, and repeatedly opened databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->