### PR TITLE
fix: harden migration 021 - audit indexes, fail-closed token backfill, crash-loop guard

### DIFF
--- a/alembic/versions/20260815_021_align_schema_with_orm.py
+++ b/alembic/versions/20260815_021_align_schema_with_orm.py
@@ -14,7 +14,15 @@ What it changes, and why each is safe:
   migrations never said so, so a PostgreSQL install accepted NULLs that the
   SQLite install of the same version rejected. Every column is backfilled with
   the ORM's own default *before* it is tightened, so a database holding NULLs
-  converges instead of crash-looping on ``SET NOT NULL``.
+  converges instead of crash-looping on ``SET NOT NULL``. The one fill that is
+  not the ORM default is ``viewer_tokens.is_revoked``, filled with ``1``: the
+  token validator only reads rows with ``is_revoked = 0``, so a NULL there was
+  an unusable token, and a token in an unknown state must stay unusable. It is
+  alone in that. The only other backfilled gate, ``no_download``, is read for
+  Python truthiness, where NULL and ``0`` are the same answer; the remaining
+  fills are timestamps, cursors and display flags whose worst case is redoing
+  idempotent work (a zeroed ``media.downloaded`` becomes a download candidate
+  again).
 * **Server defaults.** ``created_at``/``updated_at`` gain the ``func.now()``
   default the ORM declares. ``messages.is_pinned``/``is_outgoing`` and
   ``media.downloaded`` lose the literal ``0`` the ORM does not declare (their
@@ -37,20 +45,31 @@ What it changes, and why each is safe:
   forever. It is dropped ONLY when empty: on a database that really did upgrade
   through v6.0.0 with legacy media rows it still holds the pre-normalization
   pointers, and this migration will not delete those.
+* **``idx_audit_log_username`` / ``idx_audit_log_created``.** Migration 007
+  creates them, but a 7.x SQLite install provisioned by ``create_all`` was
+  stamped past 007 before models.py declared these indexes, so its
+  ``viewer_audit_log`` was born unindexed and nothing later in the chain or in
+  the app would ever index it — the admin audit page full-scans a table that
+  grows with every login. Created here when absent, on both backends.
 
 Idempotency: every step reads the live schema first and does nothing when the
 object is already in its target shape, so this runs clean against a database
 provisioned by ``create_all`` (where most of it is already true), against one
 built by this chain, and against a re-run of itself.
 
-One difference is deliberately left alone. A SQLite database created by the
-``create_all`` of a release before this one carries the reactions -> users
-foreign key unnamed, because models.py only started naming it
-``fk_reactions_user`` here. SQLite never enforces that constraint (nothing in
-this project sets ``PRAGMA foreign_keys=ON``) and never exposes its name, so
-relabelling it would mean rebuilding a table of the user's data for a label
-nothing can observe. Every freshly built schema on either backend agrees, which
-is what the parity gate checks.
+Two leftovers are deliberate. A SQLite database created by the ``create_all``
+of a release before this one carries the reactions -> users foreign key
+unnamed, because models.py only started naming it ``fk_reactions_user`` here.
+SQLite never enforces that constraint (nothing in this project sets ``PRAGMA
+foreign_keys=ON``) and never exposes its name, so relabelling it would mean
+rebuilding a table of the user's data for a label nothing can observe. Every
+freshly built schema on either backend agrees, which is what the parity gate
+checks. The same ``create_all`` databases may also keep reaction rows whose
+message is gone: the orphan delete runs only where ``fk_reaction_message`` has
+to be added, because there it is the difference between the ADD succeeding and
+failing. Where the constraint already exists it has sat unenforced since
+``create_all`` built it, and rows of the user's data are not deleted for a
+constraint nothing checks.
 
 Revision ID: 021
 Revises: 020
@@ -104,7 +123,9 @@ NOT_NULL_COLUMNS: dict[str, dict[str, str]] = {
     "viewer_sessions": {"no_download": "0"},
     "viewer_tokens": {
         "created_at": "now",
-        "is_revoked": "0",
+        # 1, not the ORM default 0: the validator matches is_revoked = 0 only,
+        # so a NULL was a dead token and must not come back to life here.
+        "is_revoked": "1",
         "no_download": "0",
         "use_count": "0",
     },
@@ -239,6 +260,22 @@ def _drop_empty_backup_table(conn: sa.Connection, inspector: sa.Inspector) -> No
     op.drop_table(BACKUP_TABLE)
 
 
+def _create_missing_audit_indexes(inspector: sa.Inspector) -> None:
+    """Create viewer_audit_log's two indexes wherever migration 007 never ran.
+
+    A 7.x SQLite install provisioned by ``create_all`` was stamped past 007
+    before models.py declared these indexes, so its audit table has none and
+    nothing later in the chain or in the app would ever add them.
+    """
+    if "viewer_audit_log" not in inspector.get_table_names():
+        return
+    existing = {index["name"] for index in inspector.get_indexes("viewer_audit_log")}
+    if "idx_audit_log_username" not in existing:
+        op.create_index("idx_audit_log_username", "viewer_audit_log", ["username"])
+    if "idx_audit_log_created" not in existing:
+        op.create_index("idx_audit_log_created", "viewer_audit_log", ["created_at"])
+
+
 # ---------------------------------------------------------------------------
 # PostgreSQL
 # ---------------------------------------------------------------------------
@@ -297,6 +334,7 @@ def _upgrade_postgresql(conn: sa.Connection) -> None:
             ["id", "chat_id"],
         )
 
+    _create_missing_audit_indexes(sa.inspect(conn))
     _drop_empty_backup_table(conn, sa.inspect(conn))
 
 
@@ -408,6 +446,10 @@ def _upgrade_sqlite(conn: sa.Connection) -> None:
         if table == "media":
             batch_kwargs["copy_from"] = _sqlite_media_copy_from(conn)
 
+        # pysqlite autocommits DDL, so a crash mid-rebuild can strand the batch
+        # copy's temporary table on disk — and its mere existence fails every
+        # later rebuild of the same table with "already exists".
+        conn.exec_driver_sql(f'DROP TABLE IF EXISTS "_alembic_tmp_{table}"')
         conn.exec_driver_sql("PRAGMA legacy_alter_table=ON")
         try:
             with op.batch_alter_table(table, **batch_kwargs) as batch_op:
@@ -444,6 +486,9 @@ def _upgrade_sqlite(conn: sa.Connection) -> None:
 
         inspector = sa.inspect(conn)
 
+    # After the rebuilds: a rebuilt viewer_audit_log recreates only the indexes
+    # reflection saw, which on a 7.x create_all database is none.
+    _create_missing_audit_indexes(sa.inspect(conn))
     _drop_empty_backup_table(conn, sa.inspect(conn))
 
 
@@ -483,6 +528,8 @@ def downgrade() -> None:
         targets = [column for column in sorted(columns) if column in present and not present[column]["nullable"]]
         if not targets:
             continue
+        # Same stranded-temporary-table hazard as the upgrade's rebuild loop.
+        conn.exec_driver_sql(f'DROP TABLE IF EXISTS "_alembic_tmp_{table}"')
         conn.exec_driver_sql("PRAGMA legacy_alter_table=ON")
         try:
             with op.batch_alter_table(table) as batch_op:

--- a/tests/test_migration_021_hardening.py
+++ b/tests/test_migration_021_hardening.py
@@ -1,0 +1,323 @@
+"""Migration 021 against the install shapes that only exist in the field.
+
+The parity gate (tests/test_schema_parity.py) compares freshly built schemas,
+so it cannot see what 021 does to a database that arrived in a shape no fresh
+build produces. Each test here manufactures one of those shapes and runs the
+real migration chain over it:
+
+* a 7.x SQLite archive provisioned by ``create_all`` was stamped past
+  migration 007 before models.py declared the ``viewer_audit_log`` indexes,
+  so 021 has to create ``idx_audit_log_username``/``idx_audit_log_created``
+  itself — on both backends;
+* a ``viewer_tokens`` row holding NULL ``is_revoked`` never matched the
+  validator's ``is_revoked = 0`` filter, so it was a dead token; the NOT NULL
+  backfill must keep it dead (fill 1), not resurrect it;
+* a crash during an earlier SQLite table rebuild can strand the batch copy's
+  ``_alembic_tmp_<table>`` table (pysqlite autocommits DDL); 021 must clear
+  it instead of failing "already exists" on every restart forever;
+* a re-run of 021 over an already-aligned schema must change nothing.
+
+Deliberately synchronous throughout: Alembic's env.py calls ``asyncio.run()``,
+which cannot be nested inside a running loop.
+"""
+
+import asyncio
+import hashlib
+import os
+import secrets
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+import sqlalchemy as sa
+from alembic.config import Config
+
+from alembic import command
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Base
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ALEMBIC_DIR = REPO_ROOT / "alembic"
+
+AUDIT_INDEXES = ("idx_audit_log_username", "idx_audit_log_created")
+
+
+# ---------------------------------------------------------------------------
+# Harness
+# ---------------------------------------------------------------------------
+
+
+def _run_alembic(async_url: str, action: str, target: str) -> None:
+    """Run ``alembic <stamp|upgrade> <target>`` against ``async_url``.
+
+    Mirrors tests/test_schema_parity.py: a ``Config`` with no ini file keeps
+    env.py from reconfiguring pytest's logging, and env.py reads the URL from
+    ``DATABASE_URL``.
+    """
+    config = Config()
+    config.set_main_option("script_location", str(ALEMBIC_DIR))
+    config.set_main_option("sqlalchemy.url", async_url)
+
+    previous = os.environ.get("DATABASE_URL")
+    os.environ["DATABASE_URL"] = async_url
+    try:
+        if action == "stamp":
+            command.stamp(config, target)
+        else:
+            command.upgrade(config, target)
+    finally:
+        if previous is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = previous
+
+
+def _build_seven_x_audit_shape(sync_url: str) -> None:
+    """``create_all`` at head models, minus the two audit indexes.
+
+    That is the shape a 7.x ``create_all`` install is really in: the same
+    tables, but ViewerAuditLog predates the ``Index()`` declarations, so the
+    audit table was born unindexed.
+    """
+    engine = sa.create_engine(sync_url)
+    try:
+        Base.metadata.create_all(engine)
+        with engine.begin() as conn:
+            for name in AUDIT_INDEXES:
+                conn.execute(sa.text(f"DROP INDEX {name}"))
+    finally:
+        engine.dispose()
+
+
+def _audit_index_names(sync_url: str) -> set[str]:
+    engine = sa.create_engine(sync_url)
+    try:
+        return {index["name"] for index in sa.inspect(engine).get_indexes("viewer_audit_log")}
+    finally:
+        engine.dispose()
+
+
+def _hash_token(plaintext: str, salt: str) -> str:
+    """Exactly the share-token hash the web layer stores (src/web/main.py)."""
+    return hashlib.pbkdf2_hmac("sha256", plaintext.encode(), bytes.fromhex(salt), 600_000).hex()
+
+
+def _seed_tokens_at_020(sync_url: str) -> tuple[str, str]:
+    """Insert a NULL-``is_revoked`` token and a live one; return their plaintexts.
+
+    NULL is unreachable through the app (model and migration 010 both default
+    the column to 0), so it is planted the way it happens in the field: a raw
+    UPDATE-style edit outside the application.
+    """
+    plaintexts = (secrets.token_hex(32), secrets.token_hex(32))
+    engine = sa.create_engine(sync_url)
+    try:
+        with engine.begin() as conn:
+            for plaintext, revoked in zip(plaintexts, (None, 0), strict=True):
+                salt = secrets.token_hex(16)
+                conn.execute(
+                    sa.text(
+                        "INSERT INTO viewer_tokens"
+                        " (label, token_hash, token_salt, created_by, allowed_chat_ids, is_revoked)"
+                        " VALUES ('synthetic', :token_hash, :salt, 'admin', '[]', :revoked)"
+                    ),
+                    {"token_hash": _hash_token(plaintext, salt), "salt": salt, "revoked": revoked},
+                )
+    finally:
+        engine.dispose()
+    return plaintexts
+
+
+def _verify_token(async_url: str, plaintext: str) -> dict[str, Any] | None:
+    """Run the real validator stack (manager -> adapter) against the database."""
+
+    async def check() -> dict[str, Any] | None:
+        manager = DatabaseManager(async_url)
+        await manager.init()
+        try:
+            return await DatabaseAdapter(manager).verify_viewer_token(plaintext)
+        finally:
+            await manager.close()
+
+    return asyncio.run(check())
+
+
+def _raw_is_revoked(sync_url: str) -> list[int | None]:
+    engine = sa.create_engine(sync_url)
+    try:
+        with engine.connect() as conn:
+            return list(conn.execute(sa.text("SELECT is_revoked FROM viewer_tokens ORDER BY id")).scalars())
+    finally:
+        engine.dispose()
+
+
+def _sqlite_schema(sync_url: str) -> list[tuple[str, str, str | None]]:
+    """Every DDL statement in the database, as one comparable snapshot."""
+    engine = sa.create_engine(sync_url)
+    try:
+        with engine.connect() as conn:
+            rows = conn.execute(
+                sa.text("SELECT type, name, sql FROM sqlite_master WHERE name NOT LIKE 'sqlite_%' ORDER BY type, name")
+            )
+            return [tuple(row) for row in rows]
+    finally:
+        engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# (a) audit indexes for the create_all-provisioned 7.x population
+# ---------------------------------------------------------------------------
+
+
+def test_021_creates_missing_audit_indexes_on_sqlite(tmp_path):
+    """A 7.x create_all archive stamped at 018 must come out of head indexed."""
+    db = tmp_path / "archive.db"
+    sync_url, async_url = f"sqlite:///{db}", f"sqlite+aiosqlite:///{db}"
+
+    _build_seven_x_audit_shape(sync_url)
+    assert _audit_index_names(sync_url).isdisjoint(AUDIT_INDEXES)  # premise: really unindexed
+
+    _run_alembic(async_url, "stamp", "018")
+    _run_alembic(async_url, "upgrade", "head")
+
+    assert _audit_index_names(sync_url) >= set(AUDIT_INDEXES)
+
+
+def test_021_creates_missing_audit_indexes_on_postgresql(require_postgres, make_postgres_database):
+    """Same repair on PostgreSQL, and a re-run over its own work stays clean."""
+    async_url, sync_url = make_postgres_database("telegram_archive_mig021_idx")
+
+    _build_seven_x_audit_shape(sync_url)
+    assert _audit_index_names(sync_url).isdisjoint(AUDIT_INDEXES)
+
+    _run_alembic(async_url, "stamp", "018")
+    _run_alembic(async_url, "upgrade", "head")
+    assert _audit_index_names(sync_url) >= set(AUDIT_INDEXES)
+
+    _run_alembic(async_url, "stamp", "020")  # make 021 execute a second time
+    _run_alembic(async_url, "upgrade", "head")
+    assert _audit_index_names(sync_url) >= set(AUDIT_INDEXES)
+
+
+# ---------------------------------------------------------------------------
+# (b) NULL is_revoked must stay dead through the NOT NULL backfill
+# ---------------------------------------------------------------------------
+
+
+def test_null_is_revoked_stays_dead_through_021_on_sqlite(tmp_path):
+    db = tmp_path / "archive.db"
+    sync_url, async_url = f"sqlite:///{db}", f"sqlite+aiosqlite:///{db}"
+
+    _run_alembic(async_url, "upgrade", "020")  # migration-built: is_revoked still nullable
+    tampered, control = _seed_tokens_at_020(sync_url)
+    assert _verify_token(async_url, tampered) is None  # premise: NULL never matched the filter
+
+    _run_alembic(async_url, "upgrade", "head")
+
+    assert _raw_is_revoked(sync_url) == [1, 0]
+    assert _verify_token(async_url, tampered) is None
+    assert _verify_token(async_url, control) is not None  # the gate itself still opens
+
+
+def test_null_is_revoked_stays_dead_through_021_on_postgresql(require_postgres, make_postgres_database):
+    async_url, sync_url = make_postgres_database("telegram_archive_mig021_revoked")
+
+    _run_alembic(async_url, "upgrade", "020")
+    tampered, control = _seed_tokens_at_020(sync_url)
+    assert _verify_token(async_url, tampered) is None
+
+    _run_alembic(async_url, "upgrade", "head")
+
+    assert _raw_is_revoked(sync_url) == [1, 0]
+    assert _verify_token(async_url, tampered) is None
+    assert _verify_token(async_url, control) is not None
+
+
+# ---------------------------------------------------------------------------
+# (c) a stranded _alembic_tmp_<table> must not wedge the upgrade
+# ---------------------------------------------------------------------------
+
+
+def test_stranded_batch_tmp_table_does_not_wedge_the_upgrade(tmp_path):
+    db = tmp_path / "archive.db"
+    sync_url, async_url = f"sqlite:///{db}", f"sqlite+aiosqlite:///{db}"
+
+    engine = sa.create_engine(sync_url)
+    try:
+        Base.metadata.create_all(engine)
+    finally:
+        engine.dispose()
+
+    conn = sqlite3.connect(db)
+    try:
+        # Rebuild media byte-identical except for the FK name: the shape of a
+        # manually repaired table, and the one thing that makes 021 rebuild it.
+        (media_sql,) = conn.execute("SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'media'").fetchone()
+        index_sql = [
+            row[0]
+            for row in conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type = 'index' AND tbl_name = 'media' AND sql IS NOT NULL"
+            )
+        ]
+        needle = next(n for n in ('CONSTRAINT "fk_media_message" ', "CONSTRAINT fk_media_message ") if n in media_sql)
+        conn.execute(
+            "INSERT INTO chats (id, title, type, is_archived, is_forum, last_synced_message_id)"
+            " VALUES (-1, 'synthetic', 'channel', 0, 0, 0)"
+        )
+        conn.execute(
+            "INSERT INTO messages (id, chat_id, date, text, is_outgoing, is_pinned)"
+            " VALUES (10, -1, '2026-01-01 00:00:00', 'synthetic', 0, 0)"
+        )
+        conn.execute(
+            "INSERT INTO media (id, message_id, chat_id, type, file_path, downloaded)"
+            " VALUES ('file-a', 10, -1, 'photo', '/data/media/a.jpg', 1)"
+        )
+        conn.execute("ALTER TABLE media RENAME TO media_old")
+        conn.execute(media_sql.replace(needle, "", 1))
+        conn.execute("INSERT INTO media SELECT * FROM media_old")
+        conn.execute("DROP TABLE media_old")
+        for statement in index_sql:
+            conn.execute(statement)
+        # The strand itself: pysqlite autocommits DDL, so a kill right after
+        # batch mode's CREATE TABLE leaves exactly this table behind.
+        conn.execute("CREATE TABLE _alembic_tmp_media (id TEXT)")
+        conn.commit()
+    finally:
+        conn.close()
+
+    _run_alembic(async_url, "stamp", "020")
+    _run_alembic(async_url, "upgrade", "head")  # must clear the strand, not die on it
+
+    conn = sqlite3.connect(db)
+    try:
+        tables = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+        assert "_alembic_tmp_media" not in tables
+        (rebuilt_sql,) = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'media'"
+        ).fetchone()
+        assert "fk_media_message" in rebuilt_sql  # the rebuild itself still happened
+        assert conn.execute("SELECT COUNT(*) FROM media").fetchone()[0] == 1  # and kept the data
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# (d) re-running 021 over an aligned schema is a no-op
+# ---------------------------------------------------------------------------
+
+
+def test_rerunning_021_over_an_aligned_schema_changes_nothing(tmp_path):
+    db = tmp_path / "archive.db"
+    sync_url, async_url = f"sqlite:///{db}", f"sqlite+aiosqlite:///{db}"
+
+    _build_seven_x_audit_shape(sync_url)
+    _run_alembic(async_url, "stamp", "018")
+    _run_alembic(async_url, "upgrade", "head")
+    aligned = _sqlite_schema(sync_url)
+    assert aligned  # premise: the snapshot really captured a schema
+
+    _run_alembic(async_url, "stamp", "020")  # make 021 execute a second time
+    _run_alembic(async_url, "upgrade", "head")
+
+    assert _sqlite_schema(sync_url) == aligned


