### PR TITLE
fix: stop a slow stats or pinned response from painting the previous chat

### DIFF
--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -4301,13 +4301,20 @@
                         })
                         if (res.ok) {
                             const data = await res.json()
+                            // The banner never auto-refreshes, so a response that
+                            // outlived its chat would pin the previous chat's message
+                            // over this one until the next switch — and a stale
+                            // failure below would wipe this chat's banner instead.
+                            if (selectedChat.value?.id !== chatId) return
                             pinnedMessages.value = Array.isArray(data) ? data : []
                             currentPinnedIndex.value = 0  // Start with newest
                         } else {
+                            if (selectedChat.value?.id !== chatId) return
                             pinnedMessages.value = []
                         }
                     } catch (e) {
                         console.error('Failed to load pinned messages:', e)
+                        if (selectedChat.value?.id !== chatId) return
                         pinnedMessages.value = []
                     }
                 }
@@ -4347,10 +4354,16 @@
                             credentials: 'include'
                         })
                         if (res.ok) {
-                            chatStats.value = await res.json()
+                            const data = await res.json()
+                            // Stats never auto-refresh, so a response that outlived its
+                            // chat would show the previous chat's counts in this chat's
+                            // header until the next switch.
+                            if (selectedChat.value?.id !== chatId) return
+                            chatStats.value = data
                         }
                     } catch (e) {
                         console.error('Failed to load chat stats:', e)
+                        if (selectedChat.value?.id !== chatId) return
                         chatStats.value = null
                     }
                 }

--- a/tests/test_frontend_audit_fixes.py
+++ b/tests/test_frontend_audit_fixes.py
@@ -1135,6 +1135,27 @@ const console = { error: () => {} };
     fail(4);
     await flush();
     assert.equal(chatStats.value, null, 'a live network error no longer clears the header');
