### PR TITLE
feat!: one archive, many Telegram accounts - account_id enters the keys

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -149,6 +149,10 @@ async def run_async_migrations() -> None:
         configuration,
         prefix="sqlalchemy.",
         poolclass=pool.NullPool,
+        # A failed statement inside a migration must never print its bound
+        # values: 022's backfill binds chat ids, which this project treats as
+        # PII. Same setting as the runtime engines in src/db/base.py.
+        hide_parameters=True,
     )
 
     async with connectable.connect() as connection:

--- a/alembic/versions/20260815_022_multi_account_keys.py
+++ b/alembic/versions/20260815_022_multi_account_keys.py
@@ -1,0 +1,990 @@
+"""Put ``account_id`` into the keys, so a second Telegram account cannot overwrite the first.
+
+Until now every key in this schema assumed one account. A Telegram chat id,
+message id, forum-topic id and dialog-filter id are only unique *within* an
+account, so a decorative ``account_id`` column would not have been enough. Each
+of these was built and run against scratch schemas before this migration was
+written:
+
+* ``message_versions`` UNIQUE(change_hash) silently DISCARDS the second
+  account's entire edit history — the hash is over the message payload, which is
+  identical for both accounts.
+* ``chat_folders`` PK(id) destroys the first account's folder title and takes
+  over all of its membership rows — Telegram numbers dialog filters per account
+  and everyone's start at 2.
+* ``messages`` PK(id, chat_id) drops the second account's copy of a message and
+  makes it read the first account's ``is_outgoing``.
+
+So the keys change:
+
+===================== ============================= ==================================
+table                 was                           becomes
+===================== ============================= ==================================
+chats                 PK (id)                       PK (account_id, id)
+messages              PK (id, chat_id)              PK (account_id, chat_id, id)
+media                 PK (id)                       PK (account_id, id)
+sync_status           PK (chat_id)                  PK (account_id, chat_id)
+forum_topics          PK (id, chat_id)              PK (account_id, chat_id, id)
+chat_folders          PK (id)                       PK (account_id, id)
+chat_folder_members   PK (folder_id, chat_id)       PK (account_id, folder_id, chat_id)
+reactions             UNIQUE uq_reaction            + account_id
+message_versions      UNIQUE(change_hash)           + account_id
+===================== ============================= ==================================
+
+``_message_version_hash``'s payload is deliberately NOT changed. It is a frozen
+contract: re-encoding it would make every version already stored hash
+differently and be re-inserted as a duplicate. The CONSTRAINT carries the
+account instead.
+
+``users`` and ``metadata`` stay global, and nothing on disk moves. Media stays
+exactly where it is under ``<media>/<chat_id>/``.
+
+Two new pieces of data ride along because they cannot be added later without a
+second rebuild of the same tables:
+
+* ``chats.ref`` — an opaque 22-character token minted once per chat, which the
+  viewer will address chats by instead of putting a chat id in a URL.
+* ``allowed_accounts`` and ``allowed_chat_refs`` on the four viewer-identity
+  tables. They are NEW columns, never a reinterpretation of ``allowed_chat_ids``,
+  because reinterpreting fails OPEN — an unconverted ``[123, 456]`` read as
+  (account 123, chat 456) grants access rather than denying it. Every restricted
+  row is converted here rather than left NULL, because NULL means "unrestricted".
+
+Safety, in the order it matters:
+
+1. **The first statement is DML.** Alembic sets ``transactional_ddl = False`` for
+   SQLite and pysqlite opens no transaction until the first DML statement, so a
+   ``CREATE TABLE`` issued before one is committed immediately and SURVIVES the
+   rollback of everything after it. The next start then dies on "table already
+   exists", forever. Writing ``alembic_version``'s row back to itself opens the
+   transaction, changes nothing, and leaves nothing behind.
+2. **Every rebuild is guarded and self-healing.** ``DROP TABLE IF EXISTS
+   <t>__new022`` precedes every create, and every step asks the live schema
+   whether its work is already done, so this is a complete no-op against a
+   database ``create_all`` already provisioned in the 8.0 shape.
+3. **Every SQLite rebuild declares its foreign keys, it never inherits them.**
+   The failure this avoids was measured: a rebuild that carries the reflected
+   constraint forward leaves ``media`` saying ``REFERENCES messages(id, chat_id)``
+   while the primary key it names has become ``(account_id, chat_id, id)``, and
+   ``PRAGMA foreign_key_check`` then reports
+   ``foreign key mismatch - "media" referencing "messages"``. That check runs at
+   the end of this migration, not only in its tests. The rebuild order is
+   parent-first as well, which is what keeps it correct if foreign key
+   enforcement is ever switched on; with enforcement off, as this project ships,
+   the finished schema is the same either way — also measured.
+4. **PostgreSQL drops the dependent foreign keys BY NAME first.** ``ALTER TABLE
+   messages DROP CONSTRAINT messages_pkey`` fails while ``fk_media_message``
+   depends on its index, and the obvious ``DROP ... CASCADE`` succeeds while
+   permanently deleting that foreign key, announcing it with nothing but a
+   NOTICE. No CASCADE appears in this file, all eight rebuilt constraints are
+   recreated by name unconditionally, and all nine are asserted by name
+   afterwards - so a lost one raises instead of being committed.
+5. **Prechecks refuse rather than half-finish.** On SQLite the rebuild peaks at
+   ~2.35x the database file — the WAL absorbs the whole rewrite inside one
+   transaction — and a viewer holding the same file open is about to have its
+   schema replaced underneath it. A third precheck makes sure SQLite is not
+   enforcing foreign keys, because dropping a parent table would then delete its
+   children first. All three run before anything is written.
+
+Cost, measured on this migration: SQLite 400k messages 152 MiB -> 218 MiB in
+2.2 s (peak 356 MiB), 1.6M messages 611 MiB -> 880 MiB in 11.9 s (peak
+1442 MiB); PostgreSQL 1.6M messages 601 MiB -> 605 MiB in 5.5 s. Roughly 7 s and
+1.8x growth per million messages on NVMe, and the ratio held across a 4x change
+in size. On PostgreSQL the whole thing is one transaction holding ACCESS
+EXCLUSIVE, so that time is startup downtime for the archive.
+
+Revision ID: 022
+Revises: 021
+Create Date: 2026-08-15
+"""
+
+import json
+import logging
+import os
+import secrets
+import shutil
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "022"
+down_revision: str | None = "021"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+logger = logging.getLogger("alembic.runtime.migration")
+
+# The account every pre-8.0.0 row is backfilled to.
+DEFAULT_ACCOUNT_ID = 1
+DEFAULT_ACCOUNT_LABEL = "default"
+
+# Suffix for the temporary table a SQLite rebuild copies through. Unique to this
+# revision so a leftover from any other migration can never be mistaken for ours.
+TEMP_SUFFIX = "__new022"
+
+# Peak transient size of the SQLite rebuild. Measured on this migration: a
+# 400k-message archive went 152 MiB -> 218 MiB with a 356 MiB peak (2.34x) in
+# 2.2 s, and a 1.6M-message one 611 MiB -> 880 MiB with a 1442 MiB peak (2.36x)
+# in 11.9 s, both on NVMe. The excess is the write-ahead log, which cannot
+# checkpoint inside a transaction, so the ratio is a property of the WAL rather
+# than of the archive's size. 3x is that measurement with a margin.
+SQLITE_DISK_HEADROOM = 3
+
+# Tables that gain account_id. Order is irrelevant here; the SQLite rebuild
+# order below is the one that matters.
+ACCOUNT_ID_TABLES: tuple[str, ...] = (
+    "chats",
+    "messages",
+    "media",
+    "reactions",
+    "message_versions",
+    "sync_status",
+    "forum_topics",
+    "chat_folders",
+    "chat_folder_members",
+)
+
+# New primary keys, in column order. Leading with account_id makes it the
+# partition key of every seek instead of a filter applied after one.
+NEW_PRIMARY_KEYS: dict[str, tuple[str, ...]] = {
+    "chats": ("account_id", "id"),
+    "chat_folders": ("account_id", "id"),
+    "messages": ("account_id", "chat_id", "id"),
+    "sync_status": ("account_id", "chat_id"),
+    "forum_topics": ("account_id", "chat_id", "id"),
+    "chat_folder_members": ("account_id", "folder_id", "chat_id"),
+    "media": ("account_id", "id"),
+}
+
+# Unique constraints that gain account_id, plus the new one on chats.ref.
+NEW_UNIQUE_CONSTRAINTS: dict[str, tuple[str, tuple[str, ...]]] = {
+    "chats": ("uq_chats_ref", ("ref",)),
+    "reactions": ("uq_reaction", ("account_id", "message_id", "chat_id", "emoji", "user_id")),
+    "message_versions": ("uq_message_versions_change_hash", ("account_id", "change_hash")),
+}
+
+# Indexes this release adds. Repairs, not speculation: until 8.0.0 the messages
+# primary key led with id and served resolve_message_chat_id /
+# get_chat_id_for_message, which look a message up without naming a chat. The
+# key now leads with account_id, so the account-qualified lookup needs its own
+# index or it walks every message ever archived.
+NEW_INDEXES: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+    ("idx_messages_account_msgid", "messages", ("account_id", "id")),
+)
+
+# The nine foreign keys of this schema, in their 8.0.0 shape. Eight are rebuilt
+# with account_id prepended to both sides; fk_reactions_user is unchanged
+# because users stays global, and it is listed so it is asserted afterwards too.
+# (name, table, columns, referred table, referred columns, ondelete)
+FOREIGN_KEYS: tuple[tuple[str, str, tuple[str, ...], str, tuple[str, ...], str | None], ...] = (
+    ("fk_messages_chat", "messages", ("account_id", "chat_id"), "chats", ("account_id", "id"), None),
+    ("fk_sync_status_chat", "sync_status", ("account_id", "chat_id"), "chats", ("account_id", "id"), None),
+    ("fk_forum_topics_chat", "forum_topics", ("account_id", "chat_id"), "chats", ("account_id", "id"), "CASCADE"),
+    (
+        "fk_folder_members_folder",
+        "chat_folder_members",
+        ("account_id", "folder_id"),
+        "chat_folders",
+        ("account_id", "id"),
+        "CASCADE",
+    ),
+    (
+        "fk_folder_members_chat",
+        "chat_folder_members",
+        ("account_id", "chat_id"),
+        "chats",
+        ("account_id", "id"),
+        "CASCADE",
+    ),
+    (
+        "fk_media_message",
+        "media",
+        ("account_id", "message_id", "chat_id"),
+        "messages",
+        ("account_id", "id", "chat_id"),
+        "CASCADE",
+    ),
+    (
+        "fk_reaction_message",
+        "reactions",
+        ("account_id", "message_id", "chat_id"),
+        "messages",
+        ("account_id", "id", "chat_id"),
+        None,
+    ),
+    (
+        "fk_message_versions_message",
+        "message_versions",
+        ("account_id", "message_id", "chat_id"),
+        "messages",
+        ("account_id", "id", "chat_id"),
+        "CASCADE",
+    ),
+    ("fk_reactions_user", "reactions", ("user_id",), "users", ("id",), "SET NULL"),
+)
+
+# The eight that this migration drops and recreates. fk_reactions_user is
+# untouched: users keeps PK(id), so nothing about that constraint changes.
+REBUILT_FOREIGN_KEYS = tuple(spec for spec in FOREIGN_KEYS if spec[0] != "fk_reactions_user")
+
+# Parent before child. Every rebuild below writes its own REFERENCES clause
+# rather than inheriting the reflected one, so with foreign key enforcement off
+# - as this project ships - the finished schema is the same in any order, and
+# that was measured rather than assumed. The order is kept because it is the one
+# that stays correct the day enforcement is switched on.
+SQLITE_REBUILD_ORDER: tuple[str, ...] = (
+    "chats",
+    "chat_folders",
+    "messages",
+    "sync_status",
+    "forum_topics",
+    "chat_folder_members",
+    "media",
+    "reactions",
+    "message_versions",
+)
+
+# Viewer identities. They are entitled to accounts and chats; they do not belong
+# to one, so they get no account_id. Value is the primary-key column used to
+# address a row during the entitlement conversion.
+ENTITLEMENT_TABLES: dict[str, str] = {
+    "viewer_accounts": "id",
+    "viewer_sessions": "token",
+    "viewer_tokens": "id",
+    "push_subscriptions": "id",
+}
+ENTITLEMENT_COLUMNS: tuple[str, ...] = ("allowed_accounts", "allowed_chat_refs")
+
+# secrets.token_urlsafe(16) is always exactly 22 characters over 128 bits. Kept
+# in step with src/db/models.py:new_chat_ref; a migration must not import the
+# ORM, which is free to move on without it.
+CHAT_REF_BYTES = 16
+CHAT_REF_LENGTH = 22
+
+
+# ---------------------------------------------------------------------------
+# Reading the live schema
+# ---------------------------------------------------------------------------
+
+
+def _tables(inspector: sa.Inspector) -> set[str]:
+    return set(inspector.get_table_names())
+
+
+def _column_names(inspector: sa.Inspector, table: str) -> set[str]:
+    if table not in inspector.get_table_names():
+        return set()
+    return {column["name"] for column in inspector.get_columns(table)}
+
+
+def _pk_columns(inspector: sa.Inspector, table: str) -> list[str]:
+    if table not in inspector.get_table_names():
+        return []
+    return list(inspector.get_pk_constraint(table).get("constrained_columns") or [])
+
+
+def _unique_columns(inspector: sa.Inspector, table: str, name: str) -> list[str] | None:
+    """Columns of the named unique constraint, or None when it does not exist."""
+    if table not in inspector.get_table_names():
+        return None
+    for constraint in inspector.get_unique_constraints(table):
+        if constraint.get("name") == name:
+            return list(constraint.get("column_names") or [])
+    return None
+
+
+def _live_foreign_keys(inspector: sa.Inspector, table: str) -> list[dict]:
+    if table not in inspector.get_table_names():
+        return []
+    return list(inspector.get_foreign_keys(table))
+
+
+def _reshape_pending(inspector: sa.Inspector) -> bool:
+    """True while any key in this schema still lacks its account dimension."""
+    for table, columns in NEW_PRIMARY_KEYS.items():
+        if table in inspector.get_table_names() and set(_pk_columns(inspector, table)) != set(columns):
+            return True
+    for table, (name, columns) in NEW_UNIQUE_CONSTRAINTS.items():
+        live = _unique_columns(inspector, table, name)
+        if table in inspector.get_table_names() and (live is None or set(live) != set(columns)):
+            return True
+    for name, table, columns, referred, _referred_columns, _ondelete in REBUILT_FOREIGN_KEYS:
+        if table not in inspector.get_table_names():
+            continue
+        matching = [
+            fk
+            for fk in _live_foreign_keys(inspector, table)
+            if fk.get("referred_table") == referred and set(fk.get("constrained_columns") or ()) == set(columns)
+        ]
+        if not any(fk.get("name") == name for fk in matching):
+            return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Prechecks. These run before anything is written and leave the database exactly
+# as they found it. Their failure is the intended outcome, not an accident.
+# ---------------------------------------------------------------------------
+
+
+def _sqlite_main_database_path(conn: sa.Connection) -> str | None:
+    for _seq, name, path in conn.exec_driver_sql("PRAGMA database_list").fetchall():
+        if name == "main" and path:
+            return str(path)
+    return None
+
+
+def _sqlite_footprint(path: str) -> int:
+    """Bytes the archive currently occupies, main file plus its WAL."""
+    total = 0
+    for candidate in (path, f"{path}-wal"):
+        try:
+            total += os.path.getsize(candidate)
+        except OSError:
+            continue
+    return total
+
+
+def _precheck_disk_space(path: str) -> None:
+    """Refuse to start a rebuild that cannot fit on the disk.
+
+    Inside one transaction SQLite cannot checkpoint, so the WAL absorbs the
+    entire rewrite: peak on-disk measured 2.34x at 400k messages and 2.36x at
+    1.6M. Running out of space mid-rebuild is safe (the transaction rolls back)
+    but the container will not start until space is freed, so failing here with
+    both numbers is strictly better than failing there with neither.
+
+    Sizes only, never the path: paths in this project carry chat ids.
+    """
+    footprint = _sqlite_footprint(path)
+    if footprint <= 0:
+        return
+    required = footprint * SQLITE_DISK_HEADROOM
+    free = shutil.disk_usage(os.path.dirname(path) or ".").free
+    if free >= required:
+        return
+    raise RuntimeError(
+        "Migration 022 needs about "
+        f"{required / (1024 * 1024):.1f} MiB free to rebuild this archive "
+        f"({SQLITE_DISK_HEADROOM}x its current {footprint / (1024 * 1024):.1f} MiB, because SQLite's "
+        f"write-ahead log holds the whole rewrite), and only {free / (1024 * 1024):.1f} MiB is free. "
+        "Free some space and start the container again. Nothing has been changed."
+    )
+
+
+def _precheck_foreign_keys_are_off(conn: sa.Connection) -> None:
+    """Make sure SQLite is not enforcing foreign keys before any table is dropped.
+
+    This is the difference between a rebuild and a disaster. With
+    ``PRAGMA foreign_keys = ON``, ``DROP TABLE chats`` performs an implicit
+    ``DELETE FROM chats`` first, which fires the ON DELETE CASCADE on
+    forum_topics and chat_folder_members and deletes their rows for real - and
+    they are not coming back from the ``_new`` table, because they were deleted
+    out of the table that was already copied. It is off by default and
+    ``alembic/env.py`` sets no pragmas, so today this is a no-op; it is here
+    because a single line added to env.py in some future release would otherwise
+    turn this migration into silent data loss.
+
+    A PRAGMA is ignored inside a transaction, which is exactly why this runs in
+    the prechecks, before the statement that opens one.
+    """
+    conn.exec_driver_sql("PRAGMA foreign_keys=OFF")
+    if conn.exec_driver_sql("PRAGMA foreign_keys").scalar():
+        raise RuntimeError(
+            "Migration 022 rebuilds tables that other tables reference and cannot run while SQLite is "
+            "enforcing foreign keys, because dropping a parent table would delete its children first. "
+            "Nothing has been changed."
+        )
+
+
+def _claim_exclusive_access(conn: sa.Connection) -> bool:
+    """Ask SQLite for exclusive use of the archive for the whole rebuild.
+
+    Not a poll - a claim. Every table in the database is about to be replaced,
+    and a viewer holding the same file open comes up serving a schema that is
+    being swapped underneath it, while ``create_all``'s own failure handler
+    downgrades "database is locked" to a warning so it never notices.
+    ``locking_mode=EXCLUSIVE`` refuses to take the lock at all while another
+    connection is attached, and then keeps that connection out for the duration
+    instead of leaving a gap between the check and the work.
+
+    The obvious version of this check - the same pragma on a SECOND connection -
+    is wrong, and measurably so: in WAL mode every attached connection holds the
+    write-ahead index, so a probe connection sees Alembic's OWN connection and
+    refuses every real upgrade there is. Asking on the connection doing the work
+    is what makes the answer mean "somebody else".
+
+    Only applied to an archive that holds data. A database with no chats and no
+    messages has nothing to protect, and refusing there would break a first-ever
+    start, where the viewer container legitimately comes up at the same time.
+    The lock is actually taken by the first write, which is why the message for
+    it lives with the statement that opens the transaction.
+    """
+    if not _sqlite_has_rows(conn):
+        return False
+    conn.exec_driver_sql("PRAGMA locking_mode=EXCLUSIVE")
+    return True
+
+
+BUSY_MESSAGE = (
+    "Migration 022 rebuilds every table in this archive and another process is holding the database "
+    "open, so it will not start. Stop the viewer container (and any other process using the archive), "
+    "then start this one again. Nothing has been changed."
+)
+
+
+def _sqlite_has_rows(conn: sa.Connection) -> bool:
+    inspector = sa.inspect(conn)
+    present = _tables(inspector)
+    for table in ("chats", "messages"):
+        if table in present and conn.execute(sa.text(f"SELECT 1 FROM {table} LIMIT 1")).first():
+            return True
+    return False
+
+
+def _run_prechecks(conn: sa.Connection) -> bool:
+    """Returns True when exclusive access was claimed and must be released.
+
+    PostgreSQL has neither check, and that is a decision, not an omission. Free
+    space cannot be read from SQL - the data directory belongs to the server,
+    not to this client - and the PostgreSQL path adds a column as catalog
+    metadata rather than rewriting the table, so it grows the database by
+    single-digit percent instead of tripling a file. Concurrent connections are
+    safe there too: the whole migration is one transaction holding ACCESS
+    EXCLUSIVE, other sessions block instead of racing, ``env.py`` already takes a
+    transaction-scoped advisory lock against a second migrator, and
+    ``create_all`` never runs against PostgreSQL. Refusing on a connection count
+    would fail every real upgrade, because the viewer container connects the
+    moment it starts.
+    """
+    if conn.dialect.name != "sqlite":
+        return False
+    _precheck_foreign_keys_are_off(conn)
+    path = _sqlite_main_database_path(conn)
+    # An in-memory database has no file to measure and no other process that
+    # could hold it; the exclusive claim below is still correct there.
+    if path and path != ":memory:":
+        _precheck_disk_space(path)
+    return _claim_exclusive_access(conn)
+
+
+# ---------------------------------------------------------------------------
+# Steps shared by both backends
+# ---------------------------------------------------------------------------
+
+
+def _open_write_transaction(conn: sa.Connection, inspector: sa.Inspector) -> None:
+    """Emit the DML that has to come before any DDL on SQLite.
+
+    See point 1 of the module docstring. Rewriting ``alembic_version``'s row with
+    its own value is a real DML statement, so pysqlite opens its implicit
+    transaction here and every ``CREATE TABLE`` below is inside it - and it
+    leaves nothing behind if this migration rolls back.
+
+    It is also where the exclusive lock claimed above is actually taken, so a
+    database another process is holding open reports itself here, before a
+    single byte has been written.
+    """
+    if "alembic_version" not in _tables(inspector):
+        return
+    try:
+        conn.execute(sa.text("UPDATE alembic_version SET version_num = version_num"))
+    except sa.exc.OperationalError as exc:
+        if conn.dialect.name == "sqlite" and "locked" in str(exc).lower():
+            raise RuntimeError(BUSY_MESSAGE) from exc
+        raise
+
+
+def _create_accounts_table(conn: sa.Connection, inspector: sa.Inspector) -> None:
+    """Create the registry, then seed the account every existing row belongs to.
+
+    The two halves are guarded separately on purpose. A viewer running 8.0.0
+    ``create_all`` against a 7.x SQLite file creates ``accounts`` and nothing
+    else, so a guard that skipped the INSERT because the table already existed
+    would leave the archive with no account at all.
+    """
+    if "accounts" not in _tables(inspector):
+        op.create_table(
+            "accounts",
+            sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+            sa.Column("label", sa.String(length=255), nullable=True),
+            sa.Column("telegram_user_id", sa.BigInteger(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+        )
+
+    seeded = conn.execute(sa.text("SELECT 1 FROM accounts WHERE id = :id"), {"id": DEFAULT_ACCOUNT_ID}).first()
+    if not seeded:
+        conn.execute(
+            sa.text("INSERT INTO accounts (id, label, telegram_user_id) VALUES (:id, :label, NULL)"),
+            {"id": DEFAULT_ACCOUNT_ID, "label": DEFAULT_ACCOUNT_LABEL},
+        )
+
+    if conn.dialect.name == "postgresql":
+        # The seed writes id explicitly, which does not advance the SERIAL
+        # sequence - the next account added would collide on id 1.
+        conn.execute(
+            sa.text(
+                "SELECT setval(pg_get_serial_sequence('accounts', 'id'), (SELECT COALESCE(MAX(id), 1) FROM accounts))"
+            )
+        )
+
+
+def _add_account_id_columns(conn: sa.Connection, inspector: sa.Inspector) -> None:
+    """Add the column itself, backfilled to account 1 by its own default.
+
+    ``NOT NULL DEFAULT '1'`` is catalog-only on PostgreSQL 11+ and on SQLite
+    (0.3 ms on 2M rows, measured), so no table is rewritten here. The default
+    stays: it is what lets a writer that does not yet name an account keep
+    working against this schema.
+    """
+    present = _tables(inspector)
+    for table in ACCOUNT_ID_TABLES:
+        if table not in present or "account_id" in _column_names(inspector, table):
+            continue
+        op.add_column(
+            table,
+            sa.Column("account_id", sa.Integer(), nullable=False, server_default=str(DEFAULT_ACCOUNT_ID)),
+        )
+
+
+def _mint_chat_refs(conn: sa.Connection, inspector: sa.Inspector) -> None:
+    """Add ``chats.ref`` and give every chat one.
+
+    Added nullable and filled here; the NOT NULL and the unique constraint are
+    applied by each backend's reshape, which is rebuilding the table anyway on
+    SQLite. Values are generated in Python so both backends and the ORM's own
+    default produce byte-identical tokens - SQLite has no base64 function, and
+    two spellings of "opaque token" would be one too many.
+    """
+    if "chats" not in _tables(inspector):
+        return
+    if "ref" not in _column_names(inspector, "chats"):
+        op.add_column("chats", sa.Column("ref", sa.String(length=CHAT_REF_LENGTH), nullable=True))
+
+    rows = conn.execute(sa.text("SELECT account_id, id FROM chats WHERE ref IS NULL")).fetchall()
+    if not rows:
+        return
+    taken = {ref for (ref,) in conn.execute(sa.text("SELECT ref FROM chats WHERE ref IS NOT NULL")).fetchall() if ref}
+    updates = []
+    for account_id, chat_id in rows:
+        ref = secrets.token_urlsafe(CHAT_REF_BYTES)
+        while ref in taken:  # pragma: no cover - 128 bits; the loop is the proof, not the path
+            ref = secrets.token_urlsafe(CHAT_REF_BYTES)
+        taken.add(ref)
+        updates.append({"ref": ref, "account_id": account_id, "chat_id": chat_id})
+    conn.execute(sa.text("UPDATE chats SET ref = :ref WHERE account_id = :account_id AND id = :chat_id"), updates)
+    logger.info("022: minted %d chat ref(s)", len(updates))
+
+
+def _add_entitlement_columns(conn: sa.Connection, inspector: sa.Inspector) -> None:
+    present = _tables(inspector)
+    for table in ENTITLEMENT_TABLES:
+        if table not in present:
+            continue
+        existing = _column_names(inspector, table)
+        for column in ENTITLEMENT_COLUMNS:
+            if column not in existing:
+                op.add_column(table, sa.Column(column, sa.Text(), nullable=True))
+
+
+def _convert_entitlements(conn: sa.Connection, inspector: sa.Inspector) -> None:
+    """Restate every restricted viewer's grant in the new columns.
+
+    Leaving them NULL would be the one failure this whole design exists to
+    prevent: NULL means "no restriction", so a viewer restricted to two chats in
+    7.x would come back entitled to everything. A row whose payload cannot be
+    read at all is converted to an empty grant, which denies rather than grants.
+
+    Unrestricted rows (allowed_chat_ids IS NULL) keep NULL in both new columns,
+    which is the same "everything" they already meant.
+    """
+    present = _tables(inspector)
+    if "chats" not in present:
+        return
+    ref_by_chat_id = {
+        chat_id: ref
+        for chat_id, ref in conn.execute(
+            sa.text("SELECT id, ref FROM chats WHERE account_id = :account"), {"account": DEFAULT_ACCOUNT_ID}
+        ).fetchall()
+    }
+    converted = 0
+    unreadable = 0
+    for table, key_column in ENTITLEMENT_TABLES.items():
+        if table not in present:
+            continue
+        columns = _column_names(inspector, table)
+        if not {"allowed_chat_ids", *ENTITLEMENT_COLUMNS}.issubset(columns):
+            continue
+        rows = conn.execute(
+            sa.text(
+                f"SELECT {key_column}, allowed_chat_ids FROM {table} "
+                "WHERE allowed_chat_ids IS NOT NULL "
+                "AND allowed_accounts IS NULL AND allowed_chat_refs IS NULL"
+            )
+        ).fetchall()
+        for key, payload in rows:
+            try:
+                chat_ids = json.loads(payload)
+            except TypeError, ValueError:
+                chat_ids = None
+            if not isinstance(chat_ids, list):
+                accounts_json, refs_json = "[]", "[]"
+                unreadable += 1
+            else:
+                refs = []
+                for entry in chat_ids:
+                    try:
+                        chat_id = int(entry)
+                    except TypeError, ValueError:
+                        continue
+                    ref = ref_by_chat_id.get(chat_id)
+                    if ref:
+                        refs.append(ref)
+                accounts_json, refs_json = json.dumps([DEFAULT_ACCOUNT_ID]), json.dumps(refs)
+            conn.execute(
+                sa.text(
+                    f"UPDATE {table} SET allowed_accounts = :accounts, allowed_chat_refs = :refs "
+                    f"WHERE {key_column} = :key"
+                ),
+                {"accounts": accounts_json, "refs": refs_json, "key": key},
+            )
+            converted += 1
+    if converted:
+        # Counts only - a grant payload is a list of chat ids.
+        logger.info(
+            "022: converted %d restricted viewer grant(s) to the account-qualified columns "
+            "(%d had an unreadable payload and were converted to an empty grant)",
+            converted,
+            unreadable,
+        )
+
+
+# ---------------------------------------------------------------------------
+# PostgreSQL
+# ---------------------------------------------------------------------------
+
+
+def _drop_rebuilt_foreign_keys(inspector: sa.Inspector) -> None:
+    """Drop, by their live names, exactly the eight constraints being replaced.
+
+    Discovery is by shape (this table -> that table), not by name, because 7.x
+    left five of them to PostgreSQL to name (``messages_chat_id_fkey`` and
+    friends). Dropping them explicitly is the whole point: the shortcut,
+    ``ALTER TABLE messages DROP CONSTRAINT messages_pkey CASCADE``, succeeds and
+    deletes ``fk_media_message`` permanently, reporting it only as a NOTICE.
+    """
+    for name, table, columns, referred, _referred_columns, _ondelete in REBUILT_FOREIGN_KEYS:
+        for fk in _live_foreign_keys(inspector, table):
+            if fk.get("referred_table") != referred:
+                continue
+            if set(fk.get("constrained_columns") or ()) == set(columns) and fk.get("name") == name:
+                continue  # already in its 8.0.0 shape
+            if fk.get("name"):
+                op.drop_constraint(fk["name"], table, type_="foreignkey")
+
+
+def _upgrade_postgresql(conn: sa.Connection) -> None:
+    inspector = sa.inspect(conn)
+
+    # chats.ref was added nullable so it could be filled; tighten it now.
+    if "ref" in _column_names(inspector, "chats"):
+        chats_columns = {column["name"]: column for column in inspector.get_columns("chats")}
+        if chats_columns["ref"]["nullable"]:
+            op.alter_column("chats", "ref", existing_type=sa.String(length=CHAT_REF_LENGTH), nullable=False)
+
+    _drop_rebuilt_foreign_keys(inspector)
+    inspector = sa.inspect(conn)
+
+    for table, columns in NEW_PRIMARY_KEYS.items():
+        if table not in _tables(inspector) or set(_pk_columns(inspector, table)) == set(columns):
+            continue
+        constraint = inspector.get_pk_constraint(table)
+        if constraint.get("name"):
+            op.drop_constraint(constraint["name"], table, type_="primary")
+        op.create_primary_key(f"{table}_pkey", table, list(columns))
+
+    for table, (name, columns) in NEW_UNIQUE_CONSTRAINTS.items():
+        if table not in _tables(inspector):
+            continue
+        live = _unique_columns(inspector, table, name)
+        if live is not None and set(live) == set(columns):
+            continue
+        if live is not None:
+            op.drop_constraint(name, table, type_="unique")
+        op.create_unique_constraint(name, table, list(columns))
+
+    inspector = sa.inspect(conn)
+    for name, table, columns, referred, referred_columns, ondelete in REBUILT_FOREIGN_KEYS:
+        if table not in _tables(inspector):
+            continue
+        if any(fk.get("name") == name for fk in _live_foreign_keys(inspector, table)):
+            continue
+        op.create_foreign_key(name, table, referred, list(columns), list(referred_columns), ondelete=ondelete)
+
+
+# ---------------------------------------------------------------------------
+# SQLite
+# ---------------------------------------------------------------------------
+
+
+def _sqlite_index_ddl(conn: sa.Connection, table: str) -> list[str]:
+    """The CREATE INDEX statements of ``table``, verbatim.
+
+    Replaying the stored DDL rather than reflecting and re-declaring is what
+    keeps ``idx_messages_chat_date_desc``'s DESC ordering: SQLite reflection
+    reports an index's columns but not their sort order, and the parity gate
+    compares column names only, so a reflected rebuild would silently downgrade
+    that index to ASC and nothing would report it. Rows with a NULL sql are the
+    implicit indexes behind UNIQUE constraints; those come back with the table.
+    """
+    rows = conn.execute(
+        sa.text("SELECT sql FROM sqlite_master WHERE type = 'index' AND tbl_name = :t AND sql IS NOT NULL"),
+        {"t": table},
+    ).fetchall()
+    return [row[0] for row in rows]
+
+
+def _fk_stub_metadata(meta: sa.MetaData, table: str) -> None:
+    """Give the rebuilt table's foreign keys something to resolve against.
+
+    Only the referenced column NAMES reach the emitted DDL, so a stub is enough
+    and is deterministic - reflecting the real parent would drag its own
+    constraints into this MetaData for no gain.
+    """
+    for _name, source, _columns, referred, referred_columns, _ondelete in FOREIGN_KEYS:
+        if source != table or referred in meta.tables:
+            continue
+        sa.Table(referred, meta, *[sa.Column(column, sa.Integer(), primary_key=True) for column in referred_columns])
+
+
+def _rebuild_sqlite_table(conn: sa.Connection, table: str) -> None:
+    """Copy ``table`` through a new one carrying the 8.0.0 keys.
+
+    Columns are taken from the live schema, so their types, nullability and
+    defaults come from the database itself and cannot drift from what earlier
+    migrations built. Only the keys and constraints are declared here.
+    """
+    inspector = sa.inspect(conn)
+    columns = inspector.get_columns(table)
+    index_ddl = _sqlite_index_ddl(conn, table)
+    temp = f"{table}{TEMP_SUFFIX}"
+
+    meta = sa.MetaData()
+    _fk_stub_metadata(meta, table)
+
+    elements: list = []
+    for column in columns:
+        kwargs: dict = {"nullable": column["nullable"]}
+        if column.get("default") is not None:
+            kwargs["server_default"] = sa.text(str(column["default"]))
+        if table == "chats" and column["name"] == "ref":
+            kwargs["nullable"] = False  # filled by _mint_chat_refs above
+        elements.append(sa.Column(column["name"], column["type"], **kwargs))
+
+    primary_key = NEW_PRIMARY_KEYS.get(table) or tuple(_pk_columns(inspector, table))
+    elements.append(sa.PrimaryKeyConstraint(*primary_key))
+
+    if table in NEW_UNIQUE_CONSTRAINTS:
+        name, unique_columns = NEW_UNIQUE_CONSTRAINTS[table]
+        elements.append(sa.UniqueConstraint(*unique_columns, name=name))
+
+    for name, source, fk_columns, referred, referred_columns, ondelete in FOREIGN_KEYS:
+        if source != table:
+            continue
+        elements.append(
+            sa.ForeignKeyConstraint(
+                list(fk_columns),
+                [f"{referred}.{column}" for column in referred_columns],
+                name=name,
+                ondelete=ondelete,
+            )
+        )
+
+    # Unreachable with the statement order this migration actually has - the
+    # transaction is open well before the first rebuild, so a crash rolls this
+    # table away with everything else, and the crash matrix confirms no run at
+    # any of its 200-plus interruption points leaves one behind. It is kept as
+    # one line of insurance against a future reordering, because the failure it
+    # would prevent is a permanent "table already exists" startup loop.
+    conn.execute(sa.text(f'DROP TABLE IF EXISTS "{temp}"'))
+    sa.Table(temp, meta, *elements).create(conn)
+
+    column_list = ", ".join(f'"{column["name"]}"' for column in columns)
+    conn.execute(sa.text(f'INSERT INTO "{temp}" ({column_list}) SELECT {column_list} FROM "{table}"'))
+    conn.execute(sa.text(f'DROP TABLE "{table}"'))
+    conn.execute(sa.text(f'ALTER TABLE "{temp}" RENAME TO "{table}"'))
+    for statement in index_ddl:
+        conn.execute(sa.text(statement))
+
+
+def _sqlite_foreign_key_violations(conn: sa.Connection) -> int | None:
+    """Rows failing a foreign key, or None when the check itself cannot run."""
+    try:
+        return len(conn.exec_driver_sql("PRAGMA foreign_key_check").fetchall())
+    except sa.exc.DatabaseError:
+        return None
+
+
+def _upgrade_sqlite(conn: sa.Connection) -> None:
+    inspector = sa.inspect(conn)
+    present = _tables(inspector)
+
+    # Establish the baseline before touching anything: an archive that already
+    # has orphan rows must not be blocked from upgrading by them, but a
+    # violation this rebuild introduces has to be fatal.
+    violations_before = _sqlite_foreign_key_violations(conn)
+
+    # Renaming over a table that other tables reference makes modern SQLite
+    # re-validate and rewrite those references. The legacy behaviour is what
+    # migration 005 and 021 already use for this table set.
+    conn.exec_driver_sql("PRAGMA legacy_alter_table=ON")
+    try:
+        for table in SQLITE_REBUILD_ORDER:
+            if table not in present:
+                continue
+            inspector = sa.inspect(conn)
+            wanted_pk = NEW_PRIMARY_KEYS.get(table)
+            if wanted_pk and set(_pk_columns(inspector, table)) != set(wanted_pk):
+                _rebuild_sqlite_table(conn, table)
+                continue
+            if table in NEW_UNIQUE_CONSTRAINTS:
+                name, columns = NEW_UNIQUE_CONSTRAINTS[table]
+                live = _unique_columns(inspector, table, name)
+                if live is None or set(live) != set(columns):
+                    _rebuild_sqlite_table(conn, table)
+                    continue
+            if any(
+                spec[1] == table and not any(fk.get("name") == spec[0] for fk in _live_foreign_keys(inspector, table))
+                for spec in REBUILT_FOREIGN_KEYS
+            ):
+                _rebuild_sqlite_table(conn, table)
+    finally:
+        conn.exec_driver_sql("PRAGMA legacy_alter_table=OFF")
+
+    violations_after = _sqlite_foreign_key_violations(conn)
+    if violations_after is None:
+        # The pragma raises "foreign key mismatch" when a REFERENCES clause names
+        # a key that no longer exists - exactly what a wrong rebuild order
+        # produces, and it must not be allowed to commit.
+        raise RuntimeError(
+            "Migration 022: PRAGMA foreign_key_check could not complete after the rebuild, which means a "
+            "foreign key now references a key that does not exist. Nothing has been committed."
+        )
+    if violations_before is not None and violations_after > violations_before:
+        raise RuntimeError(
+            "Migration 022: the rebuild introduced "
+            f"{violations_after - violations_before} foreign key violation(s) "
+            f"({violations_before} existed before it). Nothing has been committed."
+        )
+    if violations_after:
+        logger.info(
+            "022: %d pre-existing foreign key violation(s) carried over unchanged; the rebuild added none",
+            violations_after,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Result assertion
+# ---------------------------------------------------------------------------
+
+
+def _create_new_indexes(conn: sa.Connection, inspector: sa.Inspector) -> None:
+    """Add this release's new indexes, after any rebuild has replayed the old ones."""
+    present = _tables(inspector)
+    for name, table, columns in NEW_INDEXES:
+        if table not in present:
+            continue
+        if name in {index["name"] for index in inspector.get_indexes(table)}:
+            continue
+        op.create_index(name, table, list(columns))
+
+
+def _assert_foreign_keys(conn: sa.Connection) -> None:
+    """Every one of the nine constraints must exist, by name, with its columns.
+
+    This is the guard against the failure that is otherwise invisible: on
+    PostgreSQL a CASCADE drop deletes a foreign key with only a NOTICE, and on
+    SQLite a rebuild can quietly lose one. Both would leave an archive whose
+    referential integrity is gone with nothing having reported an error.
+    """
+    inspector = sa.inspect(conn)
+    present = _tables(inspector)
+    missing = []
+    for name, table, columns, referred, _referred_columns, _ondelete in FOREIGN_KEYS:
+        if table not in present:
+            continue
+        if not any(
+            fk.get("name") == name
+            and fk.get("referred_table") == referred
+            and list(fk.get("constrained_columns") or ()) == list(columns)
+            for fk in _live_foreign_keys(inspector, table)
+        ):
+            missing.append(name)
+    if missing:
+        raise RuntimeError(
+            f"Migration 022 did not leave these foreign keys in place: {', '.join(sorted(missing))}. "
+            "Nothing has been committed."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Entry points
+# ---------------------------------------------------------------------------
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+
+    if "chats" not in _tables(inspector):
+        # Nothing to key by account yet. A database this early is either being
+        # built from base by this same run or is not an archive at all.
+        return
+
+    # A schema create_all provisioned from current ORM metadata reaches this
+    # migration already in the 8.0.0 shape and skips straight past the rebuild.
+    if _reshape_pending(inspector) or "accounts" not in _tables(inspector):
+        exclusive = _run_prechecks(conn)
+        try:
+            _open_write_transaction(conn, inspector)
+            _create_accounts_table(conn, sa.inspect(conn))
+            _add_account_id_columns(conn, sa.inspect(conn))
+            _mint_chat_refs(conn, sa.inspect(conn))
+            _add_entitlement_columns(conn, sa.inspect(conn))
+            _convert_entitlements(conn, sa.inspect(conn))
+
+            if conn.dialect.name == "postgresql":
+                _upgrade_postgresql(conn)
+            else:
+                _upgrade_sqlite(conn)
+        finally:
+            if exclusive:
+                # Hands the archive back at the end of this transaction, so the
+                # viewer can attach again without waiting for the process to
+                # exit. A raise here is not swallowed - only the mode is reset.
+                conn.exec_driver_sql("PRAGMA locking_mode=NORMAL")
+
+    _create_new_indexes(conn, sa.inspect(conn))
+    _assert_foreign_keys(conn)
+
+
+def downgrade() -> None:
+    """Deliberately not implemented, because a plausible one would be a lie.
+
+    Reversing this is a second full rebuild of the same nine tables, and once a
+    second account exists it cannot be done at all: two rows that differ only by
+    account_id collapse onto one key, so a downgrade would have to choose which
+    account's copy of every shared message, folder and edit history to destroy.
+
+    The rollback that does work needs no code. This migration is one transaction
+    on both backends, so an interrupted upgrade leaves a byte-for-byte intact
+    7.x database that the previous image still runs. After a successful upgrade
+    the way back is the backup taken before it - which the release notes ask for
+    explicitly, and which is the only honest answer here.
+    """
+    raise RuntimeError(
+        "Migration 022 cannot be downgraded: the pre-8.0.0 keys cannot identify a row once more than "
+        "one account exists. Restore the backup taken before the upgrade instead."
+    )

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -297,6 +297,14 @@ if has_tables and not has_alembic:
     # already has, so detecting them could only push the stamp past data-only
     # 019. It reads the live schema per column and does nothing where the
     # target shape is already in place, so re-running it here is a no-op.
+    # 022 adds no rung, for the same reason and by the same design. Its
+    # artifacts -- account_id in the keys, chats.ref, the accounts table -- are
+    # exactly what a schema built from current ORM metadata already carries, so
+    # a '022' rung could only skip data-only 019. 022 asks the live schema
+    # whether each key already has its account dimension and rebuilds only what
+    # does not, so an 8.0.0 create_all schema stamped here at 018 runs 019, then
+    # guarded 020 and 021, then 022 as a complete no-op. Verified in
+    # tests/test_migration_022.py against a create_all-provisioned 8.0.0 schema.
     if has_018_reaction_removed_at and has_017_chat_id_id_index and has_016_download_attempts and has_015_message_versions and has_014_soft_delete:
         stamp_version = '018'
     elif has_017_chat_id_id_index and has_016_download_attempts and has_015_message_versions and has_014_soft_delete:
@@ -510,6 +518,14 @@ if has_tables and not has_alembic:
     # has, so detecting them could only push the stamp past data-only 019. It
     # inspects the live schema per column and rebuilds only the tables that
     # still differ, so re-running it against such a database does nothing.
+    # 022 adds no rung, for the same reason and by the same design. Its
+    # artifacts -- account_id in the keys, chats.ref, the accounts table -- are
+    # exactly what a schema built from current ORM metadata already carries, so
+    # a '022' rung could only skip data-only 019. 022 asks the live schema
+    # whether each key already has its account dimension and rebuilds only what
+    # does not, so an 8.0.0 create_all schema stamped here at 018 runs 019, then
+    # guarded 020 and 021, then 022 as a complete no-op. Verified in
+    # tests/test_migration_022.py against a create_all-provisioned 8.0.0 schema.
     if has_018_reaction_removed_at and has_017_chat_id_id_index and has_016_download_attempts and has_015_message_versions and has_014_soft_delete:
         stamp_version = '018'
     elif has_017_chat_id_id_index and has_016_download_attempts and has_015_message_versions and has_014_soft_delete:

--- a/src/connection.py
+++ b/src/connection.py
@@ -105,9 +105,9 @@ class TelegramConnection:
         connection = TelegramConnection(config)
         await connection.connect()
 
-        # Pass to backup and listener
-        backup = TelegramBackup(config, db, client=connection.client)
-        listener = TelegramListener(config, db, client=connection.client)
+        # Pass to backup and listener (single-account stage: account_id=1)
+        backup = TelegramBackup(config, db, client=connection.client, account_id=1)
+        listener = TelegramListener(config, db, client=connection.client, account_id=1)
 
         # Both use the same connection
         await backup.backup_all()  # Uses shared client

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -2349,6 +2349,17 @@ class DatabaseAdapter:
             await session.execute(
                 delete(SyncStatus).where(and_(SyncStatus.account_id == account_id, SyncStatus.chat_id == chat_id))
             )
+            # Delete forum topics and folder memberships explicitly: their FKs
+            # declare ondelete CASCADE, but SQLite ships with foreign_keys off,
+            # so the cascade never fires there - same reason as every delete above.
+            await session.execute(
+                delete(ForumTopic).where(and_(ForumTopic.account_id == account_id, ForumTopic.chat_id == chat_id))
+            )
+            await session.execute(
+                delete(ChatFolderMember).where(
+                    and_(ChatFolderMember.account_id == account_id, ChatFolderMember.chat_id == chat_id)
+                )
+            )
             # Delete chat
             await session.execute(delete(Chat).where(and_(Chat.account_id == account_id, Chat.id == chat_id)))
 

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -221,6 +221,19 @@ class DatabaseAdapter:
     Async database adapter compatible with the old Database class interface.
 
     All methods are async and should be awaited.
+
+    v8.0.0 account contract. Every table holding Telegram data is keyed by
+    ``account_id`` (see models.py), and the adapter names the account explicitly:
+
+    - Capture-side methods (writes, and reads that feed capture decisions such
+      as gap detection or sync state) take keyword-only ``account_id: int`` with
+      NO default — a caller that forgets the account is a TypeError at call
+      time, never a row written under the server default.
+    - Viewer/MCP-facing reads take ``account_id: int | None = None``; ``None``
+      means unscoped, which is correct while the archive holds one account.
+      Phase 4 (viewer entitlements) closes that hole by passing the account.
+    - Tables that are global by design (metadata, users, app_settings, the
+      viewer_* tables) keep their pre-8.0 signatures.
     """
 
     def __init__(self, db_manager: DatabaseManager):
@@ -268,10 +281,16 @@ class DatabaseAdapter:
                 logger.error(f"Failed to serialize raw_data even after conversion: {e2}")
                 return "{}"
 
-    def _message_values(self, message_data: dict[str, Any]) -> dict[str, Any]:
+    def _message_values(self, message_data: dict[str, Any], account_id: int) -> dict[str, Any]:
         sender_name = message_data.get("sender_name")
         sender_name = sender_name.strip() if _is_nonblank_text(sender_name) else None
         return {
+            # Always explicit, never the column's server default: an INSERT
+            # missing a server-defaulted PK column makes SQLAlchemy append
+            # RETURNING for it, and on the ON CONFLICT DO NOTHING path that
+            # changes what rowcount means — the caller then skips the update
+            # branch and an edited message's new text is silently dropped.
+            "account_id": account_id,
             "id": message_data["id"],
             "chat_id": message_data["chat_id"],
             "sender_id": message_data.get("sender_id"),
@@ -292,17 +311,32 @@ class DatabaseAdapter:
 
     def _insert_message_stmt(self, values: dict[str, Any]):
         if self._is_sqlite:
-            return sqlite_insert(Message).values(**values).on_conflict_do_nothing(index_elements=["id", "chat_id"])
-        return pg_insert(Message).values(**values).on_conflict_do_nothing(index_elements=["id", "chat_id"])
+            return (
+                sqlite_insert(Message)
+                .values(**values)
+                .on_conflict_do_nothing(index_elements=["account_id", "chat_id", "id"])
+            )
+        return (
+            pg_insert(Message).values(**values).on_conflict_do_nothing(index_elements=["account_id", "chat_id", "id"])
+        )
 
     def _insert_message_version_stmt(self, values: dict[str, Any]):
         if self._is_sqlite:
-            return sqlite_insert(MessageVersion).values(**values).on_conflict_do_nothing(index_elements=["change_hash"])
-        return pg_insert(MessageVersion).values(**values).on_conflict_do_nothing(index_elements=["change_hash"])
+            return (
+                sqlite_insert(MessageVersion)
+                .values(**values)
+                .on_conflict_do_nothing(index_elements=["account_id", "change_hash"])
+            )
+        return (
+            pg_insert(MessageVersion)
+            .values(**values)
+            .on_conflict_do_nothing(index_elements=["account_id", "change_hash"])
+        )
 
     async def _record_message_version(
         self,
         session,
+        account_id: int,
         chat_id: int,
         message_id: int,
         text: str | None,
@@ -327,6 +361,9 @@ class DatabaseAdapter:
             date=date,
         )
         values = {
+            # The hash payload is a frozen contract and does NOT carry the
+            # account; the (account_id, change_hash) constraint does instead.
+            "account_id": account_id,
             "chat_id": chat_id,
             "message_id": message_id,
             "text": text,
@@ -409,23 +446,24 @@ class DatabaseAdapter:
             return True
         return edit_date >= old_edit_date
 
-    async def _load_message_for_update(self, session, chat_id: int, message_id: int) -> Message | None:
+    async def _load_message_for_update(self, session, account_id: int, chat_id: int, message_id: int) -> Message | None:
+        pk = and_(Message.account_id == account_id, Message.chat_id == chat_id, Message.id == message_id)
         if self._is_sqlite:
             # SQLite has no row-level SELECT FOR UPDATE. A no-op write acquires the
             # transaction's write lock before we re-read and decide whether to update.
-            await session.execute(
-                update(Message).where(and_(Message.chat_id == chat_id, Message.id == message_id)).values(id=Message.id)
-            )
-            stmt = select(Message).where(and_(Message.chat_id == chat_id, Message.id == message_id))
+            await session.execute(update(Message).where(pk).values(id=Message.id))
+            stmt = select(Message).where(pk)
         else:
-            stmt = select(Message).where(and_(Message.chat_id == chat_id, Message.id == message_id)).with_for_update()
+            stmt = select(Message).where(pk).with_for_update()
 
         result = await session.execute(stmt.execution_options(populate_existing=True))
         return result.scalar_one_or_none()
 
-    async def _load_message_snapshot(self, session, chat_id: int, message_id: int) -> Message | None:
+    async def _load_message_snapshot(self, session, account_id: int, chat_id: int, message_id: int) -> Message | None:
         """Plain lock-free read, used only for the fast-path no-change check."""
-        stmt = select(Message).where(and_(Message.chat_id == chat_id, Message.id == message_id))
+        stmt = select(Message).where(
+            and_(Message.account_id == account_id, Message.chat_id == chat_id, Message.id == message_id)
+        )
         result = await session.execute(stmt.execution_options(populate_existing=True))
         return result.scalar_one_or_none()
 
@@ -469,7 +507,7 @@ class DatabaseAdapter:
 
         changed = {}
         for key, value in update_values.items():
-            if key in ("id", "chat_id"):
+            if key in ("account_id", "id", "chat_id"):
                 continue
             if getattr(existing, key) != value:
                 changed[key] = value
@@ -487,14 +525,14 @@ class DatabaseAdapter:
         # below; skipping here is safe because a concurrent writer that changes the
         # row after our snapshot has, by definition, applied data at least as new
         # as ours.
-        snapshot = await self._load_message_snapshot(session, values["chat_id"], values["id"])
+        snapshot = await self._load_message_snapshot(session, values["account_id"], values["chat_id"], values["id"])
         if snapshot is None:
             logger.debug("Upsert no-op: message row vanished during conflict resolution")
             return
         if not self._pending_update_values(snapshot, message_data, values):
             return
 
-        existing = await self._load_message_for_update(session, values["chat_id"], values["id"])
+        existing = await self._load_message_for_update(session, values["account_id"], values["chat_id"], values["id"])
         if existing is None:
             logger.debug("Upsert no-op: message row vanished during conflict resolution")
             return
@@ -505,6 +543,7 @@ class DatabaseAdapter:
         if "text" in update_values:
             await self._record_message_version(
                 session=session,
+                account_id=existing.account_id,
                 chat_id=existing.chat_id,
                 message_id=existing.id,
                 text=existing.text,
@@ -512,12 +551,18 @@ class DatabaseAdapter:
             )
         await session.execute(
             update(Message)
-            .where(and_(Message.chat_id == values["chat_id"], Message.id == values["id"]))
+            .where(
+                and_(
+                    Message.account_id == values["account_id"],
+                    Message.chat_id == values["chat_id"],
+                    Message.id == values["id"],
+                )
+            )
             .values(**update_values)
         )
 
-    async def _insert_or_update_message(self, session, message_data: dict[str, Any]) -> None:
-        values = self._message_values(message_data)
+    async def _insert_or_update_message(self, session, message_data: dict[str, Any], *, account_id: int) -> None:
+        values = self._message_values(message_data, account_id)
         result = await session.execute(self._insert_message_stmt(values))
         if result.rowcount:
             return
@@ -548,7 +593,7 @@ class DatabaseAdapter:
             row = result.scalar_one_or_none()
             return row
 
-    async def get_migration_markers(self) -> list[tuple[int, int]]:
+    async def get_migration_markers(self, *, account_id: int) -> list[tuple[int, int]]:
         """Return stored group→supergroup migration pointers (#228).
 
         Selects service messages whose ``raw_data.action_type`` is
@@ -566,7 +611,9 @@ class DatabaseAdapter:
         markers: list[tuple[int, int]] = []
         async with self.db_manager.async_session_factory() as session:
             result = await session.execute(
-                select(Message.chat_id, Message.raw_data).where(Message.raw_data.like('%"chat_migrate_to"%'))
+                select(Message.chat_id, Message.raw_data).where(
+                    and_(Message.account_id == account_id, Message.raw_data.like('%"chat_migrate_to"%'))
+                )
             )
             for chat_id, raw in result.all():
                 if not raw:
@@ -585,15 +632,21 @@ class DatabaseAdapter:
     # ========== Chat Operations ==========
 
     @retry_on_locked()
-    async def upsert_chat(self, chat_data: dict[str, Any]) -> int:
+    async def upsert_chat(self, chat_data: dict[str, Any], *, account_id: int) -> int:
         """Insert or update a chat record.
 
         Only fields present in chat_data will be updated on conflict.
         This prevents the listener (which only provides basic fields)
         from overwriting is_forum/is_archived set by the backup.
+
+        ``ref`` is deliberately absent from both the values and the update set:
+        the model's Python-side default mints one on the INSERT branch, and the
+        DO UPDATE branch never touches the column, so a ref is stable for the
+        life of the row.
         """
         async with self.db_manager.async_session_factory() as session:
             values = {
+                "account_id": account_id,
                 "id": chat_data["id"],
                 "type": chat_data.get("type", "unknown"),
                 "title": chat_data.get("title"),
@@ -635,10 +688,10 @@ class DatabaseAdapter:
 
             if self._is_sqlite:
                 stmt = sqlite_insert(Chat).values(**values)
-                stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=update_set)
+                stmt = stmt.on_conflict_do_update(index_elements=["account_id", "id"], set_=update_set)
             else:
                 stmt = pg_insert(Chat).values(**values)
-                stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=update_set)
+                stmt = stmt.on_conflict_do_update(index_elements=["account_id", "id"], set_=update_set)
 
             await session.execute(stmt)
             await session.commit()
@@ -651,6 +704,8 @@ class DatabaseAdapter:
         search: str = None,
         archived: bool | None = None,
         folder_id: int | None = None,
+        *,
+        account_id: int | None = None,
     ) -> list[dict[str, Any]]:
         """Get chats with their last message date, with optional pagination and search.
 
@@ -660,6 +715,7 @@ class DatabaseAdapter:
             search: Optional search query (case-insensitive, matches title/first_name/last_name/username)
             archived: If True, only archived chats; if False, only non-archived; if None, all
             folder_id: If set, only chats in this folder
+            account_id: If set, only this account's chats (None = unscoped until phase 4)
         """
         async with self.db_manager.async_session_factory() as session:
             # Last message date, as a CORRELATED scalar subquery — one
@@ -671,9 +727,12 @@ class DatabaseAdapter:
             # every message in the archive on every /api/chats call. Measured on
             # 1,000 chats / 1,000,000 messages: 63 ms -> 1.3 ms, and flat in
             # archive size instead of linear.
+            # The account equality rides in the correlation (not only in an
+            # optional filter): a chat id repeats across accounts, so without it
+            # the max() would read BOTH accounts' copies of the chat.
             last_message_date = (
                 select(func.max(Message.date))
-                .where(Message.chat_id == Chat.id)
+                .where(and_(Message.account_id == Chat.account_id, Message.chat_id == Chat.id))
                 .correlate(Chat)
                 .scalar_subquery()
                 .label("last_message_date")
@@ -684,8 +743,16 @@ class DatabaseAdapter:
             # Filter by folder membership
             if folder_id is not None:
                 stmt = stmt.join(
-                    ChatFolderMember, and_(ChatFolderMember.chat_id == Chat.id, ChatFolderMember.folder_id == folder_id)
+                    ChatFolderMember,
+                    and_(
+                        ChatFolderMember.account_id == Chat.account_id,
+                        ChatFolderMember.chat_id == Chat.id,
+                        ChatFolderMember.folder_id == folder_id,
+                    ),
                 )
+
+            if account_id is not None:
+                stmt = stmt.where(Chat.account_id == account_id)
 
             # Filter by archived status
             if archived is True:
@@ -743,7 +810,12 @@ class DatabaseAdapter:
             return chats
 
     async def get_chat_count(
-        self, search: str = None, archived: bool | None = None, folder_id: int | None = None
+        self,
+        search: str = None,
+        archived: bool | None = None,
+        folder_id: int | None = None,
+        *,
+        account_id: int | None = None,
     ) -> int:
         """Get total number of chats (fast count for pagination).
 
@@ -751,14 +823,23 @@ class DatabaseAdapter:
             search: Optional search query to filter count
             archived: If True, only archived chats; if False, only non-archived; if None, all
             folder_id: If set, only chats in this folder
+            account_id: If set, only this account's chats (None = unscoped until phase 4)
         """
         async with self.db_manager.async_session_factory() as session:
             stmt = select(func.count(Chat.id))
 
             if folder_id is not None:
                 stmt = stmt.join(
-                    ChatFolderMember, and_(ChatFolderMember.chat_id == Chat.id, ChatFolderMember.folder_id == folder_id)
+                    ChatFolderMember,
+                    and_(
+                        ChatFolderMember.account_id == Chat.account_id,
+                        ChatFolderMember.chat_id == Chat.id,
+                        ChatFolderMember.folder_id == folder_id,
+                    ),
                 )
+
+            if account_id is not None:
+                stmt = stmt.where(Chat.account_id == account_id)
 
             if archived is True:
                 stmt = stmt.where(Chat.is_archived == 1)
@@ -829,17 +910,17 @@ class DatabaseAdapter:
     # ========== Message Operations ==========
 
     @retry_on_locked()
-    async def insert_message(self, message_data: dict[str, Any]) -> None:
+    async def insert_message(self, message_data: dict[str, Any], *, account_id: int) -> None:
         """Insert a message record.
 
         v6.0.0: media_type, media_id, media_path removed - use insert_media() separately.
         """
         async with self.db_manager.async_session_factory() as session:
-            await self._insert_or_update_message(session, message_data)
+            await self._insert_or_update_message(session, message_data, account_id=account_id)
             await session.commit()
 
     @retry_on_locked()
-    async def insert_messages_batch(self, messages_data: list[dict[str, Any]]) -> None:
+    async def insert_messages_batch(self, messages_data: list[dict[str, Any]], *, account_id: int) -> None:
         """Insert multiple message records in a single transaction.
 
         v6.0.0: media_type, media_id, media_path removed - use insert_media() separately.
@@ -849,18 +930,25 @@ class DatabaseAdapter:
 
         async with self.db_manager.async_session_factory() as session:
             for m in messages_data:
-                await self._insert_or_update_message(session, m)
+                await self._insert_or_update_message(session, m, account_id=account_id)
 
             await session.commit()
 
     async def get_messages_by_date_range(
-        self, chat_id: int | None = None, start_date: datetime | None = None, end_date: datetime | None = None
+        self,
+        chat_id: int | None = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
+        *,
+        account_id: int | None = None,
     ) -> list[dict[str, Any]]:
-        """Get messages within a date range."""
+        """Get messages within a date range (None account_id = unscoped until phase 4)."""
         async with self.db_manager.async_session_factory() as session:
             stmt = select(Message)
 
             conditions = []
+            if account_id is not None:
+                conditions.append(Message.account_id == account_id)
             if chat_id:
                 conditions.append(Message.chat_id == chat_id)
             if start_date:
@@ -876,8 +964,10 @@ class DatabaseAdapter:
             result = await session.execute(stmt)
             return [self._message_to_dict(m) for m in result.scalars()]
 
-    async def find_message_by_date(self, chat_id: int, target_date: datetime) -> dict[str, Any] | None:
-        """Find the first message on or after a specific date."""
+    async def find_message_by_date(
+        self, chat_id: int, target_date: datetime, *, account_id: int | None = None
+    ) -> dict[str, Any] | None:
+        """Find the first message on or after a specific date (None account_id = unscoped until phase 4)."""
         async with self.db_manager.async_session_factory() as session:
             stmt = (
                 select(Message)
@@ -885,22 +975,28 @@ class DatabaseAdapter:
                 .order_by(Message.date.asc())
                 .limit(1)
             )
+            if account_id is not None:
+                stmt = stmt.where(Message.account_id == account_id)
             result = await session.execute(stmt)
             message = result.scalar_one_or_none()
             return self._message_to_dict(message) if message else None
 
-    async def get_messages_sync_data(self, chat_id: int) -> dict[int, str | None]:
+    async def get_messages_sync_data(self, chat_id: int, *, account_id: int) -> dict[int, str | None]:
         """Get message IDs and their edit dates for sync checking."""
         async with self.db_manager.async_session_factory() as session:
             # Exclude soft-deleted rows so sync doesn't re-check them. The is_(None) arm is
             # defensive (is_deleted is NOT NULL with server_default 0) and mirrors is_archived.
             stmt = select(Message.id, Message.edit_date).where(
-                and_(Message.chat_id == chat_id, or_(Message.is_deleted == 0, Message.is_deleted.is_(None)))
+                and_(
+                    Message.account_id == account_id,
+                    Message.chat_id == chat_id,
+                    or_(Message.is_deleted == 0, Message.is_deleted.is_(None)),
+                )
             )
             result = await session.execute(stmt)
             return {row.id: row.edit_date for row in result}
 
-    async def get_message_ids_since(self, chat_id: int, cutoff: datetime, limit: int) -> list[int]:
+    async def get_message_ids_since(self, chat_id: int, cutoff: datetime, limit: int, *, account_id: int) -> list[int]:
         """Return the newest message IDs in a chat dated at or after ``cutoff`` (#221).
 
         Used by the bounded reaction re-sweep to recover self-reactions Telegram
@@ -910,56 +1006,80 @@ class DatabaseAdapter:
         async with self.db_manager.async_session_factory() as session:
             stmt = (
                 select(Message.id)
-                .where(and_(Message.chat_id == chat_id, Message.date >= cutoff))
+                .where(and_(Message.account_id == account_id, Message.chat_id == chat_id, Message.date >= cutoff))
                 .order_by(Message.id.desc())
                 .limit(limit)
             )
             result = await session.execute(stmt)
             return [row.id for row in result]
 
-    async def get_chat_id_for_message(self, message_id: int) -> int | None:
+    async def get_chat_id_for_message(self, message_id: int, *, account_id: int) -> int | None:
         """
-        Look up the chat_id for a message by its ID.
+        Look up the chat_id for a message by its ID, within one account.
 
-        Used when Telegram sends deletion events without chat_id.
+        Used when Telegram sends deletion events without chat_id — the event
+        arrived on one account's session, so only that account's rows are
+        candidates (idx_messages_account_msgid serves this seek).
         Note: Message IDs are only unique within a chat, so this may return
         multiple results. Returns the first match.
         """
         async with self.db_manager.async_session_factory() as session:
-            stmt = select(Message.chat_id).where(Message.id == message_id).limit(1)
+            stmt = (
+                select(Message.chat_id).where(and_(Message.account_id == account_id, Message.id == message_id)).limit(1)
+            )
             result = await session.execute(stmt)
             row = result.first()
             return row[0] if row else None
 
     @retry_on_locked()
-    async def delete_message(self, chat_id: int, message_id: int) -> None:
+    async def delete_message(self, chat_id: int, message_id: int, *, account_id: int) -> None:
         """Delete a specific message and its media."""
         async with self.db_manager.async_session_factory() as session:
             # Delete previous versions
             await session.execute(
                 delete(MessageVersion).where(
-                    and_(MessageVersion.chat_id == chat_id, MessageVersion.message_id == message_id)
+                    and_(
+                        MessageVersion.account_id == account_id,
+                        MessageVersion.chat_id == chat_id,
+                        MessageVersion.message_id == message_id,
+                    )
                 )
             )
             # Delete associated media
-            await session.execute(delete(Media).where(and_(Media.chat_id == chat_id, Media.message_id == message_id)))
+            await session.execute(
+                delete(Media).where(
+                    and_(Media.account_id == account_id, Media.chat_id == chat_id, Media.message_id == message_id)
+                )
+            )
             # Delete reactions
             await session.execute(
-                delete(Reaction).where(and_(Reaction.chat_id == chat_id, Reaction.message_id == message_id))
+                delete(Reaction).where(
+                    and_(
+                        Reaction.account_id == account_id,
+                        Reaction.chat_id == chat_id,
+                        Reaction.message_id == message_id,
+                    )
+                )
             )
             # Delete the message
-            await session.execute(delete(Message).where(and_(Message.chat_id == chat_id, Message.id == message_id)))
+            await session.execute(
+                delete(Message).where(
+                    and_(Message.account_id == account_id, Message.chat_id == chat_id, Message.id == message_id)
+                )
+            )
             await session.commit()
             logger.debug(f"Deleted message {message_id}")
 
     @retry_on_locked()
-    async def mark_message_deleted(self, chat_id: int, message_id: int, deleted_at: datetime | None = None) -> None:
+    async def mark_message_deleted(
+        self, chat_id: int, message_id: int, deleted_at: datetime | None = None, *, account_id: int
+    ) -> None:
         """Mark a message as deleted on Telegram while keeping archive content."""
         deleted_at = _strip_tz(deleted_at) or utcnow_naive()
         async with self.db_manager.async_session_factory() as session:
             result = await session.execute(
                 update(Message)
-                .where(and_(Message.chat_id == chat_id, Message.id == message_id))
+                .where(and_(Message.account_id == account_id, Message.chat_id == chat_id, Message.id == message_id))
                 .values(
                     is_deleted=1,
                     deleted_at=func.coalesce(Message.deleted_at, deleted_at),
@@ -971,16 +1091,20 @@ class DatabaseAdapter:
             else:
                 logger.debug(f"Soft-delete no-op: message {message_id} not in archive")
 
-    async def resolve_message_chat_id(self, message_id: int) -> int | None:
+    async def resolve_message_chat_id(self, message_id: int, *, account_id: int) -> int | None:
         """
-        Find which chat a message belongs to.
+        Find which chat a message belongs to, within one account.
 
-        Returns the chat_id if found in exactly one chat.
+        Returns the chat_id if found in exactly one of the account's chats.
         Returns None if not found or ambiguous (same ID in multiple chats).
-        Telegram message IDs are only unique within a chat.
+        Telegram message IDs are only unique within a chat — and another
+        account's rows must never make this account's lookup ambiguous, nor
+        resolve a deletion onto a chat this account never archived.
         """
         async with self.db_manager.async_session_factory() as session:
-            result = await session.execute(select(Message.chat_id).where(Message.id == message_id))
+            result = await session.execute(
+                select(Message.chat_id).where(and_(Message.account_id == account_id, Message.id == message_id))
+            )
             chat_ids = [row[0] for row in result.fetchall()]
 
             if len(chat_ids) == 1:
@@ -991,7 +1115,7 @@ class DatabaseAdapter:
 
     @retry_on_locked()
     async def update_message_text(
-        self, chat_id: int, message_id: int, new_text: str, edit_date: datetime | None
+        self, chat_id: int, message_id: int, new_text: str, edit_date: datetime | None, *, account_id: int
     ) -> str:
         """Update a message's text and edit_date.
 
@@ -1002,7 +1126,7 @@ class DatabaseAdapter:
         """
         edit_date = _strip_tz(edit_date)
         async with self.db_manager.async_session_factory() as session:
-            message = await self._load_message_for_update(session, chat_id, message_id)
+            message = await self._load_message_for_update(session, account_id, chat_id, message_id)
             if message is None:
                 logger.debug("Edit no-op: message not found in archive")
                 return "not_found"
@@ -1014,6 +1138,7 @@ class DatabaseAdapter:
             if message.text != new_text:
                 await self._record_message_version(
                     session=session,
+                    account_id=account_id,
                     chat_id=chat_id,
                     message_id=message_id,
                     text=message.text,
@@ -1021,14 +1146,16 @@ class DatabaseAdapter:
                 )
             await session.execute(
                 update(Message)
-                .where(and_(Message.chat_id == chat_id, Message.id == message_id))
+                .where(and_(Message.account_id == account_id, Message.chat_id == chat_id, Message.id == message_id))
                 .values(text=new_text, edit_date=edit_date)
             )
             await session.commit()
             logger.debug("Updated archived message text")
             return "applied"
 
-    async def sender_has_message_in_chats(self, sender_id: int, chat_ids: Iterable[int]) -> bool:
+    async def sender_has_message_in_chats(
+        self, sender_id: int, chat_ids: Iterable[int], *, account_id: int | None = None
+    ) -> bool:
         """Return True if sender_id authored at least one message in any of chat_ids.
 
         SELECT-only membership probe used by the media ACL to decide whether a
@@ -1044,16 +1171,27 @@ class DatabaseAdapter:
                 .where(and_(Message.sender_id == sender_id, Message.chat_id.in_(chat_id_list)))
                 .limit(1)
             )
+            if account_id is not None:
+                stmt = stmt.where(Message.account_id == account_id)
             result = await session.execute(stmt)
             return result.first() is not None
 
-    async def backfill_is_outgoing(self, owner_id: int) -> None:
-        """Backfill is_outgoing flag for messages sent by the owner."""
+    async def backfill_is_outgoing(self, owner_id: int, *, account_id: int) -> None:
+        """Backfill is_outgoing flag for messages sent by the owner.
+
+        Scoped to the account whose owner ``owner_id`` is: the same person can
+        be a mere participant in the other account's copy of a shared chat, and
+        those rows are genuinely not outgoing there.
+        """
         async with self.db_manager.async_session_factory() as session:
             result = await session.execute(
                 update(Message)
                 .where(
-                    and_(Message.sender_id == owner_id, or_(Message.is_outgoing == 0, Message.is_outgoing.is_(None)))
+                    and_(
+                        Message.account_id == account_id,
+                        Message.sender_id == owner_id,
+                        or_(Message.is_outgoing == 0, Message.is_outgoing.is_(None)),
+                    )
                 )
                 .values(is_outgoing=1)
             )
@@ -1103,8 +1241,10 @@ class DatabaseAdapter:
             "date": row.date,
         }
 
-    async def get_message_versions(self, chat_id: int, message_id: int, limit: int = 100) -> list[dict[str, Any]]:
-        """Get preserved previous text versions for a message."""
+    async def get_message_versions(
+        self, chat_id: int, message_id: int, limit: int = 100, *, account_id: int | None = None
+    ) -> list[dict[str, Any]]:
+        """Get preserved previous text versions for a message (None account_id = unscoped until phase 4)."""
         async with self.db_manager.async_session_factory() as session:
             stmt = (
                 select(MessageVersion)
@@ -1112,6 +1252,8 @@ class DatabaseAdapter:
                 .order_by(MessageVersion.date.desc(), MessageVersion.id.desc())
                 .limit(limit)
             )
+            if account_id is not None:
+                stmt = stmt.where(MessageVersion.account_id == account_id)
             result = await session.execute(stmt)
             return [self._message_version_to_dict(row) for row in result.scalars()]
 
@@ -1120,6 +1262,7 @@ class DatabaseAdapter:
         chat_id: int | None = None,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
+        account_id: int | None = None,
     ):
         # No join to messages: versions already carry (chat_id, message_id), and
         # referential integrity is owned by the explicit deletes in
@@ -1127,6 +1270,8 @@ class DatabaseAdapter:
         stmt = select(MessageVersion)
 
         conditions = []
+        if account_id is not None:
+            conditions.append(MessageVersion.account_id == account_id)
         if chat_id is not None:
             conditions.append(MessageVersion.chat_id == chat_id)
         if start_date:
@@ -1148,39 +1293,46 @@ class DatabaseAdapter:
         chat_id: int | None = None,
         start_date: datetime | None = None,
         end_date: datetime | None = None,
+        *,
+        account_id: int | None = None,
     ) -> list[dict[str, Any]]:
-        """Get previous message versions by version date/chat filter."""
+        """Get previous message versions by version date/chat filter (None account_id = unscoped until phase 4)."""
         async with self.db_manager.async_session_factory() as session:
-            result = await session.execute(self._message_versions_query(chat_id, start_date, end_date))
+            result = await session.execute(self._message_versions_query(chat_id, start_date, end_date, account_id))
             return [self._message_version_to_dict(row) for row in result.scalars()]
 
-    async def iter_message_versions_for_export(self, chat_id: int):
+    async def iter_message_versions_for_export(self, chat_id: int, *, account_id: int | None = None):
         """Stream a chat's message versions one by one (async generator).
 
         Mirrors get_messages_for_export so the export endpoint never
         materializes an entire edit history in memory.
         """
         async with self.db_manager.async_session_factory() as session:
-            result = await session.stream(self._message_versions_query(chat_id))
+            result = await session.stream(self._message_versions_query(chat_id, account_id=account_id))
             async for row in result.scalars():
                 yield self._message_version_to_dict(row)
 
-    async def get_chat_stats(self, chat_id: int) -> dict[str, Any]:
+    async def get_chat_stats(self, chat_id: int, *, account_id: int | None = None) -> dict[str, Any]:
         """Get statistics for a specific chat (message count, media count, total size).
+
+        None account_id = unscoped until phase 4.
 
         Returns:
             Dict with keys: messages, media_files, total_size_bytes, first_message_date, last_message_date
         """
+        msg_where = [Message.chat_id == chat_id]
+        media_where = [Media.chat_id == chat_id]
+        if account_id is not None:
+            msg_where.append(Message.account_id == account_id)
+            media_where.append(Media.account_id == account_id)
         async with self.db_manager.async_session_factory() as session:
             # Message count
-            msg_result = await session.execute(select(func.count(Message.id)).where(Message.chat_id == chat_id))
+            msg_result = await session.execute(select(func.count(Message.id)).where(and_(*msg_where)))
             message_count = msg_result.scalar() or 0
 
             # Media count and total size
             media_result = await session.execute(
-                select(func.count(Media.id), func.coalesce(func.sum(Media.file_size), 0)).where(
-                    Media.chat_id == chat_id
-                )
+                select(func.count(Media.id), func.coalesce(func.sum(Media.file_size), 0)).where(and_(*media_where))
             )
             media_row = media_result.one()
             media_count = media_row[0] or 0
@@ -1188,7 +1340,7 @@ class DatabaseAdapter:
 
             # First and last message dates
             date_result = await session.execute(
-                select(func.min(Message.date), func.max(Message.date)).where(Message.chat_id == chat_id)
+                select(func.min(Message.date), func.max(Message.date)).where(and_(*msg_where))
             )
             date_row = date_result.one()
             first_message = date_row[0]
@@ -1207,7 +1359,7 @@ class DatabaseAdapter:
     # ========== Media Operations ==========
 
     @retry_on_locked()
-    async def insert_media(self, media_data: dict[str, Any]) -> None:
+    async def insert_media(self, media_data: dict[str, Any], *, account_id: int) -> None:
         """Insert (or upsert) a media file record.
 
         Contract for the ``downloaded`` key: include it whenever the caller
@@ -1219,6 +1371,7 @@ class DatabaseAdapter:
         """
         async with self.db_manager.async_session_factory() as session:
             values = {
+                "account_id": account_id,
                 "id": media_data["id"],
                 "message_id": media_data.get("message_id"),
                 "chat_id": media_data.get("chat_id"),
@@ -1284,15 +1437,24 @@ class DatabaseAdapter:
             # A fresh INSERT still lands 0 for an absent key — nothing is downloaded.
             if "downloaded" not in media_data:
                 update_values["downloaded"] = Media.downloaded
-            stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=update_values)
+            stmt = stmt.on_conflict_do_update(index_elements=["account_id", "id"], set_=update_values)
 
             await session.execute(stmt)
             await session.commit()
 
-    async def find_media_by_content_hash(self, content_hash: str) -> dict[str, Any] | None:
-        """Find an existing downloaded media record with the given SHA-256 content hash."""
+    async def find_media_by_content_hash(self, content_hash: str, *, account_id: int) -> dict[str, Any] | None:
+        """Find an existing downloaded media record with the given SHA-256 content hash.
+
+        Account-scoped on purpose: shared-store dedup must only reuse a blob the
+        SAME account's rows reference, so no account's media ever points at
+        content that exists solely under another account's lifecycle.
+        """
         async with self.db_manager.async_session_factory() as session:
-            stmt = select(Media).where(and_(Media.content_hash == content_hash, Media.downloaded == 1)).limit(1)
+            stmt = (
+                select(Media)
+                .where(and_(Media.account_id == account_id, Media.content_hash == content_hash, Media.downloaded == 1))
+                .limit(1)
+            )
             result = await session.execute(stmt)
             media = result.scalar_one_or_none()
             if media is None:
@@ -1303,9 +1465,12 @@ class DatabaseAdapter:
                 "content_hash": media.content_hash,
             }
 
-    async def get_media_for_chat(self, chat_id: int) -> list[dict[str, Any]]:
+    async def get_media_for_chat(self, chat_id: int, *, account_id: int) -> list[dict[str, Any]]:
         """
-        Get all media records for a specific chat.
+        Get all media records for one account's copy of a chat.
+
+        Feeds the chat-cleanup path that deletes files from disk, so it must
+        never surface another account's rows.
 
         Args:
             chat_id: Chat identifier
@@ -1314,7 +1479,7 @@ class DatabaseAdapter:
             List of media records with file paths and metadata
         """
         async with self.db_manager.async_session_factory() as session:
-            stmt = select(Media).where(Media.chat_id == chat_id)
+            stmt = select(Media).where(and_(Media.account_id == account_id, Media.chat_id == chat_id))
             result = await session.execute(stmt)
             media_records = result.scalars().all()
 
@@ -1338,9 +1503,16 @@ class DatabaseAdapter:
         limit: int = 50,
         before_id: str | None = None,
         after_id: str | None = None,
+        *,
+        account_id: int | None = None,
     ) -> dict[str, Any]:
         """
         Get paginated media records for a chat with cursor-based pagination.
+
+        ``account_id=None`` is unscoped until phase 4. The media↔message joins
+        below carry the account equality UNCONDITIONALLY: a ``{chat}_{msg}_{type}``
+        media id repeats across accounts, so joining without it would multiply
+        rows even for a caller that asked for no scoping.
 
         ``before_id``/``after_id`` are opaque ``Media.id`` tokens (the gallery
         round-trips the composite ``{chat}_{msg}_{type}`` string), but each is resolved
@@ -1394,11 +1566,14 @@ class DatabaseAdapter:
             key_stmt = select(Media.id.label("page_media_id")).join(
                 Message,
                 and_(
+                    Media.account_id == Message.account_id,
                     Media.message_id == Message.id,
                     Media.chat_id == Message.chat_id,
                 ),
             )
             key_stmt = key_stmt.where(and_(Media.chat_id == chat_id, Media.downloaded == 1))
+            if account_id is not None:
+                key_stmt = key_stmt.where(Media.account_id == account_id)
 
             if media_types:
                 key_stmt = key_stmt.where(Media.type.in_(media_types))
@@ -1408,10 +1583,16 @@ class DatabaseAdapter:
                     select(Media.id, Media.message_id, Message.date)
                     .join(
                         Message,
-                        and_(Media.message_id == Message.id, Media.chat_id == Message.chat_id),
+                        and_(
+                            Media.account_id == Message.account_id,
+                            Media.message_id == Message.id,
+                            Media.chat_id == Message.chat_id,
+                        ),
                     )
                     .where(and_(Media.id == cursor_token, Media.chat_id == chat_id))
                 )
+                if account_id is not None:
+                    cursor_stmt = cursor_stmt.where(Media.account_id == account_id)
                 cursor_result = await session.execute(cursor_stmt)
                 cursor_row = cursor_result.one_or_none()
                 if cursor_row is None:
@@ -1455,7 +1636,8 @@ class DatabaseAdapter:
             else:
                 order_by = (Message.date.desc(), Media.message_id.desc(), Media.id.desc())
 
-            page_keys = key_stmt.order_by(*order_by).limit(limit + 1).subquery()
+            page_keys = key_stmt.add_columns(Media.account_id.label("page_account_id")).order_by(*order_by)
+            page_keys = page_keys.limit(limit + 1).subquery()
             stmt = (
                 select(
                     Media,
@@ -1465,10 +1647,14 @@ class DatabaseAdapter:
                     User.last_name,
                     User.username,
                 )
-                .join(page_keys, Media.id == page_keys.c.page_media_id)
+                .join(
+                    page_keys,
+                    and_(Media.account_id == page_keys.c.page_account_id, Media.id == page_keys.c.page_media_id),
+                )
                 .join(
                     Message,
                     and_(
+                        Media.account_id == Message.account_id,
                         Media.message_id == Message.id,
                         Media.chat_id == Message.chat_id,
                     ),
@@ -1501,12 +1687,13 @@ class DatabaseAdapter:
 
             return {"items": items, "has_more": has_more}
 
-    async def get_media_counts(self, chat_id: int) -> dict[str, int]:
+    async def get_media_counts(self, chat_id: int, *, account_id: int | None = None) -> dict[str, int]:
         """
         Get count of downloaded media grouped by type for a chat.
 
         Args:
             chat_id: Chat identifier
+            account_id: If set, only this account's media (None = unscoped until phase 4)
 
         Returns:
             Dict mapping media type to count (only types with count > 0)
@@ -1517,12 +1704,14 @@ class DatabaseAdapter:
                 .where(and_(Media.chat_id == chat_id, Media.downloaded == 1))
                 .group_by(Media.type)
             )
+            if account_id is not None:
+                stmt = stmt.where(Media.account_id == account_id)
             result = await session.execute(stmt)
             return {row[0]: row[1] for row in result.all()}
 
-    async def delete_media_for_chat(self, chat_id: int) -> int:
+    async def delete_media_for_chat(self, chat_id: int, *, account_id: int) -> int:
         """
-        Delete all media records for a specific chat.
+        Delete one account's media records for a specific chat.
         Does not delete message records or the chat itself.
 
         Args:
@@ -1532,22 +1721,23 @@ class DatabaseAdapter:
             Number of media records deleted
         """
         async with self.db_manager.async_session_factory() as session:
-            stmt = delete(Media).where(Media.chat_id == chat_id)
+            stmt = delete(Media).where(and_(Media.account_id == account_id, Media.chat_id == chat_id))
             result = await session.execute(stmt)
             await session.commit()
             return result.rowcount
 
-    async def get_media_for_verification(self) -> list[dict[str, Any]]:
+    async def get_media_for_verification(self, *, account_id: int) -> list[dict[str, Any]]:
         """
-        Get all media records that should have files on disk.
-        Used by VERIFY_MEDIA to check for missing/corrupted files.
+        Get one account's media records that should have files on disk.
+        Used by VERIFY_MEDIA to check for missing/corrupted files — the caller
+        re-downloads what is missing, and only this account's session can.
 
         Returns media where downloaded=1 OR file_path is not null.
         """
         async with self.db_manager.async_session_factory() as session:
             stmt = (
                 select(Media)
-                .where(or_(Media.downloaded == 1, Media.file_path.isnot(None)))
+                .where(and_(Media.account_id == account_id, or_(Media.downloaded == 1, Media.file_path.isnot(None))))
                 .order_by(Media.chat_id, Media.message_id)
             )
             result = await session.execute(stmt)
@@ -1566,29 +1756,40 @@ class DatabaseAdapter:
             ]
 
     async def iter_media_paths_for_repair(self, batch_size: int = 500):
-        """Yield ``(id, file_path, file_name)`` batches for the #175 repair pass.
+        """Yield ``(account_id, id, file_path, file_name)`` batches for the #175 repair pass.
 
-        Keyset-paginated on the primary key and projecting only the three columns
-        the repair needs, so memory stays bounded regardless of table size. The
-        full-table materialization in ``get_media_for_verification`` OOM-killed
-        the 256m backup container on large archives; this streams instead.
+        Deliberately account-blind: extension repair fixes the file each row
+        points at, whatever account owns the row, so the sweep walks the whole
+        archive once. Keyset-paginated on the FULL primary key (account_id, id)
+        — ``id`` alone stopped being unique in v8.0.0, and a strict ``>`` on a
+        non-unique key silently skips the second account's copy of an id.
+        Projects only the columns the repair needs, so memory stays bounded
+        regardless of table size. The full-table materialization in
+        ``get_media_for_verification`` OOM-killed the 256m backup container on
+        large archives; this streams instead.
         """
-        last_id: str | None = None
+        last_key: tuple[int, str] | None = None
         while True:
             async with self.db_manager.async_session_factory() as session:
                 stmt = (
-                    select(Media.id, Media.file_path, Media.file_name)
+                    select(Media.account_id, Media.id, Media.file_path, Media.file_name)
                     .where(or_(Media.downloaded == 1, Media.file_path.isnot(None)))
-                    .order_by(Media.id)
+                    .order_by(Media.account_id, Media.id)
                     .limit(batch_size)
                 )
-                if last_id is not None:
-                    stmt = stmt.where(Media.id > last_id)
+                if last_key is not None:
+                    last_account, last_id = last_key
+                    stmt = stmt.where(
+                        or_(
+                            Media.account_id > last_account,
+                            and_(Media.account_id == last_account, Media.id > last_id),
+                        )
+                    )
                 rows = (await session.execute(stmt)).all()
             if not rows:
                 return
-            yield [{"id": r[0], "file_path": r[1], "file_name": r[2]} for r in rows]
-            last_id = rows[-1][0]
+            yield [{"account_id": r[0], "id": r[1], "file_path": r[2], "file_name": r[3]} for r in rows]
+            last_key = (rows[-1][0], rows[-1][1])
             if len(rows) < batch_size:
                 return
 
@@ -1597,6 +1798,8 @@ class DatabaseAdapter:
         max_media_size_bytes: int | None = None,
         max_attempts: int | None = None,
         limit: int | None = 1000,
+        *,
+        account_id: int,
     ) -> list[dict[str, Any]]:
         """Get media records that failed to download and need retry.
 
@@ -1615,6 +1818,9 @@ class DatabaseAdapter:
         """
         async with self.db_manager.async_session_factory() as session:
             conditions = [
+                # Only this account's failures: retrying them needs this
+                # account's client, and only its session can fetch them.
+                Media.account_id == account_id,
                 Media.downloaded == 0,
                 Media.type.notin_(["contact", "geo", "poll"]),
             ]
@@ -1651,18 +1857,22 @@ class DatabaseAdapter:
             ]
 
     @retry_on_locked()
-    async def increment_media_download_attempts(self, media_id: str) -> None:
-        """Bump the failed-download attempt counter for a media record (#212)."""
+    async def increment_media_download_attempts(self, media_id: str, *, account_id: int) -> None:
+        """Bump the failed-download attempt counter for a media record (#212).
+
+        A media id repeats across accounts (it is ``{chat}_{msg}_{type}``), so
+        an id-only UPDATE here would charge one account's failure to both.
+        """
         async with self.db_manager.async_session_factory() as session:
             stmt = (
                 update(Media)
-                .where(Media.id == media_id)
+                .where(and_(Media.account_id == account_id, Media.id == media_id))
                 .values(download_attempts=func.coalesce(Media.download_attempts, 0) + 1)
             )
             await session.execute(stmt)
             await session.commit()
 
-    async def mark_media_for_redownload(self, media_id: str) -> None:
+    async def mark_media_for_redownload(self, media_id: str, *, account_id: int) -> None:
         """Mark a media record as needing re-download.
 
         Also resets download_attempts so a row that previously hit the retry
@@ -1671,13 +1881,13 @@ class DatabaseAdapter:
         async with self.db_manager.async_session_factory() as session:
             stmt = (
                 update(Media)
-                .where(Media.id == media_id)
+                .where(and_(Media.account_id == account_id, Media.id == media_id))
                 .values(downloaded=0, file_path=None, download_date=None, download_attempts=0)
             )
             await session.execute(stmt)
             await session.commit()
 
-    async def count_capped_media_downloads(self, max_attempts: int) -> int:
+    async def count_capped_media_downloads(self, max_attempts: int, *, account_id: int) -> int:
         """Count downloadable media permanently skipped after hitting the retry cap (#212).
 
         Lets the caller surface an aggregate signal instead of silently abandoning
@@ -1686,6 +1896,7 @@ class DatabaseAdapter:
         async with self.db_manager.async_session_factory() as session:
             stmt = select(func.count(Media.id)).where(
                 and_(
+                    Media.account_id == account_id,
                     Media.downloaded == 0,
                     Media.type.notin_(["contact", "geo", "poll"]),
                     Media.download_attempts >= max_attempts,
@@ -1693,10 +1904,14 @@ class DatabaseAdapter:
             )
             return (await session.execute(stmt)).scalar() or 0
 
-    async def update_media_file_path(self, media_id: str, file_path: str) -> None:
+    async def update_media_file_path(self, media_id: str, file_path: str, *, account_id: int) -> None:
         """Update the stored file_path for a single media record."""
         async with self.db_manager.async_session_factory() as session:
-            stmt = update(Media).where(Media.id == media_id).values(file_path=file_path)
+            stmt = (
+                update(Media)
+                .where(and_(Media.account_id == account_id, Media.id == media_id))
+                .values(file_path=file_path)
+            )
             await session.execute(stmt)
             await session.commit()
 
@@ -1712,8 +1927,13 @@ class DatabaseAdapter:
                 await session.commit()
                 logger.info("Reset reactions_id_seq sequence")
 
-    async def get_reactions(self, message_id: int, chat_id: int) -> list[dict[str, Any]]:
-        """Get all currently-active reactions for a message (excludes tombstoned)."""
+    async def get_reactions(
+        self, message_id: int, chat_id: int, *, account_id: int | None = None
+    ) -> list[dict[str, Any]]:
+        """Get all currently-active reactions for a message (excludes tombstoned).
+
+        None account_id = unscoped until phase 4.
+        """
         async with self.db_manager.async_session_factory() as session:
             stmt = (
                 select(Reaction)
@@ -1726,6 +1946,8 @@ class DatabaseAdapter:
                 )
                 .order_by(Reaction.emoji)
             )
+            if account_id is not None:
+                stmt = stmt.where(Reaction.account_id == account_id)
             result = await session.execute(stmt)
             return [{"emoji": r.emoji, "user_id": r.user_id, "count": r.count} for r in result.scalars()]
 
@@ -1736,6 +1958,7 @@ class DatabaseAdapter:
         chat_id: int,
         observed: list[dict[str, Any]],
         *,
+        account_id: int,
         mark_removed: bool = True,
         _after_seq_reset: bool = False,
     ) -> str:
@@ -1773,13 +1996,19 @@ class DatabaseAdapter:
             # NULL user_id, so nothing else dedups them → inflated viewer counts).
             # This also guards the FK: reactions.fk_reaction_message has no CASCADE,
             # so a reaction for an unarchived message would raise on PostgreSQL.
-            if await self._load_message_for_update(session, chat_id, message_id) is None:
+            if await self._load_message_for_update(session, account_id, chat_id, message_id) is None:
                 return "no_message"
 
             existing_rows = (
                 (
                     await session.execute(
-                        select(Reaction).where(and_(Reaction.message_id == message_id, Reaction.chat_id == chat_id))
+                        select(Reaction).where(
+                            and_(
+                                Reaction.account_id == account_id,
+                                Reaction.message_id == message_id,
+                                Reaction.chat_id == chat_id,
+                            )
+                        )
                     )
                 )
                 .scalars()
@@ -1824,6 +2053,7 @@ class DatabaseAdapter:
                 else:
                     session.add(
                         Reaction(
+                            account_id=account_id,
                             message_id=message_id,
                             chat_id=chat_id,
                             emoji=emoji,
@@ -1873,27 +2103,37 @@ class DatabaseAdapter:
                     logger.warning("Reactions sequence out of sync during reconcile, resetting and retrying")
                     await self._reset_reactions_sequence()
                     return await self.reconcile_reactions(
-                        message_id, chat_id, observed, mark_removed=mark_removed, _after_seq_reset=True
+                        message_id,
+                        chat_id,
+                        observed,
+                        account_id=account_id,
+                        mark_removed=mark_removed,
+                        _after_seq_reset=True,
                     )
                 raise
             return "reconciled"
 
     # ========== Sync Status Operations ==========
 
-    async def get_last_message_id(self, chat_id: int) -> int:
-        """Get the last synced message ID for a chat."""
+    async def get_last_message_id(self, chat_id: int, *, account_id: int) -> int:
+        """Get the last synced message ID for one account's copy of a chat."""
         async with self.db_manager.async_session_factory() as session:
-            stmt = select(SyncStatus.last_message_id).where(SyncStatus.chat_id == chat_id)
+            stmt = select(SyncStatus.last_message_id).where(
+                and_(SyncStatus.account_id == account_id, SyncStatus.chat_id == chat_id)
+            )
             result = await session.execute(stmt)
             row = result.scalar_one_or_none()
             return row if row else 0
 
     @retry_on_locked()
-    async def update_sync_status(self, chat_id: int, last_message_id: int, message_count: int) -> None:
+    async def update_sync_status(
+        self, chat_id: int, last_message_id: int, message_count: int, *, account_id: int
+    ) -> None:
         """Update sync status for a chat using atomic upsert."""
         async with self.db_manager.async_session_factory() as session:
             now = utcnow_naive()
             values = {
+                "account_id": account_id,
                 "chat_id": chat_id,
                 "last_message_id": last_message_id,
                 "last_sync_date": now,
@@ -1903,7 +2143,7 @@ class DatabaseAdapter:
             if self._is_sqlite:
                 stmt = sqlite_insert(SyncStatus).values(**values)
                 stmt = stmt.on_conflict_do_update(
-                    index_elements=["chat_id"],
+                    index_elements=["account_id", "chat_id"],
                     set_={
                         "last_message_id": stmt.excluded.last_message_id,
                         "last_sync_date": stmt.excluded.last_sync_date,
@@ -1913,7 +2153,7 @@ class DatabaseAdapter:
             else:
                 stmt = pg_insert(SyncStatus).values(**values)
                 stmt = stmt.on_conflict_do_update(
-                    index_elements=["chat_id"],
+                    index_elements=["account_id", "chat_id"],
                     set_={
                         "last_message_id": stmt.excluded.last_message_id,
                         "last_sync_date": stmt.excluded.last_sync_date,
@@ -1926,10 +2166,16 @@ class DatabaseAdapter:
 
     # ========== Gap Detection ==========
 
-    async def detect_message_gaps(self, chat_id: int, threshold: int = 50) -> list[tuple[int, int, int]]:
-        """Detect gaps in message ID sequences for a chat.
+    async def detect_message_gaps(
+        self, chat_id: int, threshold: int = 50, *, account_id: int
+    ) -> list[tuple[int, int, int]]:
+        """Detect gaps in message ID sequences for one account's copy of a chat.
 
         Uses a SQL LAG() window function to find gaps larger than threshold.
+        The window MUST name the account: two accounts' id sequences for the
+        same chat interleave, so an account-blind LAG() reads them as one
+        sequence and a real gap disappears whenever the other account's ids
+        happen to fall inside it (measured on both backends).
 
         Returns:
             List of (gap_start_id, gap_end_id, gap_size) tuples where
@@ -1946,24 +2192,24 @@ class DatabaseAdapter:
                             id AS gap_end,
                             id - LAG(id) OVER (ORDER BY id) AS gap_size
                         FROM messages
-                        WHERE chat_id = :chat_id
+                        WHERE chat_id = :chat_id AND account_id = :account_id
                     ) gaps
                     WHERE gap_size > :threshold
                     ORDER BY gap_start
                     """
                 ),
-                {"chat_id": chat_id, "threshold": threshold},
+                {"chat_id": chat_id, "account_id": account_id, "threshold": threshold},
             )
             return [(row[0], row[1], row[2]) for row in result.fetchall()]
 
-    async def get_chats_with_messages(self) -> list[int]:
-        """Get all chat IDs that exist in the chats table.
+    async def get_chats_with_messages(self, *, account_id: int) -> list[int]:
+        """Get one account's chat IDs from the chats table.
 
         Queries the chats table directly instead of scanning the messages table,
         which would be extremely slow on large databases.
         """
         async with self.db_manager.async_session_factory() as session:
-            stmt = select(Chat.id)
+            stmt = select(Chat.id).where(Chat.account_id == account_id)
             result = await session.execute(stmt)
             return [row[0] for row in result.fetchall()]
 
@@ -2074,21 +2320,37 @@ class DatabaseAdapter:
 
     # ========== Delete Operations ==========
 
-    async def delete_chat_and_related_data(self, chat_id: int, media_base_path: str = None) -> None:
-        """Delete a chat and all related data."""
+    async def delete_chat_and_related_data(self, chat_id: int, media_base_path: str = None, *, account_id: int) -> None:
+        """Delete one account's copy of a chat and all related data.
+
+        The on-disk media directory below is chat-scoped, not account-scoped:
+        while the media layout stays ``<base>/<chat_id>`` this also removes any
+        files another account's copy of the chat still references. Single-account
+        (this stage) that set is empty; phase 5 owns the layout decision.
+        """
         async with self.db_manager.async_session_factory() as session:
             # Delete previous versions
-            await session.execute(delete(MessageVersion).where(MessageVersion.chat_id == chat_id))
+            await session.execute(
+                delete(MessageVersion).where(
+                    and_(MessageVersion.account_id == account_id, MessageVersion.chat_id == chat_id)
+                )
+            )
             # Delete media records
-            await session.execute(delete(Media).where(Media.chat_id == chat_id))
+            await session.execute(delete(Media).where(and_(Media.account_id == account_id, Media.chat_id == chat_id)))
             # Delete reactions
-            await session.execute(delete(Reaction).where(Reaction.chat_id == chat_id))
+            await session.execute(
+                delete(Reaction).where(and_(Reaction.account_id == account_id, Reaction.chat_id == chat_id))
+            )
             # Delete messages
-            await session.execute(delete(Message).where(Message.chat_id == chat_id))
+            await session.execute(
+                delete(Message).where(and_(Message.account_id == account_id, Message.chat_id == chat_id))
+            )
             # Delete sync status
-            await session.execute(delete(SyncStatus).where(SyncStatus.chat_id == chat_id))
+            await session.execute(
+                delete(SyncStatus).where(and_(SyncStatus.account_id == account_id, SyncStatus.chat_id == chat_id))
+            )
             # Delete chat
-            await session.execute(delete(Chat).where(Chat.id == chat_id))
+            await session.execute(delete(Chat).where(and_(Chat.account_id == account_id, Chat.id == chat_id)))
 
             await session.commit()
             logger.info("Deleted chat and all related data from database")
@@ -2125,7 +2387,9 @@ class DatabaseAdapter:
 
     # ========== Web Viewer Operations ==========
 
-    async def _attach_reply_metadata(self, session, chat_id: int, messages: list[dict[str, Any]]) -> None:
+    async def _attach_reply_metadata(
+        self, session, chat_id: int, messages: list[dict[str, Any]], account_id: int | None = None
+    ) -> None:
         """Resolve the reply targets of a whole page in ONE query (#268).
 
         THE single rule for what a reply quote block shows. Every read path that
@@ -2153,7 +2417,9 @@ class DatabaseAdapter:
 
         reply_media_type = (
             select(Media.type)
-            .where(and_(Media.chat_id == chat_id, Media.message_id == Message.id))
+            .where(
+                and_(Media.account_id == Message.account_id, Media.chat_id == chat_id, Media.message_id == Message.id)
+            )
             .order_by(Media.id)
             .limit(1)
             .scalar_subquery()
@@ -2172,6 +2438,8 @@ class DatabaseAdapter:
             .outerjoin(User, Message.sender_id == User.id)
             .where(and_(Message.chat_id == chat_id, Message.id.in_(reply_ids_needed)))
         )
+        if account_id is not None:
+            reply_stmt = reply_stmt.where(Message.account_id == account_id)
         reply_result = await session.execute(reply_stmt)
         reply_rows: dict[int, dict[str, Any]] = {
             row.id: {
@@ -2203,9 +2471,13 @@ class DatabaseAdapter:
         before_id: int | None = None,
         after_id: int | None = None,
         topic_id: int | None = None,
+        *,
+        account_id: int | None = None,
     ) -> list[dict[str, Any]]:
         """
         Get messages with user info and media info for web viewer.
+
+        ``account_id=None`` is unscoped until phase 4 (viewer entitlements).
 
         v6.0.0: Media is now returned as a nested object from the media table.
         v6.2.0: Added topic_id filter for forum topic messages.
@@ -2251,9 +2523,19 @@ class DatabaseAdapter:
                     Media.duration.label("media_duration"),
                 )
                 .outerjoin(User, Message.sender_id == User.id)
-                .outerjoin(Media, and_(Media.message_id == Message.id, Media.chat_id == Message.chat_id))
+                .outerjoin(
+                    Media,
+                    and_(
+                        Media.account_id == Message.account_id,
+                        Media.message_id == Message.id,
+                        Media.chat_id == Message.chat_id,
+                    ),
+                )
                 .where(Message.chat_id == chat_id)
             )
+
+            if account_id is not None:
+                stmt = stmt.where(Message.account_id == account_id)
 
             # v6.2.0: Filter by forum topic. NULL reply_to_top_id == General (id=1),
             # matching the coalesce in get_forum_topics counts.
@@ -2351,10 +2633,12 @@ class DatabaseAdapter:
                     )
                     .group_by(MessageVersion.message_id)
                 )
+                if account_id is not None:
+                    count_stmt = count_stmt.where(MessageVersion.account_id == account_id)
                 count_result = await session.execute(count_stmt)
                 version_counts.update({row.message_id: int(row.version_count or 0) for row in count_result})
 
-            await self._attach_reply_metadata(session, chat_id, messages)
+            await self._attach_reply_metadata(session, chat_id, messages, account_id)
 
             # Batch reactions: one query for the whole page instead of one
             # get_reactions() call per message. Ties within the same emoji are
@@ -2374,6 +2658,8 @@ class DatabaseAdapter:
                     )
                     .order_by(Reaction.message_id, Reaction.emoji, Reaction.id)
                 )
+                if account_id is not None:
+                    reactions_stmt = reactions_stmt.where(Reaction.account_id == account_id)
                 reactions_result = await session.execute(reactions_stmt)
                 for r in reactions_result.scalars():
                     reactions_by_message[r.message_id].append(
@@ -2400,8 +2686,10 @@ class DatabaseAdapter:
         chat_id: int,
         day_ranges: list[tuple[str, datetime, datetime]],
         topic_id: int | None = None,
+        *,
+        account_id: int | None = None,
     ) -> list[str]:
-        """Return the requested local-calendar dates that contain messages."""
+        """Return the requested local-calendar dates that contain messages (None account_id = unscoped until phase 4)."""
         if not day_ranges:
             return []
 
@@ -2412,6 +2700,8 @@ class DatabaseAdapter:
                 Message.date >= utc_start,
                 Message.date < utc_end,
             ]
+            if account_id is not None:
+                conditions.append(Message.account_id == account_id)
             if topic_id is not None:
                 conditions.append(func.coalesce(Message.reply_to_top_id, 1) == topic_id)
             branches.append(
@@ -2429,6 +2719,8 @@ class DatabaseAdapter:
         chat_id: int,
         target_date: datetime,
         topic_id: int | None = None,
+        *,
+        account_id: int | None = None,
     ) -> dict[str, Any] | None:
         """
         Find message by date with full user/media joins for web viewer.
@@ -2439,6 +2731,7 @@ class DatabaseAdapter:
             chat_id: Chat ID
             target_date: Target date to find message for
             topic_id: Optional forum topic ID to filter messages by thread
+            account_id: If set, only this account's messages (None = unscoped until phase 4)
 
         Returns:
             Message dictionary with user and media info, or None
@@ -2461,9 +2754,18 @@ class DatabaseAdapter:
                     Media.duration.label("media_duration"),
                 )
                 .outerjoin(User, Message.sender_id == User.id)
-                .outerjoin(Media, and_(Media.message_id == Message.id, Media.chat_id == Message.chat_id))
+                .outerjoin(
+                    Media,
+                    and_(
+                        Media.account_id == Message.account_id,
+                        Media.message_id == Message.id,
+                        Media.chat_id == Message.chat_id,
+                    ),
+                )
                 .where(Message.chat_id == chat_id)
             )
+            if account_id is not None:
+                base_stmt = base_stmt.where(Message.account_id == account_id)
             if topic_id is not None:
                 base_stmt = base_stmt.where(func.coalesce(Message.reply_to_top_id, 1) == topic_id)
 
@@ -2519,10 +2821,10 @@ class DatabaseAdapter:
             # Reply quote metadata — same helper, same rule as every other read
             # path. It replaces a text-only lookup that resolved less than the
             # message list did for the very same message.
-            await self._attach_reply_metadata(session, chat_id, [msg])
+            await self._attach_reply_metadata(session, chat_id, [msg], account_id)
 
             # Get reactions
-            reactions = await self.get_reactions(msg["id"], chat_id)
+            reactions = await self.get_reactions(msg["id"], chat_id, account_id=account_id)
             reactions_by_emoji = {}
             for reaction in reactions:
                 emoji = reaction["emoji"]
@@ -2535,10 +2837,13 @@ class DatabaseAdapter:
 
             return msg
 
-    async def get_chat_by_id(self, chat_id: int) -> dict[str, Any] | None:
-        """Get a single chat by ID."""
+    async def get_chat_by_id(self, chat_id: int, *, account_id: int | None = None) -> dict[str, Any] | None:
+        """Get a single chat by ID (None account_id = unscoped until phase 4)."""
         async with self.db_manager.async_session_factory() as session:
-            result = await session.execute(select(Chat).where(Chat.id == chat_id))
+            stmt = select(Chat).where(Chat.id == chat_id)
+            if account_id is not None:
+                stmt = stmt.where(Chat.account_id == account_id)
+            result = await session.execute(stmt)
             chat = result.scalar_one_or_none()
             if not chat:
                 return None
@@ -2556,10 +2861,11 @@ class DatabaseAdapter:
                 "is_archived": chat.is_archived,
             }
 
-    async def get_pinned_messages(self, chat_id: int) -> list[dict[str, Any]]:
+    async def get_pinned_messages(self, chat_id: int, *, account_id: int | None = None) -> list[dict[str, Any]]:
         """Get all pinned messages for a chat, ordered by date descending (newest first).
 
         v6.0.0: Media is now returned as a nested object from the media table.
+        None account_id = unscoped until phase 4.
 
         The pinned-only view swaps this list into the SAME message renderer the
         normal list uses, so a pinned reply must arrive with the same reply
@@ -2584,11 +2890,20 @@ class DatabaseAdapter:
                     Media.duration.label("media_duration"),
                 )
                 .outerjoin(User, Message.sender_id == User.id)
-                .outerjoin(Media, and_(Media.message_id == Message.id, Media.chat_id == Message.chat_id))
+                .outerjoin(
+                    Media,
+                    and_(
+                        Media.account_id == Message.account_id,
+                        Media.message_id == Message.id,
+                        Media.chat_id == Message.chat_id,
+                    ),
+                )
                 .where(Message.chat_id == chat_id)
                 .where(Message.is_pinned == 1)
                 .order_by(Message.date.desc())
             )
+            if account_id is not None:
+                stmt = stmt.where(Message.account_id == account_id)
 
             result = await session.execute(stmt)
             rows = result.all()
@@ -2627,16 +2942,18 @@ class DatabaseAdapter:
                 messages.append(msg)
 
             # One query for the whole pinned list, not one per pinned reply.
-            await self._attach_reply_metadata(session, chat_id, messages)
+            await self._attach_reply_metadata(session, chat_id, messages, account_id)
 
             return messages
 
-    async def sync_pinned_messages(self, chat_id: int, pinned_message_ids: list[int]) -> None:
+    async def sync_pinned_messages(self, chat_id: int, pinned_message_ids: list[int], *, account_id: int) -> None:
         """
-        Sync pinned messages for a chat.
+        Sync pinned messages for one account's copy of a chat.
 
         Sets is_pinned=1 for messages in the list and is_pinned=0 for all others.
         This ensures the database reflects the current state of pinned messages.
+        The unpin sweep is the dangerous half: unscoped it would strip the other
+        account's pins for the same chat id.
 
         Args:
             chat_id: Chat ID
@@ -2645,13 +2962,18 @@ class DatabaseAdapter:
         async with self.db_manager.async_session_factory() as session:
             # First, unpin all messages in this chat
             await session.execute(
-                update(Message).where(Message.chat_id == chat_id).where(Message.is_pinned == 1).values(is_pinned=0)
+                update(Message)
+                .where(Message.account_id == account_id)
+                .where(Message.chat_id == chat_id)
+                .where(Message.is_pinned == 1)
+                .values(is_pinned=0)
             )
 
             # Then, pin the specified messages (if any exist in our database)
             if pinned_message_ids:
                 await session.execute(
                     update(Message)
+                    .where(Message.account_id == account_id)
                     .where(Message.chat_id == chat_id)
                     .where(Message.id.in_(pinned_message_ids))
                     .values(is_pinned=1)
@@ -2659,7 +2981,7 @@ class DatabaseAdapter:
 
             await session.commit()
 
-    async def update_message_pinned(self, chat_id: int, message_id: int, is_pinned: bool) -> None:
+    async def update_message_pinned(self, chat_id: int, message_id: int, is_pinned: bool, *, account_id: int) -> None:
         """
         Update the pinned status of a single message.
 
@@ -2673,6 +2995,7 @@ class DatabaseAdapter:
         async with self.db_manager.async_session_factory() as session:
             await session.execute(
                 update(Message)
+                .where(Message.account_id == account_id)
                 .where(Message.chat_id == chat_id)
                 .where(Message.id == message_id)
                 .values(is_pinned=1 if is_pinned else 0)
@@ -2695,10 +3018,13 @@ class DatabaseAdapter:
                 "is_bot": user.is_bot,
             }
 
-    async def get_messages_for_export(self, chat_id: int, include_media: bool = False):
+    async def get_messages_for_export(
+        self, chat_id: int, include_media: bool = False, *, account_id: int | None = None
+    ):
         """
         Get messages for export with user info.
         Returns an async generator for streaming.
+        None account_id = unscoped until phase 4.
 
         v6.0.0: Media info now comes from the media table via JOIN.
 
@@ -2726,7 +3052,14 @@ class DatabaseAdapter:
                         User.username,
                     )
                     .outerjoin(User, Message.sender_id == User.id)
-                    .outerjoin(Media, and_(Media.message_id == Message.id, Media.chat_id == Message.chat_id))
+                    .outerjoin(
+                        Media,
+                        and_(
+                            Media.account_id == Message.account_id,
+                            Media.message_id == Message.id,
+                            Media.chat_id == Message.chat_id,
+                        ),
+                    )
                     .where(Message.chat_id == chat_id)
                     .order_by(Message.date.asc())
                 )
@@ -2747,6 +3080,9 @@ class DatabaseAdapter:
                     .where(Message.chat_id == chat_id)
                     .order_by(Message.date.asc())
                 )
+
+            if account_id is not None:
+                stmt = stmt.where(Message.account_id == account_id)
 
             result = await session.stream(stmt)
             async for row in result:
@@ -2772,10 +3108,11 @@ class DatabaseAdapter:
     # ========== Forum Topic Operations (v6.2.0) ==========
 
     @retry_on_locked()
-    async def upsert_forum_topic(self, topic_data: dict[str, Any]) -> None:
+    async def upsert_forum_topic(self, topic_data: dict[str, Any], *, account_id: int) -> None:
         """Insert or update a forum topic record."""
         async with self.db_manager.async_session_factory() as session:
             values = {
+                "account_id": account_id,
                 "id": topic_data["id"],
                 "chat_id": topic_data["chat_id"],
                 "title": topic_data["title"],
@@ -2803,29 +3140,35 @@ class DatabaseAdapter:
 
             if self._is_sqlite:
                 stmt = sqlite_insert(ForumTopic).values(**values)
-                stmt = stmt.on_conflict_do_update(index_elements=["id", "chat_id"], set_=update_set)
+                stmt = stmt.on_conflict_do_update(index_elements=["account_id", "chat_id", "id"], set_=update_set)
             else:
                 stmt = pg_insert(ForumTopic).values(**values)
-                stmt = stmt.on_conflict_do_update(index_elements=["id", "chat_id"], set_=update_set)
+                stmt = stmt.on_conflict_do_update(index_elements=["account_id", "chat_id", "id"], set_=update_set)
 
             await session.execute(stmt)
             await session.commit()
 
-    async def get_forum_topics(self, chat_id: int) -> list[dict[str, Any]]:
-        """Get all forum topics for a chat, with message count per topic."""
+    async def get_forum_topics(self, chat_id: int, *, account_id: int | None = None) -> list[dict[str, Any]]:
+        """Get all forum topics for a chat, with message count per topic.
+
+        None account_id = unscoped until phase 4.
+        """
         async with self.db_manager.async_session_factory() as session:
             # Subquery for message counts and last message date per topic.
             # Messages with reply_to_top_id=NULL are treated as General topic (id=1),
             # since pre-v6.2.0 messages and pre-forum messages lack topic assignment
             # and Telegram's client displays them under General.
             effective_topic_id = func.coalesce(Message.reply_to_top_id, 1).label("effective_topic_id")
+            msg_where = [Message.chat_id == chat_id]
+            if account_id is not None:
+                msg_where.append(Message.account_id == account_id)
             msg_subq = (
                 select(
                     effective_topic_id,
                     func.count(Message.id).label("message_count"),
                     func.max(Message.date).label("last_message_date"),
                 )
-                .where(Message.chat_id == chat_id)
+                .where(and_(*msg_where))
                 .group_by(effective_topic_id)
                 .subquery()
             )
@@ -2836,6 +3179,8 @@ class DatabaseAdapter:
                 .where(ForumTopic.chat_id == chat_id)
                 .order_by(ForumTopic.is_pinned.desc(), msg_subq.c.last_message_date.desc().nullslast())
             )
+            if account_id is not None:
+                stmt = stmt.where(ForumTopic.account_id == account_id)
 
             result = await session.execute(stmt)
             topics = []
@@ -2862,10 +3207,11 @@ class DatabaseAdapter:
     # ========== Chat Folder Operations (v6.2.0) ==========
 
     @retry_on_locked()
-    async def upsert_chat_folder(self, folder_data: dict[str, Any]) -> None:
+    async def upsert_chat_folder(self, folder_data: dict[str, Any], *, account_id: int) -> None:
         """Insert or update a chat folder."""
         async with self.db_manager.async_session_factory() as session:
             values = {
+                "account_id": account_id,
                 "id": folder_data["id"],
                 "title": folder_data["title"],
                 "emoticon": folder_data.get("emoticon"),
@@ -2882,10 +3228,10 @@ class DatabaseAdapter:
 
             if self._is_sqlite:
                 stmt = sqlite_insert(ChatFolder).values(**values)
-                stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=update_set)
+                stmt = stmt.on_conflict_do_update(index_elements=["account_id", "id"], set_=update_set)
             else:
                 stmt = pg_insert(ChatFolder).values(**values)
-                stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=update_set)
+                stmt = stmt.on_conflict_do_update(index_elements=["account_id", "id"], set_=update_set)
 
             await session.execute(stmt)
             await session.commit()
@@ -2896,11 +3242,20 @@ class DatabaseAdapter:
     _FOLDER_MEMBER_CHUNK = 500
 
     @retry_on_locked()
-    async def sync_folder_members(self, folder_id: int, chat_ids: list[int]) -> None:
-        """Sync folder membership: replace all members for a folder."""
+    async def sync_folder_members(self, folder_id: int, chat_ids: list[int], *, account_id: int) -> None:
+        """Sync folder membership: replace all members for one account's folder.
+
+        Folder ids start at 2 for every account, so the replace-all delete must
+        name the account or it wipes the other account's identically-numbered
+        folder.
+        """
         async with self.db_manager.async_session_factory() as session:
             # Delete existing members
-            await session.execute(delete(ChatFolderMember).where(ChatFolderMember.folder_id == folder_id))
+            await session.execute(
+                delete(ChatFolderMember).where(
+                    and_(ChatFolderMember.account_id == account_id, ChatFolderMember.folder_id == folder_id)
+                )
+            )
 
             # Insert new members (only for chats that exist in our DB)
             if chat_ids:
@@ -2909,16 +3264,20 @@ class DatabaseAdapter:
                 existing_ids: set[int] = set()
                 for i in range(0, len(unique_ids), self._FOLDER_MEMBER_CHUNK):
                     chunk = unique_ids[i : i + self._FOLDER_MEMBER_CHUNK]
-                    result = await session.execute(select(Chat.id).where(Chat.id.in_(chunk)))
+                    result = await session.execute(
+                        select(Chat.id).where(and_(Chat.account_id == account_id, Chat.id.in_(chunk)))
+                    )
                     existing_ids.update(row[0] for row in result)
 
                 for cid in unique_ids:
                     if cid in existing_ids:
-                        session.add(ChatFolderMember(folder_id=folder_id, chat_id=cid))
+                        session.add(ChatFolderMember(account_id=account_id, folder_id=folder_id, chat_id=cid))
 
             await session.commit()
 
-    async def get_all_folders(self, allowed_chat_ids: set[int] | None = None) -> list[dict[str, Any]]:
+    async def get_all_folders(
+        self, allowed_chat_ids: set[int] | None = None, *, account_id: int | None = None
+    ) -> list[dict[str, Any]]:
         """Get all chat folders with their chat counts.
 
         Only folders that contain at least one backed-up (and, for restricted
@@ -2931,11 +3290,14 @@ class DatabaseAdapter:
 
         Args:
             allowed_chat_ids: If set, only count chats the user can access.
+            account_id: If set, only this account's folders (None = unscoped until phase 4).
         """
         async with self.db_manager.async_session_factory() as session:
             count_q = select(ChatFolderMember.folder_id, func.count(ChatFolderMember.chat_id).label("chat_count"))
             if allowed_chat_ids is not None:
                 count_q = count_q.where(ChatFolderMember.chat_id.in_(allowed_chat_ids))
+            if account_id is not None:
+                count_q = count_q.where(ChatFolderMember.account_id == account_id)
             count_subq = count_q.group_by(ChatFolderMember.folder_id).subquery()
 
             stmt = (
@@ -2943,6 +3305,8 @@ class DatabaseAdapter:
                 .outerjoin(count_subq, ChatFolder.id == count_subq.c.folder_id)
                 .order_by(ChatFolder.sort_order, ChatFolder.title)
             )
+            if account_id is not None:
+                stmt = stmt.where(ChatFolder.account_id == account_id)
 
             result = await session.execute(stmt)
             folders = []
@@ -2963,9 +3327,12 @@ class DatabaseAdapter:
                 )
             return folders
 
-    async def get_chats_for_folder_resolution(self) -> list[dict[str, Any]]:
-        """Return every archived chat with the facts needed to evaluate a folder's
-        category flags: id, type, whether it is a bot, and archived state.
+    async def get_chats_for_folder_resolution(self, *, account_id: int) -> list[dict[str, Any]]:
+        """Return one account's archived chats with the facts needed to evaluate a
+        folder's category flags: id, type, whether it is a bot, and archived state.
+
+        Account-scoped because the result becomes folder membership WRITES for
+        this account's folders — another account's chats must never be swept in.
 
         Bot-ness is only meaningful for private chats and is read from the users
         table (chats store bots as type ``private``). The join is on ``User.id ==
@@ -2974,12 +3341,16 @@ class DatabaseAdapter:
         they always resolve to ``is_bot = 0``.
         """
         async with self.db_manager.async_session_factory() as session:
-            stmt = select(
-                Chat.id,
-                Chat.type,
-                Chat.is_archived,
-                func.coalesce(User.is_bot, 0).label("is_bot"),
-            ).outerjoin(User, User.id == Chat.id)
+            stmt = (
+                select(
+                    Chat.id,
+                    Chat.type,
+                    Chat.is_archived,
+                    func.coalesce(User.is_bot, 0).label("is_bot"),
+                )
+                .outerjoin(User, User.id == Chat.id)
+                .where(Chat.account_id == account_id)
+            )
             result = await session.execute(stmt)
             return [
                 {
@@ -2992,19 +3363,31 @@ class DatabaseAdapter:
             ]
 
     @retry_on_locked()
-    async def cleanup_stale_folders(self, active_folder_ids: list[int]) -> None:
-        """Remove folders that no longer exist in Telegram."""
+    async def cleanup_stale_folders(self, active_folder_ids: list[int], *, account_id: int) -> None:
+        """Remove one account's folders that no longer exist in Telegram.
+
+        ``active_folder_ids`` comes from ONE account's dialog filters, so the
+        NOT IN sweep must stay inside that account — unscoped it deletes every
+        other account's folders wholesale (their ids are never in this list).
+        """
         async with self.db_manager.async_session_factory() as session:
             if active_folder_ids:
-                await session.execute(delete(ChatFolder).where(ChatFolder.id.notin_(active_folder_ids)))
+                await session.execute(
+                    delete(ChatFolder).where(
+                        and_(ChatFolder.account_id == account_id, ChatFolder.id.notin_(active_folder_ids))
+                    )
+                )
             else:
-                await session.execute(delete(ChatFolder))
+                await session.execute(delete(ChatFolder).where(ChatFolder.account_id == account_id))
             await session.commit()
 
-    async def get_archived_chat_count(self) -> int:
-        """Get the count of archived chats."""
+    async def get_archived_chat_count(self, *, account_id: int | None = None) -> int:
+        """Get the count of archived chats (None account_id = unscoped until phase 4)."""
         async with self.db_manager.async_session_factory() as session:
-            result = await session.execute(select(func.count(Chat.id)).where(Chat.is_archived == 1))
+            stmt = select(func.count(Chat.id)).where(Chat.is_archived == 1)
+            if account_id is not None:
+                stmt = stmt.where(Chat.account_id == account_id)
+            result = await session.execute(stmt)
             return result.scalar() or 0
 
     # ========================================================================

--- a/src/db/migrate.py
+++ b/src/db/migrate.py
@@ -14,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from .base import DatabaseManager
 from .models import (
+    Account,
     AppSettings,
     Base,
     Chat,
@@ -36,7 +37,11 @@ from .models import (
 
 logger = logging.getLogger(__name__)
 
+# Account leads: it is the registry every account_id below points at, and it
+# carries real data — label, telegram_user_id (filled on first login) — that
+# the target's own 022 seed cannot recreate: it only knows (1, 'default', NULL).
 MIGRATION_MODELS = [
+    Account,
     User,
     Chat,
     Message,

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -3,8 +3,24 @@ SQLAlchemy ORM models for Telegram Backup.
 
 v6.0.0 - Normalized schema with proper foreign key constraints.
 Media data is now stored only in the media table, not duplicated in messages.
+
+v8.0.0 - Multi-account. ``account_id`` leads the primary key of every table
+holding Telegram data, because a Telegram chat id, message id, topic id and
+dialog-filter id are only unique *within one account*. Without it a second
+account silently overwrites the first: measured on scratch schemas, a decorative
+``account_id`` column left ``message_versions``' UNIQUE(change_hash) discarding
+the second account's entire edit history, ``chat_folders``' PK(id) destroying the
+first account's folder title and every membership row, and ``messages``' PK
+(id, chat_id) dropping the second account's copy so it read the first account's
+``is_outgoing``.
+
+``users`` stays global on purpose: a Telegram user id is the same person for
+both accounts, and per-account users turns
+``get_chats_for_folder_resolution``'s ``outerjoin(User, User.id == Chat.id)``
+into duplicate rows. The cost is last-writer-wins on a contact's display name.
 """
 
+import secrets
 from datetime import datetime
 
 from sqlalchemy import (
@@ -15,6 +31,7 @@ from sqlalchemy import (
     ForeignKeyConstraint,
     Index,
     Integer,
+    PrimaryKeyConstraint,
     String,
     Text,
     UniqueConstraint,
@@ -24,6 +41,27 @@ from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 from ..message_utils import utcnow_naive
 
+# The account every row written before v8.0.0 belongs to. Migration 022 seeds it
+# and backfills every existing row to it, and it is the server-side default of
+# every account_id column so a writer that does not name an account still lands
+# somewhere real instead of failing the NOT NULL.
+DEFAULT_ACCOUNT_ID = 1
+
+# secrets.token_urlsafe(16) is always exactly 22 characters of URL-safe base64
+# over 128 bits. Chat refs are minted once, on INSERT, and never re-rolled.
+CHAT_REF_BYTES = 16
+CHAT_REF_LENGTH = 22
+
+
+def new_chat_ref() -> str:
+    """Mint the opaque handle a chat is addressed by outside the database.
+
+    Applied as a Python-side column default, which is exactly the semantics
+    needed: an upsert's INSERT branch mints one, and its ON CONFLICT DO UPDATE
+    branch never touches the column, so a ref is stable for the life of the row.
+    """
+    return secrets.token_urlsafe(CHAT_REF_BYTES)
+
 
 class Base(DeclarativeBase):
     """Base class for all models."""
@@ -31,12 +69,33 @@ class Base(DeclarativeBase):
     pass
 
 
+class Account(Base):
+    """One archived Telegram identity.
+
+    ``id`` is a surrogate, never the Telegram user id. The row has to exist
+    before authorization completes (SESSION_NAME, PHONE_NUMBER and the chat
+    filters all describe an account that has not logged in yet), and copying a
+    real Telegram user id into every row of every table and every index would
+    spread an identifier this project treats as PII across the whole archive.
+    ``telegram_user_id`` is filled in on first login.
+    """
+
+    __tablename__ = "accounts"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    label: Mapped[str | None] = mapped_column(String(255))
+    telegram_user_id: Mapped[int | None] = mapped_column(BigInteger)
+
+
 class Chat(Base):
     """Chats table - users, groups, channels."""
 
     __tablename__ = "chats"
 
+    account_id: Mapped[int] = mapped_column(Integer, primary_key=True, server_default=str(DEFAULT_ACCOUNT_ID))
     id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=False)
+    # Opaque, URL-safe, globally unique. Minted on INSERT and never rewritten.
+    ref: Mapped[str] = mapped_column(String(CHAT_REF_LENGTH), nullable=False, default=new_chat_ref)
     type: Mapped[str] = mapped_column(String(50), nullable=False)
     title: Mapped[str | None] = mapped_column(String(255))
     username: Mapped[str | None] = mapped_column(String(255))
@@ -58,7 +117,10 @@ class Chat(Base):
     sync_status: Mapped[SyncStatus | None] = relationship("SyncStatus", back_populates="chat", uselist=False)
     forum_topics: Mapped[list[ForumTopic]] = relationship("ForumTopic", back_populates="chat", lazy="dynamic")
 
-    __table_args__ = (Index("idx_chats_username", "username"),)
+    __table_args__ = (
+        UniqueConstraint("ref", name="uq_chats_ref"),
+        Index("idx_chats_username", "username"),
+    )
 
 
 class Message(Base):
@@ -69,9 +131,11 @@ class Message(Base):
 
     __tablename__ = "messages"
 
-    # Composite primary key (id, chat_id) - message IDs are only unique within a chat
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=False)
-    chat_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("chats.id"), primary_key=True)
+    # Composite primary key (account_id, chat_id, id) - message IDs are only
+    # unique within a chat, and a chat id is only unique within an account.
+    account_id: Mapped[int] = mapped_column(Integer, nullable=False, server_default=str(DEFAULT_ACCOUNT_ID))
+    id: Mapped[int] = mapped_column(BigInteger, nullable=False, autoincrement=False)
+    chat_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
     # NOTE: sender_id has no FK constraint because it can be channel/group IDs (not in users table)
     sender_id: Mapped[int | None] = mapped_column(BigInteger)
     sender_name: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -110,14 +174,23 @@ class Message(Base):
     versions: Mapped[list[MessageVersion]] = relationship("MessageVersion", back_populates="message", lazy="dynamic")
 
     __table_args__ = (
+        PrimaryKeyConstraint("account_id", "chat_id", "id"),
+        ForeignKeyConstraint(["account_id", "chat_id"], ["chats.account_id", "chats.id"], name="fk_messages_chat"),
         Index("idx_messages_chat_id", "chat_id"),
         Index("idx_messages_date", "date"),
         Index("idx_messages_sender_id", "sender_id"),
         # Composite index for fast pagination: WHERE chat_id = ? ORDER BY date DESC
         Index("idx_messages_chat_date_desc", "chat_id", date.desc()),
         # v7.22.0: id-bounded jump-window cursors (lone before_id / after_id, #213)
-        # seek on (chat_id, id); the composite PK leads with id so it can't serve them.
+        # seek on (chat_id, id).
         Index("idx_messages_chat_id_id", "chat_id", "id"),
+        # v8.0.0: repairs a regression this release's key change introduces.
+        # resolve_message_chat_id / get_chat_id_for_message look a message up by
+        # id alone (the listener's path when Telegram reports a deletion without
+        # naming a chat). Until v8.0.0 the PK led with id and served that seek;
+        # it now leads with account_id, so the account-qualified lookup needs its
+        # own index or it degrades to a full scan of every message archived.
+        Index("idx_messages_account_msgid", "account_id", "id"),
         # Index for finding pinned messages in a chat
         Index("idx_messages_chat_pinned", "chat_id", "is_pinned"),
         # Index for reply lookups
@@ -133,6 +206,7 @@ class MessageVersion(Base):
     __tablename__ = "message_versions"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    account_id: Mapped[int] = mapped_column(Integer, nullable=False, server_default=str(DEFAULT_ACCOUNT_ID))
     message_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
     chat_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
     text: Mapped[str | None] = mapped_column(Text)
@@ -143,8 +217,12 @@ class MessageVersion(Base):
     message: Mapped[Message] = relationship(
         "Message",
         back_populates="versions",
-        primaryjoin="and_(MessageVersion.message_id==Message.id, MessageVersion.chat_id==Message.chat_id)",
-        foreign_keys="[MessageVersion.message_id, MessageVersion.chat_id]",
+        primaryjoin=(
+            "and_(MessageVersion.account_id==Message.account_id,"
+            " MessageVersion.message_id==Message.id,"
+            " MessageVersion.chat_id==Message.chat_id)"
+        ),
+        foreign_keys="[MessageVersion.account_id, MessageVersion.message_id, MessageVersion.chat_id]",
     )
 
     __table_args__ = (
@@ -153,12 +231,18 @@ class MessageVersion(Base):
         # delete_chat_and_related_data are the load-bearing cleanup. Keep them
         # in sync with any future message-deletion path.
         ForeignKeyConstraint(
-            ["message_id", "chat_id"],
-            ["messages.id", "messages.chat_id"],
+            ["account_id", "message_id", "chat_id"],
+            ["messages.account_id", "messages.id", "messages.chat_id"],
             name="fk_message_versions_message",
             ondelete="CASCADE",
         ),
-        UniqueConstraint("change_hash", name="uq_message_versions_change_hash"),
+        # v8.0.0: account-qualified. The change_hash payload built by
+        # _message_version_hash is a frozen contract and is NOT extended with the
+        # account — re-encoding it would re-admit a duplicate of every version
+        # already stored. The CONSTRAINT carries the account instead, so two
+        # accounts archiving the same edit each keep their own history row
+        # rather than the second one being silently discarded.
+        UniqueConstraint("account_id", "change_hash", name="uq_message_versions_change_hash"),
         Index("idx_message_versions_message_date", "chat_id", "message_id", "date"),
         Index("idx_message_versions_message_captured", "chat_id", "message_id", "captured_at"),
     )
@@ -202,7 +286,11 @@ class Media(Base):
 
     __tablename__ = "media"
 
-    id: Mapped[str] = mapped_column(String(255), primary_key=True)  # Telegram file_id
+    account_id: Mapped[int] = mapped_column(Integer, primary_key=True, server_default=str(DEFAULT_ACCOUNT_ID))
+    # NOT a Telegram file_id: the value is built as f"{chat_id}_{message.id}_{type}"
+    # (src/telegram_backup.py, src/listener.py), so two accounts archiving the
+    # same message produce the identical string. account_id leads the key.
+    id: Mapped[str] = mapped_column(String(255), primary_key=True)
     message_id: Mapped[int | None] = mapped_column(BigInteger)
     chat_id: Mapped[int | None] = mapped_column(BigInteger)
     type: Mapped[str | None] = mapped_column(String(50))
@@ -225,13 +313,18 @@ class Media(Base):
     message: Mapped[Message | None] = relationship(
         "Message",
         back_populates="media_items",
-        primaryjoin="and_(Media.message_id==Message.id, Media.chat_id==Message.chat_id)",
-        foreign_keys="[Media.message_id, Media.chat_id]",
+        primaryjoin=(
+            "and_(Media.account_id==Message.account_id, Media.message_id==Message.id, Media.chat_id==Message.chat_id)"
+        ),
+        foreign_keys="[Media.account_id, Media.message_id, Media.chat_id]",
     )
 
     __table_args__ = (
         ForeignKeyConstraint(
-            ["message_id", "chat_id"], ["messages.id", "messages.chat_id"], name="fk_media_message", ondelete="CASCADE"
+            ["account_id", "message_id", "chat_id"],
+            ["messages.account_id", "messages.id", "messages.chat_id"],
+            name="fk_media_message",
+            ondelete="CASCADE",
         ),
         Index("idx_media_message", "message_id", "chat_id"),
         Index("idx_media_downloaded", "chat_id", "downloaded"),
@@ -247,6 +340,7 @@ class Reaction(Base):
     __tablename__ = "reactions"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    account_id: Mapped[int] = mapped_column(Integer, nullable=False, server_default=str(DEFAULT_ACCOUNT_ID))
     message_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
     chat_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
     emoji: Mapped[str] = mapped_column(String(50), nullable=False)
@@ -268,15 +362,21 @@ class Reaction(Base):
     message: Mapped[Message] = relationship(
         "Message",
         back_populates="reactions",
-        primaryjoin="and_(Reaction.message_id==Message.id, Reaction.chat_id==Message.chat_id)",
-        foreign_keys="[Reaction.message_id, Reaction.chat_id]",
+        primaryjoin=(
+            "and_(Reaction.account_id==Message.account_id,"
+            " Reaction.message_id==Message.id,"
+            " Reaction.chat_id==Message.chat_id)"
+        ),
+        foreign_keys="[Reaction.account_id, Reaction.message_id, Reaction.chat_id]",
     )
 
     __table_args__ = (
         ForeignKeyConstraint(
-            ["message_id", "chat_id"], ["messages.id", "messages.chat_id"], name="fk_reaction_message"
+            ["account_id", "message_id", "chat_id"],
+            ["messages.account_id", "messages.id", "messages.chat_id"],
+            name="fk_reaction_message",
         ),
-        UniqueConstraint("message_id", "chat_id", "emoji", "user_id", name="uq_reaction"),
+        UniqueConstraint("account_id", "message_id", "chat_id", "emoji", "user_id", name="uq_reaction"),
         Index("idx_reactions_message", "message_id", "chat_id"),
         # v7.23.0 (#219): chat-first composite matches the schema's convention
         # (every other per-entity index leads with chat_id) and serves the
@@ -291,13 +391,22 @@ class SyncStatus(Base):
 
     __tablename__ = "sync_status"
 
-    chat_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("chats.id"), primary_key=True)
+    account_id: Mapped[int] = mapped_column(Integer, primary_key=True, server_default=str(DEFAULT_ACCOUNT_ID))
+    chat_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     last_message_id: Mapped[int] = mapped_column(BigInteger, default=0)
     last_sync_date: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
     message_count: Mapped[int] = mapped_column(Integer, default=0)
 
     # Relationship
     chat: Mapped[Chat] = relationship("Chat", back_populates="sync_status")
+
+    __table_args__ = (
+        # message_count is accumulated by update_sync_status' ON CONFLICT clause
+        # (`message_count + excluded.message_count`), so two accounts collapsing
+        # into one row would not overwrite it, they would SUM it and report a
+        # message count that never existed.
+        ForeignKeyConstraint(["account_id", "chat_id"], ["chats.account_id", "chats.id"], name="fk_sync_status_chat"),
+    )
 
 
 class Metadata(Base):
@@ -323,6 +432,12 @@ class PushSubscription(Base):
     allowed_chat_ids: Mapped[str | None] = mapped_column(
         Text
     )  # JSON snapshot of user's allowed chats at subscribe time
+    # v8.0.0 entitlement. NEW columns, never a reinterpreted allowed_chat_ids:
+    # reading an old [123, 456] payload as (account 123, chat 456) would GRANT
+    # rather than deny, so an unconverted 7.x row must never be readable as an
+    # account-qualified one. See ViewerAccount for the full reasoning.
+    allowed_accounts: Mapped[str | None] = mapped_column(Text)
+    allowed_chat_refs: Mapped[str | None] = mapped_column(Text)
     user_agent: Mapped[str | None] = mapped_column(String(500))  # Browser info for debugging
     created_at: Mapped[datetime] = mapped_column(DateTime, default=utcnow_naive, server_default=func.now())
     last_used_at: Mapped[datetime | None] = mapped_column(DateTime)  # Track activity
@@ -338,8 +453,9 @@ class ForumTopic(Base):
 
     __tablename__ = "forum_topics"
 
-    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=False)
-    chat_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("chats.id", ondelete="CASCADE"), primary_key=True)
+    account_id: Mapped[int] = mapped_column(Integer, nullable=False, server_default=str(DEFAULT_ACCOUNT_ID))
+    id: Mapped[int] = mapped_column(BigInteger, nullable=False, autoincrement=False)
+    chat_id: Mapped[int] = mapped_column(BigInteger, nullable=False)
     title: Mapped[str] = mapped_column(String(500), nullable=False)
     icon_color: Mapped[int | None] = mapped_column(Integer)
     icon_emoji_id: Mapped[int | None] = mapped_column(BigInteger)
@@ -354,7 +470,16 @@ class ForumTopic(Base):
     # Relationships
     chat: Mapped[Chat] = relationship("Chat", back_populates="forum_topics")
 
-    __table_args__ = (Index("idx_forum_topics_chat", "chat_id"),)
+    __table_args__ = (
+        PrimaryKeyConstraint("account_id", "chat_id", "id"),
+        ForeignKeyConstraint(
+            ["account_id", "chat_id"],
+            ["chats.account_id", "chats.id"],
+            name="fk_forum_topics_chat",
+            ondelete="CASCADE",
+        ),
+        Index("idx_forum_topics_chat", "chat_id"),
+    )
 
 
 class ChatFolder(Base):
@@ -365,6 +490,10 @@ class ChatFolder(Base):
 
     __tablename__ = "chat_folders"
 
+    # Telegram dialog-filter ids are per account and start at 2 for everyone, so
+    # without account_id in the key a second account's folder overwrites the
+    # first account's title and takes over its membership rows.
+    account_id: Mapped[int] = mapped_column(Integer, primary_key=True, server_default=str(DEFAULT_ACCOUNT_ID))
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=False)
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     emoticon: Mapped[str | None] = mapped_column(String(50))
@@ -386,14 +515,31 @@ class ChatFolderMember(Base):
 
     __tablename__ = "chat_folder_members"
 
-    folder_id: Mapped[int] = mapped_column(Integer, ForeignKey("chat_folders.id", ondelete="CASCADE"), primary_key=True)
-    chat_id: Mapped[int] = mapped_column(BigInteger, ForeignKey("chats.id", ondelete="CASCADE"), primary_key=True)
+    account_id: Mapped[int] = mapped_column(Integer, primary_key=True, server_default=str(DEFAULT_ACCOUNT_ID))
+    folder_id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    chat_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
 
     # Relationships
     folder: Mapped[ChatFolder] = relationship("ChatFolder", back_populates="members")
-    chat: Mapped[Chat] = relationship("Chat")
+    # viewonly: account_id belongs to BOTH composite foreign keys, so without
+    # this SQLAlchemy warns that persisting through `chat` and through `folder`
+    # would both write it. Nothing does: membership rows are built with explicit
+    # folder_id/chat_id values, and this attribute exists only to read the chat.
+    chat: Mapped[Chat] = relationship("Chat", viewonly=True)
 
     __table_args__ = (
+        ForeignKeyConstraint(
+            ["account_id", "folder_id"],
+            ["chat_folders.account_id", "chat_folders.id"],
+            name="fk_folder_members_folder",
+            ondelete="CASCADE",
+        ),
+        ForeignKeyConstraint(
+            ["account_id", "chat_id"],
+            ["chats.account_id", "chats.id"],
+            name="fk_folder_members_chat",
+            ondelete="CASCADE",
+        ),
         Index("idx_folder_members_chat", "chat_id"),
         Index("idx_folder_members_folder", "folder_id"),
     )
@@ -413,6 +559,15 @@ class ViewerAccount(Base):
     password_hash: Mapped[str] = mapped_column(String(128), nullable=False)
     salt: Mapped[str] = mapped_column(String(64), nullable=False)
     allowed_chat_ids: Mapped[str | None] = mapped_column(Text)  # JSON array of chat IDs, NULL = all
+    # v8.0.0 entitlement, as two NEW nullable columns rather than a
+    # reinterpretation of allowed_chat_ids. Reinterpreting fails OPEN: an
+    # unconverted [123, 456] read as (account 123, chat 456) grants access
+    # instead of denying it. With new columns a 7.x row is unmistakably
+    # unconverted. allowed_accounts: JSON array of account ids. allowed_chat_refs:
+    # JSON array of chats.ref values. Migration 022 converts every restricted row
+    # rather than leaving it NULL, because NULL means "no restriction".
+    allowed_accounts: Mapped[str | None] = mapped_column(Text)
+    allowed_chat_refs: Mapped[str | None] = mapped_column(Text)
     is_active: Mapped[int] = mapped_column(Integer, default=1, server_default="1")
     no_download: Mapped[int] = mapped_column(Integer, default=0, server_default="0")  # v7.2.0
     created_by: Mapped[str | None] = mapped_column(String(255))
@@ -465,6 +620,9 @@ class ViewerSession(Base):
     username: Mapped[str] = mapped_column(String(255), nullable=False)
     role: Mapped[str] = mapped_column(String(20), nullable=False)  # "master", "viewer", or "token"
     allowed_chat_ids: Mapped[str | None] = mapped_column(Text)  # JSON array or NULL = all chats
+    # v8.0.0 entitlement — see ViewerAccount for why these are new columns.
+    allowed_accounts: Mapped[str | None] = mapped_column(Text)
+    allowed_chat_refs: Mapped[str | None] = mapped_column(Text)
     no_download: Mapped[int] = mapped_column(Integer, default=0, server_default="0")  # v7.2.0
     source_token_id: Mapped[int | None] = mapped_column(Integer)  # v7.2.0: FK to viewer_tokens.id for revocation
     created_at: Mapped[float] = mapped_column(Float, nullable=False)
@@ -492,6 +650,9 @@ class ViewerToken(Base):
     token_salt: Mapped[str] = mapped_column(String(64), nullable=False)
     created_by: Mapped[str] = mapped_column(String(255), nullable=False)
     allowed_chat_ids: Mapped[str] = mapped_column(Text, nullable=False)  # JSON array of chat IDs
+    # v8.0.0 entitlement — see ViewerAccount for why these are new columns.
+    allowed_accounts: Mapped[str | None] = mapped_column(Text)
+    allowed_chat_refs: Mapped[str | None] = mapped_column(Text)
     is_revoked: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
     no_download: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
     expires_at: Mapped[datetime | None] = mapped_column(DateTime)  # NULL = no expiry

--- a/src/listener.py
+++ b/src/listener.py
@@ -37,6 +37,7 @@ from telethon.utils import get_peer_id
 from .avatar_utils import get_avatar_paths
 from .config import Config
 from .db import DatabaseAdapter, create_adapter
+from .db.models import DEFAULT_ACCOUNT_ID
 from .message_utils import (
     build_media_filename,
     compute_file_hash,
@@ -242,7 +243,7 @@ class TelegramListener:
     - For zero deletions from backup, set LISTEN_DELETIONS=false
     """
 
-    def __init__(self, config: Config, db: DatabaseAdapter, client: TelegramClient | None = None):
+    def __init__(self, config: Config, db: DatabaseAdapter, client: TelegramClient | None = None, *, account_id: int):
         """
         Initialize the listener.
 
@@ -251,10 +252,12 @@ class TelegramListener:
             db: Database adapter (must be initialized)
             client: Optional existing TelegramClient to use (for shared connection).
                    If not provided, will create a new client in connect().
+            account_id: accounts.id every row written by this listener belongs to.
         """
         self.config = config
         self.config.validate_credentials()
         self.db = db
+        self.account_id = account_id
         self.client: TelegramClient | None = client
         self._owns_client = client is None  # Track if we created the client
         self._running = False
@@ -341,19 +344,20 @@ class TelegramListener:
         logger.info("=" * 70)
 
     @classmethod
-    async def create(cls, config: Config, client: TelegramClient | None = None) -> TelegramListener:
+    async def create(cls, config: Config, client: TelegramClient | None = None, *, account_id: int) -> TelegramListener:
         """
         Factory method to create TelegramListener with initialized database.
 
         Args:
             config: Configuration object
             client: Optional existing TelegramClient to use (for shared connection)
+            account_id: accounts.id every row written by this listener belongs to
 
         Returns:
             Initialized TelegramListener instance
         """
         db = await create_adapter()
-        return cls(config, db, client=client)
+        return cls(config, db, client=client, account_id=account_id)
 
     async def connect(self) -> None:
         """
@@ -417,7 +421,7 @@ class TelegramListener:
     async def _load_tracked_chats(self) -> None:
         """Load list of chat IDs we're backing up (to filter events)."""
         try:
-            chats = await self.db.get_all_chats()
+            chats = await self.db.get_all_chats(account_id=self.account_id)
             self._tracked_chat_ids = {chat["id"] for chat in chats}
             # Supergroups adopted via FOLLOW_CHAT_MIGRATIONS (#228): keep them in
             # a dedicated set AND fold into the type-based tracked set, so the new
@@ -543,7 +547,9 @@ class TelegramListener:
         self._reaction_pending = {}
         for (chat_id, message_id), observed in pending.items():
             try:
-                outcome = await self.db.reconcile_reactions(message_id, chat_id, observed, mark_removed=True)
+                outcome = await self.db.reconcile_reactions(
+                    message_id, chat_id, observed, account_id=self.account_id, mark_removed=True
+                )
                 if outcome == "reconciled":
                     self.stats["reactions_applied"] += 1
                     await self._notify_update(
@@ -574,7 +580,7 @@ class TelegramListener:
 
         if deletion_mode == "soft":
             deleted_at = utcnow_naive()
-            await self.db.mark_message_deleted(chat_id, message_id, deleted_at=deleted_at)
+            await self.db.mark_message_deleted(chat_id, message_id, deleted_at=deleted_at, account_id=self.account_id)
             logger.debug("🗑️ Deletion marked")
             await self._notify_update(
                 "delete",
@@ -587,7 +593,7 @@ class TelegramListener:
             )
             return
 
-        await self.db.delete_message(chat_id, message_id)
+        await self.db.delete_message(chat_id, message_id, account_id=self.account_id)
         logger.debug("🗑️ Deletion applied")
         await self._notify_update(
             "delete",
@@ -826,6 +832,7 @@ class TelegramListener:
                     file_name=file_name,
                     file_path=file_path,
                     logger=logger,
+                    account_id=self.account_id,
                 )
                 if not shared_file_path and not os.path.lexists(file_path):
                     return None
@@ -934,6 +941,7 @@ class TelegramListener:
                     message_id=message.id,
                     new_text=new_text,
                     edit_date=edit_date,
+                    account_id=self.account_id,
                 )
                 if outcome != "applied":
                     self.stats["edits_skipped"] += 1
@@ -991,7 +999,7 @@ class TelegramListener:
                     effective_chat_id = chat_id
                     if effective_chat_id is None:
                         try:
-                            resolved = await self.db.resolve_message_chat_id(msg_id)
+                            resolved = await self.db.resolve_message_chat_id(msg_id, account_id=self.account_id)
                             if resolved is None:
                                 logger.debug("⚠️ Deletion skipped (not found or ambiguous)")
                                 continue
@@ -1080,7 +1088,7 @@ class TelegramListener:
                         "first_name": getattr(chat_entity, "first_name", None),
                         "last_name": getattr(chat_entity, "last_name", None),
                     }
-                    await self.db.upsert_chat(chat_data)
+                    await self.db.upsert_chat(chat_data, account_id=self.account_id)
 
                 sender = message.sender
                 if sender is None:
@@ -1134,7 +1142,7 @@ class TelegramListener:
                     media_type = self._get_media_type(message.media)
 
                 # Insert the message FIRST (required for FK constraint on media table)
-                await self.db.insert_message(message_data)
+                await self.db.insert_message(message_data, account_id=self.account_id)
                 self.stats["new_messages_saved"] += 1
 
                 # New messages can arrive already carrying reactions (fast reactors,
@@ -1178,7 +1186,7 @@ class TelegramListener:
                                     "download_date": utcnow_naive(),
                                     **media_attributes,
                                 }
-                                await self.db.insert_media(media_row)
+                                await self.db.insert_media(media_row, account_id=self.account_id)
                                 logger.debug("📎 Downloaded media")
                                 # Mirror the DB row so the WS row matches what the next poll returns.
                                 ws_media = {
@@ -1346,7 +1354,7 @@ class TelegramListener:
                 if event.new_title is not None:
                     message_data["raw_data"]["new_title"] = event.new_title
 
-                await self.db.insert_message(message_data)
+                await self.db.insert_message(message_data, account_id=self.account_id)
                 logger.info("📌 Service message saved")
 
                 # Refresh cached chat metadata on a photo or title change. A photo
@@ -1362,7 +1370,7 @@ class TelegramListener:
                                 "title": getattr(entity, "title", None),
                                 "username": getattr(entity, "username", None),
                             }
-                            await self.db.upsert_chat(chat_data)
+                            await self.db.upsert_chat(chat_data, account_id=self.account_id)
                             logger.info("✅ Chat metadata updated")
 
                             if photo_changed:
@@ -1419,7 +1427,7 @@ class TelegramListener:
 
                 # Update each message's pinned status
                 for msg_id in pinned_messages:
-                    await self.db.update_message_pinned(chat_id, msg_id, is_pinning)
+                    await self.db.update_message_pinned(chat_id, msg_id, is_pinning, account_id=self.account_id)
 
                 action = "📌 Pinned" if is_pinning else "📌 Unpinned"
                 logger.info(f"{action}: {len(pinned_messages)} message(s)")
@@ -1643,7 +1651,9 @@ async def run_listener(config: Config) -> None:
     Args:
         config: Configuration object
     """
-    listener = await TelegramListener.create(config)
+    # Single-account stage: every row belongs to the migration-seeded account.
+    # Phase 5 replaces the constant with real per-account resolution here.
+    listener = await TelegramListener.create(config, account_id=DEFAULT_ACCOUNT_ID)
 
     try:
         await listener.connect()

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -284,11 +284,15 @@ async def deduplicate_shared_file(
     db: object,
     shared_file_path: str,
     shared_dir: str,
+    *,
+    account_id: int,
 ) -> tuple[str, str | None, bool]:
     """Check if newly downloaded content already exists in the shared store.
 
     Computes a SHA-256 hash, queries the DB for a match, and if found,
     removes the duplicate file and returns the path to the existing one.
+    Dedup only reuses blobs the same account references — cross-account
+    reuse would couple deletion lifecycles between accounts.
 
     Returns (resolved_path, content_hash, reused_existing). The third
     element is True when the path points to a pre-existing canonical blob
@@ -298,7 +302,7 @@ async def deduplicate_shared_file(
     if not content_hash:
         return shared_file_path, content_hash, False
 
-    existing = await db.find_media_by_content_hash(content_hash)
+    existing = await db.find_media_by_content_hash(content_hash, account_id=account_id)
     if not existing or not existing.get("file_name"):
         return shared_file_path, content_hash, False
 
@@ -377,6 +381,8 @@ async def download_and_shard_media(
     file_name: str,
     file_path: str,
     logger: logging.Logger,
+    *,
+    account_id: int,
 ) -> tuple[str | None, str | None]:
     """Download media to sharded shared store, create symlink in chat dir.
 
@@ -388,6 +394,7 @@ async def download_and_shard_media(
         file_name: Media filename
         file_path: Full path where chat-dir symlink should be created
         logger: Logger instance
+        account_id: accounts.id whose media rows content-hash dedup may reuse
 
     Returns:
         (shared_file_path, content_hash) or (None, None) on failure
@@ -453,7 +460,9 @@ async def download_and_shard_media(
     logger.debug("Downloaded media to shared")
 
     # Content-hash dedup: check if identical content already exists
-    tmp_shared_file_path, content_hash, reused = await deduplicate_shared_file(db, tmp_shared_file_path, shared_dir)
+    tmp_shared_file_path, content_hash, reused = await deduplicate_shared_file(
+        db, tmp_shared_file_path, shared_dir, account_id=account_id
+    )
 
     # Publish the blob if we own it (not reused): ONE rename from the private
     # .part name straight to its final path, under the clean ``file_name``. With

--- a/src/repair_media_extensions.py
+++ b/src/repair_media_extensions.py
@@ -55,7 +55,7 @@ class _MediaRepairDB(Protocol):
 
     def iter_media_paths_for_repair(self, batch_size: int = ...) -> AsyncIterator[list[dict]]: ...
 
-    async def update_media_file_path(self, media_id: object, file_path: str) -> None: ...
+    async def update_media_file_path(self, media_id: object, file_path: str, *, account_id: int) -> None: ...
 
 
 def _is_corrupt_basename(basename: str, clean_name: str) -> bool:
@@ -150,10 +150,11 @@ def _repair_records_sync(records: list[dict], shared_dir: str) -> tuple[int, int
     """Do the blocking filesystem repair work off the event loop.
 
     Returns ``(repaired, deferred, pending_db_updates)`` where
-    ``pending_db_updates`` is a list of ``(media_id, clean_path)`` rows whose
-    ``media.file_path`` must be repointed by the async caller. ``deferred``
-    counts rows that hit a transient filesystem error and should be retried on
-    a later run (these block the idempotency marker).
+    ``pending_db_updates`` is a list of ``(media_id, clean_path, account_id)``
+    rows whose ``media.file_path`` must be repointed by the async caller —
+    media ids repeat across accounts, so the row's own account_id is needed to
+    address it. ``deferred`` counts rows that hit a transient filesystem error
+    and should be retried on a later run (these block the idempotency marker).
     """
     repaired = 0
     deferred = 0
@@ -179,7 +180,7 @@ def _repair_records_sync(records: list[dict], shared_dir: str) -> tuple[int, int
             if _is_corrupt_basename(os.path.basename(file_path), clean_name):
                 clean_path = os.path.join(os.path.dirname(file_path), clean_name)
                 if _repair_direct_file(file_path, clean_path):
-                    pending_db_updates.append((media_id, clean_path))
+                    pending_db_updates.append((media_id, clean_path, record["account_id"]))
                     repaired += 1
         except OSError:
             deferred += 1
@@ -298,9 +299,9 @@ async def repair_media_extensions(media_path: str, db: _MediaRepairDB) -> int:
             # Repoint media.file_path for the no-dedup rows we renamed. A failure
             # here leaves the file renamed but the row stale; defer so the marker
             # is withheld and the next run's adoption branch repoints it.
-            for media_id, clean_path in pending_db_updates:
+            for media_id, clean_path, row_account_id in pending_db_updates:
                 try:
-                    await db.update_media_file_path(media_id, clean_path)
+                    await db.update_media_file_path(media_id, clean_path, account_id=row_account_id)
                 except Exception as e:
                     logger.warning("Media repair: DB repoint failed for one record (%s)", type(e).__name__)
                     deferred += 1

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -212,12 +212,16 @@ class BackupScheduler:
             return
 
         try:
+            from .db.models import DEFAULT_ACCOUNT_ID
             from .listener import TelegramListener
 
             logger.info("Starting real-time listener...")
 
-            # Create listener with shared client
-            self._listener = await TelegramListener.create(self.config, client=self._connection.client)
+            # Create listener with shared client.
+            # Single-account stage: phase 5 resolves per-account ids here.
+            self._listener = await TelegramListener.create(
+                self.config, client=self._connection.client, account_id=DEFAULT_ACCOUNT_ID
+            )
             await self._listener.connect()
 
             # Run listener in background task

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -51,6 +51,7 @@ from telethon.utils import get_peer_id
 from .avatar_utils import get_avatar_paths
 from .config import Config
 from .db import DatabaseAdapter, create_adapter
+from .db.models import DEFAULT_ACCOUNT_ID
 from .folder_utils import FolderChat, FolderRules, resolve_folder_member_ids
 from .media_errors import is_media_location_error
 from .message_utils import (
@@ -594,7 +595,7 @@ async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
 class TelegramBackup:
     """Main class for managing Telegram backups."""
 
-    def __init__(self, config: Config, db: DatabaseAdapter, client: TelegramClient | None = None):
+    def __init__(self, config: Config, db: DatabaseAdapter, client: TelegramClient | None = None, *, account_id: int):
         """
         Initialize Telegram backup manager.
 
@@ -603,10 +604,12 @@ class TelegramBackup:
             db: Async database adapter (must be initialized before passing)
             client: Optional existing TelegramClient to use (for shared connection).
                    If not provided, will create a new client in connect().
+            account_id: accounts.id every row written by this backup belongs to.
         """
         self.config = config
         self.config.validate_credentials()
         self.db = db
+        self.account_id = account_id
         self.client: TelegramClient | None = client
         self._owns_client = client is None  # Track if we created the client
         self._cleaned_media_chats: set[int] = set()  # Track chats already cleaned this session
@@ -751,7 +754,7 @@ class TelegramBackup:
 
             # SECONDARY: stored markers (migrations that happened while offline).
             try:
-                for old_id, new_id in await self.db.get_migration_markers():
+                for old_id, new_id in await self.db.get_migration_markers(account_id=self.account_id):
                     migrations.setdefault(old_id, new_id)
             except Exception as e:
                 logger.warning("Migration marker lookup failed: %s", type(e).__name__)
@@ -840,19 +843,20 @@ class TelegramBackup:
         return True
 
     @classmethod
-    async def create(cls, config: Config, client: TelegramClient | None = None) -> TelegramBackup:
+    async def create(cls, config: Config, client: TelegramClient | None = None, *, account_id: int) -> TelegramBackup:
         """
         Factory method to create TelegramBackup with initialized database.
 
         Args:
             config: Configuration object
             client: Optional existing TelegramClient to use (for shared connection)
+            account_id: accounts.id every row written by this backup belongs to
 
         Returns:
             Initialized TelegramBackup instance
         """
         db = await create_adapter()
-        return cls(config, db, client=client)
+        return cls(config, db, client=client, account_id=account_id)
 
     async def connect(self):
         """
@@ -948,7 +952,7 @@ class TelegramBackup:
 
             # Store owner ID and backfill is_outgoing for existing messages
             await self.db.set_metadata("owner_id", str(me.id))
-            await self.db.backfill_is_outgoing(me.id)
+            await self.db.backfill_is_outgoing(me.id, account_id=self.account_id)
 
             start_time = datetime.now()
 
@@ -1257,7 +1261,9 @@ class TelegramBackup:
                     )
                     for chat_id in explicitly_excluded_chat_ids:
                         try:
-                            await self.db.delete_chat_and_related_data(chat_id, self.config.media_path)
+                            await self.db.delete_chat_and_related_data(
+                                chat_id, self.config.media_path, account_id=self.account_id
+                            )
                         except Exception as e:
                             logger.error(f"Error deleting chat: {e}", exc_info=True)
 
@@ -1293,7 +1299,10 @@ class TelegramBackup:
             # (i.e. some chats have a non-zero last_message_id recorded)
             has_synced_before = False
             for dialog in filtered_dialogs:
-                if await self.db.get_last_message_id(self._get_marked_id(dialog.entity)) > 0:
+                if (
+                    await self.db.get_last_message_id(self._get_marked_id(dialog.entity), account_id=self.account_id)
+                    > 0
+                ):
                     has_synced_before = True
                     break
 
@@ -1493,7 +1502,7 @@ class TelegramBackup:
         logger.info("=" * 60)
         logger.info("Starting media verification...")
 
-        media_records = await self.db.get_media_for_verification()
+        media_records = await self.db.get_media_for_verification(account_id=self.account_id)
         logger.info(f"Found {len(media_records)} media records to verify")
 
         missing_files = []
@@ -1611,7 +1620,7 @@ class TelegramBackup:
                         result = await self._process_media(msg, chat_id)
                         if result and result.get("downloaded"):
                             # Insert media record (message already exists for re-downloads)
-                            await self.db.insert_media(result)
+                            await self.db.insert_media(result, account_id=self.account_id)
                             redownloaded += 1
                             logger.debug("Re-downloaded media for message")
                         else:
@@ -1640,11 +1649,13 @@ class TelegramBackup:
         are skipped silently.
         """
         pending = await self.db.get_pending_media_downloads(
-            self.config.get_max_media_size_bytes(), self.config.max_media_download_attempts
+            self.config.get_max_media_size_bytes(), self.config.max_media_download_attempts, account_id=self.account_id
         )
         # Surface (don't silently swallow) files given up after hitting the retry cap —
         # the silent-loss failure mode #212 was about. Count only (no chat/file names, PII).
-        capped = await self.db.count_capped_media_downloads(self.config.max_media_download_attempts)
+        capped = await self.db.count_capped_media_downloads(
+            self.config.max_media_download_attempts, account_id=self.account_id
+        )
         if capped:
             logger.warning(
                 f"{capped} media file(s) permanently skipped after "
@@ -1709,14 +1720,14 @@ class TelegramBackup:
                     try:
                         result = await self._process_media(msg, chat_id)
                         if result and result.get("downloaded"):
-                            await self.db.insert_media(result)
+                            await self.db.insert_media(result, account_id=self.account_id)
                             downloaded += 1
                         else:
-                            await self.db.increment_media_download_attempts(record["id"])
+                            await self.db.increment_media_download_attempts(record["id"], account_id=self.account_id)
                             skipped += 1
                     except Exception as e:
                         logger.debug(f"Retry failed for pending media: {e}")
-                        await self.db.increment_media_download_attempts(record["id"])
+                        await self.db.increment_media_download_attempts(record["id"], account_id=self.account_id)
                         failed += 1
 
             except Exception as e:
@@ -1824,7 +1835,7 @@ class TelegramBackup:
 
         # Save chat information
         chat_data = self._extract_chat_data(entity, is_archived=is_archived)
-        await self.db.upsert_chat(chat_data)
+        await self.db.upsert_chat(chat_data, account_id=self.account_id)
 
         # Fetch forum topics early (cheap, message-independent API call) so the viewer
         # shows the topic list immediately, before the slow media backfill (issue #200).
@@ -1855,7 +1866,7 @@ class TelegramBackup:
             logger.error(f"Error downloading profile photo: {e}", exc_info=True)
 
         # Get last synced message ID for incremental backup
-        last_message_id = await self.db.get_last_message_id(chat_id)
+        last_message_id = await self.db.get_last_message_id(chat_id, account_id=self.account_id)
 
         # Fetch and process messages in batches with periodic checkpointing.
         # sync_status is updated every checkpoint_interval batches so that
@@ -1964,7 +1975,9 @@ class TelegramBackup:
                 logger.info(f"  → Processed {grand_total} messages...")
 
                 if batches_since_checkpoint >= checkpoint_interval:
-                    await self.db.update_sync_status(chat_id, running_max_id, uncheckpointed_count)
+                    await self.db.update_sync_status(
+                        chat_id, running_max_id, uncheckpointed_count, account_id=self.account_id
+                    )
                     uncheckpointed_count = 0
                     batches_since_checkpoint = 0
 
@@ -2001,7 +2014,7 @@ class TelegramBackup:
         # the next run starts it over), OR when the cursor advanced purely from skipped
         # (topic-filtered) messages that were never counted in uncheckpointed_count.
         if uncheckpointed_count > 0 or cursor_passed_failure or (grand_total == 0 and running_max_id > last_message_id):
-            await self.db.update_sync_status(chat_id, running_max_id, uncheckpointed_count)
+            await self.db.update_sync_status(chat_id, running_max_id, uncheckpointed_count, account_id=self.account_id)
 
         # A frozen_id the cursor has moved past — the message finally processed,
         # or it no longer exists — describes a freeze that is over and must not
@@ -2031,11 +2044,11 @@ class TelegramBackup:
 
     async def _commit_batch(self, batch_data: list[dict], chat_id: int) -> None:
         """Persist a batch of processed messages, their media and reactions to the DB."""
-        await self.db.insert_messages_batch(batch_data)
+        await self.db.insert_messages_batch(batch_data, account_id=self.account_id)
 
         for msg in batch_data:
             if msg.get("_media_data"):
-                await self.db.insert_media(msg["_media_data"])
+                await self.db.insert_media(msg["_media_data"], account_id=self.account_id)
 
         for msg in batch_data:
             # Reconcile reactions for every processed message, including those whose
@@ -2046,7 +2059,9 @@ class TelegramBackup:
             # skip rather than tombstone valid rows.
             observed = msg.get("reactions")
             if observed is not None:
-                await self.db.reconcile_reactions(msg["id"], chat_id, observed, mark_removed=True)
+                await self.db.reconcile_reactions(
+                    msg["id"], chat_id, observed, mark_removed=True, account_id=self.account_id
+                )
 
     async def _fill_gap_range(self, entity, chat_id: int, gap_start: int, gap_end: int) -> int:
         """
@@ -2127,10 +2142,10 @@ class TelegramBackup:
         else:
             # Only scan chats that current config would back up (respects
             # CHAT_IDS whitelist, CHAT_TYPES, and all exclude lists)
-            all_chat_ids = await self.db.get_chats_with_messages()
+            all_chat_ids = await self.db.get_chats_with_messages(account_id=self.account_id)
             chat_ids = []
             for cid in all_chat_ids:
-                chat_info = await self.db.get_chat_by_id(cid)
+                chat_info = await self.db.get_chat_by_id(cid, account_id=self.account_id)
                 if not chat_info:
                     continue
                 ctype = chat_info.get("type", "")
@@ -2159,7 +2174,7 @@ class TelegramBackup:
             chat_name = self._get_chat_name(entity)
 
             try:
-                gaps = await self.db.detect_message_gaps(cid, threshold)
+                gaps = await self.db.detect_message_gaps(cid, threshold, account_id=self.account_id)
             except Exception as e:
                 logger.error(f"Gap-fill: failed to detect gaps for chat: {e}")
                 summary["errors"] += 1
@@ -2214,7 +2229,7 @@ class TelegramBackup:
         logger.info("  → Syncing deletions and edits for chat...")
 
         # Get all local message IDs and their edit dates
-        local_messages = await self.db.get_messages_sync_data(chat_id)
+        local_messages = await self.db.get_messages_sync_data(chat_id, account_id=self.account_id)
         if not local_messages:
             return
 
@@ -2238,9 +2253,9 @@ class TelegramBackup:
                         if getattr(self.config, "deletion_mode", "hard") == "soft":
                             # mark_message_deleted defaults deleted_at to now(UTC); this path
                             # doesn't broadcast, so no need to pass an explicit timestamp.
-                            await self.db.mark_message_deleted(chat_id, msg_id)
+                            await self.db.mark_message_deleted(chat_id, msg_id, account_id=self.account_id)
                         else:
-                            await self.db.delete_message(chat_id, msg_id)
+                            await self.db.delete_message(chat_id, msg_id, account_id=self.account_id)
                         total_deleted += 1
                         continue
 
@@ -2258,7 +2273,7 @@ class TelegramBackup:
                         # Update text and edit_date; count only edits the archive
                         # actually accepted (the adapter re-checks under lock).
                         outcome = await self.db.update_message_text(
-                            chat_id, msg_id, remote_msg.message, remote_msg.edit_date
+                            chat_id, msg_id, remote_msg.message, remote_msg.edit_date, account_id=self.account_id
                         )
                         if outcome == "applied":
                             total_updated += 1
@@ -2271,7 +2286,9 @@ class TelegramBackup:
                     if not getattr(reactions_obj, "min", False):
                         observed = extract_reactions(reactions_obj)
                         if observed is not None:
-                            await self.db.reconcile_reactions(msg_id, chat_id, observed, mark_removed=True)
+                            await self.db.reconcile_reactions(
+                                msg_id, chat_id, observed, mark_removed=True, account_id=self.account_id
+                            )
 
             except Exception as e:
                 logger.error(f"Error syncing batch for chat: {describe_exception(e)}")
@@ -2471,7 +2488,9 @@ class TelegramBackup:
             logger.info("Reaction resweep cooldown elapsed; resuming within this run")
 
         cutoff = utcnow_naive() - timedelta(days=self.config.reaction_resweep_days)
-        ids = await self.db.get_message_ids_since(chat_id, cutoff, self.config.reaction_resweep_max_per_chat)
+        ids = await self.db.get_message_ids_since(
+            chat_id, cutoff, self.config.reaction_resweep_max_per_chat, account_id=self.account_id
+        )
         # Resume mid-chat after an earlier deferred run: the first ``skip_n``
         # (newest) ids were already covered this cycle. The window shifts between
         # runs so the offset is approximate — reconcile is idempotent, so a few
@@ -2531,7 +2550,9 @@ class TelegramBackup:
                     if observed is None:
                         continue
                     if (
-                        await self.db.reconcile_reactions(u.msg_id, chat_id, observed, mark_removed=True)
+                        await self.db.reconcile_reactions(
+                            u.msg_id, chat_id, observed, mark_removed=True, account_id=self.account_id
+                        )
                         == "reconciled"
                     ):
                         reconciled += 1
@@ -2563,7 +2584,12 @@ class TelegramBackup:
                 observed = extract_reactions(reactions_obj)
                 if observed is None:
                     continue
-                if await self.db.reconcile_reactions(msg.id, chat_id, observed, mark_removed=True) == "reconciled":
+                if (
+                    await self.db.reconcile_reactions(
+                        msg.id, chat_id, observed, mark_removed=True, account_id=self.account_id
+                    )
+                    == "reconciled"
+                ):
                     reconciled += 1
 
         # Every chunk completed: mark this chat covered for the current cycle so a
@@ -2597,11 +2623,11 @@ class TelegramBackup:
 
             if pinned_messages:
                 pinned_ids = [msg.id for msg in pinned_messages]
-                await self.db.sync_pinned_messages(chat_id, pinned_ids)
+                await self.db.sync_pinned_messages(chat_id, pinned_ids, account_id=self.account_id)
                 logger.debug(f"  → Synced {len(pinned_ids)} pinned messages")
             else:
                 # No pinned messages - clear any existing
-                await self.db.sync_pinned_messages(chat_id, [])
+                await self.db.sync_pinned_messages(chat_id, [], account_id=self.account_id)
 
         except Exception as e:
             # Don't fail the backup if pinned sync fails
@@ -2940,7 +2966,7 @@ class TelegramBackup:
             chat_id: Chat identifier
         """
         try:
-            media_records = await self.db.get_media_for_chat(chat_id)
+            media_records = await self.db.get_media_for_chat(chat_id, account_id=self.account_id)
             if not media_records:
                 logger.debug("No existing media found for chat")
                 return
@@ -2967,7 +2993,7 @@ class TelegramBackup:
                         logger.warning(f"Failed to delete media file: {type(e).__name__}")
 
             # Delete all media records from database for this chat
-            deleted_records = await self.db.delete_media_for_chat(chat_id)
+            deleted_records = await self.db.delete_media_for_chat(chat_id, account_id=self.account_id)
 
             # Clean up empty chat media directory
             chat_media_dir = os.path.join(self.config.media_path, str(chat_id))
@@ -3242,6 +3268,7 @@ class TelegramBackup:
                     file_name=file_name,
                     file_path=file_path,
                     logger=logger,
+                    account_id=self.account_id,
                 )
                 if not shared_file_path and not os.path.lexists(file_path):
                     return None
@@ -3634,7 +3661,7 @@ class TelegramBackup:
                         if self.config.should_skip_topic(chat_id, topic.id):
                             logger.debug("  → Skipping excluded topic")
                             continue
-                        await self.db.upsert_forum_topic(topic_data)
+                        await self.db.upsert_forum_topic(topic_data, account_id=self.account_id)
                         topics_count += 1
 
                     # Advance offsets from the LAST topic of this page. offset_topic is
@@ -3687,9 +3714,12 @@ class TelegramBackup:
             from .db.models import Message as MessageModel
 
             async with self.db.db_manager.async_session_factory() as session:
-                # Get unique reply_to_top_id values for this chat
+                # Get unique reply_to_top_id values for this chat. Scoped to the
+                # account: chat ids repeat across accounts, so without the filter
+                # another account's topic ids would seed this account's inference.
                 stmt = (
                     select(distinct(MessageModel.reply_to_top_id))
+                    .where(MessageModel.account_id == self.account_id)
                     .where(MessageModel.chat_id == chat_id)
                     .where(MessageModel.reply_to_top_id.isnot(None))
                 )
@@ -3712,7 +3742,7 @@ class TelegramBackup:
                             "title": msg.text[:100] if msg.text else f"Topic {topic_id}",
                             "date": msg.date,
                         }
-                        await self.db.upsert_forum_topic(topic_data)
+                        await self.db.upsert_forum_topic(topic_data, account_id=self.account_id)
                         topics_count += 1
                 except Exception as e:
                     logger.debug(f"Could not fetch topic metadata: {e}")
@@ -3843,12 +3873,12 @@ class TelegramBackup:
                     "emoticon": getattr(f, "emoticon", None),
                     "sort_order": idx,
                 }
-                await self.db.upsert_chat_folder(folder_data)
+                await self.db.upsert_chat_folder(folder_data, account_id=self.account_id)
 
                 if resolution_chats is None:
                     resolution_chats = [
                         FolderChat(id=r["id"], type=r["type"], is_bot=r["is_bot"], is_archived=r["is_archived"])
-                        for r in await self.db.get_chats_for_folder_resolution()
+                        for r in await self.db.get_chats_for_folder_resolution(account_id=self.account_id)
                     ]
 
                 rules = self._folder_rules_from_filter(f, own_id)
@@ -3861,13 +3891,13 @@ class TelegramBackup:
                 member_ids = resolve_folder_member_ids(rules, resolution_chats, contact_ids or set())
                 # Always sync (even to an empty set) so a folder that lost all its
                 # archived chats is emptied rather than keeping stale members.
-                await self.db.sync_folder_members(folder_id, list(member_ids))
+                await self.db.sync_folder_members(folder_id, list(member_ids), account_id=self.account_id)
 
                 folder_count += 1
                 logger.debug(f"  → Folder: {len(member_ids)} chats")
 
             # Remove folders that no longer exist
-            await self.db.cleanup_stale_folders(active_folder_ids)
+            await self.db.cleanup_stale_folders(active_folder_ids, account_id=self.account_id)
 
             if folder_count > 0:
                 logger.info(f"Backed up {folder_count} chat folders")
@@ -3888,7 +3918,8 @@ async def run_backup(config: Config, client: TelegramClient | None = None):
                If provided, the backup will use this client instead of creating
                its own, avoiding session file lock conflicts.
     """
-    backup = await TelegramBackup.create(config, client=client)
+    # Single-account stage: phase 5 resolves per-account ids from indexed env vars.
+    backup = await TelegramBackup.create(config, client=client, account_id=DEFAULT_ACCOUNT_ID)
     try:
         await backup.connect()
         # One-time repair of media files corrupted by the pre-7.11.3 finalize bug (#175).
@@ -3915,7 +3946,8 @@ async def run_fill_gaps(config: Config, client: TelegramClient | None = None, ch
     Returns:
         Summary dict with gap-fill statistics.
     """
-    backup = await TelegramBackup.create(config, client=client)
+    # Single-account stage: phase 5 resolves per-account ids from indexed env vars.
+    backup = await TelegramBackup.create(config, client=client, account_id=DEFAULT_ACCOUNT_ID)
     try:
         await backup.connect()
         summary = await backup._fill_gaps(chat_id=chat_id)

--- a/src/telegram_import.py
+++ b/src/telegram_import.py
@@ -18,6 +18,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 from .db import DatabaseAdapter, close_database, get_adapter, init_database
+from .db.models import DEFAULT_ACCOUNT_ID
 from .message_utils import build_media_filename, utcnow_naive
 
 logger = logging.getLogger(__name__)
@@ -563,8 +564,10 @@ def _parse_html_export(html_files: list[Path], export_path: Path) -> tuple[str, 
 class TelegramImporter:
     """Import Telegram Desktop exports into Telegram-Archive database."""
 
-    def __init__(self, db: DatabaseAdapter, media_path: str, max_filename_bytes: int = 143):
+    def __init__(self, db: DatabaseAdapter, media_path: str, max_filename_bytes: int = 143, *, account_id: int):
         self.db = db
+        # accounts.id every row written by this import belongs to.
+        self.account_id = account_id
         self.media_path = media_path
         self.media_root = Path(media_path).resolve()
         self.max_filename_bytes = max_filename_bytes
@@ -573,7 +576,9 @@ class TelegramImporter:
     async def create(cls, media_path: str, max_filename_bytes: int = 143) -> TelegramImporter:
         await init_database()
         db = await get_adapter()
-        return cls(db, media_path, max_filename_bytes)
+        # Single-account stage: imports land under the migration-seeded account.
+        # Phase 5 replaces the constant with real per-account resolution here.
+        return cls(db, media_path, max_filename_bytes, account_id=DEFAULT_ACCOUNT_ID)
 
     async def close(self) -> None:
         await close_database()
@@ -678,7 +683,7 @@ class TelegramImporter:
         logger.info(f"Importing chat (type: {export_type}) - {len(messages)} messages")
 
         if not merge and not dry_run:
-            existing = await self.db.get_chat_stats(chat_id)
+            existing = await self.db.get_chat_stats(chat_id, account_id=self.account_id)
             if existing and existing.get("messages", 0) > 0:
                 raise ValueError(
                     f"Chat {chat_id} ('{chat_name}') already has {existing['messages']} messages. "
@@ -692,7 +697,8 @@ class TelegramImporter:
                     "type": CHAT_TYPE_MAP.get(export_type, "unknown"),
                     "title": chat_name if export_type not in ("personal_chat", "bot_chat") else None,
                     "first_name": chat_name if export_type in ("personal_chat", "bot_chat") else None,
-                }
+                },
+                account_id=self.account_id,
             )
 
         seen_users: set[int] = set()
@@ -821,7 +827,7 @@ class TelegramImporter:
             media_count += await self._flush_batch(batch, media_batch)
 
         if not dry_run and msg_count > 0:
-            await self.db.update_sync_status(chat_id, max_msg_id, msg_count)
+            await self.db.update_sync_status(chat_id, max_msg_id, msg_count, account_id=self.account_id)
 
         action = "Would import" if dry_run else "Imported"
         logger.info(f"{action} {msg_count} messages and {media_count} media files")
@@ -840,7 +846,7 @@ class TelegramImporter:
         media: list[dict[str, Any]],
     ) -> int:
         """Flush a batch of messages and media to the database."""
-        await self.db.insert_messages_batch(messages)
+        await self.db.insert_messages_batch(messages, account_id=self.account_id)
         copied = 0
 
         for m in media:
@@ -861,7 +867,7 @@ class TelegramImporter:
                 logger.warning("Skipping imported media after a filesystem error (%s)", type(exc).__name__)
                 continue
 
-            await self.db.insert_media(m)
+            await self.db.insert_media(m, account_id=self.account_id)
             copied += 1
 
         return copied

--- a/tests/test_account_isolation.py
+++ b/tests/test_account_isolation.py
@@ -26,6 +26,7 @@ from src.db.models import (
     Chat,
     ChatFolder,
     ChatFolderMember,
+    ForumTopic,
     Media,
     Message,
     MessageVersion,
@@ -310,8 +311,11 @@ class TestChatsAreAccountIsolated:
         """CLEANUP_CHATS on account 2 must not be able to empty account 1's archive.
 
         Every satellite the method deletes — versions, media, reactions,
-        messages, sync status, the chat row — is seeded for both accounts, then
-        account 2's copy is deleted. Account 1 keeps all six.
+        messages, sync status, forum topics, folder memberships, the chat row —
+        is seeded for both accounts, then account 2's copy is deleted. Account 1
+        keeps all eight. Topics and memberships must be deleted explicitly: their
+        FKs cascade on paper, but SQLite runs with foreign_keys off, so relying
+        on the cascade orphans them.
         """
         await _seed_accounts(real_adapter)
         await _seed_chat(real_adapter, -100713)
@@ -326,10 +330,15 @@ class TestChatsAreAccountIsolated:
             )
             await real_adapter.reconcile_reactions(513, -100713, [{"emoji": "x", "count": 2}], account_id=account_id)
             await real_adapter.update_sync_status(-100713, 513, 1, account_id=account_id)
+            await real_adapter.upsert_forum_topic(
+                {"id": 7, "chat_id": -100713, "title": "topic"}, account_id=account_id
+            )
+            await real_adapter.upsert_chat_folder({"id": 9, "title": "folder"}, account_id=account_id)
+            await real_adapter.sync_folder_members(9, [-100713], account_id=account_id)
 
         await real_adapter.delete_chat_and_related_data(-100713, None, account_id=OTHER_ACCOUNT)
 
-        for model in (Chat, Message, MessageVersion, Media, Reaction, SyncStatus):
+        for model in (Chat, Message, MessageVersion, Media, Reaction, SyncStatus, ForumTopic, ChatFolderMember):
             survivors = await _rows(real_adapter, select(model.account_id))
             assert [a for (a,) in survivors] == [DEFAULT_ACCOUNT_ID], model.__name__
 

--- a/tests/test_account_isolation.py
+++ b/tests/test_account_isolation.py
@@ -1,0 +1,586 @@
+"""Account isolation, proved through the adapter on real engines, both backends.
+
+``tests/test_multiaccount_schema.py`` proves the v8.0.0 KEYS admit two accounts'
+rows side by side. This file proves the ADAPTER keeps them apart: for every
+method the account contract classifies REQUIRED, account 2 operating on the very
+same coordinates (chat id, message id, media id, folder id) as account 1 must
+coexist with — never overwrite, collide with, read, move or delete — account 1's
+rows. Each test is one of the silent-loss shapes the schema change was built
+against; none of them can be caught by a mocked session, so every one runs on
+SQLite and PostgreSQL for real via the ``real_adapter`` fixture.
+
+The one non-obvious member is ``detect_message_gaps``: it is raw SQL, so its
+account filter can fall off without any mapper noticing, and the failure mode is
+not an error but a WRONG ANSWER (the other account's ids fill the gap). The last
+test here seeds the measured interleave and pins the shipped method to the
+scoped result.
+"""
+
+from datetime import datetime, timedelta
+
+from sqlalchemy import and_, func, select
+
+from src.db.models import (
+    DEFAULT_ACCOUNT_ID,
+    Account,
+    Chat,
+    ChatFolder,
+    ChatFolderMember,
+    Media,
+    Message,
+    MessageVersion,
+    Reaction,
+    SyncStatus,
+)
+
+BASE_DATE = datetime(2026, 8, 15, 12, 0, 0)
+OTHER_ACCOUNT = 2
+BOTH_ACCOUNTS = (DEFAULT_ACCOUNT_ID, OTHER_ACCOUNT)
+# Obviously-fake SHA-256 hex digest for content-hash dedup tests.
+CONTENT_HASH = "ab" * 32
+
+
+async def _seed_accounts(adapter) -> None:
+    """Register both identities in the accounts table.
+
+    No data table carries a foreign key to ``accounts`` (the surrogate has to
+    exist before login), so this is hygiene rather than a constraint — but the
+    tests should look like the archive they are protecting.
+    """
+    async with adapter.db_manager.async_session_factory() as session:
+        await session.merge(Account(id=DEFAULT_ACCOUNT_ID, label="personal"))
+        await session.merge(Account(id=OTHER_ACCOUNT, label="work"))
+        await session.commit()
+
+
+async def _seed_chat(adapter, chat_id: int, *, accounts=BOTH_ACCOUNTS, is_forum: int = 0) -> None:
+    """Create each account's copy of the chat (messages/sync/topics FK to it)."""
+    for account_id in accounts:
+        await adapter.upsert_chat(
+            {"id": chat_id, "type": "supergroup", "title": f"copy of account {account_id}", "is_forum": is_forum},
+            account_id=account_id,
+        )
+
+
+def _message(chat_id: int, message_id: int, *, text: str | None = None, minutes: int = 0, **extra) -> dict:
+    data = {
+        "id": message_id,
+        "chat_id": chat_id,
+        "sender_id": 4242,
+        "date": BASE_DATE + timedelta(minutes=minutes),
+        "text": text,
+        "raw_data": {},
+    }
+    data.update(extra)
+    return data
+
+
+async def _rows(adapter, stmt) -> list:
+    async with adapter.db_manager.async_session_factory() as session:
+        return (await session.execute(stmt)).all()
+
+
+async def _scalar(adapter, stmt):
+    async with adapter.db_manager.async_session_factory() as session:
+        return (await session.execute(stmt)).scalar()
+
+
+async def _message_row(adapter, account_id: int, chat_id: int, message_id: int) -> Message | None:
+    async with adapter.db_manager.async_session_factory() as session:
+        return await session.get(Message, (account_id, chat_id, message_id))
+
+
+class TestMessagesAreAccountIsolated:
+    async def test_same_coordinates_coexist_and_an_edit_stays_in_its_account(self, real_adapter):
+        """The headline collision: PK (id, chat_id) used to drop the second copy.
+
+        Both accounts archive message 501 of the same chat. Both rows must
+        exist, and account 2 editing ITS copy (the upsert conflict branch) must
+        never rewrite account 1's text.
+        """
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100701)
+        await real_adapter.insert_message(_message(-100701, 501, text="kept by one"), account_id=DEFAULT_ACCOUNT_ID)
+        await real_adapter.insert_message(_message(-100701, 501, text="kept by two"), account_id=OTHER_ACCOUNT)
+
+        rows = await _rows(
+            real_adapter,
+            select(Message.account_id, Message.text).where(Message.chat_id == -100701).order_by(Message.account_id),
+        )
+        assert rows == [(DEFAULT_ACCOUNT_ID, "kept by one"), (OTHER_ACCOUNT, "kept by two")]
+
+        await real_adapter.insert_message(
+            _message(-100701, 501, text="edited by two", edit_date=BASE_DATE + timedelta(hours=1)),
+            account_id=OTHER_ACCOUNT,
+        )
+        one = await _message_row(real_adapter, DEFAULT_ACCOUNT_ID, -100701, 501)
+        two = await _message_row(real_adapter, OTHER_ACCOUNT, -100701, 501)
+        assert one.text == "kept by one"
+        assert two.text == "edited by two"
+
+    async def test_the_same_edit_keeps_a_version_row_in_each_account(self, real_adapter):
+        """Two accounts archiving the identical edit hash to the identical value.
+
+        ``_message_version_hash`` is a frozen contract that does NOT encode the
+        account, so both version rows carry the same change_hash and only the
+        (account_id, change_hash) constraint keeps the second one alive. With an
+        account-blind constraint the second insert is swallowed by ON CONFLICT
+        DO NOTHING and an account's edit history is silently one row short.
+        """
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100702)
+        for account_id in BOTH_ACCOUNTS:
+            await real_adapter.insert_message(_message(-100702, 502, text="original"), account_id=account_id)
+        for account_id in BOTH_ACCOUNTS:
+            outcome = await real_adapter.update_message_text(
+                -100702, 502, "rewritten", BASE_DATE + timedelta(hours=2), account_id=account_id
+            )
+            assert outcome == "applied"
+
+        versions = await _rows(
+            real_adapter,
+            select(MessageVersion.account_id, MessageVersion.change_hash)
+            .where(MessageVersion.chat_id == -100702)
+            .order_by(MessageVersion.account_id),
+        )
+        assert [account_id for account_id, _ in versions] == [DEFAULT_ACCOUNT_ID, OTHER_ACCOUNT]
+        assert versions[0][1] == versions[1][1]  # identical hash — the constraint carries the account
+
+    async def test_update_message_text_cannot_reach_the_other_accounts_row(self, real_adapter):
+        """Account 2 editing a message only account 1 archived is a not_found."""
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100703)
+        await real_adapter.insert_message(_message(-100703, 503, text="only mine"), account_id=DEFAULT_ACCOUNT_ID)
+
+        outcome = await real_adapter.update_message_text(
+            -100703, 503, "hijacked", BASE_DATE + timedelta(hours=1), account_id=OTHER_ACCOUNT
+        )
+        assert outcome == "not_found"
+        one = await _message_row(real_adapter, DEFAULT_ACCOUNT_ID, -100703, 503)
+        assert one.text == "only mine"
+        assert await _scalar(real_adapter, select(func.count()).select_from(MessageVersion)) == 0
+
+    async def test_delete_message_takes_only_its_accounts_row_and_satellites(self, real_adapter):
+        """delete_message removes versions, media and reactions too — all scoped.
+
+        Both accounts hold message 504 with a version, a media row under the
+        SAME media id string, and a reaction. Account 2's delete must leave
+        every one of account 1's four rows standing.
+        """
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100704)
+        for account_id in BOTH_ACCOUNTS:
+            await real_adapter.insert_message(_message(-100704, 504, text="v1"), account_id=account_id)
+            await real_adapter.update_message_text(
+                -100704, 504, "v2", BASE_DATE + timedelta(hours=1), account_id=account_id
+            )
+            await real_adapter.insert_media(
+                {"id": "-100704_504_photo", "message_id": 504, "chat_id": -100704, "type": "photo"},
+                account_id=account_id,
+            )
+            await real_adapter.reconcile_reactions(504, -100704, [{"emoji": "x", "count": 1}], account_id=account_id)
+
+        await real_adapter.delete_message(-100704, 504, account_id=OTHER_ACCOUNT)
+
+        for model in (Message, MessageVersion, Media, Reaction):
+            survivors = await _rows(real_adapter, select(model.account_id))
+            assert [a for (a,) in survivors] == [DEFAULT_ACCOUNT_ID], model.__name__
+
+    async def test_soft_delete_marks_one_account_and_sync_data_reads_one_account(self, real_adapter):
+        """mark_message_deleted under account 2 must not tombstone account 1's copy,
+        and get_messages_sync_data must keep serving account 1 the still-live row."""
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100705)
+        for account_id in BOTH_ACCOUNTS:
+            await real_adapter.insert_message(_message(-100705, 505, text="alive"), account_id=account_id)
+
+        await real_adapter.mark_message_deleted(-100705, 505, account_id=OTHER_ACCOUNT)
+
+        one = await _message_row(real_adapter, DEFAULT_ACCOUNT_ID, -100705, 505)
+        two = await _message_row(real_adapter, OTHER_ACCOUNT, -100705, 505)
+        assert (one.is_deleted, two.is_deleted) == (0, 1)
+        assert list(await real_adapter.get_messages_sync_data(-100705, account_id=DEFAULT_ACCOUNT_ID)) == [505]
+        assert await real_adapter.get_messages_sync_data(-100705, account_id=OTHER_ACCOUNT) == {}
+
+    async def test_message_id_lookups_never_cross_the_account(self, real_adapter):
+        """get_chat_id_for_message / resolve_message_chat_id run when Telegram
+        reports a deletion without naming a chat — on ONE account's session.
+
+        Account 2 holding id 777 in two chats must not make account 1's lookup
+        ambiguous, and an id only account 2 holds must stay invisible to
+        account 1.
+        """
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100706, accounts=(DEFAULT_ACCOUNT_ID,))
+        await _seed_chat(real_adapter, -100716, accounts=(OTHER_ACCOUNT,))
+        await _seed_chat(real_adapter, -100726, accounts=(OTHER_ACCOUNT,))
+        await real_adapter.insert_message(_message(-100706, 777), account_id=DEFAULT_ACCOUNT_ID)
+        await real_adapter.insert_message(_message(-100716, 777), account_id=OTHER_ACCOUNT)
+        await real_adapter.insert_message(_message(-100726, 777), account_id=OTHER_ACCOUNT)
+        await real_adapter.insert_message(_message(-100716, 888), account_id=OTHER_ACCOUNT)
+
+        assert await real_adapter.resolve_message_chat_id(777, account_id=DEFAULT_ACCOUNT_ID) == -100706
+        assert await real_adapter.resolve_message_chat_id(777, account_id=OTHER_ACCOUNT) is None  # ambiguous for 2
+        assert await real_adapter.get_chat_id_for_message(777, account_id=DEFAULT_ACCOUNT_ID) == -100706
+        assert await real_adapter.get_chat_id_for_message(888, account_id=DEFAULT_ACCOUNT_ID) is None
+
+    async def test_sync_reads_return_only_their_accounts_ids(self, real_adapter):
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100707)
+        await real_adapter.insert_messages_batch(
+            [_message(-100707, 10), _message(-100707, 20)], account_id=DEFAULT_ACCOUNT_ID
+        )
+        await real_adapter.insert_messages_batch(
+            [_message(-100707, 30), _message(-100707, 40)], account_id=OTHER_ACCOUNT
+        )
+
+        assert sorted(await real_adapter.get_messages_sync_data(-100707, account_id=DEFAULT_ACCOUNT_ID)) == [10, 20]
+        cutoff = BASE_DATE - timedelta(days=1)
+        assert await real_adapter.get_message_ids_since(-100707, cutoff, 10, account_id=DEFAULT_ACCOUNT_ID) == [20, 10]
+        assert await real_adapter.get_message_ids_since(-100707, cutoff, 10, account_id=OTHER_ACCOUNT) == [40, 30]
+
+    async def test_backfill_is_outgoing_flags_only_the_owning_account(self, real_adapter):
+        """The same human is the owner of account 1 and a mere participant in
+        account 2's copy of a shared chat — those rows are genuinely not
+        outgoing there, so account 1's backfill must not touch them."""
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100708)
+        await real_adapter.insert_message(_message(-100708, 601), account_id=DEFAULT_ACCOUNT_ID)
+        await real_adapter.insert_message(_message(-100708, 601), account_id=OTHER_ACCOUNT)
+
+        await real_adapter.backfill_is_outgoing(4242, account_id=DEFAULT_ACCOUNT_ID)
+
+        one = await _message_row(real_adapter, DEFAULT_ACCOUNT_ID, -100708, 601)
+        two = await _message_row(real_adapter, OTHER_ACCOUNT, -100708, 601)
+        assert (one.is_outgoing, two.is_outgoing) == (1, 0)
+
+    async def test_migration_markers_surface_only_their_accounts_migrations(self, real_adapter):
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100709, accounts=(DEFAULT_ACCOUNT_ID,))
+        await _seed_chat(real_adapter, -100719, accounts=(OTHER_ACCOUNT,))
+        await real_adapter.insert_message(
+            _message(-100709, 1, raw_data={"action_type": "chat_migrate_to", "migrate_to_id": -100777}),
+            account_id=DEFAULT_ACCOUNT_ID,
+        )
+        await real_adapter.insert_message(
+            _message(-100719, 1, raw_data={"action_type": "chat_migrate_to", "migrate_to_id": -100888}),
+            account_id=OTHER_ACCOUNT,
+        )
+
+        assert await real_adapter.get_migration_markers(account_id=DEFAULT_ACCOUNT_ID) == [(-100709, -100777)]
+        assert await real_adapter.get_migration_markers(account_id=OTHER_ACCOUNT) == [(-100719, -100888)]
+
+
+class TestChatsAreAccountIsolated:
+    async def test_same_chat_id_upserts_to_two_rows_with_their_own_stable_refs(self, real_adapter):
+        """Two rows for the same Telegram chat id, each with its own ref.
+
+        The ref is minted on INSERT and must survive the other account's — and
+        its own — later upserts: the viewer's share links die if it re-rolls.
+        """
+        await _seed_accounts(real_adapter)
+        await real_adapter.upsert_chat({"id": -100711, "type": "group", "title": "mine"}, account_id=DEFAULT_ACCOUNT_ID)
+        await real_adapter.upsert_chat({"id": -100711, "type": "group", "title": "theirs"}, account_id=OTHER_ACCOUNT)
+
+        rows = await _rows(
+            real_adapter,
+            select(Chat.account_id, Chat.title, Chat.ref).where(Chat.id == -100711).order_by(Chat.account_id),
+        )
+        assert [(a, t) for a, t, _ in rows] == [(DEFAULT_ACCOUNT_ID, "mine"), (OTHER_ACCOUNT, "theirs")]
+        refs = [ref for *_, ref in rows]
+        assert refs[0] != refs[1] and all(ref and len(ref) == 22 for ref in refs)
+
+        await real_adapter.upsert_chat({"id": -100711, "type": "group", "title": "renamed"}, account_id=OTHER_ACCOUNT)
+        rows_after = await _rows(
+            real_adapter,
+            select(Chat.account_id, Chat.title, Chat.ref).where(Chat.id == -100711).order_by(Chat.account_id),
+        )
+        assert [(a, t) for a, t, _ in rows_after] == [(DEFAULT_ACCOUNT_ID, "mine"), (OTHER_ACCOUNT, "renamed")]
+        assert [ref for *_, ref in rows_after] == refs  # update branch never touches ref
+
+    async def test_get_chats_with_messages_lists_only_that_accounts_chats(self, real_adapter):
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100712)
+        await _seed_chat(real_adapter, -100722, accounts=(OTHER_ACCOUNT,))
+
+        assert await real_adapter.get_chats_with_messages(account_id=DEFAULT_ACCOUNT_ID) == [-100712]
+        assert sorted(await real_adapter.get_chats_with_messages(account_id=OTHER_ACCOUNT)) == [-100722, -100712]
+
+    async def test_delete_chat_and_related_data_leaves_the_other_accounts_copy_whole(self, real_adapter):
+        """CLEANUP_CHATS on account 2 must not be able to empty account 1's archive.
+
+        Every satellite the method deletes — versions, media, reactions,
+        messages, sync status, the chat row — is seeded for both accounts, then
+        account 2's copy is deleted. Account 1 keeps all six.
+        """
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100713)
+        for account_id in BOTH_ACCOUNTS:
+            await real_adapter.insert_message(_message(-100713, 513, text="v1"), account_id=account_id)
+            await real_adapter.update_message_text(
+                -100713, 513, "v2", BASE_DATE + timedelta(hours=1), account_id=account_id
+            )
+            await real_adapter.insert_media(
+                {"id": "-100713_513_photo", "message_id": 513, "chat_id": -100713, "type": "photo"},
+                account_id=account_id,
+            )
+            await real_adapter.reconcile_reactions(513, -100713, [{"emoji": "x", "count": 2}], account_id=account_id)
+            await real_adapter.update_sync_status(-100713, 513, 1, account_id=account_id)
+
+        await real_adapter.delete_chat_and_related_data(-100713, None, account_id=OTHER_ACCOUNT)
+
+        for model in (Chat, Message, MessageVersion, Media, Reaction, SyncStatus):
+            survivors = await _rows(real_adapter, select(model.account_id))
+            assert [a for (a,) in survivors] == [DEFAULT_ACCOUNT_ID], model.__name__
+
+
+class TestMediaAreAccountIsolated:
+    async def _seed_media_pair(self, adapter, chat_id: int, message_id: int, media_id: str) -> None:
+        await _seed_accounts(adapter)
+        await _seed_chat(adapter, chat_id)
+        for account_id in BOTH_ACCOUNTS:
+            await adapter.insert_message(_message(chat_id, message_id), account_id=account_id)
+            await adapter.insert_media(
+                {
+                    "id": media_id,
+                    "message_id": message_id,
+                    "chat_id": chat_id,
+                    "type": "photo",
+                    "file_path": f"media/account{account_id}.jpg",
+                    "content_hash": CONTENT_HASH,
+                    "downloaded": True,
+                },
+                account_id=account_id,
+            )
+
+    async def test_same_media_id_coexists_and_path_writes_stay_scoped(self, real_adapter):
+        """A media id is ``{chat}_{msg}_{type}`` — the identical string in both
+        accounts. Dedup lookups and path rewrites must each stay home."""
+        await self._seed_media_pair(real_adapter, -100714, 514, "-100714_514_photo")
+
+        found_one = await real_adapter.find_media_by_content_hash(CONTENT_HASH, account_id=DEFAULT_ACCOUNT_ID)
+        found_two = await real_adapter.find_media_by_content_hash(CONTENT_HASH, account_id=OTHER_ACCOUNT)
+        assert found_one["file_path"] == "media/account1.jpg"
+        assert found_two["file_path"] == "media/account2.jpg"
+
+        await real_adapter.update_media_file_path("-100714_514_photo", "media/moved.jpg", account_id=OTHER_ACCOUNT)
+        await real_adapter.mark_media_for_redownload("-100714_514_photo", account_id=OTHER_ACCOUNT)
+
+        rows = await _rows(
+            real_adapter, select(Media.account_id, Media.file_path, Media.downloaded).order_by(Media.account_id)
+        )
+        assert rows == [(DEFAULT_ACCOUNT_ID, "media/account1.jpg", 1), (OTHER_ACCOUNT, None, 0)]
+        assert await real_adapter.find_media_by_content_hash(CONTENT_HASH, account_id=OTHER_ACCOUNT) is None
+        assert await real_adapter.find_media_by_content_hash(CONTENT_HASH, account_id=DEFAULT_ACCOUNT_ID) is not None
+
+    async def test_retry_bookkeeping_charges_only_the_failing_account(self, real_adapter):
+        """One account's download failures must not burn the other's retry budget
+        for the same media id."""
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100715)
+        for account_id in BOTH_ACCOUNTS:
+            await real_adapter.insert_message(_message(-100715, 515), account_id=account_id)
+            await real_adapter.insert_media(
+                {"id": "-100715_515_video", "message_id": 515, "chat_id": -100715, "type": "video"},
+                account_id=account_id,
+            )
+
+        await real_adapter.increment_media_download_attempts("-100715_515_video", account_id=OTHER_ACCOUNT)
+        await real_adapter.increment_media_download_attempts("-100715_515_video", account_id=OTHER_ACCOUNT)
+
+        attempts = await _rows(
+            real_adapter, select(Media.account_id, Media.download_attempts).order_by(Media.account_id)
+        )
+        assert attempts == [(DEFAULT_ACCOUNT_ID, 0), (OTHER_ACCOUNT, 2)]
+
+        pending_one = await real_adapter.get_pending_media_downloads(account_id=DEFAULT_ACCOUNT_ID)
+        assert [(m["id"], m["download_attempts"]) for m in pending_one] == [("-100715_515_video", 0)]
+        # Account 2 hit the cap: excluded from ITS retries, counted in ITS capped
+        # total — while account 1's identical id stays retryable and uncounted.
+        assert await real_adapter.get_pending_media_downloads(max_attempts=2, account_id=OTHER_ACCOUNT) == []
+        assert await real_adapter.count_capped_media_downloads(2, account_id=OTHER_ACCOUNT) == 1
+        assert await real_adapter.count_capped_media_downloads(2, account_id=DEFAULT_ACCOUNT_ID) == 0
+
+    async def test_chat_media_listing_and_deletion_stay_scoped(self, real_adapter):
+        """get_media_for_chat feeds file deletion — surfacing the other account's
+        rows would delete files its rows still point at."""
+        await self._seed_media_pair(real_adapter, -100717, 517, "-100717_517_photo")
+
+        listed = await real_adapter.get_media_for_chat(-100717, account_id=DEFAULT_ACCOUNT_ID)
+        assert [m["file_path"] for m in listed] == ["media/account1.jpg"]
+
+        assert await real_adapter.delete_media_for_chat(-100717, account_id=OTHER_ACCOUNT) == 1
+        assert [m["id"] for m in await real_adapter.get_media_for_chat(-100717, account_id=DEFAULT_ACCOUNT_ID)] == [
+            "-100717_517_photo"
+        ]
+        assert await real_adapter.get_media_for_verification(account_id=OTHER_ACCOUNT) == []
+        verify_one = await real_adapter.get_media_for_verification(account_id=DEFAULT_ACCOUNT_ID)
+        assert [m["file_path"] for m in verify_one] == ["media/account1.jpg"]
+
+
+class TestReactionsAreAccountIsolated:
+    async def test_snapshots_coexist_and_the_empty_sweep_stays_home(self, real_adapter):
+        """Reaction reconciliation is authoritative-by-snapshot, which makes the
+        removal half dangerous: account 2 reconciling to an EMPTY snapshot must
+        tombstone only its own rows, never account 1's live reaction."""
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100718)
+        for account_id, count in ((DEFAULT_ACCOUNT_ID, 3), (OTHER_ACCOUNT, 5)):
+            await real_adapter.insert_message(_message(-100718, 518), account_id=account_id)
+            outcome = await real_adapter.reconcile_reactions(
+                518, -100718, [{"emoji": "thumbs", "count": count}], account_id=account_id
+            )
+            assert outcome == "reconciled"
+
+        rows = await _rows(real_adapter, select(Reaction.account_id, Reaction.count).order_by(Reaction.account_id))
+        assert rows == [(DEFAULT_ACCOUNT_ID, 3), (OTHER_ACCOUNT, 5)]
+
+        assert await real_adapter.reconcile_reactions(518, -100718, [], account_id=OTHER_ACCOUNT) == "reconciled"
+        state = await _rows(
+            real_adapter,
+            select(Reaction.account_id, Reaction.count, Reaction.removed_at.is_(None)).order_by(Reaction.account_id),
+        )
+        assert state == [(DEFAULT_ACCOUNT_ID, 3, True), (OTHER_ACCOUNT, 5, False)]
+
+    async def test_reconcile_needs_its_own_accounts_message(self, real_adapter):
+        """A snapshot for a message only account 1 archived is a no_message for
+        account 2 — never a write against account 1's rows."""
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100728)
+        await real_adapter.insert_message(_message(-100728, 528), account_id=DEFAULT_ACCOUNT_ID)
+
+        outcome = await real_adapter.reconcile_reactions(
+            528, -100728, [{"emoji": "thumbs", "count": 9}], account_id=OTHER_ACCOUNT
+        )
+        assert outcome == "no_message"
+        assert await _scalar(real_adapter, select(func.count()).select_from(Reaction)) == 0
+
+
+class TestSyncStatusIsAccountIsolated:
+    async def test_account_twos_sweep_cannot_move_account_ones_cursor(self, real_adapter):
+        """The cursor decides where the next backup resumes. Account 2 dragging
+        it forward would make account 1 skip everything in between — silently.
+        The counter side matters too: the upsert ACCUMULATES message_count, so a
+        shared row would not overwrite the count but sum it into a number that
+        never existed."""
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100720)
+        await real_adapter.update_sync_status(-100720, 500, 50, account_id=DEFAULT_ACCOUNT_ID)
+        await real_adapter.update_sync_status(-100720, 999, 5, account_id=OTHER_ACCOUNT)
+        await real_adapter.update_sync_status(-100720, 1200, 5, account_id=OTHER_ACCOUNT)
+
+        assert await real_adapter.get_last_message_id(-100720, account_id=DEFAULT_ACCOUNT_ID) == 500
+        assert await real_adapter.get_last_message_id(-100720, account_id=OTHER_ACCOUNT) == 1200
+
+        counts = await _rows(
+            real_adapter, select(SyncStatus.account_id, SyncStatus.message_count).order_by(SyncStatus.account_id)
+        )
+        assert counts == [(DEFAULT_ACCOUNT_ID, 50), (OTHER_ACCOUNT, 10)]  # each accumulates only its own
+
+
+class TestPinsAreAccountIsolated:
+    async def test_the_unpin_sweep_strips_only_its_own_accounts_pins(self, real_adapter):
+        """sync_pinned_messages starts by unpinning EVERYTHING in the chat — the
+        half that, unscoped, wipes the other account's pins for the same id."""
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100724)
+        for account_id in BOTH_ACCOUNTS:
+            await real_adapter.insert_messages_batch(
+                [_message(-100724, message_id) for message_id in (1, 2, 3)], account_id=account_id
+            )
+        await real_adapter.sync_pinned_messages(-100724, [2], account_id=DEFAULT_ACCOUNT_ID)
+        await real_adapter.sync_pinned_messages(-100724, [3], account_id=OTHER_ACCOUNT)
+
+        async def pinned(account_id: int) -> list[int]:
+            rows = await _rows(
+                real_adapter,
+                select(Message.id).where(
+                    and_(Message.account_id == account_id, Message.chat_id == -100724, Message.is_pinned == 1)
+                ),
+            )
+            return sorted(i for (i,) in rows)
+
+        assert (await pinned(DEFAULT_ACCOUNT_ID), await pinned(OTHER_ACCOUNT)) == ([2], [3])
+
+        await real_adapter.sync_pinned_messages(-100724, [], account_id=OTHER_ACCOUNT)
+        assert (await pinned(DEFAULT_ACCOUNT_ID), await pinned(OTHER_ACCOUNT)) == ([2], [])
+
+        await real_adapter.update_message_pinned(-100724, 1, True, account_id=OTHER_ACCOUNT)
+        assert (await pinned(DEFAULT_ACCOUNT_ID), await pinned(OTHER_ACCOUNT)) == ([2], [1])
+
+
+class TestForumTopicsAreAccountIsolated:
+    async def test_same_topic_id_keeps_two_rows_and_updates_stay_home(self, real_adapter):
+        """Every forum has a topic 1 ("General"), so cross-account topic-id
+        collisions are the NORM, not an edge case."""
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100721, is_forum=1)
+        for account_id, title in ((DEFAULT_ACCOUNT_ID, "General"), (OTHER_ACCOUNT, "Generale")):
+            await real_adapter.upsert_forum_topic({"id": 1, "chat_id": -100721, "title": title}, account_id=account_id)
+
+        await real_adapter.upsert_forum_topic(
+            {"id": 1, "chat_id": -100721, "title": "Renamed"}, account_id=OTHER_ACCOUNT
+        )
+
+        topics_one = await real_adapter.get_forum_topics(-100721, account_id=DEFAULT_ACCOUNT_ID)
+        topics_two = await real_adapter.get_forum_topics(-100721, account_id=OTHER_ACCOUNT)
+        assert [t["title"] for t in topics_one] == ["General"]
+        assert [t["title"] for t in topics_two] == ["Renamed"]
+
+
+class TestFoldersAreAccountIsolated:
+    async def test_folder_two_of_each_account_lives_its_own_life(self, real_adapter):
+        """Telegram folder ids start at 2 for EVERY account. Membership replace,
+        the stale-folder sweep and the resolution read all have to stay inside
+        their account or one account's Telegram state rewrites the other's."""
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100731)
+        await _seed_chat(real_adapter, -100741, accounts=(DEFAULT_ACCOUNT_ID,))
+        for account_id, title in ((DEFAULT_ACCOUNT_ID, "Work"), (OTHER_ACCOUNT, "Lavoro")):
+            await real_adapter.upsert_chat_folder({"id": 2, "title": title}, account_id=account_id)
+        await real_adapter.sync_folder_members(2, [-100731, -100741], account_id=DEFAULT_ACCOUNT_ID)
+        await real_adapter.sync_folder_members(2, [-100731], account_id=OTHER_ACCOUNT)
+
+        resolution_one = await real_adapter.get_chats_for_folder_resolution(account_id=DEFAULT_ACCOUNT_ID)
+        resolution_two = await real_adapter.get_chats_for_folder_resolution(account_id=OTHER_ACCOUNT)
+        assert sorted(c["id"] for c in resolution_one) == [-100741, -100731]
+        assert [c["id"] for c in resolution_two] == [-100731]
+
+        # Account 2's replace-all to empty: account 1's memberships survive.
+        await real_adapter.sync_folder_members(2, [], account_id=OTHER_ACCOUNT)
+        members = await _rows(
+            real_adapter,
+            select(ChatFolderMember.account_id, ChatFolderMember.chat_id).order_by(
+                ChatFolderMember.account_id, ChatFolderMember.chat_id
+            ),
+        )
+        assert members == [(DEFAULT_ACCOUNT_ID, -100741), (DEFAULT_ACCOUNT_ID, -100731)]
+
+        # Account 2's Telegram now reports NO folders; account 1's folder and
+        # title are not this sweep's to take.
+        await real_adapter.cleanup_stale_folders([], account_id=OTHER_ACCOUNT)
+        folders = await _rows(real_adapter, select(ChatFolder.account_id, ChatFolder.title))
+        assert folders == [(DEFAULT_ACCOUNT_ID, "Work")]
+
+
+class TestGapDetectionIsAccountScoped:
+    async def test_the_other_accounts_interleaved_ids_cannot_hide_a_real_gap(self, real_adapter):
+        """The measured case, against the SHIPPED method. Account 1 archived ids
+        100 and 400 — a 300-wide hole it still has to fill. Account 2's ids
+        120..360 sit inside that hole, every neighbouring pair closer than the
+        threshold, so an account-blind LAG() window reads one dense sequence
+        and reports NO gap: not unscoped, WRONG. The scoped query must report
+        (100, 400, 300) for account 1 and nothing for account 2."""
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -100723)
+        await real_adapter.insert_messages_batch(
+            [_message(-100723, 100), _message(-100723, 400)], account_id=DEFAULT_ACCOUNT_ID
+        )
+        await real_adapter.insert_messages_batch(
+            [_message(-100723, message_id) for message_id in range(120, 361, 40)], account_id=OTHER_ACCOUNT
+        )
+        per_account = await _rows(real_adapter, select(Message.account_id, func.count()).group_by(Message.account_id))
+        assert dict(per_account) == {DEFAULT_ACCOUNT_ID: 2, OTHER_ACCOUNT: 7}
+
+        assert await real_adapter.detect_message_gaps(-100723, account_id=DEFAULT_ACCOUNT_ID) == [(100, 400, 300)]
+        assert await real_adapter.detect_message_gaps(-100723, account_id=OTHER_ACCOUNT) == []

--- a/tests/test_adapter_query_hardening.py
+++ b/tests/test_adapter_query_hardening.py
@@ -42,7 +42,8 @@ async def sqlite_adapter(tmp_path):
 
 async def _get_message(adapter: DatabaseAdapter, message_id: int, chat_id: int) -> Message:
     async with adapter.db_manager.async_session_factory() as session:
-        message = await session.get(Message, (message_id, chat_id))
+        # v8.0.0 PK order: (account_id, chat_id, id).
+        message = await session.get(Message, (1, chat_id, message_id))
         assert message is not None
         return message
 
@@ -110,7 +111,8 @@ async def _archive_backup_message(adapter: DatabaseAdapter, message_id: int, dat
             "raw_data": {"grouped_id": "5150", "action_type": "chat_migrate_to", "migrate_to_id": -1009999999999},
             "is_outgoing": 1,
             "is_pinned": 1,
-        }
+        },
+        account_id=1,
     )
 
 
@@ -120,7 +122,7 @@ async def test_merge_import_upsert_keeps_columns_it_never_supplied(sqlite_adapte
     date = datetime(2026, 3, 1, 12, 0)
     await _archive_backup_message(sqlite_adapter, 1, date)
 
-    await sqlite_adapter.insert_messages_batch([_merge_import_message(1, date=date)])
+    await sqlite_adapter.insert_messages_batch([_merge_import_message(1, date=date)], account_id=1)
 
     message = await _get_message(sqlite_adapter, 1, CHAT_ID)
     # Absent from the import payload -> the archived value stands. Losing
@@ -136,7 +138,7 @@ async def test_merge_import_upsert_keeps_columns_it_never_supplied(sqlite_adapte
     # extras are gone: grouped_id drives album rendering and migrate_to_id is
     # what get_migration_markers reads back.
     assert '"grouped_id": "5150"' in message.raw_data
-    assert (CHAT_ID, -1009999999999) in await sqlite_adapter.get_migration_markers()
+    assert (CHAT_ID, -1009999999999) in await sqlite_adapter.get_migration_markers(account_id=1)
 
 
 @pytest.mark.asyncio
@@ -145,7 +147,7 @@ async def test_upsert_without_optional_keys_preserves_every_archived_column(sqli
     date = datetime(2026, 3, 1, 12, 0)
     await _archive_backup_message(sqlite_adapter, 2, date)
 
-    await sqlite_adapter.insert_message({"id": 2, "chat_id": CHAT_ID, "date": date})
+    await sqlite_adapter.insert_message({"id": 2, "chat_id": CHAT_ID, "date": date}, account_id=1)
 
     message = await _get_message(sqlite_adapter, 2, CHAT_ID)
     assert message.reply_to_top_id == 77
@@ -174,7 +176,8 @@ async def test_upsert_still_writes_the_columns_it_does_supply(sqlite_adapter):
             "forward_from_id": 1234,
             "is_pinned": 0,
             "raw_data": {"grouped_id": "6000"},
-        }
+        },
+        account_id=1,
     )
 
     message = await _get_message(sqlite_adapter, 3, CHAT_ID)
@@ -188,7 +191,7 @@ async def test_upsert_still_writes_the_columns_it_does_supply(sqlite_adapter):
 async def test_upsert_may_hydrate_a_column_that_was_never_captured(sqlite_adapter):
     """An absent-key rule must not block filling a genuinely empty column."""
     date = datetime(2026, 3, 1, 12, 0)
-    await sqlite_adapter.insert_message({"id": 4, "chat_id": CHAT_ID, "date": date, "text": "hello"})
+    await sqlite_adapter.insert_message({"id": 4, "chat_id": CHAT_ID, "date": date, "text": "hello"}, account_id=1)
 
     await sqlite_adapter.insert_message(
         {
@@ -197,7 +200,8 @@ async def test_upsert_may_hydrate_a_column_that_was_never_captured(sqlite_adapte
             "date": date,
             "reply_to_top_id": 77,
             "raw_data": {"grouped_id": "7000"},
-        }
+        },
+        account_id=1,
     )
 
     message = await _get_message(sqlite_adapter, 4, CHAT_ID)
@@ -240,7 +244,7 @@ def _write_export(tmp_path) -> str:
 @pytest.mark.asyncio
 async def test_fresh_import_still_defaults_the_flags_it_cannot_know(sqlite_adapter, tmp_path):
     """First-time import: absent keys must still land as sane column defaults."""
-    importer = TelegramImporter(sqlite_adapter, media_path=str(tmp_path / "media"))
+    importer = TelegramImporter(sqlite_adapter, media_path=str(tmp_path / "media"), account_id=1)
 
     await importer.run(_write_export(tmp_path), skip_media=True)
 
@@ -265,7 +269,7 @@ async def test_merge_import_preserves_outgoing_pinned_and_forward_source(sqlite_
     """
     date = datetime(2026, 3, 1, 12, 0)
     await _archive_backup_message(sqlite_adapter, 1, date)
-    importer = TelegramImporter(sqlite_adapter, media_path=str(tmp_path / "media"))
+    importer = TelegramImporter(sqlite_adapter, media_path=str(tmp_path / "media"), account_id=1)
 
     await importer.run(_write_export(tmp_path), merge=True, skip_media=True)
 
@@ -414,7 +418,11 @@ async def test_chat_list_does_not_aggregate_the_whole_messages_table(sqlite_adap
     statement = reads[0]
     assert "GROUP BY" not in statement, "the message aggregate must not be an unbounded GROUP BY"
     assert "max(messages.date)" in statement
-    assert "WHERE messages.chat_id = chats.id" in statement, "the aggregate must be correlated to the chat row"
+    # v8.0.0: the correlation carries the account too — a chat id repeats
+    # across accounts, so correlating on chat_id alone reads both copies.
+    assert "WHERE messages.account_id = chats.account_id AND messages.chat_id = chats.id" in statement, (
+        "the aggregate must be correlated to the chat row"
+    )
 
     async with sqlite_adapter.db_manager.engine.connect() as conn:
         plan = await conn.exec_driver_sql("EXPLAIN QUERY PLAN " + statement.replace("?", "50"))

--- a/tests/test_chat_migration.py
+++ b/tests/test_chat_migration.py
@@ -172,6 +172,9 @@ class TestReconcileMigrationsWarn(unittest.TestCase):
         new_id = get_peer_id(PeerChannel(555))
         with self.assertLogs(_LOGGER, level="WARNING") as cm:
             _run(backup._reconcile_migrations([_migrated_dialog(555)], set()))
+        # Pin the account scope: AsyncMock would also accept an unscoped call,
+        # and the real adapter signature requires the keyword.
+        backup.db.get_migration_markers.assert_awaited_once_with(account_id=1)
         joined = "\n".join(cm.output)
         self.assertIn("migrated to a supergroup not in scope", joined)
         self.assertIn("1 tracked group", joined)

--- a/tests/test_chat_migration.py
+++ b/tests/test_chat_migration.py
@@ -81,6 +81,7 @@ def _make_service_message(action, text=""):
 
 def _make_process_backup():
     backup = TelegramBackup.__new__(TelegramBackup)
+    backup.account_id = 1
     backup.config = MagicMock()
     # Bare MagicMock attrs are truthy — pin should_skip_topic so a future
     # topic-skip code path can't be silently short-circuited (documented pitfall).
@@ -131,6 +132,7 @@ _LOGGER = "src.telegram_backup"
 
 def _make_reconcile_backup(follow=False):
     backup = TelegramBackup.__new__(TelegramBackup)
+    backup.account_id = 1
     cfg = MagicMock()
     cfg.follow_chat_migrations = follow
     cfg.chat_ids = set()
@@ -400,7 +402,7 @@ class TestListenerFollowScope(unittest.TestCase):
         db = AsyncMock()
         db.get_all_chats = AsyncMock(return_value=[{"id": -111}])
         db.get_metadata = AsyncMock(return_value=json.dumps([followed]))
-        listener = TelegramListener(cfg, db)
+        listener = TelegramListener(cfg, db, account_id=1)
         _run(listener._load_tracked_chats())
         self.assertIn(followed, listener._tracked_chat_ids)
         self.assertIn(followed, listener._followed_live)
@@ -413,7 +415,7 @@ class TestListenerFollowScope(unittest.TestCase):
         db = AsyncMock()
         db.get_all_chats = AsyncMock(return_value=[])
         db.get_metadata = AsyncMock(return_value=json.dumps([followed]))
-        listener = TelegramListener(cfg, db)
+        listener = TelegramListener(cfg, db, account_id=1)
         _run(listener._load_tracked_chats())
         self.assertIn(followed, listener._followed_live)
         self.assertTrue(listener._should_process_chat(followed))  # via follow
@@ -424,7 +426,7 @@ class TestListenerFollowScope(unittest.TestCase):
         cfg = _make_listener_config(follow=False)
         db = AsyncMock()
         db.get_metadata = AsyncMock(return_value=json.dumps([-1]))
-        listener = TelegramListener(cfg, db)
+        listener = TelegramListener(cfg, db, account_id=1)
         self.assertEqual(_run(listener._load_followed_migration_ids()), set())
         db.get_metadata.assert_not_awaited()
 
@@ -433,21 +435,21 @@ class TestListenerFollowScope(unittest.TestCase):
         cfg = _make_listener_config(follow=True)
         db = AsyncMock()
         db.get_metadata = AsyncMock(return_value=json.dumps([followed]))
-        listener = TelegramListener(cfg, db)
+        listener = TelegramListener(cfg, db, account_id=1)
         self.assertEqual(_run(listener._load_followed_migration_ids()), {followed})
 
     def test_load_followed_malformed_degrades_to_empty(self):
         cfg = _make_listener_config(follow=True)
         db = AsyncMock()
         db.get_metadata = AsyncMock(return_value="not json{")
-        listener = TelegramListener(cfg, db)
+        listener = TelegramListener(cfg, db, account_id=1)
         self.assertEqual(_run(listener._load_followed_migration_ids()), set())
 
     def test_load_followed_missing_degrades_to_empty(self):
         cfg = _make_listener_config(follow=True)
         db = AsyncMock()
         db.get_metadata = AsyncMock(return_value=None)
-        listener = TelegramListener(cfg, db)
+        listener = TelegramListener(cfg, db, account_id=1)
         self.assertEqual(_run(listener._load_followed_migration_ids()), set())
 
 
@@ -467,6 +469,7 @@ class _Ent:
 
 def _make_sweep_backup(*, followed, whitelist_mode, chat_ids, main_dialogs, archived_dialogs):
     backup = TelegramBackup.__new__(TelegramBackup)
+    backup.account_id = 1
     cfg = MagicMock()
     cfg.whitelist_mode = whitelist_mode
     cfg.chat_ids = chat_ids
@@ -592,22 +595,22 @@ class TestGetMigrationMarkers(unittest.TestCase):
             }
         )
         adapter = self._adapter_returning([(-777, raw)])
-        self.assertEqual(_run(adapter.get_migration_markers()), [(-777, get_peer_id(PeerChannel(555)))])
+        self.assertEqual(_run(adapter.get_migration_markers(account_id=1)), [(-777, get_peer_id(PeerChannel(555)))])
 
     def test_skips_non_migration_rows(self):
         raw = json.dumps({"action_type": "chat_edit_title", "new_title": "x"})
         adapter = self._adapter_returning([(-1, raw)])
-        self.assertEqual(_run(adapter.get_migration_markers()), [])
+        self.assertEqual(_run(adapter.get_migration_markers(account_id=1)), [])
 
     def test_skips_malformed_and_empty_rows(self):
         adapter = self._adapter_returning([(-1, "not valid json"), (-2, None)])
-        self.assertEqual(_run(adapter.get_migration_markers()), [])
+        self.assertEqual(_run(adapter.get_migration_markers(account_id=1)), [])
 
     def test_skips_when_pointer_missing_or_non_int(self):
         no_ptr = json.dumps({"action_type": "chat_migrate_to"})
         bad_ptr = json.dumps({"action_type": "chat_migrate_to", "migrate_to_id": "nope"})
         adapter = self._adapter_returning([(-1, no_ptr), (-2, bad_ptr)])
-        self.assertEqual(_run(adapter.get_migration_markers()), [])
+        self.assertEqual(_run(adapter.get_migration_markers(account_id=1)), [])
 
 
 if __name__ == "__main__":

--- a/tests/test_connection_heal_race.py
+++ b/tests/test_connection_heal_race.py
@@ -173,7 +173,7 @@ class TestWatchdogHealsWhileABackupIsSuspended:
 
     class _StubListener:
         @classmethod
-        async def create(cls, config, client=None):
+        async def create(cls, config, client=None, *, account_id):
             listener = cls()
             listener.client = client
             return listener
@@ -398,7 +398,7 @@ class TestTheOriginalFailureStillHeals:
 
         class StubListener:
             @classmethod
-            async def create(cls, config, client=None):
+            async def create(cls, config, client=None, *, account_id):
                 listener = cls()
                 listener.client = client
                 return listener

--- a/tests/test_cursor_freeze_exit.py
+++ b/tests/test_cursor_freeze_exit.py
@@ -71,13 +71,13 @@ class _FakeDb:
         self.metadata_reads: list[str] = []
         self.set_metadata_failures: list[Exception] = []
 
-    async def upsert_chat(self, chat_data):
+    async def upsert_chat(self, chat_data, *, account_id):
         return None
 
-    async def get_last_message_id(self, chat_id):
+    async def get_last_message_id(self, chat_id, *, account_id):
         return self.cursor
 
-    async def update_sync_status(self, chat_id, last_message_id, message_count):
+    async def update_sync_status(self, chat_id, last_message_id, message_count, *, account_id):
         self.cursor = last_message_id
         self.sync_writes.append(last_message_id)
 
@@ -125,6 +125,7 @@ class CursorFreezeExitTestCase(unittest.TestCase):
         backup = TelegramBackup.__new__(TelegramBackup)
         backup.config = config
         backup.db = self.db
+        backup.account_id = 1
         backup.client = MagicMock()
         backup._cleaned_media_chats = set()
         backup._get_marked_id = MagicMock(return_value=CHAT_ID)

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -594,7 +594,7 @@ class TestChatOperations:
         adapter = DatabaseAdapter(db_manager)
 
         chat_data = {"id": 12345, "type": "private", "title": "Test Chat"}
-        result = await adapter.upsert_chat(chat_data)
+        result = await adapter.upsert_chat(chat_data, account_id=1)
 
         assert result == 12345
         mock_session.execute.assert_awaited_once()
@@ -607,7 +607,7 @@ class TestChatOperations:
         adapter = DatabaseAdapter(db_manager)
 
         chat_data = {"id": 99999, "type": "group", "title": "PG Group"}
-        result = await adapter.upsert_chat(chat_data)
+        result = await adapter.upsert_chat(chat_data, account_id=1)
 
         assert result == 99999
         mock_session.execute.assert_awaited_once()
@@ -621,7 +621,7 @@ class TestChatOperations:
 
         # Provide minimal fields -- is_forum and is_archived NOT in chat_data
         chat_data = {"id": 111, "title": "Minimal"}
-        await adapter.upsert_chat(chat_data)
+        await adapter.upsert_chat(chat_data, account_id=1)
 
         # The important thing is it succeeds without error
         mock_session.execute.assert_awaited_once()
@@ -798,7 +798,7 @@ class TestMessageOperations:
             "date": datetime(2025, 1, 1),
             "text": "Hello",
         }
-        await adapter.insert_message(msg_data)
+        await adapter.insert_message(msg_data, account_id=1)
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()
@@ -815,7 +815,7 @@ class TestMessageOperations:
             "date": datetime(2025, 1, 1),
             "text": "PG Hello",
         }
-        await adapter.insert_message(msg_data)
+        await adapter.insert_message(msg_data, account_id=1)
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()
@@ -826,7 +826,7 @@ class TestMessageOperations:
         db_manager, mock_session = _make_mock_db_manager()
         adapter = DatabaseAdapter(db_manager)
 
-        await adapter.insert_messages_batch([])
+        await adapter.insert_messages_batch([], account_id=1)
 
         mock_session.execute.assert_not_awaited()
         mock_session.commit.assert_not_awaited()
@@ -841,7 +841,7 @@ class TestMessageOperations:
             {"id": 1, "chat_id": 100, "date": datetime(2025, 1, 1), "text": "msg1"},
             {"id": 2, "chat_id": 100, "date": datetime(2025, 1, 2), "text": "msg2"},
         ]
-        await adapter.insert_messages_batch(messages)
+        await adapter.insert_messages_batch(messages, account_id=1)
 
         assert mock_session.execute.await_count == 2
         mock_session.commit.assert_awaited_once()
@@ -856,7 +856,7 @@ class TestMessageOperations:
         mock_result.scalar_one_or_none.return_value = 500
         mock_session.execute.return_value = mock_result
 
-        result = await adapter.get_last_message_id(100)
+        result = await adapter.get_last_message_id(100, account_id=1)
         assert result == 500
 
     @pytest.mark.asyncio
@@ -869,7 +869,7 @@ class TestMessageOperations:
         mock_result.scalar_one_or_none.return_value = None
         mock_session.execute.return_value = mock_result
 
-        result = await adapter.get_last_message_id(999)
+        result = await adapter.get_last_message_id(999, account_id=1)
         assert result == 0
 
     @pytest.mark.asyncio
@@ -878,7 +878,7 @@ class TestMessageOperations:
         db_manager, mock_session = _make_mock_db_manager()
         adapter = DatabaseAdapter(db_manager)
 
-        await adapter.delete_message(chat_id=100, message_id=42)
+        await adapter.delete_message(chat_id=100, message_id=42, account_id=1)
 
         # 4 deletes: versions, media, reactions, message
         assert mock_session.execute.await_count == 4
@@ -895,7 +895,7 @@ class TestMessageOperations:
         mock_result.first.return_value = mock_row
         mock_session.execute.return_value = mock_result
 
-        result = await adapter.get_chat_id_for_message(42)
+        result = await adapter.get_chat_id_for_message(42, account_id=1)
         assert result == 100
 
     @pytest.mark.asyncio
@@ -908,7 +908,7 @@ class TestMessageOperations:
         mock_result.first.return_value = None
         mock_session.execute.return_value = mock_result
 
-        result = await adapter.get_chat_id_for_message(9999)
+        result = await adapter.get_chat_id_for_message(9999, account_id=1)
         assert result is None
 
     @pytest.mark.asyncio
@@ -921,7 +921,7 @@ class TestMessageOperations:
         mock_result.fetchall.return_value = [(100,)]
         mock_session.execute.return_value = mock_result
 
-        result = await adapter.resolve_message_chat_id(42)
+        result = await adapter.resolve_message_chat_id(42, account_id=1)
         assert result == 100
 
     @pytest.mark.asyncio
@@ -934,7 +934,7 @@ class TestMessageOperations:
         mock_result.fetchall.return_value = [(100,), (200,)]
         mock_session.execute.return_value = mock_result
 
-        result = await adapter.resolve_message_chat_id(42)
+        result = await adapter.resolve_message_chat_id(42, account_id=1)
         assert result is None
 
     @pytest.mark.asyncio
@@ -947,7 +947,7 @@ class TestMessageOperations:
         mock_result.fetchall.return_value = []
         mock_session.execute.return_value = mock_result
 
-        result = await adapter.resolve_message_chat_id(9999)
+        result = await adapter.resolve_message_chat_id(9999, account_id=1)
         assert result is None
 
     @pytest.mark.asyncio
@@ -967,7 +967,7 @@ class TestMessageOperations:
         # _record_message_version runs inside a SAVEPOINT (session.begin_nested)
         mock_session.begin_nested = MagicMock(return_value=AsyncMock())
 
-        outcome = await adapter.update_message_text(100, 42, "edited text", datetime(2025, 6, 1))
+        outcome = await adapter.update_message_text(100, 42, "edited text", datetime(2025, 6, 1), account_id=1)
 
         assert outcome == "applied"
         assert mock_session.execute.await_count == 4
@@ -979,7 +979,7 @@ class TestMessageOperations:
         db_manager, mock_session = _make_mock_db_manager()
         adapter = DatabaseAdapter(db_manager)
 
-        await adapter.mark_message_deleted(100, 42, datetime(2025, 6, 1))
+        await adapter.mark_message_deleted(100, 42, datetime(2025, 6, 1), account_id=1)
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()
@@ -1043,7 +1043,7 @@ class TestMediaOperations:
         adapter = DatabaseAdapter(db_manager)
 
         media_data = {"id": "file_abc", "type": "photo", "downloaded": True}
-        await adapter.insert_media(media_data)
+        await adapter.insert_media(media_data, account_id=1)
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()
@@ -1055,7 +1055,7 @@ class TestMediaOperations:
         adapter = DatabaseAdapter(db_manager)
 
         media_data = {"id": "file_xyz", "type": "video", "downloaded": False}
-        await adapter.insert_media(media_data)
+        await adapter.insert_media(media_data, account_id=1)
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()
@@ -1070,7 +1070,7 @@ class TestMediaOperations:
         mock_result.rowcount = 7
         mock_session.execute.return_value = mock_result
 
-        count = await adapter.delete_media_for_chat(100)
+        count = await adapter.delete_media_for_chat(100, account_id=1)
         assert count == 7
         mock_session.commit.assert_awaited_once()
 
@@ -1080,7 +1080,7 @@ class TestMediaOperations:
         db_manager, mock_session = _make_mock_db_manager()
         adapter = DatabaseAdapter(db_manager)
 
-        await adapter.mark_media_for_redownload("file_abc")
+        await adapter.mark_media_for_redownload("file_abc", account_id=1)
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()
@@ -1142,7 +1142,7 @@ class TestSyncStatusOperations:
         db_manager, mock_session = _make_mock_db_manager(is_sqlite=True)
         adapter = DatabaseAdapter(db_manager)
 
-        await adapter.update_sync_status(100, 500, 50)
+        await adapter.update_sync_status(100, 500, 50, account_id=1)
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()
@@ -1153,7 +1153,7 @@ class TestSyncStatusOperations:
         db_manager, mock_session = _make_mock_db_manager(is_sqlite=False)
         adapter = DatabaseAdapter(db_manager)
 
-        await adapter.update_sync_status(200, 1000, 100)
+        await adapter.update_sync_status(200, 1000, 100, account_id=1)
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()
@@ -1173,7 +1173,7 @@ class TestDeleteChatOperations:
         db_manager, mock_session = _make_mock_db_manager()
         adapter = DatabaseAdapter(db_manager)
 
-        await adapter.delete_chat_and_related_data(100)
+        await adapter.delete_chat_and_related_data(100, account_id=1)
 
         # 6 deletes: versions, media, reactions, messages, sync_status, chat
         assert mock_session.execute.await_count == 6
@@ -1190,7 +1190,7 @@ class TestDeleteChatOperations:
             patch("src.db.adapter.shutil.rmtree") as mock_rmtree,
             patch("src.db.adapter.glob.glob", return_value=[]),
         ):
-            await adapter.delete_chat_and_related_data(100, media_base_path="/data/media")
+            await adapter.delete_chat_and_related_data(100, media_base_path="/data/media", account_id=1)
 
         mock_rmtree.assert_called_once_with(os.path.join("/data/media", "100"))
 
@@ -1201,7 +1201,7 @@ class TestDeleteChatOperations:
         adapter = DatabaseAdapter(db_manager)
 
         with patch("src.db.adapter.shutil.rmtree") as mock_rmtree:
-            await adapter.delete_chat_and_related_data(100, media_base_path=None)
+            await adapter.delete_chat_and_related_data(100, media_base_path=None, account_id=1)
 
         mock_rmtree.assert_not_called()
 
@@ -1420,7 +1420,7 @@ class TestPinnedMessageOperations:
         db_manager, mock_session = _make_mock_db_manager()
         adapter = DatabaseAdapter(db_manager)
 
-        await adapter.sync_pinned_messages(100, [1, 2, 3])
+        await adapter.sync_pinned_messages(100, [1, 2, 3], account_id=1)
 
         assert mock_session.execute.await_count == 2
         mock_session.commit.assert_awaited_once()
@@ -1431,7 +1431,7 @@ class TestPinnedMessageOperations:
         db_manager, mock_session = _make_mock_db_manager()
         adapter = DatabaseAdapter(db_manager)
 
-        await adapter.sync_pinned_messages(100, [])
+        await adapter.sync_pinned_messages(100, [], account_id=1)
 
         assert mock_session.execute.await_count == 1
         mock_session.commit.assert_awaited_once()
@@ -1442,7 +1442,7 @@ class TestPinnedMessageOperations:
         db_manager, mock_session = _make_mock_db_manager()
         adapter = DatabaseAdapter(db_manager)
 
-        await adapter.update_message_pinned(100, 42, True)
+        await adapter.update_message_pinned(100, 42, True, account_id=1)
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()
@@ -1466,7 +1466,7 @@ class TestBackfillAndGapDetection:
         mock_result.rowcount = 10
         mock_session.execute.return_value = mock_result
 
-        await adapter.backfill_is_outgoing(owner_id=12345)
+        await adapter.backfill_is_outgoing(owner_id=12345, account_id=1)
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()
@@ -1481,7 +1481,7 @@ class TestBackfillAndGapDetection:
         mock_result.fetchall.return_value = [(100,), (200,), (300,)]
         mock_session.execute.return_value = mock_result
 
-        result = await adapter.get_chats_with_messages()
+        result = await adapter.get_chats_with_messages(account_id=1)
         assert result == [100, 200, 300]
 
     @pytest.mark.asyncio
@@ -1501,7 +1501,7 @@ class TestBackfillAndGapDetection:
         mock_result.__iter__ = MagicMock(return_value=iter([mock_row1, mock_row2]))
         mock_session.execute.return_value = mock_result
 
-        result = await adapter.get_messages_sync_data(100)
+        result = await adapter.get_messages_sync_data(100, account_id=1)
         assert result == {1: None, 2: "2025-06-01"}
 
 
@@ -1583,7 +1583,7 @@ class TestFolderOperations:
         adapter = DatabaseAdapter(db_manager)
 
         folder_data = {"id": 1, "title": "Work", "emoticon": None, "sort_order": 0}
-        await adapter.upsert_chat_folder(folder_data)
+        await adapter.upsert_chat_folder(folder_data, account_id=1)
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()
@@ -1594,7 +1594,7 @@ class TestFolderOperations:
         db_manager, mock_session = _make_mock_db_manager()
         adapter = DatabaseAdapter(db_manager)
 
-        await adapter.cleanup_stale_folders([1, 2, 3])
+        await adapter.cleanup_stale_folders([1, 2, 3], account_id=1)
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()
@@ -1605,7 +1605,7 @@ class TestFolderOperations:
         db_manager, mock_session = _make_mock_db_manager()
         adapter = DatabaseAdapter(db_manager)
 
-        await adapter.cleanup_stale_folders([])
+        await adapter.cleanup_stale_folders([], account_id=1)
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()
@@ -2386,7 +2386,7 @@ class TestUpsertForumTopic:
         adapter = DatabaseAdapter(db_manager)
 
         topic_data = {"id": 1, "chat_id": -1001234, "title": "General"}
-        await adapter.upsert_forum_topic(topic_data)
+        await adapter.upsert_forum_topic(topic_data, account_id=1)
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()
@@ -2398,7 +2398,7 @@ class TestUpsertForumTopic:
         adapter = DatabaseAdapter(db_manager)
 
         topic_data = {"id": 2, "chat_id": -1001234, "title": "Dev"}
-        await adapter.upsert_forum_topic(topic_data)
+        await adapter.upsert_forum_topic(topic_data, account_id=1)
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()
@@ -2539,7 +2539,7 @@ class TestSyncFolderMembers:
             existing_result,  # select existing chat IDs
         ]
 
-        await adapter.sync_folder_members(folder_id=1, chat_ids=[100, 200, 300])
+        await adapter.sync_folder_members(folder_id=1, chat_ids=[100, 200, 300], account_id=1)
 
         # delete + select existing = 2 execute calls
         assert mock_session.execute.await_count == 2
@@ -2553,7 +2553,7 @@ class TestSyncFolderMembers:
         db_manager, mock_session = _make_mock_db_manager()
         adapter = DatabaseAdapter(db_manager)
 
-        await adapter.sync_folder_members(folder_id=1, chat_ids=[])
+        await adapter.sync_folder_members(folder_id=1, chat_ids=[], account_id=1)
 
         mock_session.execute.assert_awaited_once()  # just the delete
         mock_session.commit.assert_awaited_once()
@@ -2683,7 +2683,7 @@ class TestGetChatsForFolderResolution:
         mock_result.__iter__ = MagicMock(return_value=iter([_row(500, "private", 0, 1), _row(-100, "group", 1, 0)]))
         mock_session.execute.return_value = mock_result
 
-        result = await adapter.get_chats_for_folder_resolution()
+        result = await adapter.get_chats_for_folder_resolution(account_id=1)
 
         assert result == [
             {"id": 500, "type": "private", "is_bot": True, "is_archived": False},
@@ -3379,7 +3379,7 @@ class TestUpsertChatFolderPostgres:
         adapter = DatabaseAdapter(db_manager)
 
         folder_data = {"id": 1, "title": "Work", "emoticon": None, "sort_order": 0}
-        await adapter.upsert_chat_folder(folder_data)
+        await adapter.upsert_chat_folder(folder_data, account_id=1)
 
         mock_session.execute.assert_awaited_once()
         mock_session.commit.assert_awaited_once()
@@ -3414,10 +3414,11 @@ class TestIterMediaPathsForRepair:
                         "file_name": f"f{i}.jpg",
                         "file_path": f"/data/f{i}.jpg",
                         "downloaded": True,
-                    }
+                    },
+                    account_id=1,
                 )
             # A row with downloaded=0 AND no file_path must be excluded.
-            await adapter.insert_media({"id": "skip", "type": "photo", "downloaded": False})
+            await adapter.insert_media({"id": "skip", "type": "photo", "downloaded": False}, account_id=1)
 
             batches = [b async for b in adapter.iter_media_paths_for_repair(batch_size=2)]
 
@@ -3425,7 +3426,9 @@ class TestIterMediaPathsForRepair:
             assert [len(b) for b in batches] == [2, 2, 1]
             flat = [r for b in batches for r in b]
             assert [r["id"] for r in flat] == ["id0", "id1", "id2", "id3", "id4"]
-            assert flat[0] == {"id": "id0", "file_path": "/data/f0.jpg", "file_name": "f0.jpg"}
+            # v8.0.0: rows carry account_id so the repair caller can address the
+            # exact row back (media ids repeat across accounts).
+            assert flat[0] == {"account_id": 1, "id": "id0", "file_path": "/data/f0.jpg", "file_name": "f0.jpg"}
             assert all(r["id"] != "skip" for r in flat)
         finally:
             await db_manager.close()
@@ -3509,7 +3512,8 @@ class TestCalculateAndStoreStatisticsStorage:
                     "type": "photo",
                     "file_size": 5 * 1024 * 1024 * 1024,  # 5 GiB (bogus, DB-only)
                     "downloaded": True,
-                }
+                },
+                account_id=1,
             )
 
             storage_dir = tmp_path / "storage"
@@ -3540,7 +3544,8 @@ class TestCalculateAndStoreStatisticsStorage:
                     "type": "photo",
                     "file_size": 3 * 1024 * 1024,  # 3 MiB
                     "downloaded": True,
-                }
+                },
+                account_id=1,
             )
 
             stats = await adapter.calculate_and_store_statistics()
@@ -3564,7 +3569,8 @@ class TestCalculateAndStoreStatisticsStorage:
                     "type": "photo",
                     "file_size": 4 * 1024 * 1024,  # 4 MiB recorded in DB
                     "downloaded": True,
-                }
+                },
+                account_id=1,
             )
             missing = tmp_path / "does_not_exist"  # never created → compute_directory_size returns 0
 

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -1168,15 +1168,17 @@ class TestDeleteChatOperations:
     """Test delete_chat_and_related_data and related cleanup operations."""
 
     @pytest.mark.asyncio
-    async def test_delete_chat_issues_six_deletes(self):
-        """delete_chat_and_related_data deletes versions, media, reactions, messages, sync, and chat."""
+    async def test_delete_chat_issues_eight_deletes(self):
+        """delete_chat_and_related_data deletes versions, media, reactions, messages, sync, topics, folder members, and chat."""
         db_manager, mock_session = _make_mock_db_manager()
         adapter = DatabaseAdapter(db_manager)
 
         await adapter.delete_chat_and_related_data(100, account_id=1)
 
-        # 6 deletes: versions, media, reactions, messages, sync_status, chat
-        assert mock_session.execute.await_count == 6
+        # 8 deletes: versions, media, reactions, messages, sync_status,
+        # forum_topics, chat_folder_members (explicit - SQLite runs with
+        # foreign_keys off, so their CASCADEs never fire), chat
+        assert mock_session.execute.await_count == 8
         mock_session.commit.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/test_db_adapter_real_engine.py
+++ b/tests/test_db_adapter_real_engine.py
@@ -29,7 +29,7 @@ BASE_DATE = datetime(2026, 3, 1, 12, 0, 0)
 
 async def _seed_chat(adapter, chat_id: int) -> None:
     """Insert the parent chat row messages and sync_status point at."""
-    await adapter.upsert_chat({"id": chat_id, "type": "group", "title": "fixture chat"})
+    await adapter.upsert_chat({"id": chat_id, "type": "group", "title": "fixture chat"}, account_id=1)
 
 
 def _message(chat_id: int, message_id: int, *, text: str | None = None, offset_minutes: int = 0) -> dict:
@@ -55,13 +55,13 @@ class TestUpdateSyncStatusRealEngine:
         """
         await _seed_chat(real_adapter, 900001)
 
-        await real_adapter.update_sync_status(900001, 500, 50)
+        await real_adapter.update_sync_status(900001, 500, 50, account_id=1)
         async with real_adapter.db_manager.async_session_factory() as session:
             row = (await session.execute(SyncStatus.__table__.select())).mappings().one()
         assert row["last_message_id"] == 500
         assert row["message_count"] == 50
 
-        await real_adapter.update_sync_status(900001, 750, 25)
+        await real_adapter.update_sync_status(900001, 750, 25, account_id=1)
         async with real_adapter.db_manager.async_session_factory() as session:
             row = (await session.execute(SyncStatus.__table__.select())).mappings().one()
         assert row["last_message_id"] == 750
@@ -70,10 +70,10 @@ class TestUpdateSyncStatusRealEngine:
     async def test_last_message_id_round_trips(self, real_adapter):
         """get_last_message_id reads back what the upsert wrote."""
         await _seed_chat(real_adapter, 900002)
-        assert await real_adapter.get_last_message_id(900002) == 0
+        assert await real_adapter.get_last_message_id(900002, account_id=1) == 0
 
-        await real_adapter.update_sync_status(900002, 1234, 7)
-        assert await real_adapter.get_last_message_id(900002) == 1234
+        await real_adapter.update_sync_status(900002, 1234, 7, account_id=1)
+        assert await real_adapter.get_last_message_id(900002, account_id=1) == 1234
 
 
 class TestMessageUpsertConflictRealEngine:
@@ -82,8 +82,8 @@ class TestMessageUpsertConflictRealEngine:
     async def test_reinserting_identical_message_is_a_no_op(self, real_adapter):
         """A re-scan of an unchanged message must not duplicate or mutate it."""
         await _seed_chat(real_adapter, 900003)
-        await real_adapter.insert_message(_message(900003, 10, text="hello"))
-        await real_adapter.insert_message(_message(900003, 10, text="hello"))
+        await real_adapter.insert_message(_message(900003, 10, text="hello"), account_id=1)
+        await real_adapter.insert_message(_message(900003, 10, text="hello"), account_id=1)
 
         messages = await real_adapter.get_messages_paginated(900003, limit=10)
         assert len(messages) == 1
@@ -97,11 +97,11 @@ class TestMessageUpsertConflictRealEngine:
         no-op ``UPDATE`` that acquires the write lock. Both are exercised here.
         """
         await _seed_chat(real_adapter, 900004)
-        await real_adapter.insert_message(_message(900004, 11, text="first"))
+        await real_adapter.insert_message(_message(900004, 11, text="first"), account_id=1)
 
         edited = _message(900004, 11, text="second")
         edited["edit_date"] = BASE_DATE + timedelta(minutes=5)
-        await real_adapter.insert_message(edited)
+        await real_adapter.insert_message(edited, account_id=1)
 
         messages = await real_adapter.get_messages_paginated(900004, limit=10)
         assert len(messages) == 1
@@ -114,8 +114,8 @@ class TestMessageUpsertConflictRealEngine:
         """The same message id in two chats is two rows, not a conflict."""
         await _seed_chat(real_adapter, 900005)
         await _seed_chat(real_adapter, 900006)
-        await real_adapter.insert_message(_message(900005, 12, text="in chat A"))
-        await real_adapter.insert_message(_message(900006, 12, text="in chat B"))
+        await real_adapter.insert_message(_message(900005, 12, text="in chat A"), account_id=1)
+        await real_adapter.insert_message(_message(900006, 12, text="in chat B"), account_id=1)
 
         assert (await real_adapter.get_messages_paginated(900005, limit=10))[0]["text"] == "in chat A"
         assert (await real_adapter.get_messages_paginated(900006, limit=10))[0]["text"] == "in chat B"
@@ -128,7 +128,9 @@ class TestPaginationRealEngine:
         """The (date, id) cursor returns every row exactly once, in order."""
         await _seed_chat(real_adapter, 900007)
         for index in range(6):
-            await real_adapter.insert_message(_message(900007, 100 + index, text=f"m{index}", offset_minutes=index))
+            await real_adapter.insert_message(
+                _message(900007, 100 + index, text=f"m{index}", offset_minutes=index), account_id=1
+            )
 
         first = await real_adapter.get_messages_paginated(900007, limit=4)
         assert [m["id"] for m in first] == [105, 104, 103, 102]
@@ -146,8 +148,8 @@ class TestPaginationRealEngine:
         backend honours it can only be settled by running the query.
         """
         await _seed_chat(real_adapter, 900008)
-        await real_adapter.insert_message(_message(900008, 200, text="100% done", offset_minutes=0))
-        await real_adapter.insert_message(_message(900008, 201, text="nothing here", offset_minutes=1))
+        await real_adapter.insert_message(_message(900008, 200, text="100% done", offset_minutes=0), account_id=1)
+        await real_adapter.insert_message(_message(900008, 201, text="nothing here", offset_minutes=1), account_id=1)
 
         hits = await real_adapter.get_messages_paginated(900008, limit=10, search="100%")
         assert [m["id"] for m in hits] == [200]

--- a/tests/test_db_adapter_soft_delete_upsert.py
+++ b/tests/test_db_adapter_soft_delete_upsert.py
@@ -21,7 +21,8 @@ async def sqlite_adapter(tmp_path):
 
 async def _get_message(adapter: DatabaseAdapter, message_id: int, chat_id: int) -> Message:
     async with adapter.db_manager.async_session_factory() as session:
-        message = await session.get(Message, (message_id, chat_id))
+        # v8.0.0 PK order: (account_id, chat_id, id).
+        message = await session.get(Message, (1, chat_id, message_id))
         assert message is not None
         return message
 
@@ -46,9 +47,10 @@ async def test_insert_message_upsert_preserves_soft_delete_marker(sqlite_adapter
             "chat_id": 100,
             "date": datetime(2026, 6, 25, 10, 0),
             "text": "original",
-        }
+        },
+        account_id=1,
     )
-    await sqlite_adapter.mark_message_deleted(100, 1, deleted_at)
+    await sqlite_adapter.mark_message_deleted(100, 1, deleted_at, account_id=1)
 
     await sqlite_adapter.insert_message(
         {
@@ -56,7 +58,8 @@ async def test_insert_message_upsert_preserves_soft_delete_marker(sqlite_adapter
             "chat_id": 100,
             "date": datetime(2026, 6, 25, 10, 0),
             "text": "reprocessed",
-        }
+        },
+        account_id=1,
     )
 
     message = await _get_message(sqlite_adapter, 1, 100)
@@ -79,9 +82,10 @@ async def test_insert_messages_batch_upsert_preserves_soft_delete_marker(sqlite_
                 "date": datetime(2026, 6, 25, 11, 0),
                 "text": "original",
             }
-        ]
+        ],
+        account_id=1,
     )
-    await sqlite_adapter.mark_message_deleted(100, 2, deleted_at)
+    await sqlite_adapter.mark_message_deleted(100, 2, deleted_at, account_id=1)
 
     await sqlite_adapter.insert_messages_batch(
         [
@@ -91,7 +95,8 @@ async def test_insert_messages_batch_upsert_preserves_soft_delete_marker(sqlite_
                 "date": datetime(2026, 6, 25, 11, 0),
                 "text": "reprocessed",
             }
-        ]
+        ],
+        account_id=1,
     )
 
     message = await _get_message(sqlite_adapter, 2, 100)
@@ -105,7 +110,7 @@ async def test_insert_messages_batch_upsert_preserves_soft_delete_marker(sqlite_
 async def test_fresh_insert_not_marked_deleted(sqlite_adapter):
     """A brand-new message inserts as not-deleted with a null deleted_at."""
     await sqlite_adapter.insert_message(
-        {"id": 3, "chat_id": 100, "date": datetime(2026, 6, 25, 12, 0), "text": "hello"}
+        {"id": 3, "chat_id": 100, "date": datetime(2026, 6, 25, 12, 0), "text": "hello"}, account_id=1
     )
 
     message = await _get_message(sqlite_adapter, 3, 100)
@@ -122,10 +127,12 @@ async def test_single_upsert_preserves_first_nonblank_sender_name(sqlite_adapter
         "text": "hello",
         "sender_name": "  Original Name  ",
     }
-    await sqlite_adapter.insert_message(message_data)
-    await sqlite_adapter.insert_message({**message_data, "sender_name": "Renamed User"})
-    await sqlite_adapter.insert_message({**message_data, "sender_name": "   "})
-    await sqlite_adapter.insert_message({key: value for key, value in message_data.items() if key != "sender_name"})
+    await sqlite_adapter.insert_message(message_data, account_id=1)
+    await sqlite_adapter.insert_message({**message_data, "sender_name": "Renamed User"}, account_id=1)
+    await sqlite_adapter.insert_message({**message_data, "sender_name": "   "}, account_id=1)
+    await sqlite_adapter.insert_message(
+        {key: value for key, value in message_data.items() if key != "sender_name"}, account_id=1
+    )
 
     message = await _get_message(sqlite_adapter, 8, 100)
     assert message.sender_name == "Original Name"
@@ -139,9 +146,9 @@ async def test_single_upsert_fills_missing_sender_name_once(sqlite_adapter):
         "date": datetime(2026, 7, 27, 12, 1),
         "text": "hello",
     }
-    await sqlite_adapter.insert_message(message_data)
-    await sqlite_adapter.insert_message({**message_data, "sender_name": "First Snapshot"})
-    await sqlite_adapter.insert_message({**message_data, "sender_name": "Later Snapshot"})
+    await sqlite_adapter.insert_message(message_data, account_id=1)
+    await sqlite_adapter.insert_message({**message_data, "sender_name": "First Snapshot"}, account_id=1)
+    await sqlite_adapter.insert_message({**message_data, "sender_name": "Later Snapshot"}, account_id=1)
 
     message = await _get_message(sqlite_adapter, 9, 100)
     assert message.sender_name == "First Snapshot"
@@ -156,9 +163,9 @@ async def test_batch_upsert_fills_blank_sender_name_once(sqlite_adapter):
         "text": "hello",
         "sender_name": "",
     }
-    await sqlite_adapter.insert_messages_batch([message_data])
-    await sqlite_adapter.insert_messages_batch([{**message_data, "sender_name": "Batch Snapshot"}])
-    await sqlite_adapter.insert_messages_batch([{**message_data, "sender_name": "Changed Later"}])
+    await sqlite_adapter.insert_messages_batch([message_data], account_id=1)
+    await sqlite_adapter.insert_messages_batch([{**message_data, "sender_name": "Batch Snapshot"}], account_id=1)
+    await sqlite_adapter.insert_messages_batch([{**message_data, "sender_name": "Changed Later"}], account_id=1)
 
     message = await _get_message(sqlite_adapter, 10, 100)
     assert message.sender_name == "Batch Snapshot"
@@ -174,7 +181,7 @@ async def test_sender_name_exposed_in_message_media_and_export_projections(sqlit
         "text": "hello",
         "sender_name": "Captured Name",
     }
-    await sqlite_adapter.insert_message(message_data)
+    await sqlite_adapter.insert_message(message_data, account_id=1)
     await sqlite_adapter.upsert_user({"id": 501, "first_name": "Current", "last_name": "Name", "username": "current"})
     await sqlite_adapter.insert_media(
         {
@@ -184,7 +191,8 @@ async def test_sender_name_exposed_in_message_media_and_export_projections(sqlit
             "type": "photo",
             "file_path": "/archive/photo.jpg",
             "downloaded": True,
-        }
+        },
+        account_id=1,
     )
 
     messages = await sqlite_adapter.get_messages_by_date_range(chat_id=200)
@@ -202,7 +210,7 @@ async def test_upsert_with_is_deleted_and_timestamp_sets_marker(sqlite_adapter):
     deleted_at = datetime(2026, 6, 25, 13, 30)
 
     await sqlite_adapter.insert_message(
-        {"id": 4, "chat_id": 100, "date": datetime(2026, 6, 25, 13, 0), "text": "original"}
+        {"id": 4, "chat_id": 100, "date": datetime(2026, 6, 25, 13, 0), "text": "original"}, account_id=1
     )
     await sqlite_adapter.insert_message(
         {
@@ -212,7 +220,8 @@ async def test_upsert_with_is_deleted_and_timestamp_sets_marker(sqlite_adapter):
             "text": "now deleted",
             "is_deleted": 1,
             "deleted_at": deleted_at,
-        }
+        },
+        account_id=1,
     )
 
     message = await _get_message(sqlite_adapter, 4, 100)
@@ -226,9 +235,9 @@ async def test_upsert_with_is_deleted_no_timestamp_preserves_existing(sqlite_ada
     first_deleted_at = datetime(2026, 6, 25, 14, 30)
 
     await sqlite_adapter.insert_message(
-        {"id": 5, "chat_id": 100, "date": datetime(2026, 6, 25, 14, 0), "text": "original"}
+        {"id": 5, "chat_id": 100, "date": datetime(2026, 6, 25, 14, 0), "text": "original"}, account_id=1
     )
-    await sqlite_adapter.mark_message_deleted(100, 5, first_deleted_at)
+    await sqlite_adapter.mark_message_deleted(100, 5, first_deleted_at, account_id=1)
     await sqlite_adapter.insert_message(
         {
             "id": 5,
@@ -236,7 +245,8 @@ async def test_upsert_with_is_deleted_no_timestamp_preserves_existing(sqlite_ada
             "date": datetime(2026, 6, 25, 14, 0),
             "text": "reprocessed",
             "is_deleted": 1,
-        }
+        },
+        account_id=1,
     )
 
     message = await _get_message(sqlite_adapter, 5, 100)
@@ -251,10 +261,10 @@ async def test_mark_message_deleted_twice_keeps_first_timestamp(sqlite_adapter):
     second = datetime(2026, 6, 25, 16, 0)
 
     await sqlite_adapter.insert_message(
-        {"id": 6, "chat_id": 100, "date": datetime(2026, 6, 25, 14, 0), "text": "original"}
+        {"id": 6, "chat_id": 100, "date": datetime(2026, 6, 25, 14, 0), "text": "original"}, account_id=1
     )
-    await sqlite_adapter.mark_message_deleted(100, 6, first)
-    await sqlite_adapter.mark_message_deleted(100, 6, second)
+    await sqlite_adapter.mark_message_deleted(100, 6, first, account_id=1)
+    await sqlite_adapter.mark_message_deleted(100, 6, second, account_id=1)
 
     message = await _get_message(sqlite_adapter, 6, 100)
     assert message.is_deleted == 1
@@ -265,9 +275,9 @@ async def test_mark_message_deleted_twice_keeps_first_timestamp(sqlite_adapter):
 async def test_mark_message_deleted_defaults_timestamp_when_none(sqlite_adapter):
     """Omitting deleted_at falls back to a server-generated timestamp."""
     await sqlite_adapter.insert_message(
-        {"id": 7, "chat_id": 100, "date": datetime(2026, 6, 25, 14, 0), "text": "original"}
+        {"id": 7, "chat_id": 100, "date": datetime(2026, 6, 25, 14, 0), "text": "original"}, account_id=1
     )
-    await sqlite_adapter.mark_message_deleted(100, 7)
+    await sqlite_adapter.mark_message_deleted(100, 7, account_id=1)
 
     message = await _get_message(sqlite_adapter, 7, 100)
     assert message.is_deleted == 1
@@ -278,25 +288,25 @@ async def test_mark_message_deleted_defaults_timestamp_when_none(sqlite_adapter)
 async def test_get_messages_sync_data_excludes_soft_deleted(sqlite_adapter):
     """Soft-deleted rows are excluded from the sync set so they aren't re-checked."""
     await sqlite_adapter.insert_message(
-        {"id": 10, "chat_id": 200, "date": datetime(2026, 6, 25, 17, 0), "text": "live"}
+        {"id": 10, "chat_id": 200, "date": datetime(2026, 6, 25, 17, 0), "text": "live"}, account_id=1
     )
     await sqlite_adapter.insert_message(
-        {"id": 11, "chat_id": 200, "date": datetime(2026, 6, 25, 17, 1), "text": "to delete"}
+        {"id": 11, "chat_id": 200, "date": datetime(2026, 6, 25, 17, 1), "text": "to delete"}, account_id=1
     )
-    await sqlite_adapter.mark_message_deleted(200, 11)
+    await sqlite_adapter.mark_message_deleted(200, 11, account_id=1)
 
-    sync_data = await sqlite_adapter.get_messages_sync_data(200)
+    sync_data = await sqlite_adapter.get_messages_sync_data(200, account_id=1)
     assert set(sync_data.keys()) == {10}
 
 
 @pytest.mark.asyncio
 async def test_update_message_text_records_previous_version(sqlite_adapter):
     await sqlite_adapter.insert_message(
-        {"id": 20, "chat_id": 300, "date": datetime(2026, 6, 26, 9, 0), "text": "original"}
+        {"id": 20, "chat_id": 300, "date": datetime(2026, 6, 26, 9, 0), "text": "original"}, account_id=1
     )
 
     edit_date = datetime(2026, 6, 26, 9, 5)
-    await sqlite_adapter.update_message_text(300, 20, "edited", edit_date)
+    await sqlite_adapter.update_message_text(300, 20, "edited", edit_date, account_id=1)
 
     message = await _get_message(sqlite_adapter, 20, 300)
     versions = await _get_versions(sqlite_adapter, 20, 300)
@@ -311,11 +321,11 @@ async def test_update_message_text_records_previous_version(sqlite_adapter):
 async def test_update_message_text_is_idempotent(sqlite_adapter):
     edit_date = datetime(2026, 6, 26, 10, 5)
     await sqlite_adapter.insert_message(
-        {"id": 21, "chat_id": 300, "date": datetime(2026, 6, 26, 10, 0), "text": "original"}
+        {"id": 21, "chat_id": 300, "date": datetime(2026, 6, 26, 10, 0), "text": "original"}, account_id=1
     )
 
-    await sqlite_adapter.update_message_text(300, 21, "edited", edit_date)
-    await sqlite_adapter.update_message_text(300, 21, "edited", edit_date)
+    await sqlite_adapter.update_message_text(300, 21, "edited", edit_date, account_id=1)
+    await sqlite_adapter.update_message_text(300, 21, "edited", edit_date, account_id=1)
 
     versions = await _get_versions(sqlite_adapter, 21, 300)
     assert len(versions) == 1
@@ -328,11 +338,11 @@ async def test_update_message_text_same_text_is_noop_and_does_not_bump_edit_date
     # The archive must NOT advance its stored edit_date (it would surface a phantom
     # "edited" marker with no version). Same-text edits are a no-op.
     await sqlite_adapter.insert_message(
-        {"id": 28, "chat_id": 300, "date": datetime(2026, 6, 26, 10, 0), "text": "original"}
+        {"id": 28, "chat_id": 300, "date": datetime(2026, 6, 26, 10, 0), "text": "original"}, account_id=1
     )
 
     reaction_edit_date = datetime(2026, 6, 26, 10, 15)
-    outcome = await sqlite_adapter.update_message_text(300, 28, "original", reaction_edit_date)
+    outcome = await sqlite_adapter.update_message_text(300, 28, "original", reaction_edit_date, account_id=1)
 
     message = await _get_message(sqlite_adapter, 28, 300)
     versions = await _get_versions(sqlite_adapter, 28, 300)
@@ -353,10 +363,11 @@ async def test_update_message_text_older_edit_date_does_not_roll_back(sqlite_ada
             "date": datetime(2026, 6, 26, 10, 0),
             "text": "current",
             "edit_date": current_edit_date,
-        }
+        },
+        account_id=1,
     )
 
-    await sqlite_adapter.update_message_text(300, 27, "older", old_edit_date)
+    await sqlite_adapter.update_message_text(300, 27, "older", old_edit_date, account_id=1)
 
     message = await _get_message(sqlite_adapter, 27, 300)
     versions = await _get_versions(sqlite_adapter, 27, 300)
@@ -368,10 +379,10 @@ async def test_update_message_text_older_edit_date_does_not_roll_back(sqlite_ada
 @pytest.mark.asyncio
 async def test_text_only_edit_records_previous_version(sqlite_adapter):
     await sqlite_adapter.insert_message(
-        {"id": 22, "chat_id": 300, "date": datetime(2026, 6, 26, 11, 0), "text": "caption"}
+        {"id": 22, "chat_id": 300, "date": datetime(2026, 6, 26, 11, 0), "text": "caption"}, account_id=1
     )
 
-    await sqlite_adapter.update_message_text(300, 22, "caption edited", None)
+    await sqlite_adapter.update_message_text(300, 22, "caption edited", None, account_id=1)
 
     message = await _get_message(sqlite_adapter, 22, 300)
     versions = await _get_versions(sqlite_adapter, 22, 300)
@@ -385,7 +396,7 @@ async def test_text_only_edit_records_previous_version(sqlite_adapter):
 @pytest.mark.asyncio
 async def test_upsert_with_newer_edit_date_records_previous_version(sqlite_adapter):
     await sqlite_adapter.insert_message(
-        {"id": 23, "chat_id": 300, "date": datetime(2026, 6, 26, 12, 0), "text": "original"}
+        {"id": 23, "chat_id": 300, "date": datetime(2026, 6, 26, 12, 0), "text": "original"}, account_id=1
     )
     edit_date = datetime(2026, 6, 26, 12, 30)
 
@@ -397,6 +408,7 @@ async def test_upsert_with_newer_edit_date_records_previous_version(sqlite_adapt
             "text": "edited via backup",
             "edit_date": edit_date,
         },
+        account_id=1,
     )
 
     message = await _get_message(sqlite_adapter, 23, 300)
@@ -418,7 +430,8 @@ async def test_upsert_with_same_edit_date_records_previous_version(sqlite_adapte
             "date": datetime(2026, 6, 26, 12, 0),
             "text": "original",
             "edit_date": edit_date,
-        }
+        },
+        account_id=1,
     )
 
     await sqlite_adapter.insert_message(
@@ -429,6 +442,7 @@ async def test_upsert_with_same_edit_date_records_previous_version(sqlite_adapte
             "text": "edited via backup",
             "edit_date": edit_date,
         },
+        account_id=1,
     )
 
     message = await _get_message(sqlite_adapter, 33, 300)
@@ -451,7 +465,8 @@ async def test_upsert_with_same_aware_edit_date_records_previous_version(sqlite_
             "date": datetime(2026, 6, 26, 12, 0),
             "text": "original",
             "edit_date": edit_date,
-        }
+        },
+        account_id=1,
     )
 
     await sqlite_adapter.insert_message(
@@ -462,6 +477,7 @@ async def test_upsert_with_same_aware_edit_date_records_previous_version(sqlite_
             "text": "edited via backup",
             "edit_date": aware_edit_date,
         },
+        account_id=1,
     )
 
     message = await _get_message(sqlite_adapter, 34, 300)
@@ -490,11 +506,12 @@ async def test_repeated_upsert_with_same_edit_date_is_idempotent(sqlite_adapter)
             "date": datetime(2026, 6, 26, 12, 0),
             "text": "original",
             "edit_date": edit_date,
-        }
+        },
+        account_id=1,
     )
 
-    await sqlite_adapter.insert_message(edited_message)
-    await sqlite_adapter.insert_message(edited_message)
+    await sqlite_adapter.insert_message(edited_message, account_id=1)
+    await sqlite_adapter.insert_message(edited_message, account_id=1)
 
     message = await _get_message(sqlite_adapter, 35, 300)
     versions = await _get_versions(sqlite_adapter, 35, 300)
@@ -511,7 +528,7 @@ async def test_upsert_same_text_does_not_bump_edit_date(sqlite_adapter):
     # on an unchanged-text re-scan (a re-fetched message whose only server-side
     # change was a reaction), or the phantom "edited" marker resurfaces post-sweep.
     await sqlite_adapter.insert_message(
-        {"id": 29, "chat_id": 300, "date": datetime(2026, 6, 26, 12, 0), "text": "original"}
+        {"id": 29, "chat_id": 300, "date": datetime(2026, 6, 26, 12, 0), "text": "original"}, account_id=1
     )
     reaction_edit_date = datetime(2026, 6, 26, 12, 30)
 
@@ -523,6 +540,7 @@ async def test_upsert_same_text_does_not_bump_edit_date(sqlite_adapter):
             "text": "original",
             "edit_date": reaction_edit_date,
         },
+        account_id=1,
     )
 
     message = await _get_message(sqlite_adapter, 29, 300)
@@ -543,7 +561,8 @@ async def test_upsert_with_older_edit_date_does_not_roll_back(sqlite_adapter):
             "date": datetime(2026, 6, 26, 13, 0),
             "text": "current text",
             "edit_date": current_edit_date,
-        }
+        },
+        account_id=1,
     )
 
     await sqlite_adapter.insert_message(
@@ -554,6 +573,7 @@ async def test_upsert_with_older_edit_date_does_not_roll_back(sqlite_adapter):
             "text": "old import text",
             "edit_date": old_edit_date,
         },
+        account_id=1,
     )
 
     message = await _get_message(sqlite_adapter, 24, 300)
@@ -566,7 +586,7 @@ async def test_upsert_with_older_edit_date_does_not_roll_back(sqlite_adapter):
 @pytest.mark.asyncio
 async def test_concurrent_upserts_keep_newest_edit_date(sqlite_adapter):
     await sqlite_adapter.insert_message(
-        {"id": 32, "chat_id": 300, "date": datetime(2026, 6, 26, 15, 0), "text": "original"}
+        {"id": 32, "chat_id": 300, "date": datetime(2026, 6, 26, 15, 0), "text": "original"}, account_id=1
     )
 
     async def upsert(text: str, edit_date: datetime) -> None:
@@ -578,6 +598,7 @@ async def test_concurrent_upserts_keep_newest_edit_date(sqlite_adapter):
                 "text": text,
                 "edit_date": edit_date,
             },
+            account_id=1,
         )
 
     newer = datetime(2026, 6, 26, 15, 30)
@@ -599,7 +620,8 @@ async def test_upsert_filling_empty_text_preserves_existing_edit_date(sqlite_ada
             "date": datetime(2026, 6, 26, 13, 40),
             "text": "",
             "edit_date": current_edit_date,
-        }
+        },
+        account_id=1,
     )
 
     await sqlite_adapter.insert_message(
@@ -609,6 +631,7 @@ async def test_upsert_filling_empty_text_preserves_existing_edit_date(sqlite_ada
             "date": datetime(2026, 6, 26, 13, 40),
             "text": "filled text",
         },
+        account_id=1,
     )
 
     message = await _get_message(sqlite_adapter, 26, 300)
@@ -622,9 +645,11 @@ async def test_upsert_filling_empty_text_preserves_existing_edit_date(sqlite_ada
 
 @pytest.mark.asyncio
 async def test_get_message_versions_returns_dicts(sqlite_adapter):
-    await sqlite_adapter.insert_message({"id": 25, "chat_id": 300, "date": datetime(2026, 6, 26, 14, 0), "text": "v1"})
-    await sqlite_adapter.update_message_text(300, 25, "v2", datetime(2026, 6, 26, 14, 5))
-    await sqlite_adapter.update_message_text(300, 25, "v3", datetime(2026, 6, 26, 14, 10))
+    await sqlite_adapter.insert_message(
+        {"id": 25, "chat_id": 300, "date": datetime(2026, 6, 26, 14, 0), "text": "v1"}, account_id=1
+    )
+    await sqlite_adapter.update_message_text(300, 25, "v2", datetime(2026, 6, 26, 14, 5), account_id=1)
+    await sqlite_adapter.update_message_text(300, 25, "v3", datetime(2026, 6, 26, 14, 10), account_id=1)
 
     versions = await sqlite_adapter.get_message_versions(300, 25)
     assert len(versions) == 2
@@ -645,16 +670,18 @@ async def test_get_message_versions_returns_dicts(sqlite_adapter):
 
 @pytest.mark.asyncio
 async def test_get_messages_paginated_includes_version_counts(sqlite_adapter):
-    await sqlite_adapter.insert_message({"id": 40, "chat_id": 300, "date": datetime(2026, 6, 26, 15, 0), "text": "v1"})
     await sqlite_adapter.insert_message(
-        {"id": 41, "chat_id": 300, "date": datetime(2026, 6, 26, 15, 1), "text": "unchanged"}
+        {"id": 40, "chat_id": 300, "date": datetime(2026, 6, 26, 15, 0), "text": "v1"}, account_id=1
     )
     await sqlite_adapter.insert_message(
-        {"id": 42, "chat_id": 300, "date": datetime(2026, 6, 26, 15, 2), "text": "text-only"}
+        {"id": 41, "chat_id": 300, "date": datetime(2026, 6, 26, 15, 1), "text": "unchanged"}, account_id=1
     )
-    await sqlite_adapter.update_message_text(300, 40, "v2", datetime(2026, 6, 26, 15, 5))
-    await sqlite_adapter.update_message_text(300, 40, "v3", datetime(2026, 6, 26, 15, 10))
-    await sqlite_adapter.update_message_text(300, 42, "text-only edited", None)
+    await sqlite_adapter.insert_message(
+        {"id": 42, "chat_id": 300, "date": datetime(2026, 6, 26, 15, 2), "text": "text-only"}, account_id=1
+    )
+    await sqlite_adapter.update_message_text(300, 40, "v2", datetime(2026, 6, 26, 15, 5), account_id=1)
+    await sqlite_adapter.update_message_text(300, 40, "v3", datetime(2026, 6, 26, 15, 10), account_id=1)
+    await sqlite_adapter.update_message_text(300, 42, "text-only edited", None, account_id=1)
 
     messages = await sqlite_adapter.get_messages_paginated(300, limit=10)
     counts = {message["id"]: message["version_count"] for message in messages}
@@ -665,10 +692,14 @@ async def test_get_messages_paginated_includes_version_counts(sqlite_adapter):
 
 @pytest.mark.asyncio
 async def test_get_message_versions_by_date_range_filters_version_dates(sqlite_adapter):
-    await sqlite_adapter.insert_message({"id": 30, "chat_id": 300, "date": datetime(2026, 6, 25, 14, 0), "text": "old"})
-    await sqlite_adapter.insert_message({"id": 31, "chat_id": 300, "date": datetime(2026, 6, 26, 14, 0), "text": "new"})
-    await sqlite_adapter.update_message_text(300, 30, "old edited", datetime(2026, 6, 25, 14, 5))
-    await sqlite_adapter.update_message_text(300, 31, "new edited", datetime(2026, 6, 26, 14, 5))
+    await sqlite_adapter.insert_message(
+        {"id": 30, "chat_id": 300, "date": datetime(2026, 6, 25, 14, 0), "text": "old"}, account_id=1
+    )
+    await sqlite_adapter.insert_message(
+        {"id": 31, "chat_id": 300, "date": datetime(2026, 6, 26, 14, 0), "text": "new"}, account_id=1
+    )
+    await sqlite_adapter.update_message_text(300, 30, "old edited", datetime(2026, 6, 25, 14, 5), account_id=1)
+    await sqlite_adapter.update_message_text(300, 31, "new edited", datetime(2026, 6, 26, 14, 5), account_id=1)
 
     versions = await sqlite_adapter.get_message_versions_by_date_range(
         chat_id=300,
@@ -682,12 +713,12 @@ async def test_get_message_versions_by_date_range_filters_version_dates(sqlite_a
 @pytest.mark.asyncio
 async def test_update_message_text_reports_outcome(sqlite_adapter):
     await sqlite_adapter.insert_message(
-        {"id": 50, "chat_id": 300, "date": datetime(2026, 6, 26, 9, 0), "text": "original"}
+        {"id": 50, "chat_id": 300, "date": datetime(2026, 6, 26, 9, 0), "text": "original"}, account_id=1
     )
 
-    applied = await sqlite_adapter.update_message_text(300, 50, "edited", datetime(2026, 6, 26, 9, 5))
-    noop = await sqlite_adapter.update_message_text(300, 50, "edited", datetime(2026, 6, 26, 9, 5))
-    missing = await sqlite_adapter.update_message_text(300, 999, "x", datetime(2026, 6, 26, 9, 5))
+    applied = await sqlite_adapter.update_message_text(300, 50, "edited", datetime(2026, 6, 26, 9, 5), account_id=1)
+    noop = await sqlite_adapter.update_message_text(300, 50, "edited", datetime(2026, 6, 26, 9, 5), account_id=1)
+    missing = await sqlite_adapter.update_message_text(300, 999, "x", datetime(2026, 6, 26, 9, 5), account_id=1)
 
     assert applied == "applied"
     assert noop == "noop"
@@ -702,11 +733,11 @@ async def test_upsert_preserves_is_pinned_when_absent(sqlite_adapter):
     unconditional upsert reset is_pinned to 0 on every re-scan.
     """
     await sqlite_adapter.insert_message(
-        {"id": 51, "chat_id": 300, "date": datetime(2026, 6, 26, 10, 0), "text": "pin me", "is_pinned": 1}
+        {"id": 51, "chat_id": 300, "date": datetime(2026, 6, 26, 10, 0), "text": "pin me", "is_pinned": 1}, account_id=1
     )
 
     await sqlite_adapter.insert_message(
-        {"id": 51, "chat_id": 300, "date": datetime(2026, 6, 26, 10, 0), "text": "pin me"}
+        {"id": 51, "chat_id": 300, "date": datetime(2026, 6, 26, 10, 0), "text": "pin me"}, account_id=1
     )
 
     message = await _get_message(sqlite_adapter, 51, 300)
@@ -719,11 +750,11 @@ async def test_upsert_different_text_without_any_edit_date_is_refused(sqlite_ada
     side is not applied and records no version (an upsert source must prove
     freshness via edit_date before replacing archived text)."""
     await sqlite_adapter.insert_message(
-        {"id": 52, "chat_id": 300, "date": datetime(2026, 6, 26, 11, 0), "text": "archived"}
+        {"id": 52, "chat_id": 300, "date": datetime(2026, 6, 26, 11, 0), "text": "archived"}, account_id=1
     )
 
     await sqlite_adapter.insert_message(
-        {"id": 52, "chat_id": 300, "date": datetime(2026, 6, 26, 11, 0), "text": "import text"}
+        {"id": 52, "chat_id": 300, "date": datetime(2026, 6, 26, 11, 0), "text": "import text"}, account_id=1
     )
 
     message = await _get_message(sqlite_adapter, 52, 300)
@@ -737,7 +768,7 @@ async def test_version_record_failure_does_not_abort_message_update(sqlite_adapt
     """A poisoned version insert is contained by its SAVEPOINT: the text update
     still lands, the failure only costs the history entry."""
     await sqlite_adapter.insert_message(
-        {"id": 53, "chat_id": 300, "date": datetime(2026, 6, 26, 12, 0), "text": "original"}
+        {"id": 53, "chat_id": 300, "date": datetime(2026, 6, 26, 12, 0), "text": "original"}, account_id=1
     )
 
     def _broken_stmt(values):
@@ -745,7 +776,7 @@ async def test_version_record_failure_does_not_abort_message_update(sqlite_adapt
 
     monkeypatch.setattr(sqlite_adapter, "_insert_message_version_stmt", _broken_stmt)
 
-    outcome = await sqlite_adapter.update_message_text(300, 53, "edited", datetime(2026, 6, 26, 12, 5))
+    outcome = await sqlite_adapter.update_message_text(300, 53, "edited", datetime(2026, 6, 26, 12, 5), account_id=1)
 
     message = await _get_message(sqlite_adapter, 53, 300)
     versions = await _get_versions(sqlite_adapter, 53, 300)
@@ -765,9 +796,9 @@ async def test_unchanged_reupsert_is_a_semantic_noop(sqlite_adapter):
         "text": "stable",
         "edit_date": datetime(2026, 6, 26, 13, 5),
     }
-    await sqlite_adapter.insert_message(data)
+    await sqlite_adapter.insert_message(data, account_id=1)
 
-    await sqlite_adapter.insert_message(dict(data))
+    await sqlite_adapter.insert_message(dict(data), account_id=1)
 
     message = await _get_message(sqlite_adapter, 54, 300)
     versions = await _get_versions(sqlite_adapter, 54, 300)

--- a/tests/test_db_migrate.py
+++ b/tests/test_db_migrate.py
@@ -2,6 +2,7 @@
 
 import os
 import sys
+import unittest
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -51,7 +52,7 @@ def _make_mock_engine_begin(conn_mock=None):
 # ============================================================
 
 
-class TestMigrationModelsRegistry:
+class TestMigrationModelsRegistry(unittest.TestCase):
     """The accounts registry is data like any other table.
 
     8.0 fills accounts.label / telegram_user_id on first login; the target's
@@ -59,7 +60,7 @@ class TestMigrationModelsRegistry:
     MIGRATION_MODELS would silently reset the registry on the moved archive.
     """
 
-    def test_accounts_is_copied_and_leads(self):
+    def test_accounts_is_copied_and_leads(self) -> None:
         from src.db.models import Account
 
         assert MIGRATION_MODELS[0] is Account

--- a/tests/test_db_migrate.py
+++ b/tests/test_db_migrate.py
@@ -47,6 +47,25 @@ def _make_mock_engine_begin(conn_mock=None):
 
 
 # ============================================================
+# MIGRATION_MODELS: the accounts registry rides along
+# ============================================================
+
+
+class TestMigrationModelsRegistry:
+    """The accounts registry is data like any other table.
+
+    8.0 fills accounts.label / telegram_user_id on first login; the target's
+    own 022 seed only knows (1, 'default', NULL), so dropping Account from
+    MIGRATION_MODELS would silently reset the registry on the moved archive.
+    """
+
+    def test_accounts_is_copied_and_leads(self):
+        from src.db.models import Account
+
+        assert MIGRATION_MODELS[0] is Account
+
+
+# ============================================================
 # migrate_sqlite_to_postgres: path resolution
 # ============================================================
 

--- a/tests/test_flood_wait_visibility.py
+++ b/tests/test_flood_wait_visibility.py
@@ -798,6 +798,7 @@ async def test_fetch_media_bytes_sets_flood_threshold_during_download(fake_db):
     from src.telegram_backup import TelegramBackup
 
     backup = TelegramBackup.__new__(TelegramBackup)
+    backup.account_id = 1
     config = MagicMock()
     config.media_flood_sleep_threshold = 60
     backup.config = config  # `is True` gate keeps MagicMock configs single-stream
@@ -850,6 +851,7 @@ def _make_media_backup():
     from src.telegram_backup import TelegramBackup
 
     backup = TelegramBackup.__new__(TelegramBackup)
+    backup.account_id = 1
     backup.config = MagicMock()  # non-int download_timeout_seconds → no wait_for bound
     backup.db = AsyncMock()
     backup.client = AsyncMock()

--- a/tests/test_folder_resolution_integration.py
+++ b/tests/test_folder_resolution_integration.py
@@ -54,7 +54,7 @@ class TestGetChatsForFolderResolutionSQL:
             session.add(User(id=600, is_bot=0))
             await session.commit()
 
-        rows = await adapter.get_chats_for_folder_resolution()
+        rows = await adapter.get_chats_for_folder_resolution(account_id=1)
         by_id = {r["id"]: r for r in rows}
 
         assert by_id[500]["is_bot"] is True
@@ -77,7 +77,7 @@ class TestSyncFolderMembersChunking:
 
         # Real ids + a duplicate + an id with no chat row.
         member_ids = list(range(1, n + 1)) + [1, 1, 99999999]
-        await adapter.sync_folder_members(1, member_ids)
+        await adapter.sync_folder_members(1, member_ids, account_id=1)
 
         async with adapter.db_manager.async_session_factory() as session:
             from sqlalchemy import func, select
@@ -107,7 +107,7 @@ class TestSyncFolderMembersChunking:
             session.add(ChatFolderMember(folder_id=2, chat_id=10))
             await session.commit()
 
-        await adapter.sync_folder_members(2, [])
+        await adapter.sync_folder_members(2, [], account_id=1)
 
         async with adapter.db_manager.async_session_factory() as session:
             from sqlalchemy import func, select

--- a/tests/test_gap_fill.py
+++ b/tests/test_gap_fill.py
@@ -43,7 +43,8 @@ async def _create_in_memory_adapter():
         await conn.execute(
             text(
                 "CREATE TABLE IF NOT EXISTS chats ("
-                "  id INTEGER PRIMARY KEY,"
+                "  account_id INTEGER NOT NULL DEFAULT 1,"
+                "  id INTEGER NOT NULL,"
                 "  type TEXT NOT NULL DEFAULT 'channel',"
                 "  title TEXT,"
                 "  username TEXT,"
@@ -56,13 +57,15 @@ async def _create_in_memory_adapter():
                 "  is_archived INTEGER DEFAULT 0,"
                 "  last_synced_message_id INTEGER DEFAULT 0,"
                 "  created_at TEXT DEFAULT CURRENT_TIMESTAMP,"
-                "  updated_at TEXT DEFAULT CURRENT_TIMESTAMP"
+                "  updated_at TEXT DEFAULT CURRENT_TIMESTAMP,"
+                "  PRIMARY KEY (account_id, id)"
                 ")"
             )
         )
         await conn.execute(
             text(
                 "CREATE TABLE IF NOT EXISTS messages ("
+                "  account_id INTEGER NOT NULL DEFAULT 1,"
                 "  id INTEGER NOT NULL,"
                 "  chat_id INTEGER NOT NULL,"
                 "  sender_id INTEGER,"
@@ -77,7 +80,7 @@ async def _create_in_memory_adapter():
                 "  created_at TEXT DEFAULT CURRENT_TIMESTAMP,"
                 "  is_outgoing INTEGER DEFAULT 0,"
                 "  is_pinned INTEGER DEFAULT 0,"
-                "  PRIMARY KEY (id, chat_id)"
+                "  PRIMARY KEY (account_id, chat_id, id)"
                 ")"
             )
         )
@@ -130,7 +133,7 @@ class TestDetectMessageGaps:
         adapter, engine = await _create_in_memory_adapter()
         try:
             await _insert_messages(adapter, chat_id=100, msg_ids=list(range(1, 51)))
-            gaps = await adapter.detect_message_gaps(chat_id=100, threshold=50)
+            gaps = await adapter.detect_message_gaps(chat_id=100, threshold=50, account_id=1)
             assert gaps == []
         finally:
             await engine.dispose()
@@ -141,7 +144,7 @@ class TestDetectMessageGaps:
         try:
             ids = list(range(1, 51)) + list(range(100, 151))
             await _insert_messages(adapter, chat_id=200, msg_ids=ids)
-            gaps = await adapter.detect_message_gaps(chat_id=200, threshold=49)
+            gaps = await adapter.detect_message_gaps(chat_id=200, threshold=49, account_id=1)
 
             assert len(gaps) == 1
             gap_start, gap_end, gap_size = gaps[0]
@@ -159,7 +162,7 @@ class TestDetectMessageGaps:
             # Gap 2: between 110 and 300 (size 190)
             ids = list(range(1, 11)) + list(range(100, 111)) + list(range(300, 311))
             await _insert_messages(adapter, chat_id=300, msg_ids=ids)
-            gaps = await adapter.detect_message_gaps(chat_id=300, threshold=50)
+            gaps = await adapter.detect_message_gaps(chat_id=300, threshold=50, account_id=1)
 
             assert len(gaps) == 2
             assert gaps[0] == (10, 100, 90)
@@ -177,7 +180,7 @@ class TestDetectMessageGaps:
             # gap_size = 60 - 10 = 50, and the query uses > threshold, so 50 is NOT > 50
             ids = list(range(1, 11)) + list(range(60, 71))
             await _insert_messages(adapter, chat_id=400, msg_ids=ids)
-            gaps = await adapter.detect_message_gaps(chat_id=400, threshold=50)
+            gaps = await adapter.detect_message_gaps(chat_id=400, threshold=50, account_id=1)
 
             assert gaps == [], f"Gap of exactly threshold should not be returned, got {gaps}"
         finally:
@@ -190,7 +193,7 @@ class TestDetectMessageGaps:
             # IDs 1-10 then 62-70 → gap_size = 62 - 10 = 52 > 50
             ids = list(range(1, 11)) + list(range(62, 71))
             await _insert_messages(adapter, chat_id=401, msg_ids=ids)
-            gaps = await adapter.detect_message_gaps(chat_id=401, threshold=50)
+            gaps = await adapter.detect_message_gaps(chat_id=401, threshold=50, account_id=1)
 
             assert len(gaps) == 1
             assert gaps[0] == (10, 62, 52)
@@ -202,7 +205,7 @@ class TestDetectMessageGaps:
         adapter, engine = await _create_in_memory_adapter()
         try:
             await _insert_messages(adapter, chat_id=500, msg_ids=[42])
-            gaps = await adapter.detect_message_gaps(chat_id=500, threshold=50)
+            gaps = await adapter.detect_message_gaps(chat_id=500, threshold=50, account_id=1)
             assert gaps == []
         finally:
             await engine.dispose()
@@ -211,7 +214,7 @@ class TestDetectMessageGaps:
         """A chat with zero messages should produce no gaps."""
         adapter, engine = await _create_in_memory_adapter()
         try:
-            gaps = await adapter.detect_message_gaps(chat_id=999, threshold=50)
+            gaps = await adapter.detect_message_gaps(chat_id=999, threshold=50, account_id=1)
             assert gaps == []
         finally:
             await engine.dispose()
@@ -225,8 +228,8 @@ class TestDetectMessageGaps:
             # Chat 2: no gap
             await _insert_messages(adapter, chat_id=20, msg_ids=[1, 2, 3, 4, 5])
 
-            gaps_chat1 = await adapter.detect_message_gaps(chat_id=10, threshold=50)
-            gaps_chat2 = await adapter.detect_message_gaps(chat_id=20, threshold=50)
+            gaps_chat1 = await adapter.detect_message_gaps(chat_id=10, threshold=50, account_id=1)
+            gaps_chat2 = await adapter.detect_message_gaps(chat_id=20, threshold=50, account_id=1)
 
             assert len(gaps_chat1) == 1
             assert gaps_chat1[0] == (3, 100, 97)
@@ -251,7 +254,7 @@ class TestGetChatsWithMessages:
             await _insert_chat(adapter, chat_id=-1002, title="Chat B")
             await _insert_chat(adapter, chat_id=-1003, title="Chat C")
 
-            result = await adapter.get_chats_with_messages()
+            result = await adapter.get_chats_with_messages(account_id=1)
             assert sorted(result) == [-1003, -1002, -1001]
         finally:
             await engine.dispose()
@@ -260,7 +263,7 @@ class TestGetChatsWithMessages:
         """Should return empty list when no chats exist."""
         adapter, engine = await _create_in_memory_adapter()
         try:
-            result = await adapter.get_chats_with_messages()
+            result = await adapter.get_chats_with_messages(account_id=1)
             assert result == []
         finally:
             await engine.dispose()
@@ -274,6 +277,7 @@ class TestGetChatsWithMessages:
 def _make_backup_instance(db_mock=None, client_mock=None, config_mock=None):
     """Create a TelegramBackup instance with mocked dependencies."""
     backup = TelegramBackup.__new__(TelegramBackup)
+    backup.account_id = 1
     backup.db = db_mock or AsyncMock()
     backup.client = client_mock or AsyncMock()
     backup.config = config_mock or MagicMock()
@@ -461,7 +465,7 @@ class TestFillGaps:
 
         await backup._fill_gaps(chat_id=None)
 
-        db.detect_message_gaps.assert_awaited_once_with(-1001, 123)
+        db.detect_message_gaps.assert_awaited_once_with(-1001, 123, account_id=1)
 
 
 class TestFillGapRange:

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -22,6 +22,7 @@ class TestSessionPathLogging:
         from src.telegram_backup import TelegramBackup
 
         backup = TelegramBackup.__new__(TelegramBackup)
+        backup.account_id = 1
         backup.config = MagicMock()
         backup.config.session_path = "/data/sessions/my_session"
         backup.config.api_id = 12345
@@ -117,7 +118,7 @@ class TestListenerSessionPathLogging:
         db.get_all_chats = AsyncMock(return_value=[])
         db.close = AsyncMock()
 
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
         return listener
 
     async def test_listener_connect_logs_session_path_at_info_level(self):

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -52,7 +52,7 @@ class TestTelegramListener:
 
     def test_init(self, mock_config, mock_db):
         """Test listener initialization."""
-        listener = TelegramListener(mock_config, mock_db)
+        listener = TelegramListener(mock_config, mock_db, account_id=1)
 
         assert listener.config == mock_config
         assert listener.db == mock_db
@@ -62,7 +62,7 @@ class TestTelegramListener:
 
     def test_load_tracked_chats(self, mock_config, mock_db):
         """Test loading tracked chats from database."""
-        listener = TelegramListener(mock_config, mock_db)
+        listener = TelegramListener(mock_config, mock_db, account_id=1)
 
         # Run async method synchronously
         asyncio.run(listener._load_tracked_chats())
@@ -72,7 +72,7 @@ class TestTelegramListener:
 
     def test_should_process_chat_tracked(self, mock_config, mock_db):
         """Test _should_process_chat returns True for tracked chats."""
-        listener = TelegramListener(mock_config, mock_db)
+        listener = TelegramListener(mock_config, mock_db, account_id=1)
         listener._tracked_chat_ids = {-1001234567890, 123456789}
 
         assert listener._should_process_chat(-1001234567890) is True
@@ -82,7 +82,7 @@ class TestTelegramListener:
     def test_should_process_chat_include_list(self, mock_config, mock_db):
         """Test _should_process_chat returns True for included chats."""
         mock_config.global_include_ids = {-1009999999}
-        listener = TelegramListener(mock_config, mock_db)
+        listener = TelegramListener(mock_config, mock_db, account_id=1)
         listener._tracked_chat_ids = set()
 
         assert listener._should_process_chat(-1009999999) is True
@@ -90,7 +90,7 @@ class TestTelegramListener:
 
     def test_get_marked_id(self, mock_config, mock_db):
         """Test _get_marked_id handles various inputs."""
-        listener = TelegramListener(mock_config, mock_db)
+        listener = TelegramListener(mock_config, mock_db, account_id=1)
 
         # Test with raw integer
         assert listener._get_marked_id(123456789) == 123456789
@@ -104,7 +104,7 @@ class TestTelegramListener:
 
     def test_close(self, mock_config, mock_db):
         """Test clean shutdown."""
-        listener = TelegramListener(mock_config, mock_db)
+        listener = TelegramListener(mock_config, mock_db, account_id=1)
         listener.client = AsyncMock()
         listener.client.is_connected = MagicMock(return_value=False)
 
@@ -115,7 +115,7 @@ class TestTelegramListener:
 
     def test_stats_initialization(self, mock_config, mock_db):
         """Test statistics are properly initialized."""
-        listener = TelegramListener(mock_config, mock_db)
+        listener = TelegramListener(mock_config, mock_db, account_id=1)
 
         # Check stats keys match actual implementation
         assert listener.stats["edits_received"] == 0
@@ -166,20 +166,20 @@ class TestInitConfig:
 
     def test_init_calls_validate_credentials(self, base_config, mock_db):
         """Test that __init__ validates credentials."""
-        TelegramListener(base_config, mock_db)
+        TelegramListener(base_config, mock_db, account_id=1)
         base_config.validate_credentials.assert_called_once()
 
     def test_init_with_existing_client(self, base_config, mock_db):
         """Test initialization with an externally provided client."""
         external_client = MagicMock()
-        listener = TelegramListener(base_config, mock_db, client=external_client)
+        listener = TelegramListener(base_config, mock_db, client=external_client, account_id=1)
 
         assert listener.client is external_client
         assert listener._owns_client is False
 
     def test_init_without_client_owns_client(self, base_config, mock_db):
         """Test initialization without client sets _owns_client to True."""
-        listener = TelegramListener(base_config, mock_db)
+        listener = TelegramListener(base_config, mock_db, account_id=1)
 
         assert listener.client is None
         assert listener._owns_client is True
@@ -189,14 +189,14 @@ class TestInitConfig:
         base_config.mass_operation_threshold = 25
         base_config.mass_operation_window_seconds = 60
 
-        listener = TelegramListener(base_config, mock_db)
+        listener = TelegramListener(base_config, mock_db, account_id=1)
 
         assert listener._protector.threshold == 25
         assert listener._protector.window_seconds == 60
 
     def test_init_stats_include_new_messages_counters(self, base_config, mock_db):
         """Test that stats dict includes new_messages counters."""
-        listener = TelegramListener(base_config, mock_db)
+        listener = TelegramListener(base_config, mock_db, account_id=1)
 
         assert listener.stats["new_messages_received"] == 0
         assert listener.stats["new_messages_saved"] == 0
@@ -207,20 +207,20 @@ class TestInitConfig:
         base_config.listen_new_messages = True
         base_config.listen_new_messages_media = True
         # Should not raise
-        listener = TelegramListener(base_config, mock_db)
+        listener = TelegramListener(base_config, mock_db, account_id=1)
         assert listener.config.listen_new_messages is True
 
     def test_init_with_skip_topic_ids(self, base_config, mock_db):
         """Test init logs topic exclusion info when skip_topic_ids is set."""
         base_config.skip_topic_ids = {-1001234: {100, 200}, -1005678: {300}}
         # Should not raise
-        listener = TelegramListener(base_config, mock_db)
+        listener = TelegramListener(base_config, mock_db, account_id=1)
         assert listener.config.skip_topic_ids == {-1001234: {100, 200}, -1005678: {300}}
 
     def test_init_with_listen_deletions_enabled(self, base_config, mock_db):
         """Test init when deletions are enabled triggers warning log path."""
         base_config.listen_deletions = True
-        listener = TelegramListener(base_config, mock_db)
+        listener = TelegramListener(base_config, mock_db, account_id=1)
         assert listener.config.listen_deletions is True
 
 
@@ -279,7 +279,7 @@ class TestEventHandlers:
     @pytest.fixture
     def listener_with_handlers(self, full_config, mock_db):
         """Create a listener and register handlers, capturing them for direct invocation."""
-        listener = TelegramListener(full_config, mock_db)
+        listener = TelegramListener(full_config, mock_db, account_id=1)
         listener._tracked_chat_ids = {-1001234567890}
         listener._notifier = None  # Disable notifications for unit tests
 
@@ -529,6 +529,7 @@ class TestEventHandlers:
             message_id=42,
             new_text="Updated text",
             edit_date=msg.edit_date,
+            account_id=1,
         )
 
     def test_on_message_edited_handles_none_text(self, listener_with_handlers):
@@ -683,7 +684,7 @@ class TestEventHandlers:
 
         asyncio.run(handler(event))
 
-        mock_db.resolve_message_chat_id.assert_called_once_with(42)
+        mock_db.resolve_message_chat_id.assert_called_once_with(42, account_id=1)
         assert listener.stats["deletions_applied"] == 1
 
     def test_on_message_deleted_skips_unresolvable_message(self, listener_with_handlers, mock_db):
@@ -763,7 +764,7 @@ class TestStatsTracking:
 
     @pytest.fixture
     def listener_with_handlers(self, full_config, mock_db):
-        listener = TelegramListener(full_config, mock_db)
+        listener = TelegramListener(full_config, mock_db, account_id=1)
         listener._tracked_chat_ids = {-1001234567890}
         listener._notifier = None
 
@@ -884,23 +885,23 @@ class TestWhitelistMode:
 
     def test_whitelist_mode_allows_whitelisted_chat(self, mock_config, mock_db):
         """Test whitelist mode allows chat in CHAT_IDS."""
-        listener = TelegramListener(mock_config, mock_db)
+        listener = TelegramListener(mock_config, mock_db, account_id=1)
         assert listener._should_process_chat(-1001111111) is True
 
     def test_whitelist_mode_blocks_non_whitelisted_chat(self, mock_config, mock_db):
         """Test whitelist mode blocks chat NOT in CHAT_IDS."""
-        listener = TelegramListener(mock_config, mock_db)
+        listener = TelegramListener(mock_config, mock_db, account_id=1)
         assert listener._should_process_chat(-1002222222) is False
 
     def test_whitelist_mode_ignores_include_lists(self, mock_config, mock_db):
         """Test whitelist mode ignores global_include_ids even if chat matches."""
-        listener = TelegramListener(mock_config, mock_db)
+        listener = TelegramListener(mock_config, mock_db, account_id=1)
         # -1009999999 is in global_include_ids but NOT in chat_ids
         assert listener._should_process_chat(-1009999999) is False
 
     def test_whitelist_mode_ignores_tracked_chats(self, mock_config, mock_db):
         """Test whitelist mode ignores tracked chats if not in CHAT_IDS."""
-        listener = TelegramListener(mock_config, mock_db)
+        listener = TelegramListener(mock_config, mock_db, account_id=1)
         listener._tracked_chat_ids = {-1003333333}
         assert listener._should_process_chat(-1003333333) is False
 
@@ -992,7 +993,7 @@ class TestListenerEventHandling:
 
     def test_listener_filters_untracked_chats(self, mock_config, mock_db):
         """Test that events from untracked chats are ignored."""
-        listener = TelegramListener(mock_config, mock_db)
+        listener = TelegramListener(mock_config, mock_db, account_id=1)
         listener._tracked_chat_ids = {-1001234567890}
 
         # Should process

--- a/tests/test_listener_chat_actions.py
+++ b/tests/test_listener_chat_actions.py
@@ -71,7 +71,7 @@ def _build(**config_overrides):
     db = AsyncMock()
     db.insert_message = AsyncMock()
     db.upsert_chat = AsyncMock()
-    listener = TelegramListener(_config(**config_overrides), db)
+    listener = TelegramListener(_config(**config_overrides), db, account_id=1)
     listener._tracked_chat_ids = {TRACKED}
     listener._get_marked_id = MagicMock(return_value=TRACKED)
     listener._download_avatar = AsyncMock()

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -94,7 +94,7 @@ def _make_listener_with_handlers(**config_overrides):
     """Create a TelegramListener with handlers captured for direct invocation."""
     config = _make_config(**config_overrides)
     db = _make_db()
-    listener = TelegramListener(config, db)
+    listener = TelegramListener(config, db, account_id=1)
     listener._tracked_chat_ids = {-1001234567890}
     listener._notifier = None
 
@@ -243,7 +243,7 @@ class TestShouldProcessChatIncludeLists:
         """Chat in private_include_ids is processed even if not tracked."""
         config = _make_config(private_include_ids={555})
         db = _make_db()
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
         listener._tracked_chat_ids = set()
         assert listener._should_process_chat(555) is True
 
@@ -251,7 +251,7 @@ class TestShouldProcessChatIncludeLists:
         """Chat in groups_include_ids is processed even if not tracked."""
         config = _make_config(groups_include_ids={-666})
         db = _make_db()
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
         listener._tracked_chat_ids = set()
         assert listener._should_process_chat(-666) is True
 
@@ -259,7 +259,7 @@ class TestShouldProcessChatIncludeLists:
         """Chat in channels_include_ids is processed even if not tracked."""
         config = _make_config(channels_include_ids={-1007777})
         db = _make_db()
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
         listener._tracked_chat_ids = set()
         assert listener._should_process_chat(-1007777) is True
 
@@ -267,7 +267,7 @@ class TestShouldProcessChatIncludeLists:
         """Chat not in any list or tracking set returns False."""
         config = _make_config()
         db = _make_db()
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
         listener._tracked_chat_ids = set()
         assert listener._should_process_chat(99999) is False
 
@@ -286,7 +286,7 @@ class TestGetChatType:
 
         config = _make_config()
         db = _make_db()
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
         entity = MagicMock(spec=User)
         assert listener._get_chat_type(entity) == "private"
 
@@ -296,7 +296,7 @@ class TestGetChatType:
 
         config = _make_config()
         db = _make_db()
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
         entity = MagicMock(spec=TelethonChat)
         assert listener._get_chat_type(entity) == "group"
 
@@ -306,7 +306,7 @@ class TestGetChatType:
 
         config = _make_config()
         db = _make_db()
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
         entity = MagicMock(spec=Channel)
         entity.megagroup = False
         assert listener._get_chat_type(entity) == "channel"
@@ -317,7 +317,7 @@ class TestGetChatType:
 
         config = _make_config()
         db = _make_db()
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
         entity = MagicMock(spec=Channel)
         entity.megagroup = True
         assert listener._get_chat_type(entity) == "group"
@@ -326,7 +326,7 @@ class TestGetChatType:
         """Unknown entity type maps to 'unknown'."""
         config = _make_config()
         db = _make_db()
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
         entity = MagicMock()  # Not spec'd to any known type
         assert listener._get_chat_type(entity) == "unknown"
 
@@ -340,7 +340,7 @@ class TestGetMediaType:
     """Tests for _get_media_type classification."""
 
     def _listener(self):
-        return TelegramListener(_make_config(), _make_db())
+        return TelegramListener(_make_config(), _make_db(), account_id=1)
 
     def test_photo_media(self):
         """MessageMediaPhoto returns 'photo'."""
@@ -485,7 +485,7 @@ class TestGetMediaFilename:
     """Tests for _get_media_filename generation."""
 
     def _listener(self):
-        return TelegramListener(_make_config(), _make_db())
+        return TelegramListener(_make_config(), _make_db(), account_id=1)
 
     def test_uses_original_filename_with_file_id(self):
         """When document has file_name attribute and telegram_file_id is provided, combines both."""
@@ -568,7 +568,7 @@ class TestDownloadMedia:
     def _make_listener(self, **config_overrides):
         config = _make_config(**config_overrides)
         db = _make_db()
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
         listener.client = AsyncMock()
         return listener
 
@@ -868,7 +868,7 @@ class TestDownloadAvatar:
     @patch("src.listener.get_avatar_paths", return_value=(None, "/legacy/path"))
     async def test_returns_early_when_no_avatar_set(self, mock_paths):
         """If avatar_path is None, returns without downloading."""
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         listener.client = AsyncMock()
         entity = MagicMock()
 
@@ -881,7 +881,7 @@ class TestDownloadAvatar:
     @patch("os.path.getsize", return_value=1024)
     async def test_skips_download_when_file_exists(self, mock_size, mock_islink, mock_lexists, mock_paths):
         """If avatar file already exists with content, skip download."""
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         listener.client = AsyncMock()
         entity = MagicMock()
 
@@ -892,7 +892,7 @@ class TestDownloadAvatar:
     @patch("os.path.lexists", return_value=False)
     async def test_downloads_avatar_when_file_missing(self, mock_lexists, mock_paths):
         """Downloads avatar when file does not exist."""
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         listener.client = AsyncMock()
         listener.client.download_profile_photo = AsyncMock(return_value="/path/avatar.jpg")
         entity = MagicMock()
@@ -906,7 +906,7 @@ class TestDownloadAvatar:
     @patch("os.path.getsize", return_value=0)
     async def test_downloads_avatar_when_file_empty(self, mock_size, mock_islink, mock_lexists, mock_paths):
         """Downloads avatar when file exists but is empty (0 bytes)."""
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         listener.client = AsyncMock()
         listener.client.download_profile_photo = AsyncMock(return_value="/path/avatar.jpg")
         entity = MagicMock()
@@ -917,7 +917,7 @@ class TestDownloadAvatar:
     @patch("src.listener.get_avatar_paths", side_effect=Exception("filesystem error"))
     async def test_handles_exception_gracefully(self, mock_paths):
         """Exceptions during avatar download are caught and logged."""
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         listener.client = AsyncMock()
         entity = MagicMock()
 
@@ -928,7 +928,7 @@ class TestDownloadAvatar:
     @patch("os.path.lexists", return_value=False)
     async def test_handles_none_download_result(self, mock_lexists, mock_paths):
         """When download_profile_photo returns None, logs debug instead of info."""
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         listener.client = AsyncMock()
         listener.client.download_profile_photo = AsyncMock(return_value=None)
         entity = MagicMock()
@@ -947,7 +947,7 @@ class TestNotifyUpdate:
 
     async def test_returns_early_when_no_notifier(self):
         """If _notifier is None, returns without error."""
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         listener._notifier = None
         # Should not raise
         await listener._notify_update("edit", {"chat_id": 123, "message_id": 1})
@@ -956,7 +956,7 @@ class TestNotifyUpdate:
         """Sends edit notification with correct type mapping."""
         from src.realtime import NotificationType
 
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         notifier = AsyncMock()
         listener._notifier = notifier
 
@@ -967,7 +967,7 @@ class TestNotifyUpdate:
         """Sends delete notification with correct type mapping."""
         from src.realtime import NotificationType
 
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         notifier = AsyncMock()
         listener._notifier = notifier
 
@@ -978,7 +978,7 @@ class TestNotifyUpdate:
         """Sends new_message notification with correct type mapping."""
         from src.realtime import NotificationType
 
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         notifier = AsyncMock()
         listener._notifier = notifier
 
@@ -989,7 +989,7 @@ class TestNotifyUpdate:
         """Sends pin notification with correct type mapping."""
         from src.realtime import NotificationType
 
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         notifier = AsyncMock()
         listener._notifier = notifier
 
@@ -998,7 +998,7 @@ class TestNotifyUpdate:
 
     async def test_unknown_type_returns_without_sending(self):
         """Unknown notification type logs warning and returns without sending."""
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         notifier = AsyncMock()
         listener._notifier = notifier
 
@@ -1007,7 +1007,7 @@ class TestNotifyUpdate:
 
     async def test_handles_exception_from_notifier(self):
         """Exception from notifier is caught and does not propagate."""
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         notifier = AsyncMock()
         notifier.notify = AsyncMock(side_effect=Exception("notify failed"))
         listener._notifier = notifier
@@ -1019,7 +1019,7 @@ class TestNotifyUpdate:
         """Uses 0 as default chat_id when not provided in data."""
         from src.realtime import NotificationType
 
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         notifier = AsyncMock()
         listener._notifier = notifier
 
@@ -1072,7 +1072,7 @@ class TestOnPinnedMessagesHandler:
 
         assert db.update_message_pinned.call_count == 3
         for msg_id in [10, 20, 30]:
-            db.update_message_pinned.assert_any_call(expected_chat_id, msg_id, True)
+            db.update_message_pinned.assert_any_call(expected_chat_id, msg_id, True, account_id=1)
 
     async def test_channel_unpin_updates_messages(self):
         """Channel unpin event sets pinned=False in DB."""
@@ -1090,7 +1090,7 @@ class TestOnPinnedMessagesHandler:
 
         await pin_handler(event)
 
-        db.update_message_pinned.assert_called_once_with(expected_chat_id, 10, False)
+        db.update_message_pinned.assert_called_once_with(expected_chat_id, 10, False, account_id=1)
 
     async def test_group_pin_with_user_peer(self):
         """Group pin event with user peer extracts correct chat_id."""
@@ -1112,7 +1112,7 @@ class TestOnPinnedMessagesHandler:
 
         await pin_handler(event)
 
-        db.update_message_pinned.assert_called_once_with(12345, 5, True)
+        db.update_message_pinned.assert_called_once_with(12345, 5, True, account_id=1)
 
     async def test_group_pin_with_chat_peer(self):
         """Group pin event with chat peer extracts negative chat_id."""
@@ -1135,7 +1135,7 @@ class TestOnPinnedMessagesHandler:
 
         await pin_handler(event)
 
-        db.update_message_pinned.assert_called_once_with(expected_chat_id, 7, True)
+        db.update_message_pinned.assert_called_once_with(expected_chat_id, 7, True, account_id=1)
 
     async def test_group_pin_with_channel_peer(self):
         """Group pin event with channel peer uses -1000000000000 prefix."""
@@ -1157,7 +1157,7 @@ class TestOnPinnedMessagesHandler:
 
         await pin_handler(event)
 
-        db.update_message_pinned.assert_called_once_with(expected_chat_id, 8, True)
+        db.update_message_pinned.assert_called_once_with(expected_chat_id, 8, True, account_id=1)
 
     async def test_skips_untracked_chat(self):
         """Pin event for untracked chat is ignored."""
@@ -1763,7 +1763,7 @@ class TestRunAndStopLifecycle:
         """run() sets start_time, starts protector, writes metadata, then runs client."""
         config = _make_config()
         db = _make_db()
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
 
         mock_client = AsyncMock()
         mock_client.run_until_disconnected = AsyncMock(side_effect=asyncio.CancelledError)
@@ -1779,7 +1779,7 @@ class TestRunAndStopLifecycle:
         """stop() disconnects the client when listener owns it."""
         config = _make_config()
         db = _make_db()
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
         listener._owns_client = True
         listener.stats["start_time"] = datetime.now()
 
@@ -1797,7 +1797,7 @@ class TestRunAndStopLifecycle:
         config = _make_config()
         db = _make_db()
         external_client = AsyncMock()
-        listener = TelegramListener(config, db, client=external_client)
+        listener = TelegramListener(config, db, client=external_client, account_id=1)
         listener.stats["start_time"] = datetime.now()
 
         assert listener._owns_client is False
@@ -1810,7 +1810,7 @@ class TestRunAndStopLifecycle:
         """stop() catches exceptions during disconnect."""
         config = _make_config()
         db = _make_db()
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
         listener._owns_client = True
         listener.stats["start_time"] = datetime.now()
 
@@ -1826,7 +1826,7 @@ class TestRunAndStopLifecycle:
         """close() calls stop() then db.close()."""
         config = _make_config()
         db = _make_db()
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
         listener.client = AsyncMock()
         listener.client.is_connected = MagicMock(return_value=False)
 
@@ -1838,7 +1838,7 @@ class TestRunAndStopLifecycle:
         """run() cancels _processor_task in finally block if it exists."""
         config = _make_config()
         db = _make_db()
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
 
         mock_client = AsyncMock()
         mock_client.run_until_disconnected = AsyncMock(side_effect=asyncio.CancelledError)
@@ -1869,13 +1869,13 @@ class TestLogStats:
 
     async def test_log_stats_with_no_start_time(self):
         """_log_stats does nothing when start_time is None."""
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         # Should not raise
         await listener._log_stats()
 
     async def test_log_stats_with_start_time_and_errors(self):
         """_log_stats logs error count when errors > 0."""
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         listener.stats["start_time"] = datetime.now() - timedelta(hours=1)
         listener.stats["errors"] = 5
         listener.stats["deletions_skipped"] = 10
@@ -1884,7 +1884,7 @@ class TestLogStats:
 
     async def test_log_stats_with_blocked_chats(self):
         """_log_stats logs blocked chat details when chats are rate-limited."""
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         listener.stats["start_time"] = datetime.now() - timedelta(minutes=30)
 
         # Add a blocked chat to protector
@@ -1896,7 +1896,7 @@ class TestLogStats:
 
     async def test_log_stats_shows_zero_errors_without_warning(self):
         """_log_stats with zero errors does not log the error warning."""
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         listener.stats["start_time"] = datetime.now() - timedelta(minutes=5)
         listener.stats["errors"] = 0
         listener.stats["deletions_skipped"] = 0
@@ -1916,7 +1916,7 @@ class TestLoadTrackedChatsError:
         """When get_all_chats raises, tracked_chat_ids is set to empty set."""
         db = _make_db()
         db.get_all_chats = AsyncMock(side_effect=Exception("db error"))
-        listener = TelegramListener(_make_config(), db)
+        listener = TelegramListener(_make_config(), db, account_id=1)
 
         await listener._load_tracked_chats()
 
@@ -1933,14 +1933,14 @@ class TestGetMarkedIdFallback:
 
     def test_fallback_to_raw_integer(self):
         """When get_peer_id fails and input is raw int, returns the int."""
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         # Raw int -- get_peer_id will fail, no .id attr, returns raw
         result = listener._get_marked_id(42)
         assert result == 42
 
     def test_fallback_to_entity_id(self):
         """When get_peer_id fails, falls back to entity.id."""
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         entity = MagicMock()
         entity.id = 99999
         result = listener._get_marked_id(entity)
@@ -1961,7 +1961,7 @@ class TestListenerCreateFactory:
         mock_db = _make_db()
 
         with patch("src.listener.create_adapter", new_callable=AsyncMock, return_value=mock_db):
-            listener = await TelegramListener.create(config)
+            listener = await TelegramListener.create(config, account_id=1)
 
         assert isinstance(listener, TelegramListener)
         assert listener.db is mock_db
@@ -1973,7 +1973,7 @@ class TestListenerCreateFactory:
         mock_client = MagicMock()
 
         with patch("src.listener.create_adapter", new_callable=AsyncMock, return_value=mock_db):
-            listener = await TelegramListener.create(config, client=mock_client)
+            listener = await TelegramListener.create(config, client=mock_client, account_id=1)
 
         assert listener.client is mock_client
         assert listener._owns_client is False
@@ -1993,7 +1993,7 @@ class TestListenerConnectSharedClient:
         db = _make_db()
         mock_client = MagicMock()
         mock_client.is_connected = MagicMock(return_value=False)
-        listener = TelegramListener(config, db, client=mock_client)
+        listener = TelegramListener(config, db, client=mock_client, account_id=1)
 
         import pytest
 
@@ -2015,7 +2015,7 @@ class TestListenerConnectSharedClient:
         mock_client = AsyncMock()
         mock_client.is_connected = MagicMock(return_value=True)
         mock_client.is_user_authorized = AsyncMock(return_value=False)
-        listener = TelegramListener(config, db, client=mock_client)
+        listener = TelegramListener(config, db, client=mock_client, account_id=1)
 
         import pytest
 
@@ -2030,7 +2030,7 @@ class TestListenerConnectSharedClient:
         mock_client.is_connected = MagicMock(return_value=True)
         mock_client.get_me = AsyncMock(return_value=MagicMock(first_name="Test", phone="+1"))
         mock_client.on = lambda event_type: lambda fn: fn
-        listener = TelegramListener(config, db, client=mock_client)
+        listener = TelegramListener(config, db, client=mock_client, account_id=1)
 
         mock_db_manager = MagicMock()
         mock_db_manager._is_sqlite = True
@@ -2052,7 +2052,7 @@ class TestListenerConnectNotAuthorized:
         config = _make_config()
         config.get_telegram_client_kwargs = MagicMock(return_value={})
         db = _make_db()
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
 
         mock_client = AsyncMock()
         mock_client.connect = AsyncMock()
@@ -2075,7 +2075,7 @@ class TestGetMarkedIdRawFallback:
 
     def test_raw_integer_returns_itself(self):
         """When input is a raw integer and has no .id, returns the integer."""
-        listener = TelegramListener(_make_config(), _make_db())
+        listener = TelegramListener(_make_config(), _make_db(), account_id=1)
         result = listener._get_marked_id(12345)
         assert result == 12345
 
@@ -2102,7 +2102,7 @@ class TestDownloadMediaSymlinkFallback:
 
         config = _make_config(deduplicate_media=True)
         db = _make_db()
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
         listener.client = AsyncMock()
         msg = MagicMock()
         media = MagicMock(spec=MessageMediaPhoto)
@@ -2203,7 +2203,7 @@ class TestRunMetadataWriteException:
         config = _make_config()
         db = _make_db()
         db.set_metadata = AsyncMock(side_effect=Exception("DB write failed"))
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
 
         mock_client = AsyncMock()
         mock_client.run_until_disconnected = AsyncMock(side_effect=asyncio.CancelledError)
@@ -2236,7 +2236,7 @@ class TestRunFinallyMetadataClear:
             raise Exception("clear failed")  # Second call (clearing) fails
 
         db.set_metadata = AsyncMock(side_effect=track_set_metadata)
-        listener = TelegramListener(config, db)
+        listener = TelegramListener(config, db, account_id=1)
 
         mock_client = AsyncMock()
         mock_client.run_until_disconnected = AsyncMock(side_effect=asyncio.CancelledError)
@@ -2266,9 +2266,13 @@ class TestRunListenerStandalone:
 
         config = _make_config()
 
-        with patch("src.listener.TelegramListener.create", new_callable=AsyncMock, return_value=mock_listener):
+        with patch(
+            "src.listener.TelegramListener.create", new_callable=AsyncMock, return_value=mock_listener
+        ) as mock_create:
             await run_listener(config)
 
+        # The standalone entry point is a phase-5 seam: it must name the account.
+        mock_create.assert_awaited_once_with(config, account_id=1)
         mock_listener.connect.assert_awaited_once()
         mock_listener.run.assert_awaited_once()
         mock_listener.close.assert_awaited_once()
@@ -2288,6 +2292,30 @@ class TestRunListenerStandalone:
             await run_listener(config)
 
         mock_listener.close.assert_awaited_once()
+
+    async def test_run_listener_builds_real_listener_for_the_default_account(self):
+        """The standalone entry runs the REAL TelegramListener.create/__init__ chain.
+
+        The tests above patch create() away, so they cannot catch the entry
+        dropping the required account_id kwarg. Here only leaf dependencies are
+        mocked; a missing kwarg raises TypeError out of run_listener itself.
+        """
+        from src.db.models import DEFAULT_ACCOUNT_ID
+        from src.listener import run_listener
+
+        config = _make_config()
+
+        with (
+            patch("src.listener.create_adapter", new_callable=AsyncMock, return_value=AsyncMock()),
+            patch.object(TelegramListener, "connect", autospec=True) as mock_connect,
+            patch.object(TelegramListener, "run", autospec=True),
+            patch.object(TelegramListener, "close", autospec=True),
+        ):
+            await run_listener(config)
+
+        listener = mock_connect.await_args.args[0]
+        assert isinstance(listener, TelegramListener)
+        assert listener.account_id == DEFAULT_ACCOUNT_ID
 
 
 # ===========================================================================

--- a/tests/test_listener_reactions.py
+++ b/tests/test_listener_reactions.py
@@ -48,7 +48,7 @@ def _reactions(*pairs, is_min=False):
 def _build(listen_reactions=True):
     db = AsyncMock()
     db.reconcile_reactions = AsyncMock(return_value="reconciled")
-    listener = TelegramListener(_config(listen_reactions), db)
+    listener = TelegramListener(_config(listen_reactions), db, account_id=1)
     listener._tracked_chat_ids = {TRACKED}
     listener._get_marked_id = MagicMock(return_value=TRACKED)
     listener._notifier = None
@@ -111,7 +111,9 @@ class TestReactionHandler:
         asyncio.run(handler(_event(reactions=_reactions(("👍", 3)))))
         asyncio.run(listener._flush_reactions())
 
-        db.reconcile_reactions.assert_awaited_once_with(42, TRACKED, [{"emoji": "👍", "count": 3}], mark_removed=True)
+        db.reconcile_reactions.assert_awaited_once_with(
+            42, TRACKED, [{"emoji": "👍", "count": 3}], account_id=1, mark_removed=True
+        )
         listener._notify_update.assert_awaited_once()
         args = listener._notify_update.await_args[0]
         assert args[0] == "reaction"
@@ -160,7 +162,7 @@ def _build_all(listen_reactions=True, listen_edits=True, listen_new_messages=Tru
     config = _config(listen_reactions)
     config.listen_edits = listen_edits
     config.listen_new_messages = listen_new_messages
-    listener = TelegramListener(config, db)
+    listener = TelegramListener(config, db, account_id=1)
     listener._tracked_chat_ids = {TRACKED}
     listener._get_marked_id = MagicMock(return_value=TRACKED)
     listener._notifier = None
@@ -201,7 +203,9 @@ class TestEditVectorReactions:
         listener, handlers, db = _build_all()
         asyncio.run(handlers["on_message_edited"](_edit_event(reactions=_reactions(("🔥", 1)))))
         asyncio.run(listener._flush_reactions())
-        db.reconcile_reactions.assert_awaited_once_with(42, TRACKED, [{"emoji": "🔥", "count": 1}], mark_removed=True)
+        db.reconcile_reactions.assert_awaited_once_with(
+            42, TRACKED, [{"emoji": "🔥", "count": 1}], account_id=1, mark_removed=True
+        )
 
     def test_edit_without_reactions_object_not_buffered(self):
         # A missing reactions object conveys NO information (review finding:

--- a/tests/test_media_filename.py
+++ b/tests/test_media_filename.py
@@ -186,6 +186,7 @@ def test_backup_and_listener_fallback_filenames_match():
     from src.telegram_backup import TelegramBackup
 
     backup = TelegramBackup.__new__(TelegramBackup)
+    backup.account_id = 1
     listener = TelegramListener.__new__(TelegramListener)
 
     cases = [

--- a/tests/test_media_metadata_persistence.py
+++ b/tests/test_media_metadata_persistence.py
@@ -87,6 +87,7 @@ def _message(msg_id, media):
 def _make_backup(media_root):
     """TelegramBackup wired for a real, dedup-free download into ``media_root``."""
     backup = TelegramBackup.__new__(TelegramBackup)
+    backup.account_id = 1
     backup.config = MagicMock()
     backup.config.media_path = media_root
     backup.config.deduplicate_media = False
@@ -289,14 +290,14 @@ class TestSweepPreservesLiveCapturedMetadata:
         message = _message(7, media)
         media_id = f"{CHAT_ID}_7_video"
 
-        await adapter.insert_media(self._listener_row(media_id, media))
+        await adapter.insert_media(self._listener_row(media_id, media), account_id=1)
         before = await _media_row(adapter, media_id)
         assert (before.mime_type, before.width, before.height, before.duration) == ("video/mp4", 640, 480, 12)
 
         backup = _make_backup(self.media_root)
         sweep_row = await backup._process_media(message, CHAT_ID)
         assert sweep_row is not None
-        await adapter.insert_media(sweep_row)
+        await adapter.insert_media(sweep_row, account_id=1)
 
         after = await _media_row(adapter, media_id)
         assert (after.mime_type, after.width, after.height, after.duration) == ("video/mp4", 640, 480, 12)
@@ -321,7 +322,7 @@ class TestSweepPreservesLiveCapturedMetadata:
         backup = _make_backup(self.media_root)
         sweep_row = await backup._process_media(_message(7, media), CHAT_ID)
 
-        await adapter.insert_media(sweep_row)
+        await adapter.insert_media(sweep_row, account_id=1)
 
         stored = await _media_row(adapter, f"{CHAT_ID}_7_video")
         assert stored.duration == 12
@@ -336,7 +337,7 @@ class TestSweepPreservesLiveCapturedMetadata:
         """
         media_id = f"{CHAT_ID}_7_video"
         listener_row = self._listener_row(media_id, _video_media())
-        await adapter.insert_media(listener_row)
+        await adapter.insert_media(listener_row, account_id=1)
 
         await adapter.insert_media(
             {
@@ -345,7 +346,8 @@ class TestSweepPreservesLiveCapturedMetadata:
                 "chat_id": CHAT_ID,
                 "type": "video",
                 "downloaded": False,
-            }
+            },
+            account_id=1,
         )
 
         stored = await _media_row(adapter, media_id)
@@ -366,7 +368,7 @@ class TestSweepPreservesLiveCapturedMetadata:
         false). Pinning the flag at 1 stranded the row pointing at a missing file.
         """
         media_id = f"{CHAT_ID}_7_video"
-        await adapter.insert_media(self._listener_row(media_id, _video_media()))
+        await adapter.insert_media(self._listener_row(media_id, _video_media()), account_id=1)
 
         await adapter.insert_media(
             {
@@ -375,12 +377,13 @@ class TestSweepPreservesLiveCapturedMetadata:
                 "chat_id": CHAT_ID,
                 "type": "video",
                 "downloaded": False,
-            }
+            },
+            account_id=1,
         )
 
         stored = await _media_row(adapter, media_id)
         assert stored.downloaded == 0
-        pending = await adapter.get_pending_media_downloads(100 * 1024 * 1024, 5)
+        pending = await adapter.get_pending_media_downloads(100 * 1024 * 1024, 5, account_id=1)
         assert [row["id"] for row in pending] == [media_id]
 
     async def test_oversize_skip_row_does_not_strand_an_already_downloaded_file(self, adapter):
@@ -393,13 +396,13 @@ class TestSweepPreservesLiveCapturedMetadata:
         """
         media_id = f"{CHAT_ID}_7_video"
         listener_row = self._listener_row(media_id, _video_media())
-        await adapter.insert_media(listener_row)
+        await adapter.insert_media(listener_row, account_id=1)
 
         backup = _make_backup(self.media_root)
         backup.config.get_max_media_size_bytes = MagicMock(return_value=1)
         skip_row = await backup._process_media(_message(7, _video_media()), CHAT_ID)
         assert "downloaded" not in skip_row
-        await adapter.insert_media(skip_row)
+        await adapter.insert_media(skip_row, account_id=1)
 
         stored = await _media_row(adapter, media_id)
         assert stored.downloaded == 1
@@ -412,21 +415,21 @@ class TestSweepPreservesLiveCapturedMetadata:
         backup = _make_backup(self.media_root)
         backup.config.get_max_media_size_bytes = MagicMock(return_value=1)
         skip_row = await backup._process_media(_message(7, _video_media(size=90000)), CHAT_ID)
-        await adapter.insert_media(skip_row)
+        await adapter.insert_media(skip_row, account_id=1)
 
         stored = await _media_row(adapter, skip_row["id"])
         assert stored.downloaded == 0
         assert stored.file_size == 90000
-        assert await adapter.get_pending_media_downloads(1, 5) == []
+        assert await adapter.get_pending_media_downloads(1, 5, account_id=1) == []
         # Positive control: raise the limit and the very same row IS retryable.
-        assert [row["id"] for row in await adapter.get_pending_media_downloads(100 * 1024 * 1024, 5)] == [
+        assert [row["id"] for row in await adapter.get_pending_media_downloads(100 * 1024 * 1024, 5, account_id=1)] == [
             skip_row["id"]
         ]
 
     async def test_redownload_to_a_new_path_still_updates_the_row(self, adapter):
         """Positive control: COALESCE only falls back on NULL, it never pins a value."""
         media_id = f"{CHAT_ID}_7_video"
-        await adapter.insert_media(self._listener_row(media_id, _video_media()))
+        await adapter.insert_media(self._listener_row(media_id, _video_media()), account_id=1)
 
         new_path = os.path.join(self.media_root, "_shared", "ab", "moved.mp4")
         await adapter.insert_media(
@@ -442,7 +445,8 @@ class TestSweepPreservesLiveCapturedMetadata:
                 "content_hash": "hash456",
                 "downloaded": True,
                 "download_date": utcnow_naive(),
-            }
+            },
+            account_id=1,
         )
 
         stored = await _media_row(adapter, media_id)
@@ -454,9 +458,9 @@ class TestSweepPreservesLiveCapturedMetadata:
     async def test_deliberate_clear_path_still_clears(self, adapter):
         """mark_media_for_redownload is the ONE writer allowed to null the file record."""
         media_id = f"{CHAT_ID}_7_video"
-        await adapter.insert_media(self._listener_row(media_id, _video_media()))
+        await adapter.insert_media(self._listener_row(media_id, _video_media()), account_id=1)
 
-        await adapter.mark_media_for_redownload(media_id)
+        await adapter.mark_media_for_redownload(media_id, account_id=1)
 
         stored = await _media_row(adapter, media_id)
         assert stored.downloaded == 0
@@ -477,7 +481,7 @@ class TestSweepPreservesLiveCapturedMetadata:
             async_ctx.__aexit__ = AsyncMock(return_value=False)
             db_manager.async_session_factory.return_value = async_ctx
 
-            await DatabaseAdapter(db_manager).insert_media(media_data)
+            await DatabaseAdapter(db_manager).insert_media(media_data, account_id=1)
             return str(session.execute.await_args[0][0].compile(dialect=dialect))
 
         for dialect in (sqlite.dialect(), postgresql.psycopg2.dialect()):
@@ -492,7 +496,7 @@ class TestSweepPreservesLiveCapturedMetadata:
 
     async def test_upsert_still_overwrites_a_real_value_with_a_real_value(self, adapter):
         media_id = f"{CHAT_ID}_7_video"
-        await adapter.insert_media(self._listener_row(media_id, _video_media()))
+        await adapter.insert_media(self._listener_row(media_id, _video_media()), account_id=1)
 
         await adapter.insert_media(
             {
@@ -505,7 +509,8 @@ class TestSweepPreservesLiveCapturedMetadata:
                 "height": 1080,
                 "duration": 99,
                 "downloaded": True,
-            }
+            },
+            account_id=1,
         )
 
         stored = await _media_row(adapter, media_id)

--- a/tests/test_media_retry_cap.py
+++ b/tests/test_media_retry_cap.py
@@ -57,7 +57,7 @@ class TestRetryCap:
         await _add(adapter, "over_cap", attempts=9)  # past cap
         await _add(adapter, "done", downloaded=1, attempts=0)  # already downloaded
 
-        pending = await adapter.get_pending_media_downloads(max_attempts=5)
+        pending = await adapter.get_pending_media_downloads(max_attempts=5, account_id=1)
         ids = {p["id"] for p in pending}
 
         assert ids == {"under"}
@@ -68,14 +68,14 @@ class TestRetryCap:
         await _add(adapter, "a", attempts=99)
         await _add(adapter, "b", attempts=0)
 
-        pending = await adapter.get_pending_media_downloads()  # max_attempts=None → no cap
+        pending = await adapter.get_pending_media_downloads(account_id=1)  # max_attempts=None → no cap
         assert {p["id"] for p in pending} == {"a", "b"}
 
     @pytest.mark.asyncio
     async def test_increment_bumps_and_eventually_excludes(self, adapter):
         await _add(adapter, "m", attempts=4)
 
-        await adapter.increment_media_download_attempts("m")
+        await adapter.increment_media_download_attempts("m", account_id=1)
 
         async with adapter.db_manager.async_session_factory() as session:
             from sqlalchemy import select
@@ -83,7 +83,7 @@ class TestRetryCap:
             val = (await session.execute(select(Media.download_attempts).where(Media.id == "m"))).scalar()
         assert val == 5
         # now at the cap → no longer pending
-        assert await adapter.get_pending_media_downloads(max_attempts=5) == []
+        assert await adapter.get_pending_media_downloads(max_attempts=5, account_id=1) == []
 
     @pytest.mark.asyncio
     async def test_metadata_types_never_pending(self, adapter):
@@ -91,7 +91,7 @@ class TestRetryCap:
         await _add(adapter, "poll", mtype="poll")
         await _add(adapter, "real", mtype="document")
 
-        pending = await adapter.get_pending_media_downloads(max_attempts=5)
+        pending = await adapter.get_pending_media_downloads(max_attempts=5, account_id=1)
         assert {p["id"] for p in pending} == {"real"}
 
     @pytest.mark.asyncio
@@ -102,13 +102,13 @@ class TestRetryCap:
         await _add(adapter, "done", downloaded=1, attempts=9)  # downloaded → not counted
         await _add(adapter, "geo_capped", attempts=9, mtype="geo")  # metadata → not counted
 
-        assert await adapter.count_capped_media_downloads(5) == 2  # at_cap + over_cap
+        assert await adapter.count_capped_media_downloads(5, account_id=1) == 2  # at_cap + over_cap
 
     @pytest.mark.asyncio
     async def test_mark_for_redownload_resets_attempts(self, adapter):
         await _add(adapter, "capped", downloaded=1, attempts=9)
 
-        await adapter.mark_media_for_redownload("capped")
+        await adapter.mark_media_for_redownload("capped", account_id=1)
 
         # attempts reset to 0 and downloaded cleared → eligible for retry again
         async with adapter.db_manager.async_session_factory() as session:
@@ -122,4 +122,4 @@ class TestRetryCap:
         assert row.download_attempts == 0
         assert row.downloaded == 0
         assert row.file_path is None
-        assert {p["id"] for p in await adapter.get_pending_media_downloads(max_attempts=5)} == {"capped"}
+        assert {p["id"] for p in await adapter.get_pending_media_downloads(max_attempts=5, account_id=1)} == {"capped"}

--- a/tests/test_media_symlink_integrity.py
+++ b/tests/test_media_symlink_integrity.py
@@ -66,6 +66,7 @@ class TestSharedStorePublishIsAtomic(unittest.TestCase):
             file_name=self.FILE_NAME,
             file_path=os.path.join(chat_dir, self.FILE_NAME),
             logger=logger,
+            account_id=1,
         )
 
     def _flat_entries(self):
@@ -74,7 +75,7 @@ class TestSharedStorePublishIsAtomic(unittest.TestCase):
     def test_blob_is_not_discoverable_before_it_is_final(self):
         observed = {}
 
-        async def _observe(content_hash):
+        async def _observe(content_hash, *, account_id):
             # Runs at the dedup await — exactly where a competing ingest gets to
             # look at the shared store while this download is still in flight.
             observed["resolved"] = resolve_shared_file_path(self.shared_dir, self.FILE_NAME, None)
@@ -97,7 +98,7 @@ class TestSharedStorePublishIsAtomic(unittest.TestCase):
         first_at_dedup = asyncio.Event()
         second_done = asyncio.Event()
 
-        async def _park(content_hash):
+        async def _park(content_hash, *, account_id):
             first_at_dedup.set()
             await second_done.wait()
             return None

--- a/tests/test_media_symlink_integrity.py
+++ b/tests/test_media_symlink_integrity.py
@@ -75,7 +75,7 @@ class TestSharedStorePublishIsAtomic(unittest.TestCase):
     def test_blob_is_not_discoverable_before_it_is_final(self):
         observed = {}
 
-        async def _observe(content_hash, *, account_id):
+        async def _observe(content_hash: str, *, account_id: int) -> None:
             # Runs at the dedup await — exactly where a competing ingest gets to
             # look at the shared store while this download is still in flight.
             observed["resolved"] = resolve_shared_file_path(self.shared_dir, self.FILE_NAME, None)
@@ -98,7 +98,7 @@ class TestSharedStorePublishIsAtomic(unittest.TestCase):
         first_at_dedup = asyncio.Event()
         second_done = asyncio.Event()
 
-        async def _park(content_hash, *, account_id):
+        async def _park(content_hash: str, *, account_id: int) -> None:
             first_at_dedup.set()
             await second_done.wait()
             return None

--- a/tests/test_messages_page_batching.py
+++ b/tests/test_messages_page_batching.py
@@ -168,10 +168,10 @@ class TestPendingMediaDownloadsLimit:
         await self._add_media(adapter, "b", attempts=0)
         await self._add_media(adapter, "d", attempts=1)
 
-        limited = await adapter.get_pending_media_downloads(limit=2)
+        limited = await adapter.get_pending_media_downloads(limit=2, account_id=1)
         assert [m["id"] for m in limited] == ["a", "b"]
 
-        unlimited = await adapter.get_pending_media_downloads(limit=None)
+        unlimited = await adapter.get_pending_media_downloads(limit=None, account_id=1)
         assert [m["id"] for m in unlimited] == ["a", "b", "d", "c"]
 
     @pytest.mark.asyncio
@@ -180,7 +180,7 @@ class TestPendingMediaDownloadsLimit:
             await self._add_media(adapter, f"m{i}", attempts=0)
 
         # Default limit=1000 is well above 5 rows, so nothing gets truncated.
-        pending = await adapter.get_pending_media_downloads()
+        pending = await adapter.get_pending_media_downloads(account_id=1)
         assert len(pending) == 5
 
     @pytest.mark.asyncio
@@ -189,12 +189,12 @@ class TestPendingMediaDownloadsLimit:
             await self._add_media(adapter, f"m{i}", attempts=0)
 
         with caplog.at_level(logging.INFO, logger="src.db.adapter"):
-            limited = await adapter.get_pending_media_downloads(limit=3)
+            limited = await adapter.get_pending_media_downloads(limit=3, account_id=1)
         assert len(limited) == 3
         assert any("media retry: processing 3 of 5 pending" in r.getMessage() for r in caplog.records)
 
         caplog.clear()
         with caplog.at_level(logging.INFO, logger="src.db.adapter"):
-            not_truncated = await adapter.get_pending_media_downloads(limit=5)
+            not_truncated = await adapter.get_pending_media_downloads(limit=5, account_id=1)
         assert len(not_truncated) == 5
         assert not any("media retry" in r.getMessage() for r in caplog.records)

--- a/tests/test_migration_021_hardening.py
+++ b/tests/test_migration_021_hardening.py
@@ -143,6 +143,21 @@ def _verify_token(async_url: str, plaintext: str) -> dict[str, Any] | None:
     return asyncio.run(check())
 
 
+def _raw_live_token_count(sync_url: str) -> int:
+    """How many tokens the 7.x validator filter (``is_revoked = 0``) can see.
+
+    The premise checks run against a 020-shaped database, where the 8.0
+    validator stack cannot execute (its entitlement columns arrive in 022), so
+    the pre-upgrade semantics are asserted with the filter's own SQL instead.
+    """
+    engine = sa.create_engine(sync_url)
+    try:
+        with engine.connect() as conn:
+            return conn.execute(sa.text("SELECT COUNT(*) FROM viewer_tokens WHERE is_revoked = 0")).scalar_one()
+    finally:
+        engine.dispose()
+
+
 def _raw_is_revoked(sync_url: str) -> list[int | None]:
     engine = sa.create_engine(sync_url)
     try:
@@ -211,7 +226,7 @@ def test_null_is_revoked_stays_dead_through_021_on_sqlite(tmp_path):
 
     _run_alembic(async_url, "upgrade", "020")  # migration-built: is_revoked still nullable
     tampered, control = _seed_tokens_at_020(sync_url)
-    assert _verify_token(async_url, tampered) is None  # premise: NULL never matched the filter
+    assert _raw_live_token_count(sync_url) == 1  # premise: NULL never matched the filter
 
     _run_alembic(async_url, "upgrade", "head")
 
@@ -225,7 +240,7 @@ def test_null_is_revoked_stays_dead_through_021_on_postgresql(require_postgres, 
 
     _run_alembic(async_url, "upgrade", "020")
     tampered, control = _seed_tokens_at_020(sync_url)
-    assert _verify_token(async_url, tampered) is None
+    assert _raw_live_token_count(sync_url) == 1  # premise: NULL never matched the filter
 
     _run_alembic(async_url, "upgrade", "head")
 
@@ -262,8 +277,10 @@ def test_stranded_batch_tmp_table_does_not_wedge_the_upgrade(tmp_path):
         ]
         needle = next(n for n in ('CONSTRAINT "fk_media_message" ', "CONSTRAINT fk_media_message ") if n in media_sql)
         conn.execute(
-            "INSERT INTO chats (id, title, type, is_archived, is_forum, last_synced_message_id)"
-            " VALUES (-1, 'synthetic', 'channel', 0, 0, 0)"
+            # ref is supplied raw: the column is NOT NULL with a Python-side
+            # default only, and this fixture writes past the ORM on purpose.
+            "INSERT INTO chats (id, title, type, is_archived, is_forum, last_synced_message_id, ref)"
+            " VALUES (-1, 'synthetic', 'channel', 0, 0, 0, 'strandtestref000000000')"
         )
         conn.execute(
             "INSERT INTO messages (id, chat_id, date, text, is_outgoing, is_pinned)"

--- a/tests/test_migration_022.py
+++ b/tests/test_migration_022.py
@@ -1,0 +1,859 @@
+"""Gates for Alembic migration 022 — the one that rewrites every table.
+
+For most people running this project the database is the only copy of their
+Telegram history, so the bar for this migration is not "it works on my machine":
+every claim below is a check that has been shown to go RED when the guard it
+covers is removed.
+
+* **The crash matrix** interrupts the migration before every single statement it
+  issues — all ~225 of them — and after each one asserts that the data is
+  untouched, that ``alembic_version`` has NOT advanced, that no temporary table
+  survived, and that replaying converges on the same schema and the same rows.
+  It costs roughly 20 seconds, which is the right price for the only proof that
+  a power cut mid-upgrade is survivable. Deleting the DML that opens the
+  transaction turns it red at 211 of those points, with the ``accounts`` table
+  surviving a rollback that was supposed to remove it.
+* **Foreign keys** are asserted individually by name on both backends. On
+  PostgreSQL a ``DROP ... CASCADE`` deletes one permanently and says so only in
+  a NOTICE; on SQLite a rebuild that inherits its reflected constraints leaves
+  ``media`` pointing at a key that no longer exists, which
+  ``PRAGMA foreign_key_check`` reports as a mismatch.
+* **The prechecks** must refuse loudly and change nothing — and, just as
+  important, must NOT refuse when they are alone. The first version of the
+  exclusive-access check used a second connection, which in WAL mode sees
+  Alembic's own connection and would have refused every real upgrade there is.
+"""
+
+import importlib.util
+import json
+import os
+import shutil
+import sqlite3
+import sys
+import unittest
+from datetime import datetime
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import sqlalchemy as sa
+from alembic.config import Config
+
+from alembic import command
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+ALEMBIC_DIR = REPO_ROOT / "alembic"
+MIGRATION_PATH = ALEMBIC_DIR / "versions" / "20260815_022_multi_account_keys.py"
+ENTRYPOINT_PATH = REPO_ROOT / "scripts" / "entrypoint.sh"
+
+WHEN = datetime(2026, 8, 15, 12, 0, 0)
+CHAT_IDS = (-1001234567890, -1009876543210, 55501)
+
+# Tables the digest reads, so a comparison cannot silently skip one.
+DIGESTED_TABLES = (
+    "accounts",
+    "app_settings",
+    "chat_folder_members",
+    "chat_folders",
+    "chats",
+    "forum_topics",
+    "media",
+    "message_versions",
+    "messages",
+    "metadata",
+    "push_subscriptions",
+    "reactions",
+    "sync_status",
+    "users",
+    "viewer_accounts",
+    "viewer_audit_log",
+    "viewer_sessions",
+    "viewer_tokens",
+)
+
+
+def load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("migration_022", MIGRATION_PATH)
+    if spec is None or spec.loader is None:  # pragma: no cover - import plumbing
+        raise RuntimeError("Unable to load migration 022")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def upgrade_to(url: str, target: str = "head") -> None:
+    """Run the project's real Alembic environment against ``url``."""
+    config = Config()
+    config.set_main_option("script_location", str(ALEMBIC_DIR))
+    config.set_main_option("sqlalchemy.url", url)
+    previous = os.environ.get("DATABASE_URL")
+    os.environ["DATABASE_URL"] = url
+    try:
+        command.upgrade(config, target)
+    finally:
+        if previous is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = previous
+
+
+# ---------------------------------------------------------------------------
+# A small archive with a row in every table this migration touches
+# ---------------------------------------------------------------------------
+
+
+def seed(sync_url: str) -> None:
+    engine = sa.create_engine(sync_url)
+    try:
+        inspector = sa.inspect(engine)
+        with engine.begin() as conn:
+            for table, rows in _seed_rows().items():
+                columns = {column["name"] for column in inspector.get_columns(table)}
+                for row in rows:
+                    usable = {key: value for key, value in row.items() if key in columns}
+                    names = ", ".join(f'"{key}"' for key in usable)
+                    binds = ", ".join(f":{key}" for key in usable)
+                    conn.execute(sa.text(f'INSERT INTO "{table}" ({names}) VALUES ({binds})'), usable)
+    finally:
+        engine.dispose()
+
+
+def _seed_rows() -> dict[str, list[dict]]:
+    messages = [
+        {
+            "id": n,
+            "chat_id": chat_id,
+            "sender_id": 7001,
+            "sender_name": f"S{n}",
+            "date": WHEN,
+            "text": f"m{n}",
+            "raw_data": json.dumps({"n": n}),
+            "created_at": WHEN,
+            "is_outgoing": n % 2,
+            "is_pinned": 0,
+            "is_deleted": 0,
+        }
+        for chat_id in CHAT_IDS
+        for n in (1, 2, 3)
+    ]
+    return {
+        "chats": [
+            {
+                "id": chat_id,
+                "type": "supergroup",
+                "title": f"c{index}",
+                "username": f"u{index}",
+                "is_forum": 1 if index == 0 else 0,
+                "is_archived": 0,
+                "last_synced_message_id": 3,
+                "created_at": WHEN,
+                "updated_at": WHEN,
+            }
+            for index, chat_id in enumerate(CHAT_IDS)
+        ],
+        "users": [{"id": 7001, "username": "someone", "is_bot": 0, "created_at": WHEN, "updated_at": WHEN}],
+        "messages": messages,
+        "media": [
+            {
+                "id": f"{CHAT_IDS[0]}_1_photo",
+                "message_id": 1,
+                "chat_id": CHAT_IDS[0],
+                "type": "photo",
+                "file_path": "/data/media/x/1_photo.jpg",
+                "file_name": "1_photo.jpg",
+                "file_size": 10,
+                "content_hash": "hash",
+                "downloaded": 1,
+                "download_attempts": 0,
+                "created_at": WHEN,
+            },
+            # message_id/chat_id NULL: a composite FK with a NULL column is not
+            # enforced, so this row has to survive the rebuild too.
+            {"id": "metadata_only", "type": "document", "downloaded": 0, "download_attempts": 2, "created_at": WHEN},
+        ],
+        "reactions": [
+            {"message_id": 1, "chat_id": CHAT_IDS[0], "emoji": "+1", "user_id": 7001, "count": 2, "created_at": WHEN},
+            {
+                "message_id": 1,
+                "chat_id": CHAT_IDS[0],
+                "emoji": "heart",
+                "user_id": None,
+                "count": 1,
+                "created_at": WHEN,
+                "removed_at": WHEN,
+            },
+        ],
+        "message_versions": [
+            {
+                "message_id": 1,
+                "chat_id": CHAT_IDS[0],
+                "text": "was",
+                "date": WHEN,
+                "change_hash": "hash-a",
+                "captured_at": WHEN,
+            },
+        ],
+        "sync_status": [
+            {"chat_id": chat_id, "last_message_id": 3, "last_sync_date": WHEN, "message_count": 3}
+            for chat_id in CHAT_IDS
+        ],
+        "forum_topics": [
+            {
+                "id": 1,
+                "chat_id": CHAT_IDS[0],
+                "title": "General",
+                "is_closed": 0,
+                "is_pinned": 1,
+                "is_hidden": 0,
+                "date": WHEN,
+                "created_at": WHEN,
+                "updated_at": WHEN,
+            },
+        ],
+        "chat_folders": [
+            {"id": 2, "title": "Work", "sort_order": 0, "created_at": WHEN, "updated_at": WHEN},
+        ],
+        "chat_folder_members": [{"folder_id": 2, "chat_id": CHAT_IDS[0]}],
+        "metadata": [{"key": "owner_id", "value": "7001"}],
+        "app_settings": [{"key": "backup_schedule", "value": "0 3 * * *", "updated_at": WHEN}],
+        "viewer_accounts": [
+            {
+                "username": "restricted",
+                "password_hash": "hash",
+                "salt": "salt",
+                "is_active": 1,
+                "no_download": 0,
+                "created_at": WHEN,
+                "updated_at": WHEN,
+                "allowed_chat_ids": json.dumps([CHAT_IDS[0], CHAT_IDS[2]]),
+            },
+            {
+                "username": "unrestricted",
+                "password_hash": "hash",
+                "salt": "salt",
+                "is_active": 1,
+                "no_download": 0,
+                "created_at": WHEN,
+                "updated_at": WHEN,
+                "allowed_chat_ids": None,
+            },
+            {
+                "username": "corrupt",
+                "password_hash": "hash",
+                "salt": "salt",
+                "is_active": 1,
+                "no_download": 0,
+                "created_at": WHEN,
+                "updated_at": WHEN,
+                "allowed_chat_ids": "{not json",
+            },
+        ],
+        "viewer_tokens": [
+            {
+                "label": "share",
+                "token_hash": "hash",
+                "token_salt": "salt",
+                "created_by": "master",
+                "allowed_chat_ids": json.dumps([CHAT_IDS[1]]),
+                "is_revoked": 0,
+                "no_download": 1,
+                "use_count": 0,
+                "created_at": WHEN,
+            },
+        ],
+        "viewer_sessions": [
+            {
+                "token": "session-restricted",
+                "username": "restricted",
+                "role": "viewer",
+                "allowed_chat_ids": json.dumps([CHAT_IDS[0]]),
+                "no_download": 0,
+                "created_at": 1.0,
+                "last_accessed": 2.0,
+            },
+            {
+                "token": "session-master",
+                "username": "master",
+                "role": "master",
+                "allowed_chat_ids": None,
+                "no_download": 0,
+                "created_at": 1.0,
+                "last_accessed": 2.0,
+            },
+        ],
+        "push_subscriptions": [
+            {
+                "endpoint": "https://push.invalid/1",
+                "p256dh": "key",
+                "auth": "auth",
+                "chat_id": CHAT_IDS[0],
+                "username": "restricted",
+                "allowed_chat_ids": json.dumps([CHAT_IDS[0]]),
+                "created_at": WHEN,
+            },
+        ],
+        "viewer_audit_log": [
+            {"username": "restricted", "role": "viewer", "action": "login", "created_at": WHEN},
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reading a database back
+# ---------------------------------------------------------------------------
+
+
+def sqlite_digest(path: Path) -> dict:
+    """Every row of every table, column by column, with refs canonicalised.
+
+    A ref is random per run, so raw values would differ on every replay.
+    Rewriting each one to the chat it names keeps the comparison strict: a grant
+    pointing at the wrong chat, or a ref that never reached the entitlement
+    columns, still shows up as a difference.
+    """
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    try:
+        live = {row[0] for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+        out: dict[str, list[dict]] = {}
+        ref_to_chat: dict[str, str] = {}
+        if "chats" in live and "ref" in {c[1] for c in conn.execute("PRAGMA table_info(chats)")}:
+            ref_to_chat = {row[0]: str(row[1]) for row in conn.execute("SELECT ref, id FROM chats") if row[0]}
+
+        def canonical(value):
+            return f"<ref:{ref_to_chat.get(value, '?')}>" if value in ref_to_chat else value
+
+        for table in DIGESTED_TABLES:
+            if table not in live:
+                continue
+            columns = [column[1] for column in conn.execute(f"PRAGMA table_info({table})")]
+            order = ", ".join(f'"{column}"' for column in columns)
+            rows = []
+            for record in conn.execute(f'SELECT {order} FROM "{table}" ORDER BY {order}'):
+                row = {column: (None if record[column] is None else str(record[column])) for column in columns}
+                if table == "chats" and row.get("ref"):
+                    row["ref"] = canonical(row["ref"])
+                if row.get("allowed_chat_refs"):
+                    try:
+                        row["allowed_chat_refs"] = json.dumps(
+                            [canonical(r) for r in json.loads(row["allowed_chat_refs"])]
+                        )
+                    except ValueError:  # pragma: no cover - the migration always writes valid JSON
+                        pass
+                rows.append(row)
+            out[table] = rows
+        return out
+    finally:
+        conn.close()
+
+
+def orphan_tables(path: Path) -> list[str]:
+    conn = sqlite3.connect(str(path))
+    try:
+        return [
+            row[0]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+            if row[0].endswith("__new022")
+        ]
+    finally:
+        conn.close()
+
+
+def run_shipped_stamping_ladder(path: Path) -> str | None:
+    """Execute the SQLite stamping block sliced out of the shipped entrypoint.
+
+    The block lives inside a bash double-quoted ``python -c`` heredoc, so its
+    embedded quotes are escaped; the slice and the de-escape are the same ones
+    tests/test_entrypoint_schema_detection.py already uses. Running the real
+    thing is the point: a reimplementation would only ever test itself.
+    """
+    script = ENTRYPOINT_PATH.read_text(encoding="utf-8")
+    start = script.index("database_url = os.getenv('DATABASE_URL', '')")
+    end = script.index("conn.close()", start) + len("conn.close()")
+    block = script[start:end].replace('\\"', '"')
+
+    namespace: dict = {"os": os, "sqlite3": sqlite3}
+    saved_url, saved_path = os.environ.get("DATABASE_URL"), os.environ.get("DB_PATH")
+    os.environ.pop("DATABASE_URL", None)
+    os.environ["DB_PATH"] = str(path)
+    try:
+        exec(compile(block, str(ENTRYPOINT_PATH), "exec"), namespace)
+    finally:
+        if saved_url is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = saved_url
+        if saved_path is None:
+            os.environ.pop("DB_PATH", None)
+        else:
+            os.environ["DB_PATH"] = saved_path
+    return namespace.get("stamp_version")
+
+
+def alembic_version(path: Path) -> str | None:
+    conn = sqlite3.connect(str(path))
+    try:
+        return conn.execute("SELECT version_num FROM alembic_version").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def foreign_keys_by_name(sync_url: str) -> dict[str, tuple[str, tuple[str, ...], str]]:
+    engine = sa.create_engine(sync_url)
+    try:
+        inspector = sa.inspect(engine)
+        found = {}
+        for table in inspector.get_table_names():
+            for fk in inspector.get_foreign_keys(table):
+                if fk.get("name"):
+                    found[fk["name"]] = (table, tuple(fk["constrained_columns"]), fk["referred_table"])
+        return found
+    finally:
+        engine.dispose()
+
+
+EXPECTED_FOREIGN_KEYS = {
+    "fk_messages_chat": ("messages", ("account_id", "chat_id"), "chats"),
+    "fk_sync_status_chat": ("sync_status", ("account_id", "chat_id"), "chats"),
+    "fk_forum_topics_chat": ("forum_topics", ("account_id", "chat_id"), "chats"),
+    "fk_folder_members_folder": ("chat_folder_members", ("account_id", "folder_id"), "chat_folders"),
+    "fk_folder_members_chat": ("chat_folder_members", ("account_id", "chat_id"), "chats"),
+    "fk_media_message": ("media", ("account_id", "message_id", "chat_id"), "messages"),
+    "fk_reaction_message": ("reactions", ("account_id", "message_id", "chat_id"), "messages"),
+    "fk_message_versions_message": ("message_versions", ("account_id", "message_id", "chat_id"), "messages"),
+    "fk_reactions_user": ("reactions", ("user_id",), "users"),
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def pristine_021(tmp_path_factory) -> Path:
+    """A seeded SQLite archive at revision 021, built once and copied per test."""
+    path = tmp_path_factory.mktemp("pristine") / "archive.db"
+    upgrade_to(f"sqlite+aiosqlite:///{path}", "021")
+    seed(f"sqlite:///{path}")
+    # WAL is what src/db/base.py leaves behind, and it is load-bearing for the
+    # exclusive-access gate: in WAL mode every attached connection holds the
+    # write-ahead index.
+    conn = sqlite3.connect(str(path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.commit()
+    conn.close()
+    return path
+
+
+@pytest.fixture
+def archive(pristine_021, tmp_path) -> Path:
+    path = tmp_path / "archive.db"
+    shutil.copy(pristine_021, path)
+    return path
+
+
+# ---------------------------------------------------------------------------
+# The migration itself
+# ---------------------------------------------------------------------------
+
+
+class TestRevision(unittest.TestCase):
+    def test_it_chains_from_021(self) -> None:
+        migration = load_migration()
+        self.assertEqual(migration.revision, "022")
+        self.assertEqual(migration.down_revision, "021")
+
+    def test_downgrade_refuses_instead_of_pretending(self) -> None:
+        """A plausible downgrade would be a lie once a second account exists:
+        two rows differing only by account_id collapse onto one key, so it would
+        have to choose whose copy to destroy."""
+        migration = load_migration()
+        with self.assertRaises(RuntimeError) as raised:
+            migration.downgrade()
+        self.assertIn("backup", str(raised.exception))
+
+
+class TestCrashMatrix:
+    """Interrupt before every statement; nothing may be lost, everything replays."""
+
+    class Interrupted(RuntimeError):
+        pass
+
+    def _upgrade(self, path: Path, crash_at: int | None = None) -> int:
+        seen = {"n": 0}
+
+        def listener(conn, cursor, statement, parameters, context, executemany):
+            seen["n"] += 1
+            if crash_at is not None and seen["n"] == crash_at:
+                raise self.Interrupted(f"simulated interruption before statement {crash_at}")
+
+        sa.event.listen(sa.engine.Engine, "before_cursor_execute", listener)
+        try:
+            upgrade_to(f"sqlite+aiosqlite:///{path}")
+        finally:
+            sa.event.remove(sa.engine.Engine, "before_cursor_execute", listener)
+        return seen["n"]
+
+    def test_every_interruption_point_is_survivable(self, pristine_021, tmp_path):
+        before = sqlite_digest(pristine_021)
+        assert alembic_version(pristine_021) == "021"
+
+        clean = tmp_path / "clean.db"
+        shutil.copy(pristine_021, clean)
+        total = self._upgrade(clean)
+        expected = sqlite_digest(clean)
+        assert total > 100, "the matrix is only meaningful if the migration really issues statements"
+
+        work = tmp_path / "work.db"
+        problems = []
+        replays = 0
+        for point in range(1, total + 1):
+            for suffix in ("", "-wal", "-shm"):
+                Path(f"{work}{suffix}").unlink(missing_ok=True)
+            shutil.copy(pristine_021, work)
+            try:
+                self._upgrade(work, crash_at=point)
+            except self.Interrupted:
+                pass
+            except Exception as exc:  # the migration's own refusals count as interruptions too
+                if not isinstance(exc, RuntimeError):
+                    problems.append(f"{point}: unexpected {type(exc).__name__}")
+
+            if alembic_version(work) != "021":
+                problems.append(f"{point}: alembic_version advanced")
+            if orphan_tables(work):
+                problems.append(f"{point}: left {orphan_tables(work)} behind")
+            interrupted_state = sqlite_digest(work)
+            unchanged = interrupted_state == before
+            if not unchanged:
+                problems.append(f"{point}: data changed")
+
+            # Replay whenever the interrupted state is NOT the pristine one -
+            # that is the only case where the replay is a different experiment -
+            # and at a fixed sample regardless, so the converging half of the
+            # matrix is exercised directly rather than only by implication.
+            if not unchanged or point % 25 == 0 or point in (1, total):
+                replays += 1
+                self._upgrade(work)
+                if alembic_version(work) != "022":
+                    problems.append(f"{point}: replay did not reach 022")
+                if sqlite_digest(work) != expected:
+                    problems.append(f"{point}: replay did not converge")
+            if problems:
+                break  # one is enough; the whole point is that there are none
+        assert not problems, f"crash matrix failed over {total} interruption points: {problems}"
+        assert replays >= 5, "the converging half of the matrix has to actually run"
+
+
+class TestForeignKeys:
+    def test_all_nine_exist_by_name_on_sqlite(self, archive):
+        upgrade_to(f"sqlite+aiosqlite:///{archive}")
+        found = foreign_keys_by_name(f"sqlite:///{archive}")
+        for name, expected in sorted(EXPECTED_FOREIGN_KEYS.items()):
+            assert found.get(name) == expected, f"{name} is missing or reshaped: {found.get(name)}"
+
+    def test_all_nine_exist_by_name_on_postgresql(self, require_postgres, make_postgres_database):
+        """The one that a DROP ... CASCADE would delete with only a NOTICE."""
+        async_url, sync_url = make_postgres_database("telegram_archive_migration_022")
+        upgrade_to(async_url, "021")
+        seed(sync_url)
+        upgrade_to(async_url)
+        found = foreign_keys_by_name(sync_url)
+        for name, expected in sorted(EXPECTED_FOREIGN_KEYS.items()):
+            assert found.get(name) == expected, f"{name} is missing or reshaped: {found.get(name)}"
+
+    def test_foreign_key_check_is_clean_afterwards(self, archive):
+        upgrade_to(f"sqlite+aiosqlite:///{archive}")
+        conn = sqlite3.connect(str(archive))
+        try:
+            # A rebuild that inherited its constraints raises "foreign key
+            # mismatch" here rather than returning rows, so both are checked.
+            assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+        finally:
+            conn.close()
+
+
+class TestPrechecks:
+    def test_it_refuses_without_disk_headroom_and_changes_nothing(self, archive, monkeypatch):
+        migration = load_migration()
+        before = sqlite_digest(archive)
+
+        class Full:
+            total = 1 << 40
+            used = total
+            free = 1
+
+        monkeypatch.setattr(migration.shutil, "disk_usage", lambda _path: Full())
+        monkeypatch.setattr(shutil, "disk_usage", lambda _path: Full())
+        with pytest.raises(RuntimeError) as raised:
+            upgrade_to(f"sqlite+aiosqlite:///{archive}")
+        message = str(raised.value)
+        assert "MiB" in message
+        assert str(archive) not in message, "a path may carry a chat id; report sizes only"
+        assert sqlite_digest(archive) == before
+        assert alembic_version(archive) == "021"
+
+    @pytest.mark.parametrize("holder_sql", [None, "BEGIN", "BEGIN IMMEDIATE"])
+    def test_it_refuses_while_another_connection_holds_the_archive(self, archive, holder_sql):
+        before = sqlite_digest(archive)
+        holder = sqlite3.connect(str(archive), isolation_level=None)
+        holder.execute("SELECT COUNT(*) FROM chats").fetchall()
+        if holder_sql:
+            holder.execute(holder_sql)
+            holder.execute("SELECT COUNT(*) FROM chats").fetchall()
+        try:
+            with pytest.raises(RuntimeError) as raised:
+                upgrade_to(f"sqlite+aiosqlite:///{archive}")
+            assert "Stop the viewer" in str(raised.value)
+            assert sqlite_digest(archive) == before
+            assert alembic_version(archive) == "021"
+        finally:
+            try:
+                holder.execute("ROLLBACK")
+            except sqlite3.OperationalError:
+                pass
+            holder.close()
+
+    def test_it_does_not_refuse_when_it_is_alone_on_a_wal_archive(self, archive):
+        """The check that broke the first version of this guard.
+
+        A probe on a SECOND connection sees Alembic's own connection in WAL mode
+        and refuses every real upgrade there is. Claiming the lock on the
+        connection doing the work is what makes the answer mean "somebody else".
+        """
+        conn = sqlite3.connect(str(archive))
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "wal"
+        conn.close()
+        upgrade_to(f"sqlite+aiosqlite:///{archive}")
+        assert alembic_version(archive) == "022"
+
+    def test_it_does_not_refuse_a_first_ever_start(self, tmp_path):
+        """A brand-new install has nothing to protect, and the viewer container
+        legitimately comes up against the same empty file at the same time."""
+        path = tmp_path / "firstboot.db"
+        holder = sqlite3.connect(str(path), isolation_level=None)
+        holder.execute("PRAGMA journal_mode=WAL")
+        try:
+            upgrade_to(f"sqlite+aiosqlite:///{path}")
+        finally:
+            holder.close()
+        assert alembic_version(path) == "022"
+
+    def test_it_turns_sqlite_foreign_key_enforcement_off_before_dropping_anything(self, tmp_path):
+        """With enforcement on, DROP TABLE chats deletes its children first.
+
+        SQLite performs an implicit DELETE FROM before dropping a table when
+        foreign keys are enforced, which fires the ON DELETE CASCADE on
+        forum_topics and chat_folder_members for real - out of the table that
+        was already copied, so the rows are simply gone.
+        """
+        migration = load_migration()
+        engine = sa.create_engine(f"sqlite:///{tmp_path / 'x.db'}")
+        try:
+            with engine.connect() as conn:
+                conn.exec_driver_sql("PRAGMA foreign_keys=ON")
+                assert conn.exec_driver_sql("PRAGMA foreign_keys").scalar() == 1
+                migration._precheck_foreign_keys_are_off(conn)
+                assert conn.exec_driver_sql("PRAGMA foreign_keys").scalar() == 0
+        finally:
+            engine.dispose()
+
+    def test_it_refuses_when_enforcement_cannot_be_turned_off(self, tmp_path):
+        """A PRAGMA is ignored inside a transaction, so the read-back is the check."""
+        migration = load_migration()
+        engine = sa.create_engine(f"sqlite:///{tmp_path / 'y.db'}")
+        try:
+            with engine.connect() as conn:
+                conn.exec_driver_sql("PRAGMA foreign_keys=ON")
+                conn.exec_driver_sql("CREATE TABLE t (a INTEGER)")
+                conn.exec_driver_sql("INSERT INTO t VALUES (1)")  # opens the transaction
+                with pytest.raises(RuntimeError) as raised:
+                    migration._precheck_foreign_keys_are_off(conn)
+                assert "foreign keys" in str(raised.value)
+        finally:
+            engine.dispose()
+
+
+class TestResult:
+    def test_every_row_lands_on_account_one(self, archive):
+        upgrade_to(f"sqlite+aiosqlite:///{archive}")
+        conn = sqlite3.connect(str(archive))
+        try:
+            for table in (
+                "chats",
+                "messages",
+                "media",
+                "reactions",
+                "message_versions",
+                "sync_status",
+                "forum_topics",
+                "chat_folders",
+                "chat_folder_members",
+            ):
+                total, on_one = conn.execute(
+                    f"SELECT COUNT(*), SUM(CASE WHEN account_id = 1 THEN 1 ELSE 0 END) FROM {table}"
+                ).fetchone()
+                assert total and total == on_one, f"{table}: {total} rows, {on_one} on account 1"
+            assert conn.execute("SELECT id, label, telegram_user_id FROM accounts").fetchall() == [(1, "default", None)]
+        finally:
+            conn.close()
+
+    def test_every_chat_gets_its_own_ref(self, archive):
+        upgrade_to(f"sqlite+aiosqlite:///{archive}")
+        conn = sqlite3.connect(str(archive))
+        try:
+            total, distinct, shortest, longest = conn.execute(
+                "SELECT COUNT(*), COUNT(DISTINCT ref), MIN(LENGTH(ref)), MAX(LENGTH(ref)) FROM chats"
+            ).fetchone()
+            assert total == len(CHAT_IDS)
+            assert distinct == total
+            assert (shortest, longest) == (22, 22)
+        finally:
+            conn.close()
+
+    def test_a_restricted_grant_is_converted_and_an_unrestricted_one_is_left_alone(self, archive):
+        """Leaving a restricted row NULL would fail OPEN: NULL means everything."""
+        upgrade_to(f"sqlite+aiosqlite:///{archive}")
+        conn = sqlite3.connect(str(archive))
+        try:
+            refs = {row[0] for row in conn.execute("SELECT ref FROM chats")}
+            rows = dict(
+                (row[0], row[1:])
+                for row in conn.execute(
+                    "SELECT username, allowed_chat_ids, allowed_accounts, allowed_chat_refs FROM viewer_accounts"
+                )
+            )
+            _, accounts, chat_refs = rows["restricted"]
+            assert json.loads(accounts) == [1]
+            assert set(json.loads(chat_refs)) <= refs
+            assert len(json.loads(chat_refs)) == 2
+
+            assert rows["unrestricted"][1] is None and rows["unrestricted"][2] is None
+
+            # An unreadable payload converts to an empty grant, not to "everything".
+            assert rows["corrupt"][1] == "[]" and rows["corrupt"][2] == "[]"
+
+            for table in ("viewer_sessions", "viewer_tokens", "push_subscriptions"):
+                for old, accounts, chat_refs in conn.execute(
+                    f"SELECT allowed_chat_ids, allowed_accounts, allowed_chat_refs FROM {table}"
+                ):
+                    if old is None:
+                        assert accounts is None and chat_refs is None
+                    else:
+                        assert accounts is not None and chat_refs is not None
+        finally:
+            conn.close()
+
+    def test_no_row_is_deleted(self, archive):
+        before = sqlite_digest(archive)
+        upgrade_to(f"sqlite+aiosqlite:///{archive}")
+        after = sqlite_digest(archive)
+        for table, rows in before.items():
+            assert len(after[table]) == len(rows), f"{table} lost or gained rows"
+
+    def test_running_it_again_changes_nothing(self, archive):
+        upgrade_to(f"sqlite+aiosqlite:///{archive}")
+        once = sqlite_digest(archive)
+        upgrade_to(f"sqlite+aiosqlite:///{archive}")
+        assert sqlite_digest(archive) == once
+
+    def test_it_is_a_no_op_against_a_create_all_provisioned_80_schema(self, tmp_path):
+        """The shape most installs actually have: the viewer built the schema
+        from ORM metadata, and the stamping ladder then sends it through here.
+
+        The ladder is the one the container really runs, extracted verbatim from
+        scripts/entrypoint.sh rather than reimplemented, because a
+        reimplementation of it would test itself.
+        """
+        from src.db.models import Base
+
+        path = tmp_path / "createall.db"
+        engine = sa.create_engine(f"sqlite:///{path}")
+        try:
+            Base.metadata.create_all(engine)
+            inspector = sa.inspect(engine)
+            before = {
+                table: (
+                    sorted(inspector.get_pk_constraint(table).get("constrained_columns") or []),
+                    sorted(
+                        (fk.get("name") or "?", tuple(fk["constrained_columns"]))
+                        for fk in inspector.get_foreign_keys(table)
+                    ),
+                    sorted(
+                        (u.get("name") or "?", tuple(sorted(u["column_names"])))
+                        for u in inspector.get_unique_constraints(table)
+                    ),
+                    sorted(index["name"] for index in inspector.get_indexes(table)),
+                )
+                for table in inspector.get_table_names()
+            }
+        finally:
+            engine.dispose()
+
+        assert run_shipped_stamping_ladder(path) == "018"
+        upgrade_to(f"sqlite+aiosqlite:///{path}")
+
+        engine = sa.create_engine(f"sqlite:///{path}")
+        try:
+            inspector = sa.inspect(engine)
+            after = {
+                table: (
+                    sorted(inspector.get_pk_constraint(table).get("constrained_columns") or []),
+                    sorted(
+                        (fk.get("name") or "?", tuple(fk["constrained_columns"]))
+                        for fk in inspector.get_foreign_keys(table)
+                    ),
+                    sorted(
+                        (u.get("name") or "?", tuple(sorted(u["column_names"])))
+                        for u in inspector.get_unique_constraints(table)
+                    ),
+                    sorted(index["name"] for index in inspector.get_indexes(table)),
+                )
+                for table in inspector.get_table_names()
+                if table != "alembic_version"
+            }
+        finally:
+            engine.dispose()
+        assert after == before
+
+
+class TestEntrypointLadder(unittest.TestCase):
+    """022 adds no rung, in either block, and that is the decision.
+
+    The ladder caps at 018 because migration 019 is data-only and has no
+    detectable artifact: a schema built from current ORM metadata must still be
+    stamped at 018 so 019 runs. 022's artifacts — account_id, chats.ref, the
+    accounts table — are exactly what such a schema already has, so a '022' rung
+    could only push the stamp PAST 019. 022 reads the live schema and does
+    nothing where the target shape is already in place, which is what makes
+    stamping at 018 correct rather than merely tolerable.
+    """
+
+    def setUp(self) -> None:
+        self.source = ENTRYPOINT_PATH.read_text(encoding="utf-8")
+
+    def test_neither_block_stamps_past_018(self) -> None:
+        for version in ("019", "020", "021", "022"):
+            self.assertNotIn(f"stamp_version = '{version}'", self.source)
+        self.assertEqual(self.source.count("stamp_version = '018'"), 2, "one rung per block")
+
+    def test_both_blocks_explain_why_022_adds_no_rung(self) -> None:
+        self.assertEqual(self.source.count("022 adds no rung"), 2)
+
+    def test_a_create_all_80_schema_is_stamped_at_018(self) -> None:
+        """Run the SHIPPED ladder, extracted verbatim, over an 8.0 schema."""
+        import tempfile
+
+        from src.db.models import Base
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "archive.db"
+            engine = sa.create_engine(f"sqlite:///{path}")
+            try:
+                Base.metadata.create_all(engine)
+            finally:
+                engine.dispose()
+            self.assertEqual(run_shipped_stamping_ladder(path), "018")

--- a/tests/test_multiaccount_schema.py
+++ b/tests/test_multiaccount_schema.py
@@ -1,0 +1,623 @@
+"""What the v8.0.0 keys buy, proved against real databases on both backends.
+
+Every test here is a collision that a decorative ``account_id`` column would NOT
+have prevented. They were built and run against scratch schemas before the
+schema was changed, and each one describes silent, permanent loss of a second
+account's data — not an error anyone would have seen.
+
+The tests use a real engine on SQLite and on PostgreSQL. They talk to the tables
+directly rather than through ``DatabaseAdapter`` on purpose: what is under test
+is the shape of the schema, and the adapter's own account plumbing lands in the
+change after this one.
+"""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from conftest import NO_POSTGRES_REASON, REAL_BACKENDS
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from src.db.models import CHAT_REF_LENGTH, DEFAULT_ACCOUNT_ID, Base, new_chat_ref  # noqa: E402
+
+WHEN = datetime(2026, 8, 15, 12, 0, 0)
+CHAT_ID = -1001234567890
+OTHER_ACCOUNT = 2
+
+
+@pytest.fixture(params=REAL_BACKENDS)
+def schema_engine(request, tmp_path, postgres_server_url, make_postgres_database):
+    """A real, empty, ORM-built schema, once per backend."""
+    if request.param == "postgresql":
+        if not postgres_server_url:
+            pytest.skip(NO_POSTGRES_REASON)
+        _, sync_url = make_postgres_database("telegram_archive_multiaccount")
+    else:
+        sync_url = f"sqlite:///{tmp_path / 'archive.db'}"
+    engine = sa.create_engine(sync_url)
+    Base.metadata.create_all(engine)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+def _insert(conn: sa.Connection, table: str, **values) -> None:
+    columns = ", ".join(f'"{name}"' for name in values)
+    binds = ", ".join(f":{name}" for name in values)
+    conn.execute(sa.text(f'INSERT INTO "{table}" ({columns}) VALUES ({binds})'), values)
+
+
+def _seed_two_accounts(conn: sa.Connection) -> None:
+    """Two accounts that archive the same chat — the whole point of the release."""
+    for account_id, label in ((DEFAULT_ACCOUNT_ID, "personal"), (OTHER_ACCOUNT, "work")):
+        _insert(conn, "accounts", id=account_id, label=label)
+        _insert(
+            conn,
+            "chats",
+            account_id=account_id,
+            id=CHAT_ID,
+            ref=new_chat_ref(),
+            type="supergroup",
+            title=f"seen by {label}",
+            is_forum=1,
+            is_archived=0,
+            last_synced_message_id=0,
+            created_at=WHEN,
+            updated_at=WHEN,
+        )
+
+
+def _rows(conn: sa.Connection, sql: str, **params) -> list[tuple]:
+    return [tuple(row) for row in conn.execute(sa.text(sql), params).fetchall()]
+
+
+class TestCollisionsTheOldKeysWouldHaveCaused:
+    """Each of these lost data silently before account_id entered the key."""
+
+    def test_both_accounts_keep_their_own_copy_of_the_same_message(self, schema_engine):
+        """PK (id, chat_id) dropped the second copy and served the first instead.
+
+        The damage was not the missing row: the second account then READ the
+        first account's ``is_outgoing``, so a message it received was displayed
+        as one it had sent.
+        """
+        with schema_engine.begin() as conn:
+            _seed_two_accounts(conn)
+            for account_id, outgoing, text in ((DEFAULT_ACCOUNT_ID, 1, "sent by me"), (OTHER_ACCOUNT, 0, "received")):
+                _insert(
+                    conn,
+                    "messages",
+                    account_id=account_id,
+                    id=500,
+                    chat_id=CHAT_ID,
+                    date=WHEN,
+                    text=text,
+                    created_at=WHEN,
+                    is_outgoing=outgoing,
+                    is_pinned=0,
+                    is_deleted=0,
+                )
+            assert _rows(
+                conn,
+                "SELECT account_id, is_outgoing, text FROM messages WHERE chat_id = :c ORDER BY account_id",
+                c=CHAT_ID,
+            ) == [(DEFAULT_ACCOUNT_ID, 1, "sent by me"), (OTHER_ACCOUNT, 0, "received")]
+
+    def test_the_old_message_key_really_did_collide(self, schema_engine):
+        """The other half of the proof: without the account it is one key.
+
+        A test that only shows the new schema working cannot tell you the old
+        one was broken. This one inserts the same (chat_id, id) twice into a
+        table keyed the old way and watches it be rejected.
+        """
+        with schema_engine.begin() as conn:
+            conn.execute(
+                sa.text(
+                    "CREATE TABLE old_messages (id BIGINT NOT NULL, chat_id BIGINT NOT NULL, PRIMARY KEY (id, chat_id))"
+                )
+            )
+            _insert(conn, "old_messages", id=500, chat_id=CHAT_ID)
+            with pytest.raises(sa.exc.IntegrityError):
+                _insert(conn, "old_messages", id=500, chat_id=CHAT_ID)
+
+    def test_both_accounts_keep_their_own_edit_history(self, schema_engine):
+        """UNIQUE(change_hash) discarded the second account's history entirely.
+
+        The hash is over the message payload, which is byte-identical for both
+        accounts, so every edit either account recorded collapsed onto one row.
+        """
+        with schema_engine.begin() as conn:
+            _seed_two_accounts(conn)
+            for account_id in (DEFAULT_ACCOUNT_ID, OTHER_ACCOUNT):
+                _insert(
+                    conn,
+                    "messages",
+                    account_id=account_id,
+                    id=500,
+                    chat_id=CHAT_ID,
+                    date=WHEN,
+                    created_at=WHEN,
+                    is_outgoing=0,
+                    is_pinned=0,
+                    is_deleted=0,
+                )
+                _insert(
+                    conn,
+                    "message_versions",
+                    account_id=account_id,
+                    message_id=500,
+                    chat_id=CHAT_ID,
+                    text="before the edit",
+                    date=WHEN,
+                    change_hash="the-same-hash-for-both-accounts",
+                    captured_at=WHEN,
+                )
+            assert _rows(
+                conn,
+                "SELECT account_id FROM message_versions WHERE change_hash = :h ORDER BY account_id",
+                h="the-same-hash-for-both-accounts",
+            ) == [(DEFAULT_ACCOUNT_ID,), (OTHER_ACCOUNT,)]
+
+    def test_the_version_hash_payload_is_still_the_frozen_contract(self):
+        """account_id must NOT enter the hash — only the constraint.
+
+        Re-encoding the payload would make every version already stored hash
+        differently and be re-inserted as a duplicate of itself. This pins the
+        digest so that cannot happen by accident.
+        """
+        from src.db.adapter import _message_version_hash
+
+        digest = _message_version_hash(CHAT_ID, 500, "before the edit", WHEN)
+        assert digest == "423d89b27bd1db2065c717a6c4559d43df148704718bb685837c50cdbf82e177"
+
+    def test_both_accounts_keep_their_own_folder_and_its_members(self, schema_engine):
+        """PK(id) destroyed the first account's folder title AND its members.
+
+        Telegram numbers dialog filters per account and everybody's start at 2,
+        so this collided for every user who added a second account, on their
+        first sweep.
+        """
+        with schema_engine.begin() as conn:
+            _seed_two_accounts(conn)
+            for account_id, title in ((DEFAULT_ACCOUNT_ID, "Personal folder"), (OTHER_ACCOUNT, "Work folder")):
+                _insert(
+                    conn,
+                    "chat_folders",
+                    account_id=account_id,
+                    id=2,
+                    title=title,
+                    sort_order=0,
+                    created_at=WHEN,
+                    updated_at=WHEN,
+                )
+                _insert(conn, "chat_folder_members", account_id=account_id, folder_id=2, chat_id=CHAT_ID)
+            assert _rows(conn, "SELECT account_id, title FROM chat_folders ORDER BY account_id") == [
+                (DEFAULT_ACCOUNT_ID, "Personal folder"),
+                (OTHER_ACCOUNT, "Work folder"),
+            ]
+            assert _rows(conn, "SELECT account_id FROM chat_folder_members ORDER BY account_id") == [
+                (DEFAULT_ACCOUNT_ID,),
+                (OTHER_ACCOUNT,),
+            ]
+
+    def test_both_accounts_keep_their_own_media_row(self, schema_engine):
+        """media.id is built as f"{chat_id}_{message_id}_{type}", not a file id.
+
+        Two accounts archiving the same message therefore produce the identical
+        string, and the old PK(id) kept exactly one of them.
+        """
+        with schema_engine.begin() as conn:
+            _seed_two_accounts(conn)
+            media_id = f"{CHAT_ID}_500_photo"
+            for account_id, path in ((DEFAULT_ACCOUNT_ID, "/data/media/a.jpg"), (OTHER_ACCOUNT, "/data/media/b.jpg")):
+                _insert(
+                    conn,
+                    "messages",
+                    account_id=account_id,
+                    id=500,
+                    chat_id=CHAT_ID,
+                    date=WHEN,
+                    created_at=WHEN,
+                    is_outgoing=0,
+                    is_pinned=0,
+                    is_deleted=0,
+                )
+                _insert(
+                    conn,
+                    "media",
+                    account_id=account_id,
+                    id=media_id,
+                    message_id=500,
+                    chat_id=CHAT_ID,
+                    type="photo",
+                    file_path=path,
+                    downloaded=1,
+                    download_attempts=0,
+                    created_at=WHEN,
+                )
+            assert _rows(conn, "SELECT account_id, file_path FROM media ORDER BY account_id") == [
+                (DEFAULT_ACCOUNT_ID, "/data/media/a.jpg"),
+                (OTHER_ACCOUNT, "/data/media/b.jpg"),
+            ]
+
+    def test_both_accounts_keep_their_own_reaction(self, schema_engine):
+        with schema_engine.begin() as conn:
+            _seed_two_accounts(conn)
+            _insert(conn, "users", id=77, is_bot=0, created_at=WHEN, updated_at=WHEN)
+            for account_id, count in ((DEFAULT_ACCOUNT_ID, 3), (OTHER_ACCOUNT, 9)):
+                _insert(
+                    conn,
+                    "messages",
+                    account_id=account_id,
+                    id=500,
+                    chat_id=CHAT_ID,
+                    date=WHEN,
+                    created_at=WHEN,
+                    is_outgoing=0,
+                    is_pinned=0,
+                    is_deleted=0,
+                )
+                _insert(
+                    conn,
+                    "reactions",
+                    account_id=account_id,
+                    message_id=500,
+                    chat_id=CHAT_ID,
+                    emoji="+1",
+                    user_id=77,
+                    count=count,
+                    created_at=WHEN,
+                )
+            assert _rows(conn, "SELECT account_id, count FROM reactions ORDER BY account_id") == [
+                (DEFAULT_ACCOUNT_ID, 3),
+                (OTHER_ACCOUNT, 9),
+            ]
+
+    def test_both_accounts_keep_their_own_sync_counter(self, schema_engine):
+        """update_sync_status ACCUMULATES message_count on conflict.
+
+        Two accounts collapsing onto PK(chat_id) did not overwrite that counter,
+        they summed it, and the archive reported a message count that never
+        existed.
+        """
+        with schema_engine.begin() as conn:
+            _seed_two_accounts(conn)
+            for account_id, count in ((DEFAULT_ACCOUNT_ID, 120), (OTHER_ACCOUNT, 7)):
+                _insert(
+                    conn,
+                    "sync_status",
+                    account_id=account_id,
+                    chat_id=CHAT_ID,
+                    last_message_id=count,
+                    last_sync_date=WHEN,
+                    message_count=count,
+                )
+            assert _rows(conn, "SELECT account_id, message_count FROM sync_status ORDER BY account_id") == [
+                (DEFAULT_ACCOUNT_ID, 120),
+                (OTHER_ACCOUNT, 7),
+            ]
+
+    def test_both_accounts_keep_their_own_forum_topics(self, schema_engine):
+        with schema_engine.begin() as conn:
+            _seed_two_accounts(conn)
+            for account_id, title in ((DEFAULT_ACCOUNT_ID, "General"), (OTHER_ACCOUNT, "Generale")):
+                _insert(
+                    conn,
+                    "forum_topics",
+                    account_id=account_id,
+                    id=1,
+                    chat_id=CHAT_ID,
+                    title=title,
+                    is_closed=0,
+                    is_pinned=0,
+                    is_hidden=0,
+                    created_at=WHEN,
+                    updated_at=WHEN,
+                )
+            assert _rows(conn, "SELECT account_id, title FROM forum_topics ORDER BY account_id") == [
+                (DEFAULT_ACCOUNT_ID, "General"),
+                (OTHER_ACCOUNT, "Generale"),
+            ]
+
+
+class TestTheQuietOne:
+    """detect_message_gaps is raw SQL that no type checker will ever object to.
+
+    ``LAG(id) OVER (ORDER BY id) ... WHERE chat_id = ?`` reads every account's
+    copy of a chat as one id sequence. Two accounts' sequences interleave inside
+    that window, so the gap list it returns is not merely unscoped — it is
+    WRONG: real gaps disappear because the other account's ids fill them in.
+
+    The schema cannot fix this on its own; the query has to name the account.
+    Both spellings are run here so the difference is a measurement rather than a
+    warning, and so the corrected SQL is written down where the change that
+    needs it will find it.
+    """
+
+    GAP_SQL = """
+        SELECT gap_start, gap_end, gap_size FROM (
+            SELECT
+                LAG(id) OVER (ORDER BY id) AS gap_start,
+                id AS gap_end,
+                id - LAG(id) OVER (ORDER BY id) AS gap_size
+            FROM messages
+            WHERE chat_id = :chat_id {account_filter}
+        ) gaps
+        WHERE gap_size > :threshold
+        ORDER BY gap_start
+    """
+
+    def _seed_interleaved(self, conn: sa.Connection) -> None:
+        _seed_two_accounts(conn)
+        # Account 1 archived 100 and 400: a gap of 300 it still has to fill.
+        # Account 2 happens to hold 200 and 300, right inside that gap.
+        for account_id, ids in ((DEFAULT_ACCOUNT_ID, (100, 400)), (OTHER_ACCOUNT, (200, 300))):
+            for message_id in ids:
+                _insert(
+                    conn,
+                    "messages",
+                    account_id=account_id,
+                    id=message_id,
+                    chat_id=CHAT_ID,
+                    date=WHEN,
+                    created_at=WHEN,
+                    is_outgoing=0,
+                    is_pinned=0,
+                    is_deleted=0,
+                )
+
+    def test_the_account_blind_window_hides_a_real_gap(self, schema_engine):
+        with schema_engine.begin() as conn:
+            self._seed_interleaved(conn)
+            gaps = _rows(
+                conn,
+                self.GAP_SQL.format(account_filter=""),
+                chat_id=CHAT_ID,
+                threshold=150,
+            )
+            # 100 -> 200 -> 300 -> 400: every step is 100, so nothing exceeds the
+            # threshold and account 1's 300-wide hole is reported as no gap at all.
+            assert gaps == []
+
+    def test_naming_the_account_finds_it(self, schema_engine):
+        with schema_engine.begin() as conn:
+            self._seed_interleaved(conn)
+            gaps = _rows(
+                conn,
+                self.GAP_SQL.format(account_filter="AND account_id = :account_id"),
+                chat_id=CHAT_ID,
+                threshold=150,
+                account_id=DEFAULT_ACCOUNT_ID,
+            )
+            assert gaps == [(100, 400, 300)]
+
+
+class TestChatRef:
+    def test_a_ref_is_minted_on_insert_without_anyone_asking(self, schema_engine):
+        """The ORM's own default does it, so an existing writer needs no change."""
+        from src.db.models import Chat
+
+        with schema_engine.begin() as conn:
+            _insert(conn, "accounts", id=DEFAULT_ACCOUNT_ID, label="personal")
+            conn.execute(
+                sa.insert(Chat).values(id=CHAT_ID, type="supergroup", title="minted", created_at=WHEN, updated_at=WHEN)
+            )
+            (ref,) = conn.execute(sa.text("SELECT ref FROM chats")).first()
+        assert len(ref) == CHAT_REF_LENGTH
+        assert set(ref) <= set("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+
+    def test_an_update_never_re_rolls_it(self, schema_engine):
+        """A ref that changed on every backup cycle would break every open tab.
+
+        An upsert's ON CONFLICT DO UPDATE branch must not touch the column, and
+        the Python-side default gives exactly that for free: it applies to the
+        INSERT and to nothing else.
+        """
+        from src.db.models import Chat
+
+        with schema_engine.begin() as conn:
+            _insert(conn, "accounts", id=DEFAULT_ACCOUNT_ID, label="personal")
+            conn.execute(
+                sa.insert(Chat).values(id=CHAT_ID, type="supergroup", title="first", created_at=WHEN, updated_at=WHEN)
+            )
+            (before,) = conn.execute(sa.text("SELECT ref FROM chats")).first()
+            conn.execute(sa.update(Chat).values(title="renamed"))
+            (after,) = conn.execute(sa.text("SELECT ref FROM chats")).first()
+        assert before == after
+
+    def test_two_chats_cannot_share_a_ref(self, schema_engine):
+        with schema_engine.begin() as conn:
+            _insert(conn, "accounts", id=DEFAULT_ACCOUNT_ID, label="personal")
+            shared = new_chat_ref()
+            _insert(
+                conn,
+                "chats",
+                account_id=DEFAULT_ACCOUNT_ID,
+                id=1,
+                ref=shared,
+                type="private",
+                is_forum=0,
+                is_archived=0,
+                last_synced_message_id=0,
+                created_at=WHEN,
+                updated_at=WHEN,
+            )
+            with pytest.raises(sa.exc.IntegrityError):
+                _insert(
+                    conn,
+                    "chats",
+                    account_id=DEFAULT_ACCOUNT_ID,
+                    id=2,
+                    ref=shared,
+                    type="private",
+                    is_forum=0,
+                    is_archived=0,
+                    last_synced_message_id=0,
+                    created_at=WHEN,
+                    updated_at=WHEN,
+                )
+
+    def test_refs_do_not_repeat(self):
+        assert len({new_chat_ref() for _ in range(2000)}) == 2000
+
+
+class TestEntitlementColumnsAreNew:
+    """A reinterpreted allowed_chat_ids fails OPEN; a new column cannot.
+
+    An unconverted 7.x payload ``[123, 456]`` read as (account 123, chat 456)
+    GRANTS access instead of denying it. These columns exist so an unconverted
+    row is unmistakably unconverted.
+    """
+
+    @pytest.mark.parametrize("table", ["viewer_accounts", "viewer_sessions", "viewer_tokens", "push_subscriptions"])
+    def test_both_columns_exist_beside_the_old_one(self, schema_engine, table):
+        columns = {column["name"]: column for column in sa.inspect(schema_engine).get_columns(table)}
+        assert "allowed_chat_ids" in columns, "the 7.x column must survive, not be renamed"
+        for name in ("allowed_accounts", "allowed_chat_refs"):
+            assert name in columns
+            assert columns[name]["nullable"] is True
+
+
+class TestWhatDidNotChange:
+    def test_users_stay_global(self, schema_engine):
+        """Per-account users turns the folder-resolution outerjoin into duplicates.
+
+        get_chats_for_folder_resolution joins User on ``User.id == Chat.id``. With
+        users keyed per account and two accounts holding the same person, that
+        join returns a row per account and the folder counts silently double.
+        """
+        assert sa.inspect(schema_engine).get_pk_constraint("users")["constrained_columns"] == ["id"]
+
+    def test_metadata_is_not_split(self, schema_engine):
+        assert sa.inspect(schema_engine).get_pk_constraint("metadata")["constrained_columns"] == ["key"]
+
+    def test_media_gained_no_new_column(self, schema_engine):
+        """The media URL scheme needs no opaque id: media.id is already unique
+        per account, and chats.ref is what takes chat ids out of the URL."""
+        columns = {column["name"] for column in sa.inspect(schema_engine).get_columns("media")}
+        assert "uid" not in columns and "url_key" not in columns
+
+    def test_a_writer_that_names_no_account_still_lands_somewhere_real(self, schema_engine):
+        """Every account_id carries a server-side default of 1.
+
+        This is what lets the single-account writers keep working against the
+        new keys while the account is threaded through them.
+        """
+        with schema_engine.begin() as conn:
+            _insert(conn, "accounts", id=DEFAULT_ACCOUNT_ID, label="personal")
+            _insert(
+                conn,
+                "chats",
+                id=CHAT_ID,
+                ref=new_chat_ref(),
+                type="private",
+                is_forum=0,
+                is_archived=0,
+                last_synced_message_id=0,
+                created_at=WHEN,
+                updated_at=WHEN,
+            )
+            _insert(
+                conn,
+                "messages",
+                id=1,
+                chat_id=CHAT_ID,
+                date=WHEN,
+                created_at=WHEN,
+                is_outgoing=0,
+                is_pinned=0,
+                is_deleted=0,
+            )
+            assert _rows(conn, "SELECT account_id FROM messages") == [(DEFAULT_ACCOUNT_ID,)]
+
+    def test_the_accounts_table_has_exactly_three_columns(self, schema_engine):
+        """No status, no soft delete, no session name. Nobody has asked for them."""
+        columns = {column["name"] for column in sa.inspect(schema_engine).get_columns("accounts")}
+        assert columns == {"id", "label", "telegram_user_id"}
+
+    def test_the_account_id_is_a_surrogate_not_a_telegram_user_id(self, schema_engine):
+        """A Telegram user id is an identifier this project treats as PII, and it
+        would otherwise be copied into every row of every table and every index."""
+        with schema_engine.begin() as conn:
+            conn.execute(sa.text("INSERT INTO accounts (label, telegram_user_id) VALUES ('personal', NULL)"))
+            assert _rows(conn, "SELECT id, telegram_user_id FROM accounts") == [(1, None)]
+
+
+def test_no_account_or_chat_identifier_is_logged_by_the_migration():
+    """PII rule: counts and type names only, never an id, a ref or a payload."""
+    source = (
+        Path(__file__).resolve().parent.parent / "alembic" / "versions" / "20260815_022_multi_account_keys.py"
+    ).read_text(encoding="utf-8")
+    logged = [line for line in source.splitlines() if "logger." in line or "raise RuntimeError" in line]
+    assert logged, "the guard is worthless if it matches nothing"
+    # A log line may name a count of refs; it may never interpolate one, or a
+    # chat id, a grant payload, a Telegram user id, or a filesystem path.
+    forbidden = (
+        "chat_id",
+        "chat_ids",
+        "allowed_",
+        "telegram_user_id",
+        "payload",
+        "path",
+        "%s",
+        "{ref",
+        "row[",
+        "value",
+    )
+    for line in logged:
+        for needle in forbidden:
+            assert needle not in line, f"a log or error line may carry {needle}: {line.strip()}"
+
+
+def test_the_mappers_configure_without_a_relationship_warning():
+    """account_id sits in two composite foreign keys on chat_folder_members.
+
+    SQLAlchemy warns when two relationships would both persist the same column,
+    and a warning nobody reads is how an ORM-level overwrite gets shipped. The
+    membership row's `chat` is viewonly, which says out loud that only `folder`
+    writes it.
+    """
+    import subprocess
+
+    # In a subprocess: configure_mappers() only warns the first time, so doing
+    # this in-process would be a check that cannot fail.
+    script = (
+        "import warnings, sqlalchemy.orm as orm;"
+        "warnings.simplefilter('error', orm.exc.sa_exc.SAWarning);"
+        "import src.db.models;"
+        "orm.configure_mappers()"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        cwd=str(Path(__file__).resolve().parent.parent),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr[-2000:]
+
+    # And the reason it is quiet, stated directly: exactly one relationship on
+    # the membership row may persist its columns.
+    from src.db.models import ChatFolderMember
+
+    writers = sorted(rel.key for rel in sa.inspect(ChatFolderMember).relationships if not rel.viewonly)
+    assert writers == ["folder"]
+
+
+def test_the_migration_never_uses_cascade():
+    """DROP CONSTRAINT ... CASCADE succeeds while deleting a foreign key, with
+    only a NOTICE to say so. Measured on a real server; it must never appear."""
+    source = (
+        Path(__file__).resolve().parent.parent / "alembic" / "versions" / "20260815_022_multi_account_keys.py"
+    ).read_text(encoding="utf-8")
+    executed = [
+        line
+        for line in source.splitlines()
+        if "op.execute(" in line or "conn.execute(" in line or "exec_driver_sql(" in line
+    ]
+    assert executed, "the guard is worthless if it matches nothing"
+    assert not any("CASCADE" in line.upper() for line in executed)
+    assert "op.drop_constraint(" in source, "constraints must be dropped explicitly, by name"

--- a/tests/test_multiaccount_schema.py
+++ b/tests/test_multiaccount_schema.py
@@ -335,7 +335,8 @@ class TestTheQuietOne:
     The schema cannot fix this on its own; the query has to name the account.
     Both spellings are run here so the difference is a measurement rather than a
     warning, and so the corrected SQL is written down where the change that
-    needs it will find it.
+    needs it will find it. The adapter now ships that SQL, and the last test
+    here calls the real method — losing the filter again cannot be silent.
     """
 
     GAP_SQL = """
@@ -394,6 +395,30 @@ class TestTheQuietOne:
                 account_id=DEFAULT_ACCOUNT_ID,
             )
             assert gaps == [(100, 400, 300)]
+
+    async def test_the_shipped_adapter_names_the_account(self, real_adapter):
+        """Pin ``DatabaseAdapter.detect_message_gaps`` itself, not a copy of it.
+
+        The two tests above measure the SQL; this one seeds the same interleave
+        THROUGH the adapter and calls the real method. If the shipped query ever
+        drops its account filter, account 2's ids fill the hole and account 1's
+        answer degrades to [] — which this test turns from a silent wrong answer
+        into a red one.
+        """
+        for account_id in (DEFAULT_ACCOUNT_ID, OTHER_ACCOUNT):
+            await real_adapter.upsert_chat({"id": CHAT_ID, "type": "supergroup"}, account_id=account_id)
+        await real_adapter.insert_messages_batch(
+            [{"id": message_id, "chat_id": CHAT_ID, "date": WHEN, "raw_data": {}} for message_id in (100, 400)],
+            account_id=DEFAULT_ACCOUNT_ID,
+        )
+        await real_adapter.insert_messages_batch(
+            [{"id": message_id, "chat_id": CHAT_ID, "date": WHEN, "raw_data": {}} for message_id in (200, 300)],
+            account_id=OTHER_ACCOUNT,
+        )
+
+        gaps = await real_adapter.detect_message_gaps(CHAT_ID, threshold=150, account_id=DEFAULT_ACCOUNT_ID)
+        assert gaps == [(100, 400, 300)]
+        assert await real_adapter.detect_message_gaps(CHAT_ID, threshold=150, account_id=OTHER_ACCOUNT) == []
 
 
 class TestChatRef:

--- a/tests/test_parallel_download.py
+++ b/tests/test_parallel_download.py
@@ -176,6 +176,7 @@ class ForeignDCClient(FakeClient):
 
 def _make_backup(*, enabled: bool, min_mb: int = 20, conns: int = 4, part_kb: int = 512) -> TelegramBackup:
     backup = TelegramBackup.__new__(TelegramBackup)
+    backup.account_id = 1
     cfg = MagicMock()
     cfg.should_skip_topic = MagicMock(return_value=False)
     cfg.parallel_download_enabled = enabled

--- a/tests/test_poison_message_isolation.py
+++ b/tests/test_poison_message_isolation.py
@@ -67,6 +67,7 @@ class TestDocumentEmptyIsNotFatal(unittest.TestCase):
 
     def setUp(self):
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.listener = TelegramListener.__new__(TelegramListener)
 
     def test_documentempty_is_truthy_but_has_no_attributes(self):
@@ -142,6 +143,7 @@ class TestOneBadMessageCannotWedgeAChat(unittest.TestCase):
         self.db.get_last_message_id.return_value = 0
 
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.backup.config = self.config
         self.backup.db = self.db
         self.backup.client = MagicMock()
@@ -272,6 +274,7 @@ class TestPeerResolutionErrorsNeverReachTheLogs(unittest.TestCase):
 
         self.db = AsyncMock()
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.backup.config = self.config
         self.backup.db = self.db
         self.backup.client = MagicMock()
@@ -408,7 +411,7 @@ class TestListenerDetachesItsHandlers(unittest.TestCase):
     """
 
     def _make_listener(self, client):
-        return TelegramListener(_listener_config(), AsyncMock(), client=client)
+        return TelegramListener(_listener_config(), AsyncMock(), client=client, account_id=1)
 
     def test_stop_detaches_every_handler_it_registered(self):
         client = _FakeEventClient()
@@ -447,7 +450,7 @@ class TestListenerMediaDownloadDiscipline(unittest.TestCase):
 
     def _make_listener(self, **overrides):
         config = _listener_config(media_path=self.temp_dir, **overrides)
-        listener = TelegramListener(config, AsyncMock())
+        listener = TelegramListener(config, AsyncMock(), account_id=1)
         listener.db.find_media_by_content_hash = AsyncMock(return_value=None)
         listener.client = MagicMock()
         listener.client.flood_sleep_threshold = 0

--- a/tests/test_reaction_resweep.py
+++ b/tests/test_reaction_resweep.py
@@ -114,7 +114,7 @@ class TestGetMessageIdsSince:
             session.add(Message(id=99, chat_id=-200, date=now, text="other"))  # different chat
             await session.commit()
 
-        ids = await adapter.get_message_ids_since(CHAT, now - timedelta(days=7), 500)
+        ids = await adapter.get_message_ids_since(CHAT, now - timedelta(days=7), 500, account_id=1)
         assert ids == [3, 2, 1]  # newest id first; old + other-chat excluded
 
     async def test_cap_limits_results_newest_first(self, adapter):
@@ -124,7 +124,7 @@ class TestGetMessageIdsSince:
                 session.add(Message(id=i, chat_id=CHAT, date=base, text="x"))
             await session.commit()
 
-        ids = await adapter.get_message_ids_since(CHAT, base - timedelta(days=1), 3)
+        ids = await adapter.get_message_ids_since(CHAT, base - timedelta(days=1), 3, account_id=1)
         assert ids == [10, 9, 8]
 
     async def test_empty_when_nothing_in_window(self, adapter):
@@ -132,7 +132,7 @@ class TestGetMessageIdsSince:
         async with adapter.db_manager.async_session_factory() as session:
             session.add(Message(id=1, chat_id=CHAT, date=base - timedelta(days=100), text="a"))
             await session.commit()
-        assert await adapter.get_message_ids_since(CHAT, base - timedelta(days=7), 500) == []
+        assert await adapter.get_message_ids_since(CHAT, base - timedelta(days=7), 500, account_id=1) == []
 
 
 # ---------------------------------------------------------------------------
@@ -142,6 +142,7 @@ class TestGetMessageIdsSince:
 
 def _backup(days=7.0, max_per_chat=500, delay=0.0):
     b = TelegramBackup.__new__(TelegramBackup)
+    b.account_id = 1
     b.config = MagicMock()
     b.config.reaction_resweep_days = days
     b.config.reaction_resweep_max_per_chat = max_per_chat
@@ -268,6 +269,7 @@ class TestResweepReactions:
 
 def _dialog_backup(days):
     b = TelegramBackup.__new__(TelegramBackup)
+    b.account_id = 1
     b.config = MagicMock()
     b.config.batch_size = 100
     b.config.checkpoint_interval = 1

--- a/tests/test_reactions_realtime.py
+++ b/tests/test_reactions_realtime.py
@@ -68,30 +68,32 @@ def and_cond(mid, cid):
 
 class TestReconcileReactions:
     async def test_add_creates_aggregate_row(self, adapter):
-        out = await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 3}])
+        out = await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 3}], account_id=1)
         assert out == "reconciled"
         active = await adapter.get_reactions(MSG_ID, CHAT_ID)
         assert active == [{"emoji": "👍", "user_id": None, "count": 3}]
 
     async def test_idempotent_noop(self, adapter):
-        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 3}])
-        out = await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 3}])
+        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 3}], account_id=1)
+        out = await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 3}], account_id=1)
         assert out == "noop"
 
     async def test_count_change_updates_in_place_preserving_created_at(self, adapter):
-        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 3}])
+        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 3}], account_id=1)
         rows = await _rows(adapter)
         created = rows[0].created_at
-        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 5}])
+        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 5}], account_id=1)
         rows = await _rows(adapter)
         assert len(rows) == 1
         assert rows[0].count == 5
         assert rows[0].created_at == created  # first-seen preserved (F6)
 
     async def test_removal_tombstones_and_excludes_from_live_count(self, adapter):
-        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 1}, {"emoji": "🔥", "count": 2}])
+        await adapter.reconcile_reactions(
+            MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 1}, {"emoji": "🔥", "count": 2}], account_id=1
+        )
         # 🔥 removed
-        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 1}])
+        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 1}], account_id=1)
         active = await adapter.get_reactions(MSG_ID, CHAT_ID)
         assert active == [{"emoji": "👍", "user_id": None, "count": 1}]
         all_rows = await _rows(adapter)
@@ -99,17 +101,17 @@ class TestReconcileReactions:
         assert fire.removed_at is not None  # retained, not deleted
 
     async def test_zero_clear_tombstones_all(self, adapter):
-        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 1}])
-        out = await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [])
+        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 1}], account_id=1)
+        out = await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [], account_id=1)
         assert out == "reconciled"
         assert await adapter.get_reactions(MSG_ID, CHAT_ID) == []
         assert all(r.removed_at is not None for r in await _rows(adapter))
 
     async def test_readd_revives_tombstone_keeping_created_at(self, adapter):
-        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 1}])
+        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 1}], account_id=1)
         created = (await _rows(adapter))[0].created_at
-        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [])  # removed
-        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 2}])  # re-added
+        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [], account_id=1)  # removed
+        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 2}], account_id=1)  # re-added
         active = await adapter.get_reactions(MSG_ID, CHAT_ID)
         assert active == [{"emoji": "👍", "user_id": None, "count": 2}]
         rows = await _rows(adapter)
@@ -117,8 +119,8 @@ class TestReconcileReactions:
         assert rows[0].created_at == created
 
     async def test_hard_delete_when_mark_removed_false(self, adapter):
-        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 1}])
-        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [], mark_removed=False)
+        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 1}], account_id=1)
+        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [], mark_removed=False, account_id=1)
         assert await _rows(adapter) == []
 
     async def test_collapses_legacy_multi_row_per_emoji(self, adapter):
@@ -131,26 +133,26 @@ class TestReconcileReactions:
                 ]
             )
             await session.commit()
-        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 4}])
+        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 4}], account_id=1)
         rows = await _rows(adapter)
         assert len(rows) == 1
         assert rows[0].user_id is None
         assert rows[0].count == 4
 
     async def test_skips_when_message_not_archived(self, adapter):
-        out = await adapter.reconcile_reactions(999999, CHAT_ID, [{"emoji": "👍", "count": 1}])
+        out = await adapter.reconcile_reactions(999999, CHAT_ID, [{"emoji": "👍", "count": 1}], account_id=1)
         assert out == "no_message"
         assert await _rows(adapter) == []
 
     async def test_unknown_reaction_variant_ignored(self, adapter):
         # Extractor yields nothing for an unrecognized variant, so reconcile is a noop.
-        out = await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [])
+        out = await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [], account_id=1)
         assert out == "noop"
 
     async def test_zero_or_negative_count_treated_as_absent(self, adapter):
         # A snapshot entry with count<=0 must not revive/retain a reaction.
-        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 2}])
-        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 0}])
+        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 2}], account_id=1)
+        await adapter.reconcile_reactions(MSG_ID, CHAT_ID, [{"emoji": "👍", "count": 0}], account_id=1)
         assert await adapter.get_reactions(MSG_ID, CHAT_ID) == []
         assert all(r.removed_at is not None for r in await _rows(adapter))
 
@@ -210,7 +212,7 @@ async def test_reaction_only_edit_does_not_create_phantom(adapter):
     """#219 e2e: a reaction-only edit (unchanged text, newer edit_date) must not
     bump edit_date, so the viewer never shows a phantom 'edited' marker."""
     reaction_edit = datetime(2026, 7, 18, 12, 30)
-    outcome = await adapter.update_message_text(CHAT_ID, MSG_ID, "hi", reaction_edit)
+    outcome = await adapter.update_message_text(CHAT_ID, MSG_ID, "hi", reaction_edit, account_id=1)
     assert outcome == "noop"
     async with adapter.db_manager.async_session_factory() as session:
         msg = (

--- a/tests/test_reconnect_before_retry.py
+++ b/tests/test_reconnect_before_retry.py
@@ -454,6 +454,7 @@ class TestMediaRefreshPassesItsClient:
         client.get_messages = get_messages
 
         backup = TelegramBackup.__new__(TelegramBackup)
+        backup.account_id = 1
         backup.client = client
         backup.config = MagicMock()
 
@@ -607,7 +608,7 @@ class TestListenerRestartAfterAGiveUp:
 
         class StubListener:
             @classmethod
-            async def create(cls, config, client=None):
+            async def create(cls, config, client=None, *, account_id):
                 listener = cls()
                 listener.client = client
                 return listener

--- a/tests/test_repair_media_extensions.py
+++ b/tests/test_repair_media_extensions.py
@@ -21,7 +21,8 @@ class _FakeDB:
     """Minimal async stand-in for the DatabaseAdapter media surface."""
 
     def __init__(self, records, fail_update_ids=None, batch_size=500):
-        self._records = records
+        # The real adapter stamps every yielded row with its account_id.
+        self._records = [{"account_id": 1, **r} for r in records]
         self.updates = {}
         self._fail_update_ids = set(fail_update_ids or ())
         self._batch_size = batch_size
@@ -31,7 +32,7 @@ class _FakeDB:
         for start in range(0, len(self._records), size):
             yield [dict(r) for r in self._records[start : start + size]]
 
-    async def update_media_file_path(self, media_id, file_path):
+    async def update_media_file_path(self, media_id, file_path, *, account_id):
         if media_id in self._fail_update_ids:
             raise RuntimeError("simulated DB write failure")
         self.updates[media_id] = file_path
@@ -481,12 +482,12 @@ def test_repair_records_sync_returns_pending_update_for_direct_file(tmp_path):
     corrupt = chat / "abc.mp4.7.140234567890"
     corrupt.write_bytes(b"video")
 
-    records = [{"id": "m1", "file_name": "abc.mp4", "file_path": str(corrupt)}]
+    records = [{"account_id": 1, "id": "m1", "file_name": "abc.mp4", "file_path": str(corrupt)}]
     repaired, deferred, pending = _repair_records_sync(records, str(media / "_shared"))
 
     assert repaired == 1
     assert deferred == 0
-    assert pending == [("m1", str(chat / "abc.mp4"))]
+    assert pending == [("m1", str(chat / "abc.mp4"), 1)]
     assert (chat / "abc.mp4").read_bytes() == b"video"
 
 
@@ -497,7 +498,7 @@ def test_repair_records_sync_counts_oserror_as_deferred(tmp_path):
     corrupt = chat / "abc.mp4.7.140234567890"
     corrupt.write_bytes(b"video")
 
-    records = [{"id": "m1", "file_name": "abc.mp4", "file_path": str(corrupt)}]
+    records = [{"account_id": 1, "id": "m1", "file_name": "abc.mp4", "file_path": str(corrupt)}]
     with mock.patch("src.repair_media_extensions.os.replace", side_effect=OSError("EIO")):
         repaired, deferred, pending = _repair_records_sync(records, str(media / "_shared"))
 
@@ -817,7 +818,7 @@ class _ReadFailDB:
         raise RuntimeError("simulated DB read failure")
         yield  # pragma: no cover - makes this an async generator
 
-    async def update_media_file_path(self, media_id, file_path):  # pragma: no cover
+    async def update_media_file_path(self, media_id, file_path, *, account_id):  # pragma: no cover
         self.updates[media_id] = file_path
 
 

--- a/tests/test_reply_sender.py
+++ b/tests/test_reply_sender.py
@@ -314,7 +314,7 @@ class TestPinnedListParity:
     "Reply to / Message" in the pinned view."""
 
     async def _pinned_by_id(self, adapter, ids):
-        await adapter.sync_pinned_messages(CHAT_ID, ids)
+        await adapter.sync_pinned_messages(CHAT_ID, ids, account_id=1)
         return {m["id"]: m for m in await adapter.get_pinned_messages(CHAT_ID)}
 
     async def test_pinned_rows_carry_the_same_reply_fields_as_the_list(self, env):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -424,6 +424,7 @@ class TestBackupSchedulerListener:
             config = MagicMock()
             config.enable_listener = True
             config.skip_topic_ids = {}
+            config.should_skip_topic = MagicMock(return_value=False)
             config.mass_operation_threshold = 10
             config.mass_operation_window_seconds = 30
             config.mass_operation_buffer_delay = 2.0

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -407,6 +407,44 @@ class TestBackupSchedulerListener:
                     mock_task.return_value = MagicMock()
                     await scheduler._start_listener()
 
+    async def test_start_listener_builds_real_listener_for_the_default_account(self):
+        """The scheduler path runs the REAL TelegramListener.create/__init__ chain.
+
+        Only leaf dependencies are mocked (DB adapter, network methods): if the
+        create() call at the scheduler's composition seam ever drops the required
+        account_id kwarg, the TypeError is swallowed by _start_listener's except
+        and _listener stays None — which these assertions turn red. The patched
+        class in the test above cannot catch that.
+        """
+        with patch("src.scheduler.signal.signal"):
+            from src.db.models import DEFAULT_ACCOUNT_ID
+            from src.listener import TelegramListener
+            from src.scheduler import BackupScheduler
+
+            config = MagicMock()
+            config.enable_listener = True
+            config.skip_topic_ids = {}
+            config.mass_operation_threshold = 10
+            config.mass_operation_window_seconds = 30
+            config.mass_operation_buffer_delay = 2.0
+            scheduler = BackupScheduler(config)
+            scheduler._connection = MagicMock()
+            scheduler._connection.ensure_connected = AsyncMock()
+            scheduler._connection.is_connected = True
+            scheduler._connection.client = MagicMock()
+
+            with (
+                patch("src.listener.create_adapter", new_callable=AsyncMock, return_value=AsyncMock()),
+                patch.object(TelegramListener, "connect", new_callable=AsyncMock),
+                patch.object(TelegramListener, "run", new_callable=AsyncMock),
+            ):
+                await scheduler._start_listener()
+
+                assert isinstance(scheduler._listener, TelegramListener)
+                assert scheduler._listener.account_id == DEFAULT_ACCOUNT_ID
+                assert scheduler._listener_task is not None
+                await scheduler._listener_task
+
     async def test_start_listener_handles_exception_gracefully(self):
         """_start_listener catches exceptions during listener creation."""
         with patch("src.scheduler.signal.signal"):

--- a/tests/test_symlink_dedup.py
+++ b/tests/test_symlink_dedup.py
@@ -137,6 +137,7 @@ class TestDownloadReturnValueCapture(unittest.TestCase):
 
         # Set up backup instance
         backup = TelegramBackup.__new__(TelegramBackup)
+        backup.account_id = 1
         backup.config = MagicMock()
         backup.config.media_path = self.media_path
         backup.config.deduplicate_media = True
@@ -187,6 +188,7 @@ class TestProcessMediaDedupSymlink(unittest.TestCase):
         os.makedirs(self.media_path)
 
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.backup.config = MagicMock()
         self.backup.config.media_path = self.media_path
         self.backup.config.deduplicate_media = True
@@ -315,6 +317,7 @@ class TestVerifyCleanupDanglingSymlink(unittest.TestCase):
         os.makedirs(self.media_path)
 
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.backup.config = MagicMock()
         self.backup.config.media_path = self.media_path
         self.backup.config.verify_media = True
@@ -441,6 +444,7 @@ class TestShutilMoveFallback(unittest.TestCase):
         os.makedirs(self.media_path)
 
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.backup.config = MagicMock()
         self.backup.config.media_path = self.media_path
         self.backup.config.deduplicate_media = True
@@ -565,6 +569,7 @@ class TestListenerDownloadMediaDedup(unittest.TestCase):
         self.listener.config.deduplicate_media = True
         self.listener.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
         self.listener.client = AsyncMock()
+        self.listener.account_id = 1
         self.listener.db = AsyncMock()
         self.listener.db.find_media_by_content_hash = AsyncMock(return_value=None)
 
@@ -771,6 +776,7 @@ class TestBackupDedupSharedExistsPreUnlink(unittest.TestCase):
         os.makedirs(self.media_path)
 
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.backup.config = MagicMock()
         self.backup.config.media_path = self.media_path
         self.backup.config.deduplicate_media = True
@@ -882,6 +888,7 @@ class TestBackupNonDedupCapturesReturnValue(unittest.TestCase):
         os.makedirs(self.media_path)
 
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.backup.config = MagicMock()
         self.backup.config.media_path = self.media_path
         self.backup.config.deduplicate_media = False
@@ -946,6 +953,7 @@ class TestBackupDedupSymlinkFailFallback(unittest.TestCase):
         os.makedirs(self.media_path)
 
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.backup.config = MagicMock()
         self.backup.config.media_path = self.media_path
         self.backup.config.deduplicate_media = True

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -90,6 +90,7 @@ class TestCleanupExistingMedia(unittest.TestCase):
 
         self.db = AsyncMock()
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.backup.config = self.config
         self.backup.db = self.db
         self.backup._cleaned_media_chats = set()
@@ -130,7 +131,7 @@ class TestCleanupExistingMedia(unittest.TestCase):
         self._run(self.backup._cleanup_existing_media(chat_id))
 
         self.assertFalse(os.path.exists(file_path))
-        self.db.delete_media_for_chat.assert_awaited_once_with(chat_id)
+        self.db.delete_media_for_chat.assert_awaited_once_with(chat_id, account_id=1)
 
     def test_cleanup_removes_symlinks_without_counting_freed_bytes(self):
         """Symlink removal should not count toward freed bytes."""
@@ -254,7 +255,7 @@ class TestCleanupExistingMedia(unittest.TestCase):
 
         self._run(self.backup._cleanup_existing_media(chat_id))
 
-        self.db.delete_media_for_chat.assert_awaited_once_with(chat_id)
+        self.db.delete_media_for_chat.assert_awaited_once_with(chat_id, account_id=1)
 
     def test_cleanup_session_cache_prevents_rerun(self):
         """Second call for same chat should be skipped via session cache."""
@@ -342,6 +343,7 @@ class TestBackupCheckpointing(unittest.TestCase):
         self.db.get_last_message_id.return_value = 0
 
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.backup.config = self.config
         self.backup.db = self.db
         self.backup.client = MagicMock()
@@ -478,6 +480,7 @@ class TestBackupCheckpointing(unittest.TestCase):
         (extraction failure) is skipped so it can't tombstone valid reactions.
         """
         backup = TelegramBackup.__new__(TelegramBackup)
+        backup.account_id = 1
         backup.db = AsyncMock()
 
         batch = [
@@ -491,12 +494,14 @@ class TestBackupCheckpointing(unittest.TestCase):
         finally:
             loop.close()
 
-        backup.db.insert_messages_batch.assert_awaited_once_with(batch)
-        backup.db.insert_media.assert_awaited_once_with({"file_path": "/a.jpg"})
+        backup.db.insert_messages_batch.assert_awaited_once_with(batch, account_id=1)
+        backup.db.insert_media.assert_awaited_once_with({"file_path": "/a.jpg"}, account_id=1)
         # Reconciled once per message: empty snapshot for msg 1, the aggregate for msg 2.
         self.assertEqual(backup.db.reconcile_reactions.await_count, 2)
-        backup.db.reconcile_reactions.assert_any_await(1, 100, [], mark_removed=True)
-        backup.db.reconcile_reactions.assert_any_await(2, 100, [{"emoji": "👍", "count": 3}], mark_removed=True)
+        backup.db.reconcile_reactions.assert_any_await(1, 100, [], mark_removed=True, account_id=1)
+        backup.db.reconcile_reactions.assert_any_await(
+            2, 100, [{"emoji": "👍", "count": 3}], mark_removed=True, account_id=1
+        )
 
 
 class TestTopicFilteringInBackupDialog(unittest.TestCase):
@@ -518,6 +523,7 @@ class TestTopicFilteringInBackupDialog(unittest.TestCase):
         self.db.get_last_message_id.return_value = 0
 
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.backup.config = self.config
         self.backup.db = self.db
         self.backup.client = MagicMock()
@@ -654,6 +660,7 @@ class TestWhitelistModeBackup(unittest.TestCase):
         os.makedirs(self.config.media_path, exist_ok=True)
 
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.backup.config = self.config
         self.backup.client = AsyncMock()
         self.backup.db = AsyncMock()
@@ -1152,6 +1159,7 @@ class TestExtractForwardFromId(unittest.TestCase):
 
     def setUp(self):
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
 
     def test_returns_none_when_no_fwd_from(self):
         """Returns None when message has no forward info."""
@@ -1207,6 +1215,7 @@ class TestTextWithEntitiesToString(unittest.TestCase):
 
     def setUp(self):
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
 
     def test_returns_empty_string_for_none(self):
         """Returns empty string when input is None."""
@@ -1235,6 +1244,7 @@ class TestGetMediaType(unittest.TestCase):
 
     def setUp(self):
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
 
     def test_photo_returns_photo(self):
         """MessageMediaPhoto is detected as photo type."""
@@ -1338,6 +1348,7 @@ class TestGetMediaExtension(unittest.TestCase):
 
     def setUp(self):
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
 
     def test_photo_returns_jpg(self):
         """Photo type maps to jpg extension."""
@@ -1369,6 +1380,7 @@ class TestExtractChatData(unittest.TestCase):
 
     def setUp(self):
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.backup._get_marked_id = MagicMock(return_value=100)
 
     def test_user_entity_extracts_private_chat(self):
@@ -1454,6 +1466,7 @@ class TestExtractUserData(unittest.TestCase):
 
     def setUp(self):
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
 
     def test_extracts_user_fields(self):
         """Returns dict with all user fields for a User entity."""
@@ -1488,6 +1501,7 @@ class TestGetChatName(unittest.TestCase):
 
     def setUp(self):
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
 
     def test_user_with_full_name_and_username(self):
         """User with first, last name and username returns formatted string."""
@@ -1542,6 +1556,7 @@ class TestProcessMessage(unittest.TestCase):
 
     def setUp(self):
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.backup.db = AsyncMock()
         self.backup.config = MagicMock()
         self.backup.config.should_download_media_for_chat = MagicMock(return_value=False)
@@ -1933,6 +1948,7 @@ class TestCommitBatchReactions(unittest.TestCase):
 
     def setUp(self):
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.backup.db = AsyncMock()
 
     def _run(self, coro):
@@ -1951,7 +1967,9 @@ class TestCommitBatchReactions(unittest.TestCase):
 
         self._run(self.backup._commit_batch(batch, 100))
 
-        self.backup.db.reconcile_reactions.assert_any_await(1, 100, [{"emoji": "heart", "count": 5}], mark_removed=True)
+        self.backup.db.reconcile_reactions.assert_any_await(
+            1, 100, [{"emoji": "heart", "count": 5}], mark_removed=True, account_id=1
+        )
 
     def test_empty_reactions_still_reconciled(self):
         """#219 (F2): reconcile runs for an empty snapshot ([]) so removals-to-zero
@@ -1960,7 +1978,7 @@ class TestCommitBatchReactions(unittest.TestCase):
 
         self._run(self.backup._commit_batch(batch, 100))
 
-        self.backup.db.reconcile_reactions.assert_awaited_once_with(3, 100, [], mark_removed=True)
+        self.backup.db.reconcile_reactions.assert_awaited_once_with(3, 100, [], mark_removed=True, account_id=1)
 
     def test_extraction_failure_skips_reconcile(self):
         """#219: a None snapshot means extraction FAILED (shape drift) — skip
@@ -1987,6 +2005,7 @@ class TestBackupForumTopics(unittest.TestCase):
 
     def setUp(self):
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.backup.db = AsyncMock()
         self.backup.client = AsyncMock()
         self.backup.config = MagicMock()
@@ -2105,6 +2124,7 @@ class TestBackupDialogCursorAdvancesOnSkippedMessages(unittest.TestCase):
         self.db.get_last_message_id.return_value = 0
 
         self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
         self.backup.config = self.config
         self.backup.db = self.db
         self.backup.client = MagicMock()

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -51,6 +51,7 @@ def _run(coro):
 def _make_backup(**overrides):
     """Create a TelegramBackup instance via __new__ with sensible mock defaults."""
     backup = TelegramBackup.__new__(TelegramBackup)
+    backup.account_id = 1
     backup.config = overrides.get("config", MagicMock())
     backup.config.should_skip_topic = MagicMock(return_value=False)
     backup.config.deletion_mode = "hard"
@@ -104,17 +105,18 @@ class TestInit(unittest.TestCase):
         """When no client is passed, _owns_client should be True."""
         config = MagicMock()
         db = AsyncMock()
-        backup = TelegramBackup(config, db)
+        backup = TelegramBackup(config, db, account_id=1)
         self.assertTrue(backup._owns_client)
         self.assertIsNone(backup.client)
         self.assertIsInstance(backup._cleaned_media_chats, set)
+        self.assertEqual(backup.account_id, 1)
 
     def test_init_with_client_sets_owns_client_false(self):
         """When a client is passed, _owns_client should be False."""
         config = MagicMock()
         db = AsyncMock()
         client = MagicMock()
-        backup = TelegramBackup(config, db, client=client)
+        backup = TelegramBackup(config, db, client=client, account_id=1)
         self.assertFalse(backup._owns_client)
         self.assertIs(backup.client, client)
 
@@ -122,7 +124,7 @@ class TestInit(unittest.TestCase):
         """__init__ must call config.validate_credentials()."""
         config = MagicMock()
         db = AsyncMock()
-        TelegramBackup(config, db)
+        TelegramBackup(config, db, account_id=1)
         config.validate_credentials.assert_called_once()
 
 
@@ -141,11 +143,12 @@ class TestCreateFactory(unittest.TestCase):
         mock_create_adapter.return_value = mock_db
         config = MagicMock()
 
-        result = _run(TelegramBackup.create(config))
+        result = _run(TelegramBackup.create(config, account_id=1))
 
         mock_create_adapter.assert_awaited_once()
         self.assertIsInstance(result, TelegramBackup)
         self.assertIs(result.db, mock_db)
+        self.assertEqual(result.account_id, 1)
 
     @patch("src.telegram_backup.create_adapter", new_callable=AsyncMock)
     def test_create_passes_client_through(self, mock_create_adapter):
@@ -154,7 +157,7 @@ class TestCreateFactory(unittest.TestCase):
         config = MagicMock()
         client = MagicMock()
 
-        result = _run(TelegramBackup.create(config, client=client))
+        result = _run(TelegramBackup.create(config, client=client, account_id=1))
 
         self.assertIs(result.client, client)
         self.assertFalse(result._owns_client)
@@ -886,7 +889,7 @@ class TestSyncDeletionsAndEdits(unittest.TestCase):
 
         _run(self.backup._sync_deletions_and_edits(100, entity))
 
-        self.backup.db.delete_message.assert_awaited_once_with(100, 1)
+        self.backup.db.delete_message.assert_awaited_once_with(100, 1, account_id=1)
 
     def test_deleted_message_soft_marked(self):
         """DELETION_MODE=soft marks deleted messages instead of hard deleting."""
@@ -973,7 +976,7 @@ class TestSyncPinnedMessages(unittest.TestCase):
 
         _run(self.backup._sync_pinned_messages(100, entity))
 
-        self.backup.db.sync_pinned_messages.assert_awaited_once_with(100, [10, 20])
+        self.backup.db.sync_pinned_messages.assert_awaited_once_with(100, [10, 20], account_id=1)
 
     def test_no_pinned_messages_clears_existing(self):
         """When no pinned messages, sync with empty list."""
@@ -982,7 +985,7 @@ class TestSyncPinnedMessages(unittest.TestCase):
 
         _run(self.backup._sync_pinned_messages(100, entity))
 
-        self.backup.db.sync_pinned_messages.assert_awaited_once_with(100, [])
+        self.backup.db.sync_pinned_messages.assert_awaited_once_with(100, [], account_id=1)
 
     def test_exception_does_not_crash(self):
         """Exception during pinned sync should not propagate."""
@@ -3626,19 +3629,19 @@ class TestRetryPendingMediaCap(unittest.TestCase):
     def test_passes_attempt_cap_to_query(self):
         self.backup._process_media = AsyncMock(return_value={"downloaded": True, "id": "f1"})
         _run(self.backup._retry_pending_media_downloads())
-        self.backup.db.get_pending_media_downloads.assert_awaited_once_with(100 * 1024 * 1024, 5)
+        self.backup.db.get_pending_media_downloads.assert_awaited_once_with(100 * 1024 * 1024, 5, account_id=1)
 
     def test_increment_on_failed_download(self):
         """A download that raises bumps the attempt counter (the #212 name-too-long case)."""
         self.backup._process_media = AsyncMock(side_effect=OSError(36, "File name too long"))
         _run(self.backup._retry_pending_media_downloads())
-        self.backup.db.increment_media_download_attempts.assert_awaited_once_with("f1")
+        self.backup.db.increment_media_download_attempts.assert_awaited_once_with("f1", account_id=1)
 
     def test_increment_on_no_download_result(self):
         """A re-attempt that returns no download (e.g. still over a limit) also counts."""
         self.backup._process_media = AsyncMock(return_value=None)
         _run(self.backup._retry_pending_media_downloads())
-        self.backup.db.increment_media_download_attempts.assert_awaited_once_with("f1")
+        self.backup.db.increment_media_download_attempts.assert_awaited_once_with("f1", account_id=1)
 
     def test_no_increment_on_success(self):
         """A successful re-download does not bump the counter (row leaves the pending set)."""
@@ -3653,7 +3656,7 @@ class TestRetryPendingMediaCap(unittest.TestCase):
         self.backup.db.count_capped_media_downloads = AsyncMock(return_value=3)
         with self.assertLogs("src.telegram_backup", level="WARNING") as cm:
             _run(self.backup._retry_pending_media_downloads())
-        self.backup.db.count_capped_media_downloads.assert_awaited_once_with(5)
+        self.backup.db.count_capped_media_downloads.assert_awaited_once_with(5, account_id=1)
         assert any("permanently skipped" in line for line in cm.output)
 
 

--- a/tests/test_telegram_import.py
+++ b/tests/test_telegram_import.py
@@ -217,7 +217,7 @@ class TestBuildServiceText(unittest.TestCase):
 class TestTelegramImporterExtractChats(unittest.TestCase):
     def _make_importer(self):
         db = MagicMock()
-        return TelegramImporter(db, "/tmp/media")
+        return TelegramImporter(db, "/tmp/media", account_id=1)
 
     def test_single_chat_export(self):
         data = {"name": "Test Chat", "type": "personal_chat", "id": 123, "messages": []}
@@ -292,7 +292,7 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
 
         db = AsyncMock()
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir, dry_run=True))
 
@@ -315,7 +315,7 @@ class TestTelegramImporterRun(unittest.TestCase):
 
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 100}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         with self.assertRaises(ValueError) as ctx:
             self._run(importer.run(self.export_dir, merge=False))
@@ -350,14 +350,14 @@ class TestTelegramImporterRun(unittest.TestCase):
 
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir))
 
         self.assertEqual(summary["total_messages"], 2)
         db.upsert_chat.assert_called_once()
         db.insert_messages_batch.assert_called_once()
-        db.update_sync_status.assert_called_once_with(42, 2, 2)
+        db.update_sync_status.assert_called_once_with(42, 2, 2, account_id=1)
         inserted = db.insert_messages_batch.call_args.args[0]
         self.assertEqual(inserted[0]["sender_name"], "Alice")
         self.assertEqual(inserted[1]["sender_name"], "Alice")
@@ -382,7 +382,7 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         self._run(importer.run(self.export_dir))
 
@@ -421,7 +421,7 @@ class TestTelegramImporterRun(unittest.TestCase):
         media_dir = os.path.join(self.temp_dir, "media")
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, media_dir)
+        importer = TelegramImporter(db, media_dir, account_id=1)
 
         summary = self._run(importer.run(self.export_dir))
 
@@ -458,7 +458,7 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir))
 
@@ -490,7 +490,7 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir))
 
@@ -521,7 +521,7 @@ class TestTelegramImporterRun(unittest.TestCase):
         media_dir = Path(self.temp_dir, "media")
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, str(media_dir), max_filename_bytes=143)
+        importer = TelegramImporter(db, str(media_dir), max_filename_bytes=143, account_id=1)
 
         summary = self._run(importer.run(self.export_dir))
 
@@ -559,7 +559,7 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
         real_copy2 = shutil.copy2
         copy_calls = 0
 
@@ -608,7 +608,7 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         with patch("src.telegram_import.BATCH_SIZE", 1):
             summary = self._run(importer.run(self.export_dir))
@@ -644,7 +644,7 @@ class TestTelegramImporterRun(unittest.TestCase):
 
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir, skip_media=True))
 
@@ -653,7 +653,7 @@ class TestTelegramImporterRun(unittest.TestCase):
 
     def test_missing_result_json(self):
         db = AsyncMock()
-        importer = TelegramImporter(db, "/tmp/media")
+        importer = TelegramImporter(db, "/tmp/media", account_id=1)
 
         with self.assertRaises(FileNotFoundError):
             self._run(importer.run(self.export_dir))
@@ -666,7 +666,7 @@ class TestTelegramImporterRun(unittest.TestCase):
             encoding="utf-8",
         )
         os.symlink(outside_result, Path(self.export_dir, "result.json"))
-        importer = TelegramImporter(AsyncMock(), os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(AsyncMock(), os.path.join(self.temp_dir, "media"), account_id=1)
 
         with self.assertRaises(FileNotFoundError):
             self._run(importer.run(self.export_dir))
@@ -676,7 +676,7 @@ class TestTelegramImporterRun(unittest.TestCase):
         outside_html = Path(self.temp_dir, "outside-messages.html")
         outside_html.write_text(SAMPLE_HTML_MESSAGE, encoding="utf-8")
         os.symlink(outside_html, Path(self.export_dir, "messages.html"))
-        importer = TelegramImporter(AsyncMock(), os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(AsyncMock(), os.path.join(self.temp_dir, "media"), account_id=1)
 
         with self.assertRaises(FileNotFoundError):
             self._run(importer.run(self.export_dir, chat_id_override=42))
@@ -701,7 +701,7 @@ class TestTelegramImporterRun(unittest.TestCase):
 
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         self._run(importer.run(self.export_dir))
 
@@ -722,7 +722,7 @@ class TestTelegramImporterRun(unittest.TestCase):
 
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir, chat_id_override=-1009999))
 
@@ -1209,7 +1209,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
     def test_html_import_requires_chat_id(self):
         self._write_html(SAMPLE_HTML_MESSAGE)
         db = AsyncMock()
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         with self.assertRaises(ValueError) as ctx:
             self._run(importer.run(self.export_dir))
@@ -1219,7 +1219,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
         self._write_html(SAMPLE_HTML_MESSAGE)
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir, chat_id_override=-1001234567890))
 
@@ -1236,7 +1236,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
     def test_html_import_dry_run(self):
         self._write_html(SAMPLE_HTML_MESSAGE)
         db = AsyncMock()
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir, chat_id_override=42, dry_run=True))
 
@@ -1256,7 +1256,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
         media_dir = os.path.join(self.temp_dir, "media")
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, media_dir)
+        importer = TelegramImporter(db, media_dir, account_id=1)
 
         summary = self._run(importer.run(self.export_dir, chat_id_override=42))
 
@@ -1276,7 +1276,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
 
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir, chat_id_override=42, skip_media=True))
 
@@ -1287,7 +1287,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
         self._write_html(SAMPLE_HTML_FORWARDED)
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         self._run(importer.run(self.export_dir, chat_id_override=42))
 
@@ -1298,7 +1298,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
         self._write_html(SAMPLE_HTML_REPLY)
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         self._run(importer.run(self.export_dir, chat_id_override=42))
 
@@ -1327,7 +1327,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
 
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir))
 
@@ -1337,7 +1337,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
     def test_no_export_files_raises_error(self):
         """Neither result.json nor messages.html should raise FileNotFoundError."""
         db = AsyncMock()
-        importer = TelegramImporter(db, "/tmp/media")
+        importer = TelegramImporter(db, "/tmp/media", account_id=1)
 
         with self.assertRaises(FileNotFoundError) as ctx:
             self._run(importer.run(self.export_dir))

--- a/tests/test_telegram_import_extended.py
+++ b/tests/test_telegram_import_extended.py
@@ -541,7 +541,7 @@ class TestTelegramImporterClose(unittest.TestCase):
         """TelegramImporter.close delegates to close_database."""
         mock_close_db.return_value = None
         db = AsyncMock()
-        importer = TelegramImporter(db, "/tmp/media")
+        importer = TelegramImporter(db, "/tmp/media", account_id=1)
 
         self._run(importer.close())
 
@@ -574,7 +574,7 @@ class TestImporterRunEdgeCases(unittest.TestCase):
         """run raises ValueError when export has no chats (line 558)."""
         self._write_export({"chats": {"list": []}})
         db = AsyncMock()
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         with self.assertRaises(ValueError) as ctx:
             self._run(importer.run(self.export_dir))
@@ -599,7 +599,7 @@ class TestImporterRunEdgeCases(unittest.TestCase):
             }
         )
         db = AsyncMock()
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir))
 
@@ -634,7 +634,7 @@ class TestImporterRunEdgeCases(unittest.TestCase):
         )
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir, chat_id_override=-1009999))
 
@@ -656,7 +656,7 @@ class TestImporterRunEdgeCases(unittest.TestCase):
         )
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir))
 
@@ -677,7 +677,7 @@ class TestImporterRunEdgeCases(unittest.TestCase):
         )
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir))
 
@@ -704,7 +704,7 @@ class TestImporterRunEdgeCases(unittest.TestCase):
         )
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir))
 
@@ -738,7 +738,7 @@ class TestImporterRunEdgeCases(unittest.TestCase):
 
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 0}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir))
 
@@ -761,7 +761,7 @@ class TestImporterRunEdgeCases(unittest.TestCase):
         )
         db = AsyncMock()
         db.get_chat_stats.return_value = {"messages": 500}
-        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"))
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir, merge=True))
 

--- a/tests/test_telegram_proxy.py
+++ b/tests/test_telegram_proxy.py
@@ -124,7 +124,7 @@ async def test_backup_connect_passes_proxy_kwargs():
     _, _, TelegramBackup = _get_telegram_classes()
 
     db = AsyncMock()
-    backup = TelegramBackup(config, db)
+    backup = TelegramBackup(config, db, account_id=1)
 
     client = AsyncMock()
     client.session = SimpleNamespace(_conn=None)
@@ -172,7 +172,7 @@ async def test_listener_connect_passes_proxy_kwargs():
 
     db = AsyncMock()
     db.get_all_chats.return_value = []
-    listener = TelegramListener(config, db)
+    listener = TelegramListener(config, db, account_id=1)
 
     client = AsyncMock()
     client.is_user_authorized.return_value = True

--- a/tests/test_viewer_on_8_0_schema.py
+++ b/tests/test_viewer_on_8_0_schema.py
@@ -1,0 +1,446 @@
+"""The viewer runs UNTOUCHED on the 8.0 multi-account schema.
+
+The 8.0 contract says every adapter method the web viewer calls is
+OPTIONAL-UNSCOPED (``account_id: int | None = None``), so ``src/web/`` needs no
+edits when the primary keys gain ``account_id``. That claim is only worth
+something if it is pinned against the real schema: this suite builds its
+database with ``alembic upgrade head`` from this tree — never
+``Base.metadata.create_all`` — seeds it through the ORM models with
+``account_id=1`` (the row migration 022 itself seeds), and drives the real
+FastAPI app over ASGI with a real ``DatabaseAdapter``. Any viewer route that
+starts requiring ``account_id`` surfaces here as a TypeError-backed 500.
+
+The deployed MCP server (telegram-archive-mcp, a separate repo) fronts these
+same HTTP endpoints, so this file is also the MCP-surface baseline: no MCP
+module exists under ``src/``.
+"""
+
+import hashlib
+import inspect
+import json
+import os
+import shutil
+import tempfile
+import unittest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+import sqlalchemy as sa
+from alembic.config import Config as AlembicConfig
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.orm import Session
+
+from alembic import command
+
+os.environ.setdefault("BACKUP_PATH", tempfile.mkdtemp(prefix="ta_test_v8_viewer_"))
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Chat, Media, Message, Reaction, ViewerAccount
+from src.web import main as web_main
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+CHAT_A = -1001000000001
+CHAT_B = 77001
+BASE_DATE = datetime(2026, 3, 1, 12, 0, 0)
+
+VIEWER_USERNAME = "stage-verify-viewer"
+VIEWER_PASSWORD = "viewer-pass@test/value"  # obvious fake
+VIEWER_SALT = "stage-verify-salt"
+
+# The 21 OPTIONAL-UNSCOPED reads from the 8.0 contract manifest. Every method
+# here must keep ``account_id`` keyword-only WITH default None: the moment one
+# grows a required account_id, src/web/ (and the deployed MCP server fronting
+# it) breaks without any web code having changed.
+OPTIONAL_UNSCOPED_METHODS = (
+    "get_all_chats",
+    "get_chat_count",
+    "get_messages_by_date_range",
+    "find_message_by_date",
+    "sender_has_message_in_chats",
+    "get_message_versions",
+    "get_message_versions_by_date_range",
+    "iter_message_versions_for_export",
+    "get_chat_stats",
+    "get_media_paginated",
+    "get_media_counts",
+    "get_reactions",
+    "get_messages_paginated",
+    "get_message_dates",
+    "find_message_by_date_with_joins",
+    "get_chat_by_id",
+    "get_pinned_messages",
+    "get_messages_for_export",
+    "get_forum_topics",
+    "get_all_folders",
+    "get_archived_chat_count",
+)
+
+
+def _upgrade_to_head(sync_url: str) -> None:
+    """Run this tree's real Alembic environment against ``sync_url``."""
+    config = AlembicConfig()
+    config.set_main_option("script_location", str(REPO_ROOT / "alembic"))
+    config.set_main_option("sqlalchemy.url", sync_url)
+    previous = os.environ.get("DATABASE_URL")
+    os.environ["DATABASE_URL"] = sync_url
+    try:
+        command.upgrade(config, "head")
+    finally:
+        if previous is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = previous
+
+
+def _seed(sync_url: str) -> None:
+    """Two chats, colliding message ids, two media rows, one reaction, one viewer.
+
+    Message id 1..5 exists in BOTH chats on purpose: on the 7.x schema that
+    violated the (id, chat_id) key ordering assumptions nowhere, but on 8.0 it
+    exercises PK (account_id, chat_id, id) directly.
+    """
+    engine = sa.create_engine(sync_url)
+    try:
+        with Session(engine) as session:
+            session.add(Chat(account_id=1, id=CHAT_A, type="channel", title="Synthetic Alpha", username="synth_alpha"))
+            session.add(
+                Chat(account_id=1, id=CHAT_B, type="private", first_name="Beta", last_name="T", username="synth_beta")
+            )
+            for i in range(1, 31):
+                session.add(
+                    Message(
+                        account_id=1,
+                        id=i,
+                        chat_id=CHAT_A,
+                        date=BASE_DATE + timedelta(minutes=i),
+                        text="the needle hides here" if i == 7 else f"alpha message {i}",
+                    )
+                )
+            for i in range(1, 6):
+                session.add(
+                    Message(
+                        account_id=1,
+                        id=i,
+                        chat_id=CHAT_B,
+                        date=BASE_DATE + timedelta(hours=1, minutes=i),
+                        text=f"beta message {i}",
+                    )
+                )
+            session.add(
+                Media(
+                    account_id=1,
+                    id=f"{CHAT_A}_30_photo",
+                    message_id=30,
+                    chat_id=CHAT_A,
+                    type="photo",
+                    file_path=f"{CHAT_A}/30_photo.jpg",
+                    file_name="30_photo.jpg",
+                    file_size=3,
+                    mime_type="image/jpeg",
+                    downloaded=1,
+                )
+            )
+            # Not yet downloaded: the gallery and the counts endpoint must both
+            # keep filtering it out on the 8.0 schema.
+            session.add(
+                Media(
+                    account_id=1,
+                    id=f"{CHAT_A}_29_document",
+                    message_id=29,
+                    chat_id=CHAT_A,
+                    type="document",
+                    file_name="pending.bin",
+                    file_size=9,
+                    downloaded=0,
+                )
+            )
+            session.add(Reaction(account_id=1, message_id=30, chat_id=CHAT_A, emoji="\U0001f44d", count=2))
+            password_hash = hashlib.pbkdf2_hmac("sha256", VIEWER_PASSWORD.encode(), VIEWER_SALT.encode(), 600_000).hex()
+            session.add(
+                ViewerAccount(
+                    username=VIEWER_USERNAME,
+                    password_hash=password_hash,
+                    salt=VIEWER_SALT,
+                    allowed_chat_ids=None,
+                    is_active=1,
+                )
+            )
+            session.commit()
+    finally:
+        engine.dispose()
+
+
+class TestViewerOn80Schema(unittest.IsolatedAsyncioTestCase):
+    """End-to-end viewer checks against an alembic-built 8.0 SQLite database."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.root = Path(tempfile.mkdtemp(prefix="ta_v8_viewer_"))
+        cls.addClassCleanup(shutil.rmtree, cls.root, ignore_errors=True)
+        cls.db_path = cls.root / "telegram_backup.db"
+        cls.media_root = cls.root / "media"
+        (cls.media_root / str(CHAT_A)).mkdir(parents=True)
+        (cls.media_root / str(CHAT_A) / "30_photo.jpg").write_bytes(b"jpg")
+
+        sync_url = f"sqlite:///{cls.db_path}"
+        _upgrade_to_head(sync_url)
+        _seed(sync_url)
+
+    async def asyncSetUp(self):
+        self.manager = DatabaseManager(f"sqlite+aiosqlite:///{self.db_path}")
+        await self.manager.init()
+        self.adapter = DatabaseAdapter(self.manager)
+
+        self._saved = {
+            "db": web_main.db,
+            "auth_enabled": web_main.AUTH_ENABLED,
+            "allow_anonymous": web_main.ALLOW_ANONYMOUS_VIEWER,
+            "sessions": dict(web_main._sessions),
+            "login_attempts": dict(web_main._login_attempts),
+            "display_chat_ids": web_main.config.display_chat_ids,
+            "media_path": web_main.config.media_path,
+            "media_root": web_main._media_root,
+            "avatar_cache": dict(web_main._avatar_cache),
+            "avatar_cache_time": web_main._avatar_cache_time,
+            "chat_stats_cache": dict(web_main._chat_stats_cache),
+        }
+        web_main.db = self.adapter
+        web_main.AUTH_ENABLED = True
+        web_main.ALLOW_ANONYMOUS_VIEWER = False
+        web_main._sessions.clear()
+        web_main._login_attempts.clear()
+        web_main.config.display_chat_ids = set()
+        web_main.config.media_path = str(self.media_root)
+        web_main._media_root = self.media_root.resolve()
+        web_main._avatar_cache.clear()
+        web_main._avatar_cache_time = None
+        web_main._chat_stats_cache.clear()
+
+    async def asyncTearDown(self):
+        web_main.db = self._saved["db"]
+        web_main.AUTH_ENABLED = self._saved["auth_enabled"]
+        web_main.ALLOW_ANONYMOUS_VIEWER = self._saved["allow_anonymous"]
+        web_main._sessions.clear()
+        web_main._sessions.update(self._saved["sessions"])
+        web_main._login_attempts.clear()
+        web_main._login_attempts.update(self._saved["login_attempts"])
+        web_main.config.display_chat_ids = self._saved["display_chat_ids"]
+        web_main.config.media_path = self._saved["media_path"]
+        web_main._media_root = self._saved["media_root"]
+        web_main._avatar_cache.clear()
+        web_main._avatar_cache.update(self._saved["avatar_cache"])
+        web_main._avatar_cache_time = self._saved["avatar_cache_time"]
+        web_main._chat_stats_cache.clear()
+        web_main._chat_stats_cache.update(self._saved["chat_stats_cache"])
+        await self.manager.close()
+
+    def _client(self) -> AsyncClient:
+        return AsyncClient(transport=ASGITransport(app=web_main.app), base_url="http://test")
+
+    async def _login(self, client: AsyncClient) -> str:
+        resp = await client.post("/api/login", json={"username": VIEWER_USERNAME, "password": VIEWER_PASSWORD})
+        self.assertEqual(resp.status_code, 200, resp.text)
+        token = resp.cookies.get("viewer_auth")
+        self.assertTrue(token)
+        return token
+
+    def test_schema_came_from_alembic_and_seeded_the_default_account(self):
+        """The fixture DB is migration-built: version stamped, account (1, 'default') present, refs minted."""
+        engine = sa.create_engine(f"sqlite:///{self.db_path}")
+        try:
+            with engine.connect() as conn:
+                version = conn.execute(sa.text("SELECT version_num FROM alembic_version")).scalar()
+                accounts = conn.execute(sa.text("SELECT id, label FROM accounts")).fetchall()
+                refs = conn.execute(sa.text("SELECT ref FROM chats")).scalars().all()
+        finally:
+            engine.dispose()
+        self.assertIsNotNone(version)
+        self.assertEqual(accounts, [(1, "default")])
+        # The ORM minted a distinct opaque ref per chat on INSERT (phase 4 currency).
+        self.assertEqual(len(refs), 2)
+        self.assertEqual(len(set(refs)), 2)
+        self.assertTrue(all(ref for ref in refs))
+
+    async def test_login_persists_a_session_and_auth_check_accepts_it(self):
+        async with self._client() as client:
+            token = await self._login(client)
+
+            row = await self.adapter.get_session(token)
+            self.assertIsNotNone(row)
+            self.assertEqual(row["username"], VIEWER_USERNAME)
+            self.assertEqual(row["role"], "viewer")
+
+            resp = await client.get("/api/auth/check")
+            self.assertEqual(resp.status_code, 200, resp.text)
+            data = resp.json()
+            self.assertTrue(data["authenticated"])
+            self.assertEqual(data["username"], VIEWER_USERNAME)
+
+    async def test_chat_list_returns_both_chats(self):
+        async with self._client() as client:
+            await self._login(client)
+            resp = await client.get("/api/chats")
+            self.assertEqual(resp.status_code, 200, resp.text)
+            data = resp.json()
+            self.assertEqual(data["total"], 2)
+            by_id = {chat["id"]: chat for chat in data["chats"]}
+            self.assertEqual(set(by_id), {CHAT_A, CHAT_B})
+            self.assertEqual(by_id[CHAT_A]["title"], "Synthetic Alpha")
+            self.assertEqual(by_id[CHAT_B]["username"], "synth_beta")
+            self.assertFalse(data["has_more"])
+
+    async def test_message_pagination_offset_and_cursor_agree(self):
+        async with self._client() as client:
+            await self._login(client)
+
+            resp = await client.get(f"/api/chats/{CHAT_A}/messages", params={"limit": 10})
+            self.assertEqual(resp.status_code, 200, resp.text)
+            page1 = resp.json()
+            self.assertEqual([m["id"] for m in page1], list(range(30, 20, -1)))
+
+            resp = await client.get(f"/api/chats/{CHAT_A}/messages", params={"limit": 10, "offset": 10})
+            self.assertEqual(resp.status_code, 200, resp.text)
+            page2 = resp.json()
+            self.assertEqual([m["id"] for m in page2], list(range(20, 10, -1)))
+
+            # Cursor mode (the infinite-scroll path) must land on the same rows.
+            oldest = page1[-1]
+            resp = await client.get(
+                f"/api/chats/{CHAT_A}/messages",
+                params={"limit": 10, "before_date": oldest["date"], "before_id": oldest["id"]},
+            )
+            self.assertEqual(resp.status_code, 200, resp.text)
+            self.assertEqual([m["id"] for m in resp.json()], [m["id"] for m in page2])
+
+    async def test_message_search_returns_only_the_matching_row(self):
+        async with self._client() as client:
+            await self._login(client)
+            resp = await client.get(f"/api/chats/{CHAT_A}/messages", params={"search": "needle"})
+            self.assertEqual(resp.status_code, 200, resp.text)
+            hits = resp.json()
+            self.assertEqual([m["id"] for m in hits], [7])
+            self.assertIn("needle", hits[0]["text"])
+
+    async def test_chat_search_matches_username(self):
+        async with self._client() as client:
+            await self._login(client)
+            resp = await client.get("/api/chats", params={"search": "synth_beta"})
+            self.assertEqual(resp.status_code, 200, resp.text)
+            self.assertEqual([chat["id"] for chat in resp.json()["chats"]], [CHAT_B])
+
+    async def test_media_listing_resolves_and_original_bytes_are_served(self):
+        async with self._client() as client:
+            await self._login(client)
+
+            resp = await client.get(f"/api/chats/{CHAT_A}/media")
+            self.assertEqual(resp.status_code, 200, resp.text)
+            items = resp.json()["items"]
+            # Exactly one: the seeded downloaded=0 document must stay filtered out.
+            self.assertEqual(len(items), 1)
+            item = items[0]
+            self.assertEqual(item["id"], f"{CHAT_A}_30_photo")
+            self.assertEqual(item["media_url"], f"/media/{CHAT_A}/30_photo.jpg")
+
+            resp = await client.get(item["media_url"])
+            self.assertEqual(resp.status_code, 200, resp.text)
+            self.assertEqual(resp.content, b"jpg")
+
+            # The message payload nests the same media row and its reaction —
+            # the joins that now carry Media.account_id == Message.account_id.
+            resp = await client.get(f"/api/chats/{CHAT_A}/messages", params={"limit": 1})
+            self.assertEqual(resp.status_code, 200, resp.text)
+            top = resp.json()[0]
+            self.assertEqual(top["id"], 30)
+            self.assertEqual(top["media"]["id"], f"{CHAT_A}_30_photo")
+            self.assertEqual(top["reactions"], [{"emoji": "\U0001f44d", "count": 2, "user_ids": []}])
+
+    def test_every_viewer_read_keeps_account_id_optional(self):
+        """The OPTIONAL-UNSCOPED contract, pinned at the signature level.
+
+        The route sweeps below only prove the paths they drive; this proves the
+        whole classified surface, including reads the CLI export uses.
+        """
+        for name in OPTIONAL_UNSCOPED_METHODS:
+            with self.subTest(method=name):
+                params = inspect.signature(getattr(DatabaseAdapter, name)).parameters
+                self.assertIn("account_id", params)
+                param = params["account_id"]
+                self.assertIs(param.kind, inspect.Parameter.KEYWORD_ONLY)
+                self.assertIsNone(param.default)
+
+    async def test_remaining_read_routes_answer_200_with_correct_aggregates(self):
+        """The read surface beyond the five headline paths: no hidden 500s.
+
+        Every handler here wraps adapter calls in an except-all that turns a
+        TypeError into a 500, so status 200 is exactly the no-missing-kwarg
+        check.
+        """
+        async with self._client() as client:
+            await self._login(client)
+
+            resp = await client.get("/api/stats")
+            self.assertEqual(resp.status_code, 200, resp.text)
+
+            resp = await client.get("/api/folders")
+            self.assertEqual(resp.status_code, 200, resp.text)
+            self.assertEqual(resp.json()["folders"], [])
+
+            resp = await client.get(f"/api/chats/{CHAT_A}/topics")
+            self.assertEqual(resp.status_code, 200, resp.text)
+            self.assertEqual(resp.json()["topics"], [])
+
+            resp = await client.get(f"/api/chats/{CHAT_A}/pinned")
+            self.assertEqual(resp.status_code, 200, resp.text)
+            self.assertEqual(resp.json(), [])
+
+            resp = await client.get("/api/archived/count")
+            self.assertEqual(resp.status_code, 200, resp.text)
+            self.assertEqual(resp.json()["count"], 0)
+
+            resp = await client.get(f"/api/chats/{CHAT_A}/media/counts")
+            self.assertEqual(resp.status_code, 200, resp.text)
+            self.assertEqual(resp.json(), {"photo": 1})
+
+            resp = await client.get(f"/api/chats/{CHAT_A}/messages/30/versions")
+            self.assertEqual(resp.status_code, 200, resp.text)
+            self.assertEqual(resp.json(), [])
+
+            resp = await client.get(f"/api/chats/{CHAT_A}/stats")
+            self.assertEqual(resp.status_code, 200, resp.text)
+            stats = resp.json()
+            self.assertEqual(stats["messages"], 30)
+            # Chat stats count media RECORDS (pending included) — unlike the
+            # gallery and /media/counts, which filter to downloaded=1.
+            self.assertEqual(stats["media_files"], 2)
+
+    async def test_date_navigation_and_export_stream(self):
+        async with self._client() as client:
+            await self._login(client)
+
+            resp = await client.get(
+                f"/api/chats/{CHAT_A}/messages/by-date",
+                params={"date": "2026-03-01", "timezone": "UTC"},
+            )
+            self.assertEqual(resp.status_code, 200, resp.text)
+            self.assertEqual(resp.json()["id"], 1)
+
+            resp = await client.get(
+                f"/api/chats/{CHAT_A}/messages/dates",
+                params={"month": "2026-03", "timezone": "UTC"},
+            )
+            self.assertEqual(resp.status_code, 200, resp.text)
+            self.assertEqual(resp.json()["dates"], ["2026-03-01"])
+
+            resp = await client.get(f"/api/chats/{CHAT_A}/export")
+            self.assertEqual(resp.status_code, 200, resp.text)
+            export = json.loads(resp.text)
+            self.assertEqual(export["chat"]["id"], CHAT_A)
+            self.assertEqual(len(export["messages"]), 30)
+            self.assertEqual(export["message_versions"], [])

--- a/tests/test_viewer_on_8_0_schema.py
+++ b/tests/test_viewer_on_8_0_schema.py
@@ -37,7 +37,8 @@ from sqlalchemy.orm import Session
 
 from alembic import command
 
-os.environ.setdefault("BACKUP_PATH", tempfile.mkdtemp(prefix="ta_test_v8_viewer_"))
+if not os.environ.get("BACKUP_PATH"):
+    os.environ["BACKUP_PATH"] = tempfile.mkdtemp(prefix="ta_test_v8_viewer_")
 
 from src.db.adapter import DatabaseAdapter
 from src.db.base import DatabaseManager


### PR DESCRIPTION
## The problem

One archive, many Telegram accounts — one container, one database, one media volume. Today that is impossible: all seventeen tables are keyed by `chat_id`, and `chat_id` is **not** unique across accounts. A decorative `account_id` column is not enough, and we proved it three ways on real schemas before designing this: a shared supergroup loses the second account's copy and then lies about `is_outgoing`; colliding dialog-filter ids destroy the first account's folders; `UNIQUE(change_hash)` silently discards the second account's entire edit history.

## What this PR does

The account dimension becomes part of identity, in two commits:

**Migration 022 + the 8.0 models.** A three-column `accounts` table seeded `(1, 'default')` so every existing archive *is* account 1. `account_id` leads the primary keys of `chats`, `messages`, `sync_status`, `forum_topics`, `chat_folders`, `chat_folder_members`, `media`, and enters `uq_reaction` and `uq_message_versions_change_hash`. `chats.ref` — a random unique token minted at insert — is what the viewer's URLs and entitlements will speak in the next stage. `allowed_accounts`/`allowed_chat_refs` land as **new nullable columns** beside the old grant column, so an unconverted 7.x row can only fail closed; restricted grants are converted by the migration itself, sessions and push subscriptions are **converted, not deleted** — nobody gets logged out. Media stays exactly where it is on disk.

**The threading.** All seven `ON CONFLICT` targets lead with `account_id`, and every INSERT supplies it in VALUES — with a server-defaulted PK column, omitting it makes SQLAlchemy append `RETURNING`, which flips what rowcount means on the DO-NOTHING path and silently drops message edits (reproduced, then pinned by test). 31 capture-side adapter methods take keyword-only `account_id` with no default, so a missed caller is a `TypeError`, not a silent write into someone else's archive; 21 viewer-facing reads take an optional scope, so **`src/web/` is untouched** (verified: zero-line diff, plus a pinned viewer test-drive against a real migrated 8.0 database). `detect_message_gaps` and the media-repair keyset are account-scoped — measured on both backends, an account-blind LAG window swallows a real 300-message gap when two accounts' id sequences interleave.

## Why the migration can be trusted with the only copy of someone's history

- **Crash matrix**: interrupted before every statement it issues — 225 SQLite + 19 PostgreSQL kill points, plus a 120-point independent re-run — every interrupted state leaves rows byte-identical, `alembic_version` unmoved, no scaffold tables; every replay converges.
- **Seven real upgrade shapes** built from `main`'s own code (create_all-provisioned through the shipped entrypoint ladder extracted verbatim, alembic-provisioned at head and at old revisions 005/014, both backends), digested row-by-row, column-by-column: byte-identical, zero rows deleted.
- **All nine foreign keys recreated by name** and asserted from `pg_constraint`/`sqlite_master` directly. The obvious `DROP … CASCADE` shortcut was reproduced silently deleting three FKs with only a NOTICE — this migration never uses CASCADE, and a mutant that skips one recreation makes the migration's own guard raise and roll back to 021.
- **SQLite rebuilds declare their constraints** rather than inherit reflected ones (the inherited path reproduces the `foreign key mismatch` the design review measured) and replay index DDL verbatim so `DESC` orderings survive.
- **Prechecks refuse loudly**: ~3× free disk (measured — WAL cannot checkpoint inside the transaction) and exclusive access via `locking_mode=EXCLUSIVE` on the working connection (a second-connection probe false-positives on WAL — measured, tested in both directions). An upgrade needs `docker compose stop` first; the migration self-heals once the viewer stops.
- `downgrade()` refuses by design: once a second account exists the old keys cannot identify a row. The way back is the pre-upgrade backup, and the release notes will say so.
- **14/14 migration mutants red**, including the transaction-anchor and stamping-ladder controls; the entrypoint ladder deliberately gains **no** 022 rung, with the reasoning in both blocks, proven by a no-op run over a create_all-provisioned 8.0 schema.

## Isolation, proven not assumed

`tests/test_account_isolation.py`: 22 tests on **real engines, both backends** — same message coordinates under two accounts coexist; same `change_hash` both survive; same chat id gives two rows with distinct refs; account 2's sweep cannot move account 1's cursor; account 1's gap is reported even with account 2's ids interleaved. Positive controls: stripping the scoping from a shipped method in a throwaway copy turns the suite red — re-executed independently by the review lane.

## Verification of the whole

Full suite with a real PostgreSQL service, run three times by three different actors (integrator, independent reviewer, and once more after rebasing onto current `main` absorbing #292/#294/#296/#297/#298): **3184 passed, 0 failed, 0 skipped**. AST audit: 55/55 call sites of keyword-required methods pass `account_id` explicitly, zero splats; composition seams pinned through the real constructor chain with mutation-proven reds. `ruff check` and `format --check` clean. Versions untouched at 7.33.6 — the single 8.0.0 bump comes at the end of the programme.

Still single-account at runtime: every writer passes account 1. The viewer's `chat_ref` move and the indexed env-var accounts are the next two stages.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added multi-account support, isolating chats, messages, media, reactions, folders, and synchronization data.
  - Added account-specific viewer access controls.
  - Added stable, opaque chat references for account-scoped access.
  - Existing setups continue using a default account automatically.

- **Bug Fixes**
  - Prevented cross-account identifier collisions and data mixing.
  - Improved media repair and deduplication accuracy.

- **Security**
  - Migration errors no longer expose bound parameter values in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->