### PR DESCRIPTION
## The problem

Three lanes of the pre-8.0 re-review independently converged on gaps in migration 021 — all safe to amend in place because 021 is merged but unreleased (every real user upgrades from ≤7.33.6):

1. **The audit-log indexes never materialize for the most common install.** A create_all-provisioned 7.x SQLite archive upgraded through the shipped entrypoint keeps `viewer_audit_log` unindexed forever — measured 22.3ms vs 3.1ms on the admin audit page at 500k rows — and the parity gate can't see it because it only compares freshly built schemas.
2. **The `is_revoked NULL→0` backfill resurrects dead tokens.** The validator filters `is_revoked == 0`, which excludes NULL — so a NULL token was unusable in 7.x, and backfilling 0 brings it back to life. Security-relevant direction.
3. **Crash atomicity on SQLite was an emergent property of statement order.** If batch DDL ever runs first (a manually repaired database), pysqlite autocommits `CREATE TABLE _alembic_tmp_<t>`; a crash there leaves a poison table that crash-loops every subsequent start, with no cleanup path anywhere.

## The fix

1. Guarded `op.create_index` for `idx_audit_log_username`/`idx_audit_log_created` on both backends, mirroring migration 007's style.
2. The backfill flips to `NULL→1`: a token in unknown state stays dead. Every other backfilled column was re-audited: `no_download` is the only other access gate and is read via Python truthiness where NULL and 0 behave identically; the `Media.downloaded` fill re-queues a formerly invisible row (safe, work-redoing direction) — the docstring now states this precisely instead of a false absolute.
3. `DROP TABLE IF EXISTS "_alembic_tmp_<t>"` before every SQLite batch rebuild, upgrade and downgrade — self-healing against the poison table. The orphan-reaction DELETE was deliberately **not** made unconditional: unguarded it would delete rows on create_all archives, contradicting the documented we-do-not-delete-data-we-are-not-forced-to decision.
4. The docstring now names both deliberate leftovers (the unnamed reactions→users FK, and pre-existing orphan reaction rows on create_all archives).

## Verification

New `tests/test_migration_021_hardening.py`, both backends: index creation, NULL-token stays dead, poison-tmp-table self-heal, and re-run no-op. The three behavioural cases were watched fail against the pre-fix migration — including the exact `table _alembic_tmp_media already exists` crash-loop. `tests/test_schema_parity.py` stays green with an **empty** allow-list on both backends. Independent reviewer re-ran the probes both ways. No version bump: still 7.33.6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved confidence in database upgrades by covering missing audit indexes, revoked-token handling, and cleanup of temporary migration tables.
  * Ensured repeated application of migration 021 remains safe and does not alter already-correct schemas.

* **Tests**
  * Added coverage for migration behavior across SQLite and PostgreSQL, including legacy schemas and interrupted rebuild scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->