### PR TITLE
perf(db): add a pg_trgm GIN index for the viewer's message search

### DIFF
--- a/alembic/versions/20260815_022_add_message_text_trgm_index.py
+++ b/alembic/versions/20260815_022_add_message_text_trgm_index.py
@@ -1,0 +1,91 @@
+"""Add a pg_trgm GIN index on messages.text for the viewer's search (PostgreSQL).
+
+get_messages_paginated / get_all_chats' search filters both use
+``Message.text.ILIKE('%term%')`` (leading wildcard - substring search, not a
+prefix match). A plain B-tree index can't serve that pattern at all, so every
+search was a sequential scan of the whole messages table, with cost growing
+linearly as the archive grows. Verified on a live ~100k-row instance:
+
+    EXPLAIN ANALYZE SELECT id FROM messages WHERE text ILIKE '%test%' LIMIT 20;
+
+    Before: Seq Scan on messages (actual time=4.556..36.063, Rows Removed by
+            Filter: 6080) - Execution Time: 41.764 ms
+    After:  Bitmap Heap Scan on messages using idx_messages_text_trgm
+            (actual time=0.147..0.368) - Execution Time: 0.438 ms
+
+~95x faster on this dataset, and critically the scan cost moves from O(table
+size) to roughly O(matching rows) - a sequential scan degrades linearly as
+more messages are backed up, while the trigram index does not.
+
+The index is created on every dialect (same name/column, so ORM- and
+Alembic-built schemas agree per tests/test_schema_parity.py), but only
+PostgreSQL gets the GIN/pg_trgm treatment that actually makes it useful.
+SQLite has no pg_trgm equivalent, so it gets a plain B-tree there instead -
+harmless, if unused for this particular query pattern, and matches what
+``postgresql_using``/``postgresql_ops`` (dialect-scoped kwargs on the
+models.py Index()) already produce via ``Base.metadata.create_all()``:
+SQLAlchemy silently drops PostgreSQL-only kwargs on every other dialect
+rather than erroring.
+
+No CONCURRENTLY: this project's existing index migrations run inside
+Alembic's normal transactional DDL (see #213/017), so this one does too for
+consistency. On an already-large `messages` table this will briefly hold a
+lock for the duration of the index build - acceptable for the same reason
+prior structural changes to this table were: migrations run once, and this
+one is asymptotically the same cost class as REINDEXing an existing index.
+
+Revision ID: 022
+Revises: 021
+Create Date: 2026-08-15
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "022"
+down_revision: str | None = "021"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+TABLE_NAME = "messages"
+INDEX_NAME = "idx_messages_text_trgm"
+
+
+def _index_exists(inspector: sa.Inspector) -> bool:
+    return INDEX_NAME in {ix["name"] for ix in inspector.get_indexes(TABLE_NAME)}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    dialect = conn.dialect.name
+    is_postgresql = dialect == "postgresql"
+
+    if is_postgresql:
+        conn.execute(sa.text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
+
+    inspector = sa.inspect(conn)
+    # Idempotent: create_all()-provisioned databases may already have the index.
+    if TABLE_NAME in inspector.get_table_names() and not _index_exists(inspector):
+        # Same index name/column on every dialect (matches what models.py's
+        # Index() produces via create_all(), so ORM- and Alembic-built
+        # schemas agree - see tests/test_schema_parity.py). Only PostgreSQL
+        # gets the GIN/pg_trgm treatment that makes it actually fast;
+        # postgresql_using/postgresql_ops are dialect-scoped kwargs that
+        # SQLAlchemy silently drops on every other dialect, producing a
+        # harmless, unused plain B-tree there instead.
+        kwargs = {"postgresql_using": "gin", "postgresql_ops": {"text": "gin_trgm_ops"}} if is_postgresql else {}
+        op.create_index(INDEX_NAME, TABLE_NAME, ["text"], **kwargs)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if TABLE_NAME in inspector.get_table_names() and _index_exists(inspector):
+        op.drop_index(INDEX_NAME, table_name=TABLE_NAME)
+    # pg_trgm extension is left installed on PostgreSQL - it's harmless and
+    # other indexes (e.g. a future chats.title/first_name search index) may
+    # want it too.

--- a/alembic/versions/20260816_023_add_message_text_trgm_index.py
+++ b/alembic/versions/20260816_023_add_message_text_trgm_index.py
@@ -34,9 +34,9 @@ lock for the duration of the index build - acceptable for the same reason
 prior structural changes to this table were: migrations run once, and this
 one is asymptotically the same cost class as REINDEXing an existing index.
 
-Revision ID: 022
-Revises: 021
-Create Date: 2026-08-15
+Revision ID: 023
+Revises: 022
+Create Date: 2026-08-16
 """
 
 from collections.abc import Sequence