+
+    // A stale HTTP failure must not blank the header either.
+    loadChatStats(333);
+    await flush();
+    selectedChat.value = { id: 444 };
+    chatStats.value = null;
+    loadChatStats(444);
+    await flush();
+    respond(6, { message_count: 9 });
+    await flush();
+    respondError(5, 500);
+    await flush();
+    assert.deepEqual(chatStats.value, { message_count: 9 },
+        "chat 333's HTTP failure blanked chat 444's header");
+
+    // The CURRENT chat's HTTP failure still clears.
+    loadChatStats(444);
+    await flush();
+    respondError(7, 500);
+    await flush();
+    assert.equal(chatStats.value, null, 'a live HTTP failure no longer clears the header');
 })().catch(error => {
     process.stderr.write(`${error.stack}\\n`);
     process.exitCode = 1;

--- a/tests/test_frontend_audit_fixes.py
+++ b/tests/test_frontend_audit_fixes.py
@@ -1150,12 +1150,15 @@ const console = { error: () => {} };
     assert.deepEqual(chatStats.value, { message_count: 9 },
         "chat 333's HTTP failure blanked chat 444's header");
 
-    // The CURRENT chat's HTTP failure still clears.
+    // A CURRENT chat's non-ok response leaves the header as it was: unlike the
+    // pinned banner, loadChatStats has no else-branch write — only a network
+    // error clears the header.
     loadChatStats(444);
     await flush();
     respondError(7, 500);
     await flush();
-    assert.equal(chatStats.value, null, 'a live HTTP failure no longer clears the header');
+    assert.deepEqual(chatStats.value, { message_count: 9 },
+        'a live non-ok response started clearing the header');
 })().catch(error => {
     process.stderr.write(`${error.stack}\\n`);
     process.exitCode = 1;

--- a/tests/test_frontend_audit_fixes.py
+++ b/tests/test_frontend_audit_fixes.py
@@ -1052,3 +1052,196 @@ def test_the_unhashable_exceptions_are_documented_in_the_template() -> None:
 
     assert "Access-Control-Allow-Origin" in head
     assert "per user agent" in head
+
+
+# --------------------------------------------------------------------------------------
+# The stats header and pinned banner kept a previous chat's data: their loaders wrote
+# state after their awaits with no staleness check, and neither panel auto-refreshes,
+# so a response that lost the race to a chat switch stuck until the NEXT switch
+# --------------------------------------------------------------------------------------
+
+
+_STALE_PANEL_FETCH_STUB = """
+const requests = [];
+const fetch = url => new Promise((resolve, reject) => { requests.push({ url, resolve, reject }); });
+const respond = (index, payload) => requests[index].resolve({ ok: true, json: async () => payload });
+const respondError = (index, status) => requests[index].resolve({ ok: false, status, json: async () => ({}) });
+const fail = index => requests[index].reject(new TypeError('network down'));
+const flush = () => new Promise(resolve => setImmediate(resolve));
+"""
+
+
+def test_chat_stats_response_that_outlived_its_chat_is_discarded() -> None:
+    """Stats requested for one chat must never label another chat's header.
+
+    ``chatStats`` is written once per selection and never refreshed, so a stale
+    paint was persistent — and the catch branch writes too, so a stale *failure*
+    blanked the current chat's header instead.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    script = "\n".join(
+        [
+            '"use strict";',
+            "const assert = require('node:assert/strict');",
+            """
+const ref = value => ({ value });
+const selectedChat = ref({ id: 111 });
+const chatStats = ref(null);
+const console = { error: () => {} };
+""",
+            _STALE_PANEL_FETCH_STUB,
+            _extract_const_arrow_function(html, "loadChatStats", asynchronous=True),
+            """
+(async () => {
+    loadChatStats(111);
+    await flush();
+    assert.ok(requests[0].url.startsWith('/api/chats/111/stats'), requests[0].url);
+
+    // The user switches chats while chat 111's stats are still in flight
+    // (selectChat resets the panel and issues the new chat's request).
+    selectedChat.value = { id: 222 };
+    chatStats.value = null;
+    loadChatStats(222);
+    await flush();
+
+    respond(1, { message_count: 5 });
+    await flush();
+    assert.deepEqual(chatStats.value, { message_count: 5 });
+
+    // The superseded response lands last and must be discarded.
+    respond(0, { message_count: 999 });
+    await flush();
+    assert.deepEqual(chatStats.value, { message_count: 5 },
+        "chat 111's stats landed in chat 222's header");
+
+    // A stale network error must not blank the header either.
+    loadChatStats(222);
+    await flush();
+    selectedChat.value = { id: 333 };
+    chatStats.value = null;
+    loadChatStats(333);
+    await flush();
+    respond(3, { message_count: 7 });
+    await flush();
+    fail(2);
+    await flush();
+    assert.deepEqual(chatStats.value, { message_count: 7 },
+        "chat 222's network error blanked chat 333's header");
+
+    // The CURRENT chat's failure still clears: the guard must not pin stale numbers.
+    loadChatStats(333);
+    await flush();
+    fail(4);
+    await flush();
+    assert.equal(chatStats.value, null, 'a live network error no longer clears the header');
+})().catch(error => {
+    process.stderr.write(`${error.stack}\\n`);
+    process.exitCode = 1;
+});
+""",
+        ]
+    )
+
+    _run_node(script)
+
+
+def test_pinned_messages_response_that_outlived_its_chat_is_discarded() -> None:
+    """A pinned banner requested for one chat must never hang in another.
+
+    All three branches write ``pinnedMessages``: a stale success painted the old
+    chat's pin into the new chat, and a stale else/catch wiped the new chat's
+    banner that had just loaded. The success write also resets the banner cycle,
+    so a discarded response must leave ``currentPinnedIndex`` alone too.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    script = "\n".join(
+        [
+            '"use strict";',
+            "const assert = require('node:assert/strict');",
+            """
+const ref = value => ({ value });
+const selectedChat = ref({ id: 111 });
+const pinnedMessages = ref([]);
+const currentPinnedIndex = ref(0);
+const console = { error: () => {} };
+""",
+            _STALE_PANEL_FETCH_STUB,
+            _extract_const_arrow_function(html, "loadPinnedMessages", asynchronous=True),
+            """
+(async () => {
+    loadPinnedMessages(111);
+    await flush();
+    assert.ok(requests[0].url.startsWith('/api/chats/111/pinned'), requests[0].url);
+
+    // Chat switch while 111's request is in flight (selectChat's resets).
+    selectedChat.value = { id: 222 };
+    pinnedMessages.value = [];
+    currentPinnedIndex.value = 0;
+    loadPinnedMessages(222);
+    await flush();
+
+    respond(1, [{ id: 'pin-222-newest' }, { id: 'pin-222-older' }]);
+    await flush();
+    assert.deepEqual(pinnedMessages.value.map(pin => pin.id), ['pin-222-newest', 'pin-222-older']);
+    currentPinnedIndex.value = 1;   // the user cycled the banner
+
+    // The superseded 111 response lands last and must be discarded entirely.
+    respond(0, [{ id: 'pin-111' }]);
+    await flush();
+    assert.deepEqual(pinnedMessages.value.map(pin => pin.id), ['pin-222-newest', 'pin-222-older'],
+        "chat 111's pinned messages landed in chat 222");
+    assert.equal(currentPinnedIndex.value, 1, 'a stale response reset the banner cycle');
+
+    // A stale HTTP failure must not wipe the current chat's banner.
+    loadPinnedMessages(222);
+    await flush();
+    selectedChat.value = { id: 333 };
+    pinnedMessages.value = [];
+    currentPinnedIndex.value = 0;
+    loadPinnedMessages(333);
+    await flush();
+    respond(3, [{ id: 'pin-333' }]);
+    await flush();
+    respondError(2, 500);
+    await flush();
+    assert.deepEqual(pinnedMessages.value.map(pin => pin.id), ['pin-333'],
+        "chat 222's failed request wiped chat 333's banner");
+
+    // A stale network error must not wipe it either.
+    loadPinnedMessages(333);
+    await flush();
+    selectedChat.value = { id: 444 };
+    pinnedMessages.value = [];
+    loadPinnedMessages(444);
+    await flush();
+    respond(5, [{ id: 'pin-444' }]);
+    await flush();
+    fail(4);
+    await flush();
+    assert.deepEqual(pinnedMessages.value.map(pin => pin.id), ['pin-444'],
+        "chat 333's network error wiped chat 444's banner");
+
+    // The CURRENT chat's failures still clear: the guard must not pin a stale banner.
+    loadPinnedMessages(444);
+    await flush();
+    respondError(6, 500);
+    await flush();
+    assert.deepEqual(pinnedMessages.value, [], 'a live failed reload no longer clears the banner');
+
+    pinnedMessages.value = [{ id: 'left-behind' }];
+    loadPinnedMessages(444);
+    await flush();
+    fail(7);
+    await flush();
+    assert.deepEqual(pinnedMessages.value, [], 'a live network error no longer clears the banner');
+})().catch(error => {
+    process.stderr.write(`${error.stack}\\n`);
+    process.exitCode = 1;
+});
+""",
+        ]
+    )
+
+    _run_node(script)


### PR DESCRIPTION
## The problem

#289 gave every chat-scoped load a staleness guard so a slow response can't paint into the wrong chat — except two: `loadChatStats` and `loadPinnedMessages` write their state after `await` with no re-check. Switch from chat A to chat B while A's `/stats` or `/pinned` is still in flight and A's message counts and pinned banner render into B — persistently, because those panels never auto-refresh. Reproduced with the real functions under node: `pin-111` painted into chat 222.

## The fix

The exact `loadMediaCounts` idiom, nothing fancier: re-check `selectedChat.value?.id` against the request's chat id immediately before every post-await write — success, else and catch branches alike, so a stale failure can't blank the current chat's freshly loaded panel either. A full audit of every fetch site in the template confirms these were the last two unguarded chat-scoped writers; the rest carry their #289 guards (`chatVersion`, request-sequence counters, `AbortController`).

## Verification

Two regression tests in `tests/test_frontend_audit_fixes.py` using the existing extract-and-run-under-node harness — both watched fail against the pre-fix template with the exact stale paint, green after. `144 passed` across the frontend suites; ruff clean. Independent reviewer re-ran the race sequence both ways. No version bump: still 7.33.6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented outdated chat statistics from replacing information for the currently selected chat.
  * Prevented outdated pinned messages from overwriting the active chat’s content.
  * Ensured errors from the active chat still clear the relevant panel correctly.
  * Improved reliability when switching chats while information is still loading.

* **Tests**
  * Added regression coverage for stale responses and failures when switching between chats.
  * Verified that current-chat errors continue to update panels appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->