### PR TITLE
fix: never advance the cursor past a message whose skip record failed to persist

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -195,9 +195,12 @@ def retry_on_locked(
 
                     last_exception = e
                     if attempt < max_retries:
+                        # Type name only: the raw exception text can carry the SQL
+                        # statement, bound values, or a connection DSN, and this
+                        # wraps writers whose payloads identify chats.
                         logger.warning(
                             f"Database error on {func.__name__}, attempt {attempt + 1}/{max_retries + 1}. "
-                            f"Retrying in {delay:.2f}s... Error: {e}"
+                            f"Retrying in {delay:.2f}s... Error type: {type(e).__name__}"
                         )
                         await asyncio.sleep(delay)
                         delay = min(delay * backoff_factor, max_delay)

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -523,6 +523,7 @@ class DatabaseAdapter:
 
     # ========== Metadata Operations ==========
 
+    @retry_on_locked()
     async def set_metadata(self, key: str, value: str) -> None:
         """Set a metadata key-value pair."""
         async with self.db_manager.async_session_factory() as session:
@@ -536,6 +537,7 @@ class DatabaseAdapter:
             await session.execute(stmt)
             await session.commit()
 
+    @retry_on_locked()
     async def get_metadata(self, key: str) -> str | None:
         """Get a metadata value by key."""
         async with self.db_manager.async_session_factory() as session:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -1757,8 +1757,11 @@ class TelegramBackup:
             state["given_up_ids"] = {i for i in ids if isinstance(i, int)}
         return state
 
-    async def _save_message_failures(self, chat_id: int, state: dict) -> None:
+    async def _save_message_failures(self, chat_id: int, state: dict) -> bool:
         """Persist one chat's message-failure record. Never raises.
+
+        Returns whether the record actually landed on disk: the give-up branch
+        must not let the cursor pass a message whose record did not.
 
         Only the most recent ``MESSAGE_GIVE_UP_RECORD_LIMIT`` ids are kept (ids
         grow over time, so the highest are the newest); ``given_up_total`` counts
@@ -1778,6 +1781,8 @@ class TelegramBackup:
             )
         except Exception as e:
             logger.debug("Could not persist the message-failure record (%s)", type(e).__name__)
+            return False
+        return True
 
     async def _backup_dialog(self, dialog, is_archived: bool = False) -> int:
         """
@@ -1879,7 +1884,6 @@ class TelegramBackup:
                     # makes it stick: if a previous run gave up here but died before
                     # its checkpoint landed, this message would otherwise start its
                     # count again and the chat would never get past it.
-                    given_up_messages += 1
                     if message.id not in failures["given_up_ids"]:
                         failures["given_up_ids"].add(message.id)
                         failures["given_up_total"] += 1
@@ -1892,10 +1896,18 @@ class TelegramBackup:
                     # window where the process dies having skipped the message
                     # with nothing on disk saying so — the silent skip this
                     # whole mechanism exists to prevent.
-                    await self._save_message_failures(chat_id, failures)
-                    if not cursor_frozen:
-                        running_max_id = max(running_max_id, message.id)
-                        cursor_passed_failure = True
+                    if await self._save_message_failures(chat_id, failures):
+                        given_up_messages += 1
+                        if not cursor_frozen:
+                            running_max_id = max(running_max_id, message.id)
+                            cursor_passed_failure = True
+                    else:
+                        # No record on disk means no give-up: the freeze holds
+                        # for one more run, and the next run whose write lands
+                        # completes it. The message did fail this run too, so
+                        # it belongs in the retried-next-run count.
+                        failed_messages += 1
+                        cursor_frozen = True
                     continue
 
                 failed_messages += 1
@@ -1909,6 +1921,13 @@ class TelegramBackup:
                     await self._save_message_failures(chat_id, failures)
                 continue
 
+            if failures is not None and failures["frozen_id"] == message.id:
+                # The message the cursor was parked behind finally made it, so a
+                # record still naming it would describe a freeze that is over.
+                # Persisted by whichever failure-record write comes next; a run
+                # with none leaves the disk record for the end-of-dialog check.
+                failures["frozen_id"] = 0
+                failures["runs"] = 0
             if not cursor_frozen:
                 running_max_id = max(running_max_id, message.id)
             batch_data.append(msg_data)
@@ -1960,6 +1979,18 @@ class TelegramBackup:
         # (topic-filtered) messages that were never counted in uncheckpointed_count.
         if uncheckpointed_count > 0 or cursor_passed_failure or (grand_total == 0 and running_max_id > last_message_id):
             await self.db.update_sync_status(chat_id, running_max_id, uncheckpointed_count)
+
+        # A frozen_id the cursor has moved past — the message finally processed,
+        # or it no longer exists — describes a freeze that is over and must not
+        # outlive it. A run with a failure refreshed the record above, so this
+        # costs one read only when the cursor made progress without one; a
+        # chat's first sync pays nothing, keeping clean dialogs read-free.
+        if failures is None and last_message_id > 0 and running_max_id > last_message_id:
+            failures = await self._load_message_failures(chat_id)
+            if failures["frozen_id"] and failures["frozen_id"] <= running_max_id:
+                failures["frozen_id"] = 0
+                failures["runs"] = 0
+                await self._save_message_failures(chat_id, failures)
 
         # Sync deletions and edits if enabled (expensive!)
         if self.config.sync_deletions_edits:

--- a/tests/test_cursor_freeze_exit.py
+++ b/tests/test_cursor_freeze_exit.py
@@ -37,6 +37,7 @@ import tempfile
 import unittest
 from unittest.mock import AsyncMock, MagicMock
 
+from src.db.adapter import DatabaseAdapter
 from src.telegram_backup import (
     MESSAGE_GIVE_UP_RECORD_LIMIT,
     MESSAGE_MAX_PROCESS_ATTEMPTS,
@@ -68,6 +69,7 @@ class _FakeDb:
         self.committed: list[int] = []
         self.sync_writes: list[int] = []
         self.metadata_reads: list[str] = []
+        self.set_metadata_failures: list[Exception] = []
 
     async def upsert_chat(self, chat_data):
         return None
@@ -84,6 +86,8 @@ class _FakeDb:
         return self.metadata.get(key)
 
     async def set_metadata(self, key, value):
+        if self.set_metadata_failures:
+            raise self.set_metadata_failures.pop(0)
         self.metadata[key] = value
 
     def failure_record(self, chat_id=CHAT_ID):
@@ -511,3 +515,149 @@ class TestTheRecordSurvivesACrashMidDialog(CursorFreezeExitTestCase):
             self.db.cursor < 3 or 3 in skipped,
             f"cursor {self.db.cursor} moved past message 3 with skipped={skipped}",
         )
+
+
+class TestAGiveUpIsOnlyAsGoodAsItsRecord(CursorFreezeExitTestCase):
+    """The cursor must never pass a message whose give-up record is not on disk.
+
+    The record write is the whole difference between "given up, durably
+    recorded" and the silent skip this mechanism exists to prevent. So a failed
+    write means the give-up did not happen: the freeze holds for one more run,
+    and the next run whose write lands completes the give-up. That converges --
+    at the cost of one extra run, never of an unrecorded skip.
+    """
+
+    def test_a_failed_record_write_keeps_the_freeze_instead_of_skipping(self):
+        self.available = list(range(1, 11))
+        self.poison_ids = {5}
+
+        self._run_backup()  # run 1: freeze behind 5
+        record_after_freeze = self.db.failure_record()
+
+        self.db.set_metadata_failures = [RuntimeError("metadata write failed")]
+        self._run_backup()  # run 2: gives up on 5, but the record write fails
+
+        self.assertEqual(self.db.cursor, 4, "cursor passed a message with no record of the skip")
+        self.assertNotIn(5, self.db.committed)
+        self.assertEqual(self.db.failure_record(), record_after_freeze)
+
+        self._run_backup()  # run 3: the write works again, the give-up lands
+
+        self.assertEqual(self.db.cursor, 10)
+        record = self.db.failure_record()
+        self.assertEqual(record["given_up_ids"], [5])
+        self.assertEqual(record["given_up_total"], 1)
+        self.assertNotIn(5, self.db.committed)
+
+    def test_a_failed_record_write_is_not_reported_as_a_recorded_skip(self):
+        """The warning must describe what actually happened: a held freeze.
+
+        "their ids are kept in the backup metadata" would be false for a
+        message whose record write just failed, and "passed over" would be
+        false for a cursor that stayed put.
+        """
+        self.available = [1, 2, 3]
+        self.poison_ids = {3}
+
+        self._run_backup()  # freeze behind 3
+        self.db.set_metadata_failures = [RuntimeError("metadata write failed")]
+
+        backup = self._make_backup()
+        with self.assertLogs("src.telegram_backup", level="WARNING") as cm:
+            _run(backup._backup_dialog(MagicMock()))
+
+        messages = [r.getMessage() for r in cm.records]
+        self.assertEqual([m for m in messages if "passed over" in m], [])
+        self.assertEqual(len([m for m in messages if "could not be processed" in m]), 1)
+
+
+class TestALockedDatabaseIsRetriedNotGivenUpOn(CursorFreezeExitTestCase):
+    """'database is locked' is transient contention, not a broken database.
+
+    The listener writes the same SQLite file concurrently, so the realistic
+    failure of the record write is a lock the other process is about to
+    release. The adapter's metadata methods retry it exactly as
+    ``update_sync_status`` does, and the give-up completes durably.
+    """
+
+    def test_the_record_write_retries_through_transient_lock_contention(self):
+        self.available = list(range(1, 11))
+        self.poison_ids = {5}
+
+        self._run_backup()  # run 1: freeze behind 5
+
+        # The REAL adapter's set_metadata, over a session whose first two
+        # writes find the database locked; later ones land in the shared
+        # fake store, so the whole give-up flow sees what actually persisted.
+        db_manager = MagicMock()
+        db_manager._is_sqlite = True
+        session = AsyncMock()
+        lock_errors = [Exception("database is locked"), Exception("database is locked")]
+
+        async def execute(stmt, *args, **kwargs):
+            if lock_errors:
+                raise lock_errors.pop(0)
+            params = stmt.compile().params
+            self.db.metadata[params["key"]] = params["value"]
+            return MagicMock()
+
+        session.execute = AsyncMock(side_effect=execute)
+        ctx = AsyncMock()
+        ctx.__aenter__ = AsyncMock(return_value=session)
+        ctx.__aexit__ = AsyncMock(return_value=False)
+        db_manager.async_session_factory.return_value = ctx
+        self.db.set_metadata = DatabaseAdapter(db_manager).set_metadata
+
+        self._run_backup()  # run 2: the give-up completes despite the lock
+
+        self.assertEqual(lock_errors, [], "both transient lock errors should have been absorbed")
+        self.assertEqual(self.db.cursor, 10)
+        record = self.db.failure_record()
+        self.assertEqual(record["given_up_ids"], [5])
+        self.assertEqual(record["given_up_total"], 1)
+
+
+class TestTheFrozenHalfDoesNotOutliveTheFreeze(CursorFreezeExitTestCase):
+    """frozen_id/runs describe the message the cursor is parked behind.
+
+    Once the cursor has moved past that id -- the message finally processed,
+    or no longer exists -- a record still naming it claims a freeze that is
+    over. The frozen half must be dropped; the give-up half is a permanent log
+    and stays.
+    """
+
+    def test_the_frozen_half_is_cleared_after_the_message_finally_succeeds(self):
+        self.available = list(range(1, 11))
+        self.poison_ids = {5}
+
+        self._run_backup()  # run 1: freeze behind 5
+        record = self.db.failure_record()
+        self.assertEqual((record["frozen_id"], record["runs"]), (5, 1))
+
+        self.poison_ids = set()  # whatever it was, it cleared
+        self._run_backup()  # run 2: 5 archives and the freeze is over
+
+        self.assertIn(5, self.db.committed)
+        self.assertEqual(self.db.cursor, 10)
+        record = self.db.failure_record()
+        self.assertEqual(record["frozen_id"], 0)
+        self.assertEqual(record["runs"], 0)
+        self.assertEqual(record["given_up_total"], 0)  # a recovery is not a give-up
+
+    def test_the_give_up_half_survives_the_clearing_of_the_frozen_half(self):
+        """The two halves are independent: dropping one must not touch the other."""
+        self.available = list(range(1, 11))
+        self.poison_ids = {3, 5}
+
+        self._run_backup()  # freeze behind 3
+        self._run_backup()  # give up on 3, freeze behind 5
+        self._run_backup()  # give up on 5 too
+        self.poison_ids = set()
+        self._grow_chat(2)  # ids 11, 12
+        self._run_backup()  # a clean run over new messages only
+
+        record = self.db.failure_record()
+        self.assertEqual(record["given_up_ids"], [3, 5])
+        self.assertEqual(record["given_up_total"], 2)
+        self.assertEqual(record["frozen_id"], 0)
+        self.assertEqual(record["runs"], 0)


### PR DESCRIPTION
## The problem

#292 made the backup record every message it gives up on, so the cursor never silently passes an unarchived message. The pre-8.0 re-review found the one crack left in that promise: the record write itself could fail — `set_metadata` has no `database is locked` retry, and the listener writes the same SQLite file concurrently — and the failure was swallowed at debug level while the cursor advanced anyway. The run's WARNING then claimed "their ids are kept in the backup metadata" when nothing had landed. Reproduced end to end before fixing: cursor at 10, message 5 never committed, record still showing the old freeze.

## The fix

- `set_metadata` / `get_metadata` gain `@retry_on_locked()`, mirroring `update_sync_status` — transient lock contention no longer reaches the swallow at all.
- `_save_message_failures` now reports whether the record landed, and the give-up branch advances the cursor **only when it did**. A failed write holds the freeze for one more run, which converges; the accurate "cursor stays behind them" warning covers the held case, and the "ids are kept" warning can now only fire for records that actually landed.
- Housekeeping from the same review: the `frozen_id`/`runs` half of the record is cleared once the frozen message finally succeeds (free in-memory check when the record was already loaded, plus one gated read at dialog end), so it no longer survives forever after recovery. A dedicated guard test pins that this clearing can never touch the give-up half.

## Verification

- Five new tests in `tests/test_cursor_freeze_exit.py`; the four behavioural ones were watched fail against the pre-fix code with exactly the reported symptoms (cursor passed with no record; false WARNING; lock errors reaching the swallow; stale frozen half).
- The lock-retry test drives the real decorated `set_metadata` through two genuine-shaped `database is locked` errors and asserts the give-up landed durably.
- Independent reviewer re-ran the original finding's repro: not reproducible here, still reproducible on unfixed `main` — and the full suite with a real PostgreSQL leg: **3042 passed, 0 failed, 0 skipped**. ruff check and format clean.

No version bump: still 7.33.6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when message-failure records cannot be saved.
  * Prevented cursor progress until skipped-message records are successfully persisted.
  * Added automatic retry handling for temporary database locks.
  * Cleared stale frozen-message states after successful recovery.
  * Improved warnings to distinguish held failures from recorded skips.
  * Ensured failed message handling can resume safely on a later run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->