@@ -45,8 +45,8 @@ import sqlalchemy as sa
 
 from alembic import op
 
-revision: str = "022"
-down_revision: str | None = "021"
+revision: str = "023"
+down_revision: str | None = "022"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
@@ -77,8 +77,17 @@ def upgrade() -> None:
         # postgresql_using/postgresql_ops are dialect-scoped kwargs that
         # SQLAlchemy silently drops on every other dialect, producing a
         # harmless, unused plain B-tree there instead.
-        kwargs = {"postgresql_using": "gin", "postgresql_ops": {"text": "gin_trgm_ops"}} if is_postgresql else {}
-        op.create_index(INDEX_NAME, TABLE_NAME, ["text"], **kwargs)
+        # PostgreSQL only: a same-name B-tree on SQLite would duplicate the
+        # entire text column into an index no query can use (models.py scopes
+        # its Index() with ddl_if(dialect="postgresql") for the same reason).
+        if is_postgresql:
+            op.create_index(
+                INDEX_NAME,
+                TABLE_NAME,
+                ["text"],
+                postgresql_using="gin",
+                postgresql_ops={"text": "gin_trgm_ops"},
+            )
 
 
 def downgrade() -> None:

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -207,24 +207,24 @@ class Message(Base):
         # size (measured ~95x faster on a ~100k-row instance: 41.8ms ->
         # 0.4ms). ``postgresql_using``/``postgresql_ops`` are dialect-
         # scoped kwargs - SQLAlchemy drops them for every dialect other
-        # than PostgreSQL, so create_all() on SQLite still gets a same-
-        # name/same-column index, just a plain (unused but harmless)
-        # B-tree instead. Requires the pg_trgm extension, created by the
-        # DDL hook below (create_all() path) and by migration 022 (Alembic
-        # path, which is authoritative for PostgreSQL - see 021's
-        # docstring).
+        # than PostgreSQL. ddl_if scopes creation itself to PostgreSQL: a
+        # same-name B-tree on SQLite would copy the entire text column into
+        # an index no SQLite query plan can use - on a multi-gigabyte
+        # archive that is real, permanent file growth for nothing. The
+        # pg_trgm extension is created by the DDL hook below (create_all()
+        # path) and by migration 023 (Alembic path).
         Index(
             "idx_messages_text_trgm",
             "text",
             postgresql_using="gin",
             postgresql_ops={"text": "gin_trgm_ops"},
-        ),
+        ).ddl_if(dialect="postgresql"),
     )
 
 
 # idx_messages_text_trgm's gin_trgm_ops needs the pg_trgm extension to exist
 # before create_all() reaches that index - fired here rather than relying on
-# migration 022 alone, since create_all() (the SQLite-and-test-fixture path,
+# migration 023 alone, since create_all() (the SQLite-and-test-fixture path,
 # not the app's own PostgreSQL runtime path - see 021's docstring) never
 # runs Alembic. execute_if scopes this to PostgreSQL only; SQLite's
 # create_all() run never touches it.

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -24,6 +24,7 @@ import secrets
 from datetime import datetime
 
 from sqlalchemy import (
+    DDL,
     BigInteger,
     DateTime,
     Float,
@@ -35,6 +36,7 @@ from sqlalchemy import (
     String,
     Text,
     UniqueConstraint,
+    event,
     func,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
@@ -197,7 +199,40 @@ class Message(Base):
         Index("idx_messages_reply_to", "chat_id", "reply_to_msg_id"),
         # v6.2.0: Index for topic message lookups in forum chats
         Index("idx_messages_topic", "chat_id", "reply_to_top_id"),
+        # PostgreSQL-only (#295-perf): the viewer's text search is
+        # Message.text.ilike('%term%') - a leading wildcard, which a B-tree
+        # can't serve at all, so every search was a full sequential scan
+        # that gets linearly slower as the archive grows. A GIN trigram
+        # index turns it into a bounded-cost lookup regardless of table
+        # size (measured ~95x faster on a ~100k-row instance: 41.8ms ->
+        # 0.4ms). ``postgresql_using``/``postgresql_ops`` are dialect-
+        # scoped kwargs - SQLAlchemy drops them for every dialect other
+        # than PostgreSQL, so create_all() on SQLite still gets a same-
+        # name/same-column index, just a plain (unused but harmless)
+        # B-tree instead. Requires the pg_trgm extension, created by the
+        # DDL hook below (create_all() path) and by migration 022 (Alembic
+        # path, which is authoritative for PostgreSQL - see 021's
+        # docstring).
+        Index(
+            "idx_messages_text_trgm",
+            "text",
+            postgresql_using="gin",
+            postgresql_ops={"text": "gin_trgm_ops"},
+        ),
     )
+
+
+# idx_messages_text_trgm's gin_trgm_ops needs the pg_trgm extension to exist
+# before create_all() reaches that index - fired here rather than relying on
+# migration 022 alone, since create_all() (the SQLite-and-test-fixture path,
+# not the app's own PostgreSQL runtime path - see 021's docstring) never
+# runs Alembic. execute_if scopes this to PostgreSQL only; SQLite's
+# create_all() run never touches it.
+event.listen(
+    Message.__table__,
+    "before_create",
+    DDL("CREATE EXTENSION IF NOT EXISTS pg_trgm").execute_if(dialect="postgresql"),
+)
 
 
 class MessageVersion(Base):

--- a/tests/test_db_adapter_real_engine.py
+++ b/tests/test_db_adapter_real_engine.py
@@ -158,3 +158,42 @@ class TestPaginationRealEngine:
         # Unescaped it is the match-everything wildcard and would return both.
         bare = await real_adapter.get_messages_paginated(900008, limit=10, search="%")
         assert [m["id"] for m in bare] == [200]
+
+    async def test_trgm_index_exists_on_postgresql(self, real_adapter):
+        """idx_messages_text_trgm must be a real GIN/pg_trgm index, not just present by name.
+
+        #295-perf: this is what makes the leading-wildcard ILIKE search's cost
+        independent of table size instead of scaling linearly with it. Checked
+        against the catalog (not EXPLAIN) deliberately - on a near-empty test
+        table the planner can rightfully prefer a seq scan over any index
+        regardless of what exists, so asserting on the *chosen plan* here
+        would be a table-size-dependent flake, not a check of the fix.
+        SQLite has no gin_trgm_ops equivalent (see migration 022 / models.py's
+        Index() dialect kwargs), so this only runs on PostgreSQL.
+        """
+        if real_adapter.db_manager.engine.dialect.name != "postgresql":
+            import pytest
+
+            pytest.skip("trigram index is PostgreSQL-only")
+
+        from sqlalchemy import text as sa_text
+
+        async with real_adapter.db_manager.async_session_factory() as session:
+            row = (
+                await session.execute(
+                    sa_text(
+                        "SELECT am.amname, array_agg(opc.opcname) "
+                        "FROM pg_index ix "
+                        "JOIN pg_class i ON i.oid = ix.indexrelid "
+                        "JOIN pg_am am ON am.oid = i.relam "
+                        "JOIN pg_opclass opc ON opc.oid = ANY(ix.indclass) "
+                        "WHERE i.relname = 'idx_messages_text_trgm' "
+                        "GROUP BY am.amname"
+                    )
+                )
+            ).first()
+
+        assert row is not None, "idx_messages_text_trgm does not exist"
+        index_method, opclasses = row
+        assert index_method == "gin", f"expected a GIN index, got {index_method!r}"
+        assert "gin_trgm_ops" in opclasses, f"expected gin_trgm_ops, got {opclasses!r}"

--- a/tests/test_db_adapter_real_engine.py
+++ b/tests/test_db_adapter_real_engine.py
@@ -197,3 +197,22 @@ class TestPaginationRealEngine:
         index_method, opclasses = row
         assert index_method == "gin", f"expected a GIN index, got {index_method!r}"
         assert "gin_trgm_ops" in opclasses, f"expected gin_trgm_ops, got {opclasses!r}"
+
+    async def test_trgm_index_absent_on_sqlite(self, real_adapter):
+        """SQLite must not carry the trigram index at all.
+
+        A same-name B-tree would duplicate the entire text column into an
+        index SQLite's ILIKE plan can never use — permanent file growth for
+        nothing — so both provisioning paths skip it there (models.py's
+        ddl_if(dialect="postgresql") and migration 023's dialect guard).
+        """
+        if real_adapter.db_manager.engine.dialect.name == "postgresql":
+            import pytest
+
+            pytest.skip("absence pin is the SQLite half; the GIN pin covers PostgreSQL")
+
+        import sqlalchemy as sa
+
+        async with real_adapter.db_manager.engine.connect() as conn:
+            names = await conn.run_sync(lambda c: {ix["name"] for ix in sa.inspect(c).get_indexes("messages")})
+        assert "idx_messages_text_trgm" not in names

--- a/tests/test_migration_022.py
+++ b/tests/test_migration_022.py
@@ -392,6 +392,15 @@ def run_shipped_stamping_ladder(path: Path) -> str | None:
     return namespace.get("stamp_version")
 
 
+def chain_head() -> str:
+    """The migration chain's live head, so reached-head assertions survive new revisions."""
+    from alembic.script import ScriptDirectory
+
+    config = Config()
+    config.set_main_option("script_location", str(ALEMBIC_DIR))
+    return ScriptDirectory.from_config(config).get_current_head()
+
+
 def alembic_version(path: Path) -> str | None:
     conn = sqlite3.connect(str(path))
     try:
@@ -492,7 +501,11 @@ class TestCrashMatrix:
 
         sa.event.listen(sa.engine.Engine, "before_cursor_execute", listener)
         try:
-            upgrade_to(f"sqlite+aiosqlite:///{path}")
+            # Target 022 alone: the matrix's invariants (version never advances,
+            # rows untouched, replay converges) bracket THIS migration's single
+            # transaction; later chained revisions commit their own transactions
+            # and carry their own suites.
+            upgrade_to(f"sqlite+aiosqlite:///{path}", "022")
         finally:
             sa.event.remove(sa.engine.Engine, "before_cursor_execute", listener)
         return seen["n"]
@@ -628,7 +641,7 @@ class TestPrechecks:
         assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
         conn.close()
         upgrade_to(f"sqlite+aiosqlite:///{archive}")
-        assert alembic_version(archive) == "022"
+        assert alembic_version(archive) == chain_head()
 
     def test_it_does_not_refuse_a_first_ever_start(self, tmp_path):
         """A brand-new install has nothing to protect, and the viewer container
@@ -640,7 +653,7 @@ class TestPrechecks:
             upgrade_to(f"sqlite+aiosqlite:///{path}")
         finally:
             holder.close()
-        assert alembic_version(path) == "022"
+        assert alembic_version(path) == chain_head()
 
     def test_it_turns_sqlite_foreign_key_enforcement_off_before_dropping_anything(self, tmp_path):
         """With enforcement on, DROP TABLE chats deletes its children first.


### PR DESCRIPTION
## Summary

- Message search (`Message.text.ilike('%term%')`, used by both the viewer's chat search and message search) currently forces a **full sequential scan** of the `messages` table on every query - a leading-wildcard `ILIKE` can't use a plain B-tree index at all. Cost scales linearly with archive size.
- Adds a `pg_trgm` GIN index (`idx_messages_text_trgm`) on `messages.text`. Verified live on a ~100k-row PostgreSQL instance:

  | | Plan | Rows filtered | Execution time |
  |---|---|---|---|
  | **Before** | `Seq Scan on messages` | 6,080 removed by filter | **41.764 ms** |
  | **After** | `Bitmap Heap Scan` using `idx_messages_text_trgm` | 6 removed by index recheck | **0.438 ms** |

  **~95x faster** on this dataset - and the more important number is the shape of the cost curve, not the multiple: a sequential scan is O(table size), the trigram index is roughly O(matching rows). The seq scan gets slower every single day this project's own incremental backups add more messages; the index does not.

## Type of Change

- [ ] Bug fix
- [x] New feature (non-breaking - a new index, additive only)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Infrastructure/CI change

## Database Changes

- [x] Schema changes (Alembic migration required) - `alembic/versions/20260815_022_add_message_text_trgm_index.py`
- [ ] Data migration script added in `scripts/`
- [ ] No database changes

## Data Consistency Checklist

- [x] N/A - index-only change, no data written or read differently

## Testing

- [x] Tests pass locally (`python -m pytest tests/ -v`) - 3038 passed, 1 skipped, run with a real local PostgreSQL 18 server so the PostgreSQL leg of the parity/adapter suites actually executed (not just the SQLite leg)
- [x] Linting passes (`ruff check .`)
- [x] Formatting passes (`ruff format --check .`)
- [x] Manually tested in development environment - `EXPLAIN ANALYZE` before/after on a live instance with real backed-up data (see Summary table); new catalog-level test (`test_trgm_index_exists_on_postgresql`) added so a future refactor can't silently drop the index type back to a plain B-tree without a test failing

## Security Checklist

- [x] No secrets or credentials committed
- [x] No new input surface (search input handling is unchanged - same `ilike(..., escape="\\")` call as before, just now index-accelerated)
- [x] N/A - no auth-relevant code touched

## Deployment Notes

- SQLite deployments: no behavior change. `pg_trgm`/`gin_trgm_ops` are PostgreSQL-only; on SQLite the same-named index is still created (via `Base.metadata.create_all()`, since SQLAlchemy silently drops PostgreSQL-only dialect kwargs elsewhere) but as a plain, currently-unused B-tree, purely to keep `tests/test_schema_parity.py` passing (ORM- and Alembic-built schemas must agree on every dialect, not just PostgreSQL).
- PostgreSQL deployments: migration 022 runs `CREATE EXTENSION IF NOT EXISTS pg_trgm` (a standard, always-available contrib extension - doesn't require any server-level `shared_preload_libraries` change, unlike `pg_stat_statements`) before creating the index. No `CONCURRENTLY` - this project's other index migrations (e.g. #213/017) also run inside Alembic's normal transactional DDL, so this one does too for consistency; on an already-large `messages` table the index build will briefly hold a lock, same cost class as a one-time `REINDEX`.

## Analysis / why this approach

- **Why `pg_trgm` and not `tsvector`/full-text search:** the existing query is already a literal substring match (`ILIKE '%term%'`), which is what users searching chat history actually expect (Telegram's own client search is substring-ish, not stemmed/tokenized). `pg_trgm` accelerates exactly that predicate shape with zero query-code changes required - `tsvector` would need the query rewritten to `@@ to_tsquery(...)`, changing match semantics (stemming, no partial-word matches) as a side effect of a "just make it fast" fix.
- **Why the index also has to exist on SQLite:** discovered this the hard way - the ORM (`Base.metadata.create_all()`, authoritative for SQLite per #294/021's docstring) doesn't know to skip an `Index()` for a specific dialect; `postgresql_using`/`postgresql_ops` are dialect-scoped kwargs SQLAlchemy just drops elsewhere, so `create_all()` still emits a plain index on SQLite. Making the Alembic migration `return` early on non-PostgreSQL (my first attempt) skipped creating that same index there, and `test_orm_and_alembic_schemas_agree_on_sqlite` correctly caught the resulting drift (`index-only-in-orm`). The migration now creates the same plain index on every dialect and only adds the GIN/`pg_trgm_ops` treatment on PostgreSQL.
- **Why a catalog check instead of `EXPLAIN`:** first draft of the new test asserted on the query plan directly. On a near-empty per-test table the planner correctly prefers a sequential scan over any index (an index scan on 1-2 rows has *more* overhead, not less) - regardless of whether the trigram index exists, so that assertion would have been a size-dependent flake, not a real check of the fix. Querying `pg_index`/`pg_am`/`pg_opclass` for the actual access method and operator class is deterministic at any table size.

I have a production instance already running this (verified the before/after numbers above against it) - happy to answer questions about real-world behavior at whatever scale you want more data on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved message text-search performance in PostgreSQL databases with optimized trigram indexing.
  * Automatically enables the required PostgreSQL text-search extension during database setup.
* **Compatibility**
  * SQLite databases continue to operate without PostgreSQL-specific text-search indexes.
* **Tests**
  * Added integration coverage for PostgreSQL index creation and SQLite compatibility.
  * Improved migration tests to remain reliable as the migration chain evolves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->