### PR TITLE
feat!: the viewer speaks chat_ref, and entitlements fail closed

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1757,17 +1757,17 @@ class DatabaseAdapter:
             result = await session.execute(stmt)
             return {row[0]: row[1] for row in result.all()}
 
-    async def get_media_by_id(self, media_id: str, *, account_id: int | None = None) -> dict[str, Any] | None:
+    async def get_media_by_id(self, media_id: str, *, account_id: int) -> dict[str, Any] | None:
         """Get one media row by its ``{chat_id}_{message_id}_{type}`` storage key.
 
         Phase 4: the ref-addressed media routes reconstruct this key from a
         resolved chat plus the URL's ``{message_id}_{type}`` suffix, then serve
         the row's ``file_path`` — the URL itself never carries the chat id.
+        The account is required: the storage key is only unique per account,
+        so an unscoped lookup could raise on — or leak — another account's row.
         """
         async with self.db_manager.async_session_factory() as session:
-            stmt = select(Media).where(Media.id == media_id)
-            if account_id is not None:
-                stmt = stmt.where(Media.account_id == account_id)
+            stmt = select(Media).where(and_(Media.account_id == account_id, Media.id == media_id))
             result = await session.execute(stmt)
             media = result.scalar_one_or_none()
             if not media:

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -86,6 +86,34 @@ def _has_raw_payload(value: Any) -> bool:
     return bool(value) and value != "{}"
 
 
+def parse_entitlement_column(raw: str | None, element_type: type) -> set | None:
+    """Read one v8.0.0 entitlement column (allowed_accounts / allowed_chat_refs) fail-closed.
+
+    The reader half of migration 022's converter, shared by the viewer and the
+    push filter so the two can never diverge. NULL means "no restriction" and
+    returns None. A well-formed JSON list whose every element is exactly
+    ``element_type`` returns that set — including the empty set, which denies
+    everything. ANY other payload (unparseable JSON, a non-list, a list with a
+    foreign element) also returns the empty set: a grant that cannot be read
+    must deny, never widen. bool is excluded from int on purpose — True would
+    otherwise read as account 1.
+    """
+    if raw is None:
+        return None
+    try:
+        parsed = json.loads(raw)
+    except TypeError, ValueError:
+        return set()
+    if not isinstance(parsed, list):
+        return set()
+    values = set()
+    for element in parsed:
+        if not isinstance(element, element_type) or isinstance(element, bool):
+            return set()
+        values.add(element)
+    return values
+
+
 # Message columns an upsert may refresh ONLY when the writer actually supplied
 # the key. ``_message_values`` materialises every column with a ``.get()``
 # default, so an absent key is indistinguishable from an explicit NULL by the
@@ -791,6 +819,8 @@ class DatabaseAdapter:
             for row in result:
                 chat_dict = {
                     "id": row.Chat.id,
+                    "account_id": row.Chat.account_id,
+                    "ref": row.Chat.ref,
                     "type": row.Chat.type,
                     "title": row.Chat.title,
                     "username": row.Chat.username,
@@ -1112,6 +1142,24 @@ class DatabaseAdapter:
             if len(chat_ids) > 1:
                 logger.warning(f"Message {message_id} found in {len(chat_ids)} chats, skipping ambiguous deletion")
             return None
+
+    async def get_message_sender_id(
+        self, chat_id: int, message_id: int, *, account_id: int | None = None
+    ) -> int | None:
+        """Sender of one message, or None when the message is absent or senderless.
+
+        Phase 4: the ref-addressed sender-avatar route
+        (``/media/avatar/{chat_ref}/{message_id}``) resolves the sender through
+        the message so no user id has to appear in the URL — for a private chat
+        the peer's user id IS the chat id, which must stay out of access logs.
+        """
+        async with self.db_manager.async_session_factory() as session:
+            stmt = select(Message.sender_id).where(and_(Message.chat_id == chat_id, Message.id == message_id))
+            if account_id is not None:
+                stmt = stmt.where(Message.account_id == account_id)
+            result = await session.execute(stmt)
+            row = result.first()
+            return row[0] if row else None
 
     @retry_on_locked()
     async def update_message_text(
@@ -1708,6 +1756,34 @@ class DatabaseAdapter:
                 stmt = stmt.where(Media.account_id == account_id)
             result = await session.execute(stmt)
             return {row[0]: row[1] for row in result.all()}
+
+    async def get_media_by_id(self, media_id: str, *, account_id: int | None = None) -> dict[str, Any] | None:
+        """Get one media row by its ``{chat_id}_{message_id}_{type}`` storage key.
+
+        Phase 4: the ref-addressed media routes reconstruct this key from a
+        resolved chat plus the URL's ``{message_id}_{type}`` suffix, then serve
+        the row's ``file_path`` — the URL itself never carries the chat id.
+        """
+        async with self.db_manager.async_session_factory() as session:
+            stmt = select(Media).where(Media.id == media_id)
+            if account_id is not None:
+                stmt = stmt.where(Media.account_id == account_id)
+            result = await session.execute(stmt)
+            media = result.scalar_one_or_none()
+            if not media:
+                return None
+            return {
+                "id": media.id,
+                "account_id": media.account_id,
+                "message_id": media.message_id,
+                "chat_id": media.chat_id,
+                "type": media.type,
+                "file_path": media.file_path,
+                "file_name": media.file_name,
+                "file_size": media.file_size,
+                "mime_type": media.mime_type,
+                "downloaded": media.downloaded,
+            }
 
     async def delete_media_for_chat(self, chat_id: int, *, account_id: int) -> int:
         """
@@ -2848,6 +2924,24 @@ class DatabaseAdapter:
 
             return msg
 
+    @staticmethod
+    def _chat_row_to_dict(chat: Chat) -> dict[str, Any]:
+        return {
+            "id": chat.id,
+            "account_id": chat.account_id,
+            "ref": chat.ref,
+            "type": chat.type,
+            "title": chat.title,
+            "username": chat.username,
+            "first_name": chat.first_name,
+            "last_name": chat.last_name,
+            "phone": chat.phone,
+            "description": chat.description,
+            "participants_count": chat.participants_count,
+            "is_forum": chat.is_forum,
+            "is_archived": chat.is_archived,
+        }
+
     async def get_chat_by_id(self, chat_id: int, *, account_id: int | None = None) -> dict[str, Any] | None:
         """Get a single chat by ID (None account_id = unscoped until phase 4)."""
         async with self.db_manager.async_session_factory() as session:
@@ -2858,19 +2952,27 @@ class DatabaseAdapter:
             chat = result.scalar_one_or_none()
             if not chat:
                 return None
-            return {
-                "id": chat.id,
-                "type": chat.type,
-                "title": chat.title,
-                "username": chat.username,
-                "first_name": chat.first_name,
-                "last_name": chat.last_name,
-                "phone": chat.phone,
-                "description": chat.description,
-                "participants_count": chat.participants_count,
-                "is_forum": chat.is_forum,
-                "is_archived": chat.is_archived,
-            }
+            return self._chat_row_to_dict(chat)
+
+    async def get_chat_by_ref(self, ref: str, *, account_id: int | None = None) -> dict[str, Any] | None:
+        """Resolve an opaque chat ref to its chat row, or None when no chat carries it.
+
+        The viewer's phase-4 resolver: ``chats.ref`` is globally UNIQUE
+        (uq_chats_ref spans accounts), so a bare ref names exactly one
+        (account_id, chat_id) pair. The parameterised equality on a VARCHAR(22)
+        makes any malformed or oversized candidate a plain index miss — one code
+        path for well-formed-unknown and garbage alike, so response timing does
+        not classify the input.
+        """
+        async with self.db_manager.async_session_factory() as session:
+            stmt = select(Chat).where(Chat.ref == ref)
+            if account_id is not None:
+                stmt = stmt.where(Chat.account_id == account_id)
+            result = await session.execute(stmt)
+            chat = result.scalar_one_or_none()
+            if not chat:
+                return None
+            return self._chat_row_to_dict(chat)
 
     async def get_pinned_messages(self, chat_id: int, *, account_id: int | None = None) -> list[dict[str, Any]]:
         """Get all pinned messages for a chat, ordered by date descending (newest first).
@@ -3415,14 +3517,24 @@ class DatabaseAdapter:
         created_by: str | None = None,
         is_active: int = 1,
         no_download: int = 0,
+        allowed_accounts: str | None = None,
+        allowed_chat_refs: str | None = None,
     ) -> dict[str, Any]:
-        """Create a new viewer account. Returns the created account dict."""
+        """Create a new viewer account. Returns the created account dict.
+
+        ``allowed_accounts``/``allowed_chat_refs`` are the v8.0.0 grant columns
+        (JSON lists, NULL = unrestricted). ``allowed_chat_ids`` survives as
+        rollback data only: 8.0 code never reads it, and restricted callers
+        write ``"[]"`` there so a 7.x rollback denies instead of failing open.
+        """
         async with self.db_manager.async_session_factory() as session:
             account = ViewerAccount(
                 username=username,
                 password_hash=password_hash,
                 salt=salt,
                 allowed_chat_ids=allowed_chat_ids,
+                allowed_accounts=allowed_accounts,
+                allowed_chat_refs=allowed_chat_refs,
                 created_by=created_by,
                 is_active=is_active,
                 no_download=no_download,
@@ -3480,6 +3592,8 @@ class DatabaseAdapter:
             "password_hash": account.password_hash,
             "salt": account.salt,
             "allowed_chat_ids": account.allowed_chat_ids,
+            "allowed_accounts": account.allowed_accounts,
+            "allowed_chat_refs": account.allowed_chat_refs,
             "is_active": account.is_active,
             "no_download": account.no_download,
             "created_by": account.created_by,
@@ -3564,14 +3678,23 @@ class DatabaseAdapter:
         last_accessed: float,
         no_download: int = 0,
         source_token_id: int | None = None,
+        allowed_accounts: str | None = None,
+        allowed_chat_refs: str | None = None,
     ) -> None:
-        """Save or update a session in the database."""
+        """Save or update a session in the database.
+
+        ``allowed_accounts``/``allowed_chat_refs`` carry the v8.0.0 grant;
+        ``allowed_chat_ids`` is the 7.x rollback tombstone ("[]" for restricted
+        sessions, NULL for unrestricted) and is never read back by 8.0 code.
+        """
         async with self.db_manager.async_session_factory() as session:
             values = {
                 "token": token,
                 "username": username,
                 "role": role,
                 "allowed_chat_ids": allowed_chat_ids,
+                "allowed_accounts": allowed_accounts,
+                "allowed_chat_refs": allowed_chat_refs,
                 "no_download": no_download,
                 "source_token_id": source_token_id,
                 "created_at": created_at,
@@ -3647,6 +3770,8 @@ class DatabaseAdapter:
             "username": row.username,
             "role": row.role,
             "allowed_chat_ids": row.allowed_chat_ids,
+            "allowed_accounts": row.allowed_accounts,
+            "allowed_chat_refs": row.allowed_chat_refs,
             "no_download": row.no_download,
             "source_token_id": row.source_token_id,
             "created_at": row.created_at,
@@ -3667,8 +3792,15 @@ class DatabaseAdapter:
         allowed_chat_ids: str,
         no_download: int = 0,
         expires_at: datetime | None = None,
+        allowed_accounts: str | None = None,
+        allowed_chat_refs: str | None = None,
     ) -> dict[str, Any]:
-        """Create a new share token. Returns the created token dict."""
+        """Create a new share token. Returns the created token dict.
+
+        ``allowed_chat_refs`` is the v8.0.0 grant; ``allowed_chat_ids`` (a NOT
+        NULL column) takes the "[]" rollback tombstone so a 7.x binary reading
+        this row denies rather than fails open. 8.0 code never reads it.
+        """
         async with self.db_manager.async_session_factory() as session:
             token = ViewerToken(
                 label=label,
@@ -3676,6 +3808,8 @@ class DatabaseAdapter:
                 token_salt=token_salt,
                 created_by=created_by,
                 allowed_chat_ids=allowed_chat_ids,
+                allowed_accounts=allowed_accounts,
+                allowed_chat_refs=allowed_chat_refs,
                 no_download=no_download,
                 expires_at=expires_at,
             )
@@ -3715,7 +3849,14 @@ class DatabaseAdapter:
             token = result.scalar_one_or_none()
             if not token:
                 return None
-            allowed_fields = {"label", "allowed_chat_ids", "is_revoked", "no_download"}
+            allowed_fields = {
+                "label",
+                "allowed_chat_ids",
+                "allowed_accounts",
+                "allowed_chat_refs",
+                "is_revoked",
+                "no_download",
+            }
             for key, value in kwargs.items():
                 if key in allowed_fields:
                     setattr(token, key, value)
@@ -3739,6 +3880,8 @@ class DatabaseAdapter:
             "token_salt": token.token_salt,
             "created_by": token.created_by,
             "allowed_chat_ids": token.allowed_chat_ids,
+            "allowed_accounts": token.allowed_accounts,
+            "allowed_chat_refs": token.allowed_chat_refs,
             "is_revoked": token.is_revoked,
             "no_download": token.no_download,
             "expires_at": token.expires_at.isoformat() if token.expires_at else None,

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -32,9 +32,10 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from ..config import Config
 from ..db import DatabaseAdapter, close_database, get_db_manager, init_database
+from ..db.adapter import parse_entitlement_column
 from ..message_utils import describe_exception, media_display_filename
 from ..realtime import RealtimeListener
-from .media_utils import THUMBNAIL_EXTENSIONS, legacy_folder_alternates, legacy_marked_chat_ids
+from .media_utils import THUMBNAIL_EXTENSIONS, legacy_folder_alternates
 
 if TYPE_CHECKING:
     from .push import PushNotificationManager
@@ -55,55 +56,64 @@ mimetypes.add_type("image/webp", ".webp")
 
 # WebSocket Connection Manager for real-time updates
 class ConnectionManager:
-    """Manages WebSocket connections for real-time updates."""
+    """Manages WebSocket connections for real-time updates.
+
+    Phase 4: subscriptions are keyed by the chat's opaque ref, and each socket
+    carries the UserContext it authenticated with. Entitlement for a subscribe
+    is enforced by the endpoint through the SAME resolver the HTTP routes use;
+    broadcast_to_chat re-checks the chat against the socket's context so a frame
+    can never outrun the grant it rode in on.
+    """
 
     def __init__(self):
-        self.active_connections: dict[WebSocket, set[int]] = {}
-        self._allowed_chats: dict[WebSocket, set[int] | None] = {}
+        self.active_connections: dict[WebSocket, set[str]] = {}
+        self._contexts: dict[WebSocket, UserContext] = {}
 
-    async def connect(self, websocket: WebSocket, allowed_chat_ids: set[int] | None = None):
+    async def connect(self, websocket: WebSocket, user: UserContext):
         await websocket.accept()
         self.active_connections[websocket] = set()
-        self._allowed_chats[websocket] = allowed_chat_ids
+        self._contexts[websocket] = user
         logger.info(f"WebSocket connected. Total connections: {len(self.active_connections)}")
 
     def disconnect(self, websocket: WebSocket):
         self.active_connections.pop(websocket, None)
-        self._allowed_chats.pop(websocket, None)
+        self._contexts.pop(websocket, None)
         logger.info(f"WebSocket disconnected. Total connections: {len(self.active_connections)}")
 
-    def subscribe(self, websocket: WebSocket, chat_id: int) -> bool:
-        """Subscribe a connection to updates for a specific chat. Returns False if denied by ACL."""
+    def subscribe(self, websocket: WebSocket, chat_ref: str) -> bool:
+        """Record a subscription for an already-authorized chat ref."""
         if websocket in self.active_connections:
-            allowed = self._allowed_chats.get(websocket)
-            if allowed is not None and chat_id not in allowed:
-                return False
-            self.active_connections[websocket].add(chat_id)
+            self.active_connections[websocket].add(chat_ref)
             return True
         return False
 
-    def unsubscribe(self, websocket: WebSocket, chat_id: int):
+    def unsubscribe(self, websocket: WebSocket, chat_ref: str):
         """Unsubscribe a connection from a specific chat."""
         if websocket in self.active_connections:
-            self.active_connections[websocket].discard(chat_id)
+            self.active_connections[websocket].discard(chat_ref)
 
-    async def broadcast_to_chat(self, chat_id: int, message: dict):
-        """Broadcast a message to all connections subscribed to a chat."""
+    async def broadcast_to_chat(self, chat: dict, message: dict):
+        """Broadcast a message to every connection subscribed AND entitled to ``chat``.
+
+        ``chat`` is the resolved chat row (id, account_id, ref); ``message`` is
+        the ref-addressed frame to deliver.
+        """
         disconnected = []
         # Snapshot first: send_json suspends, and a connect/disconnect landing in
         # another task during that await mutates active_connections. Iterating it
         # live raises RuntimeError at the `for`, which aborts the whole broadcast
         # and silently drops the event for every client not yet reached.
-        for websocket, subscribed_chats in list(self.active_connections.items()):
-            allowed = self._allowed_chats.get(websocket)
-            if allowed is not None and chat_id not in allowed:
+        for websocket, subscribed_refs in list(self.active_connections.items()):
+            if chat["ref"] not in subscribed_refs:
                 continue
-            if chat_id in subscribed_chats:
-                try:
-                    await websocket.send_json(message)
-                except Exception as e:
-                    logger.warning(f"Failed to send to websocket: {e}")
-                    disconnected.append(websocket)
+            user = self._contexts.get(websocket)
+            if user is None or not _chat_visible(user, chat):
+                continue
+            try:
+                await websocket.send_json(message)
+            except Exception as e:
+                logger.warning(f"Failed to send to websocket: {e}")
+                disconnected.append(websocket)
 
         # Clean up disconnected sockets
         for ws in disconnected:
@@ -208,6 +218,36 @@ realtime_listener: RealtimeListener | None = None
 push_manager: PushNotificationManager | None = None
 
 
+# The realtime/push side resolves a writer-side chat id to its row (ref, account,
+# title) once per event; a short TTL keeps a busy chat from re-querying per event.
+_broadcast_chat_cache: dict[int, tuple[float, dict | None]] = {}
+_BROADCAST_CHAT_CACHE_TTL_SECONDS = 60
+
+
+async def _broadcast_chat_row(chat_id: int) -> dict | None:
+    """Chat row for a realtime event's chat id, or None when it cannot be addressed.
+
+    The writer side (listener/backup) speaks chat ids; every outward frame and
+    push payload speaks refs. An id that resolves to no row — or ambiguously,
+    once a second account shares it (phase 5) — drops the event rather than
+    emit a frame that names a chat id.
+    """
+    if not db:
+        return None
+    cached = _broadcast_chat_cache.get(chat_id)
+    if cached is not None and time.monotonic() - cached[0] <= _BROADCAST_CHAT_CACHE_TTL_SECONDS:
+        return cached[1]
+    try:
+        chat = await db.get_chat_by_id(chat_id)
+    except Exception as e:
+        logger.warning(f"Realtime chat resolution failed ({type(e).__name__}); dropping event")
+        return None
+    if chat is not None and not chat.get("ref"):
+        chat = None
+    _broadcast_chat_cache[chat_id] = (time.monotonic(), chat)
+    return chat
+
+
 async def handle_realtime_notification(payload: dict):
     """Handle real-time notifications and broadcast to WebSocket clients + push notifications."""
     notification_type = payload.get("type")
@@ -219,17 +259,20 @@ async def handle_realtime_notification(payload: dict):
         # This viewer is restricted to specific chats, ignore notifications for other chats
         return
 
+    chat = await _broadcast_chat_row(chat_id)
+    if chat is None:
+        return
+    chat_ref = chat["ref"]
+
     if notification_type == "new_message":
         await ws_manager.broadcast_to_chat(
-            chat_id, {"type": "new_message", "chat_id": chat_id, "message": data.get("message")}
+            chat, {"type": "new_message", "chat_ref": chat_ref, "message": data.get("message")}
         )
 
         # Send Web Push notification for new messages
         if push_manager and push_manager.is_enabled:
             message = data.get("message", {})
-            # Get chat info for the notification
-            chat = await db.get_chat_by_id(chat_id) if db else None
-            chat_title = chat.get("title", "Telegram") if chat else "Telegram"
+            chat_title = chat.get("title") or "Telegram"
 
             snapshot_name = message.get("sender_name")
             sender_name = snapshot_name.strip() if isinstance(snapshot_name, str) else ""
@@ -243,18 +286,20 @@ async def handle_realtime_notification(payload: dict):
 
             await push_manager.notify_new_message(
                 chat_id=chat_id,
+                chat_ref=chat_ref,
                 chat_title=chat_title,
                 sender_name=sender_name,
                 message_text=message.get("text", "") or "[Media]",
                 message_id=message.get("id", 0),
+                account_id=chat.get("account_id"),
             )
 
     elif notification_type == "edit":
         await ws_manager.broadcast_to_chat(
-            chat_id,
+            chat,
             {
                 "type": "edit",
-                "chat_id": chat_id,
+                "chat_ref": chat_ref,
                 "message_id": data.get("message_id"),
                 "new_text": data.get("new_text"),
                 "edit_date": data.get("edit_date"),
@@ -262,10 +307,10 @@ async def handle_realtime_notification(payload: dict):
         )
     elif notification_type == "delete":
         await ws_manager.broadcast_to_chat(
-            chat_id,
+            chat,
             {
                 "type": "delete",
-                "chat_id": chat_id,
+                "chat_ref": chat_ref,
                 "message_id": data.get("message_id"),
                 "deletion_mode": data.get("deletion_mode", "hard"),
                 "deleted_at": data.get("deleted_at"),
@@ -273,20 +318,20 @@ async def handle_realtime_notification(payload: dict):
         )
     elif notification_type == "pin":
         await ws_manager.broadcast_to_chat(
-            chat_id,
+            chat,
             {
                 "type": "pin",
-                "chat_id": chat_id,
+                "chat_ref": chat_ref,
                 "message_ids": data.get("message_ids", []),
                 "pinned": data.get("pinned", True),
             },
         )
     elif notification_type == "reaction":
         await ws_manager.broadcast_to_chat(
-            chat_id,
+            chat,
             {
                 "type": "reaction",
-                "chat_id": chat_id,
+                "chat_ref": chat_ref,
                 "message_id": data.get("message_id"),
                 "reactions": data.get("reactions", []),
             },
@@ -388,17 +433,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
             for row in rows:
                 if now - row["created_at"] > AUTH_SESSION_SECONDS:
                     continue  # skip expired, cleanup task will purge from DB
-                allowed = None
-                if row["allowed_chat_ids"]:
-                    try:
-                        allowed = set(json.loads(row["allowed_chat_ids"]))
-                    except json.JSONDecodeError, TypeError:
-                        logger.warning(f"Skipping session with corrupted allowed_chat_ids for {row['username']}")
-                        continue
+                # Grants come from the v8.0.0 columns only; an unreadable grant
+                # restores as an EMPTY one (sees nothing) rather than being
+                # dropped or widened. The legacy allowed_chat_ids is never read.
+                allowed_accounts, allowed_chat_refs = _grants_from_row(row)
                 _sessions[row["token"]] = SessionData(
                     username=row["username"],
                     role=row["role"],
-                    allowed_chat_ids=allowed,
+                    allowed_accounts=allowed_accounts,
+                    allowed_chat_refs=allowed_chat_refs,
                     no_download=bool(row.get("no_download", 0)),
                     source_token_id=row.get("source_token_id"),
                     created_at=row["created_at"],
@@ -533,9 +576,18 @@ else:
 
 @dataclass
 class UserContext:
+    """The authenticated principal and its v8.0.0 entitlement.
+
+    ``allowed_accounts``/``allowed_chat_refs``: None = unrestricted; a set is
+    the grant, and the EMPTY set (what an unparseable stored grant parses to)
+    denies everything. The legacy allowed_chat_ids column no longer reaches
+    this context — 8.0 code never reads it.
+    """
+
     username: str
     role: str  # "master", "viewer", or "token"
-    allowed_chat_ids: set[int] | None = None  # None = all chats
+    allowed_accounts: set[int] | None = None  # None = all accounts
+    allowed_chat_refs: set[str] | None = None  # None = all chats
     no_download: bool = False  # v7.2.0: restrict file downloads
 
 
@@ -543,7 +595,8 @@ class UserContext:
 class SessionData:
     username: str
     role: str
-    allowed_chat_ids: set[int] | None = None
+    allowed_accounts: set[int] | None = None
+    allowed_chat_refs: set[str] | None = None
     no_download: bool = False
     source_token_id: int | None = None  # v7.2.0: tracks originating share token for revocation
     created_at: float = field(default_factory=time.time)
@@ -552,6 +605,93 @@ class SessionData:
 
 _sessions: dict[str, SessionData] = {}
 _login_attempts: dict[str, list[float]] = {}  # ip -> list of timestamps
+
+
+def _grants_from_row(row: dict) -> tuple[set[int] | None, set[str] | None]:
+    """(allowed_accounts, allowed_chat_refs) of a viewer/session/token row, fail-closed.
+
+    The grant lives ONLY in the v8.0.0 columns migration 022 populated. Each
+    parses independently — NULL means unrestricted, anything unreadable becomes
+    the empty set, which denies. The legacy allowed_chat_ids is never a grant
+    source; its one permitted use is the deny-only guard below: a row carrying
+    a legacy grant while BOTH new columns are NULL is an unconverted 7.x
+    restriction (022 converts every such row, so a live one means the migration
+    was bypassed), and reading it as unrestricted would be exactly the fail-open
+    this design exists to prevent. Such a row gets the empty grant.
+    """
+    accounts = parse_entitlement_column(row.get("allowed_accounts"), int)
+    refs = parse_entitlement_column(row.get("allowed_chat_refs"), str)
+    if accounts is None and refs is None and row.get("allowed_chat_ids") is not None:
+        logger.warning("Viewer identity carries an unconverted legacy grant; denying all chats")
+        return set(), set()
+    return accounts, refs
+
+
+@dataclass(frozen=True)
+class ChatContext:
+    """One resolved, entitlement-checked chat: what a ref-addressed route works with."""
+
+    account_id: int
+    chat_id: int
+    ref: str
+    type: str | None = None
+
+
+def _chat_visible(user: UserContext, chat: dict) -> bool:
+    """Whether ``user`` may see ``chat`` (a row dict carrying id, account_id, ref).
+
+    One rule for every surface — HTTP routes, list filtering, websocket
+    broadcast, and the resolver below all decide through here. The operator's
+    DISPLAY_CHAT_IDS filter binds every role (as get_user_chat_ids did);
+    entitlements bind sessions whose grant is a set (masters carry None).
+    """
+    if config.display_chat_ids and chat["id"] not in config.display_chat_ids:
+        return False
+    if user.allowed_accounts is not None and chat["account_id"] not in user.allowed_accounts:
+        return False
+    if user.allowed_chat_refs is not None and chat["ref"] not in user.allowed_chat_refs:
+        return False
+    return True
+
+
+def _user_is_restricted(user: UserContext) -> bool:
+    """True when the visible-chat set is narrower than "everything"."""
+    return bool(config.display_chat_ids) or user.allowed_accounts is not None or user.allowed_chat_refs is not None
+
+
+async def _visible_chat_id_set(user: UserContext) -> set[int] | None:
+    """Chat ids the user may see, or None when unrestricted.
+
+    The bridge that lets id-keyed internals (folder counts, cached stats) keep
+    working: entitlements are ref-based, so the set is computed by filtering
+    the chat list. Single-account caveat: the ids are bare (phase 5 will need
+    account-qualified sets once a second account can collide on an id).
+    """
+    if not _user_is_restricted(user):
+        return None
+    chats = await db.get_all_chats()
+    return {c["id"] for c in chats if _chat_visible(user, c)}
+
+
+async def _resolve_chat_ref(chat_ref: str, user: UserContext) -> ChatContext:
+    """The ONE resolver: opaque ref -> entitled ChatContext, or 404.
+
+    Unknown, malformed, and forbidden refs are indistinguishable — same status,
+    same body, and the same single indexed SELECT for every candidate string,
+    so neither the response nor its latency says whether a chat exists. A 503
+    (database down) is the only other outcome; it carries no per-chat signal.
+    """
+    if not db:
+        raise HTTPException(status_code=503, detail="Database not available")
+    try:
+        chat = await db.get_chat_by_ref(chat_ref)
+    except Exception as e:
+        if _is_db_connection_error(e):
+            raise HTTPException(status_code=503, detail="Database temporarily unavailable")
+        raise
+    if not chat or not _chat_visible(user, chat):
+        raise HTTPException(status_code=404, detail="Chat not found")
+    return ChatContext(account_id=chat["account_id"], chat_id=chat["id"], ref=chat["ref"], type=chat.get("type"))
 
 
 def _hash_password(password: str, salt: str) -> str:
@@ -644,7 +784,8 @@ def _is_db_connection_error(exc: Exception) -> bool:
 async def _create_session(
     username: str,
     role: str,
-    allowed_chat_ids: set[int] | None = None,
+    allowed_accounts: set[int] | None = None,
+    allowed_chat_refs: set[str] | None = None,
     no_download: bool = False,
     source_token_id: int | None = None,
 ) -> str:
@@ -665,7 +806,8 @@ async def _create_session(
     _sessions[token] = SessionData(
         username=username,
         role=role,
-        allowed_chat_ids=allowed_chat_ids,
+        allowed_accounts=allowed_accounts,
+        allowed_chat_refs=allowed_chat_refs,
         no_download=no_download,
         source_token_id=source_token_id,
         created_at=now,
@@ -675,12 +817,19 @@ async def _create_session(
     # Persist to database
     if db:
         try:
-            chat_ids_json = json.dumps(list(allowed_chat_ids)) if allowed_chat_ids is not None else None
+            accounts_json = json.dumps(sorted(allowed_accounts)) if allowed_accounts is not None else None
+            refs_json = json.dumps(sorted(allowed_chat_refs)) if allowed_chat_refs is not None else None
+            restricted = accounts_json is not None or refs_json is not None
             await db.save_session(
                 token=token,
                 username=username,
                 role=role,
-                allowed_chat_ids=chat_ids_json,
+                # Rollback tombstone: a 7.x binary reads allowed_chat_ids, and
+                # NULL there means "everything" — so a restricted 8.0 session
+                # writes the empty grant, which denies under rollback too.
+                allowed_chat_ids="[]" if restricted else None,
+                allowed_accounts=accounts_json,
+                allowed_chat_refs=refs_json,
                 created_at=now,
                 last_accessed=now,
                 no_download=1 if no_download else 0,
@@ -743,18 +892,14 @@ async def _resolve_session(auth_cookie: str) -> SessionData | None:
     if not row or time.time() - row["created_at"] > AUTH_SESSION_SECONDS:
         return None
 
-    allowed = None
-    if row["allowed_chat_ids"]:
-        try:
-            allowed = set(json.loads(row["allowed_chat_ids"]))
-        except json.JSONDecodeError, TypeError:
-            logger.warning(f"Corrupted allowed_chat_ids for session {row['username']}, denying access")
-            return None
+    # v8.0.0 grant columns only; unreadable parses to the empty grant (denies).
+    allowed_accounts, allowed_chat_refs = _grants_from_row(row)
 
     session = SessionData(
         username=row["username"],
         role=row["role"],
-        allowed_chat_ids=allowed,
+        allowed_accounts=allowed_accounts,
+        allowed_chat_refs=allowed_chat_refs,
         no_download=bool(row.get("no_download", 0)),
         source_token_id=row.get("source_token_id"),
         created_at=row["created_at"],
@@ -772,7 +917,7 @@ async def _resolve_proxy_user(proxy_username: str) -> UserContext:
     AUTH_PROXY_DEFAULT_ACCESS (none = no chats until admin grants, all = full access).
     """
     if proxy_username in AUTH_PROXY_ADMIN_USERS:
-        return UserContext(username=proxy_username, role="master", allowed_chat_ids=None)
+        return UserContext(username=proxy_username, role="master")
 
     # Look up or auto-create viewer account
     if db:
@@ -780,35 +925,34 @@ async def _resolve_proxy_user(proxy_username: str) -> UserContext:
         if viewer:
             if not viewer["is_active"]:
                 raise HTTPException(status_code=403, detail="Account disabled")
-            allowed = None
-            if viewer["allowed_chat_ids"]:
-                try:
-                    allowed = set(json.loads(viewer["allowed_chat_ids"]))
-                except json.JSONDecodeError, TypeError:
-                    allowed = set()
+            allowed_accounts, allowed_chat_refs = _grants_from_row(viewer)
             return UserContext(
                 username=proxy_username,
                 role="viewer",
-                allowed_chat_ids=allowed,
+                allowed_accounts=allowed_accounts,
+                allowed_chat_refs=allowed_chat_refs,
                 no_download=bool(viewer.get("no_download", 0)),
             )
 
-        # Auto-create with configured default access
-        allowed_json = None  # None = all chats
+        # Auto-create with configured default access. The grant lives in
+        # allowed_chat_refs; allowed_chat_ids carries the matching rollback
+        # tombstone ("[]" = nothing under 7.x too, never fail-open NULL).
+        refs_json = None  # None = all chats
         if AUTH_PROXY_DEFAULT_ACCESS != "all":
-            allowed_json = "[]"  # Empty = no chats until admin grants access
+            refs_json = "[]"  # Empty = no chats until admin grants access
         await db.create_viewer_account(
             username=proxy_username,
             password_hash="",
             salt="proxy-auth",
-            allowed_chat_ids=allowed_json,
+            allowed_chat_ids=refs_json,
+            allowed_chat_refs=refs_json,
             created_by="proxy-auth",
             is_active=1,
         )
         logger.info(f"Auto-created proxy-authenticated viewer account: {proxy_username}")
 
-        allowed_set: set[int] | None = None if AUTH_PROXY_DEFAULT_ACCESS == "all" else set()
-        return UserContext(username=proxy_username, role="viewer", allowed_chat_ids=allowed_set)
+        refs_set: set[str] | None = None if AUTH_PROXY_DEFAULT_ACCESS == "all" else set()
+        return UserContext(username=proxy_username, role="viewer", allowed_chat_refs=refs_set)
 
     # No DB — proxy admin users are the only ones that work without DB
     raise HTTPException(status_code=503, detail="Database required for proxy authentication")
@@ -830,7 +974,7 @@ async def _resolve_user_context(proxy_header_value: str | None, auth_cookie: str
         if ALLOW_ANONYMOUS_VIEWER:
             # Read-only viewer, not master: anonymous internet users must never get
             # admin capabilities (create viewers, mint tokens, read audit log, settings).
-            return UserContext(username="anonymous", role="viewer", allowed_chat_ids=None, no_download=False)
+            return UserContext(username="anonymous", role="viewer", no_download=False)
         raise HTTPException(status_code=503, detail="Viewer authentication is not configured")
 
     # Trusted proxy header authentication (v7.9.0)
@@ -857,7 +1001,8 @@ async def _resolve_user_context(proxy_header_value: str | None, auth_cookie: str
     return UserContext(
         username=session.username,
         role=session.role,
-        allowed_chat_ids=session.allowed_chat_ids,
+        allowed_accounts=session.allowed_accounts,
+        allowed_chat_refs=session.allowed_chat_refs,
         no_download=session.no_download,
     )
 
@@ -879,82 +1024,24 @@ def require_master(request: Request, user: UserContext = Depends(require_auth)) 
     return user
 
 
-def get_user_chat_ids(user: UserContext) -> set[int] | None:
-    """Get the effective chat IDs a user can access.
+async def require_chat(chat_ref: str, user: UserContext = Depends(require_auth)) -> ChatContext:
+    """Dependency behind every {chat_ref} route: resolve + entitle, or a uniform 404.
 
-    Returns None if the user can see all chats (no restriction).
+    This single dependency replaces the per-route ACL preambles: by the time a
+    handler body runs, the chat exists AND the caller may see it. FastAPI's
+    per-request dependency cache shares the require_auth resolution with the
+    handler's own ``user`` parameter.
     """
-    master_filter = config.display_chat_ids or None  # empty set -> None
-
-    if user.role == "master":
-        return master_filter
-
-    # Viewer: use their allowed_chat_ids, intersected with master filter
-    if user.allowed_chat_ids is None:
-        return master_filter
-    if master_filter is None:
-        return user.allowed_chat_ids
-    return user.allowed_chat_ids & master_filter
-
-
-def _enforce_media_acl(path: str, user: UserContext, *, thumbnail: bool = False, member_ok: bool = False) -> None:
-    """Enforce chat-scoped access for a media URL path before serving bytes.
-
-    member_ok is a pre-resolved membership verdict for user-avatar paths
-    (avatars/users/{user_id}_...): the async endpoints run the SELECT-only
-    probe and pass True when the requested user has spoken in a chat the
-    viewer is authorized for. It is only honored for the avatars/users/
-    branch; avatars/chats/ and regular media ACL are unchanged.
-    """
-    user_chat_ids = get_user_chat_ids(user)
-    if user_chat_ids is None:
-        return
-
-    parts = path.split("/")
-    if len(parts) < 2:
-        raise HTTPException(status_code=403, detail="Access denied")
-
-    if parts[0] == "avatars":
-        # Avatar path: avatars/{users|chats}/{id}_{photo_id}.jpg
-        if len(parts) < 3:
-            raise HTTPException(status_code=403, detail="Access denied")
-        subfolder = parts[1]
-        name = parts[2].rsplit(".", 1)[0] if "." in parts[2] else parts[2]
-        try:
-            avatar_id = int(name.split("_")[0])
-        except ValueError:
-            raise HTTPException(status_code=403, detail="Access denied")
-        # Direct grant: a chat avatar for an allowed chat, or a 1:1 contact
-        # avatar whose user id == the private chat id the viewer can see.
-        if avatar_id in user_chat_ids:
-            return
-        # avatars/users/{user_id}: the first segment is a USER id, not a chat
-        # id. Serve it when that user is a member of a visible chat (they have
-        # spoken in a chat the viewer is authorized for). member_ok carries
-        # that pre-resolved DB verdict from the endpoint.
-        if subfolder == "users" and member_ok:
-            return
-        raise HTTPException(status_code=403, detail="Access denied")
-
-    try:
-        media_chat_id = int(parts[0])
-    except ValueError:
-        logger.warning("Blocked restricted media request for non-numeric folder")
-        raise HTTPException(status_code=403, detail="Access denied")
-    if media_chat_id not in user_chat_ids:
-        # Legacy fallback: positive folder may correspond to negative marked ID
-        if media_chat_id > 0 and any(mid in user_chat_ids for mid in legacy_marked_chat_ids(media_chat_id)):
-            logger.debug("ACL legacy grant: positive folder mapped to allowed chat via marked-ID convention")
-        else:
-            raise HTTPException(status_code=403, detail="Access denied")
+    return await _resolve_chat_ref(chat_ref, user)
 
 
 def _strip_original_media_paths(messages: list[dict]) -> None:
-    """Remove original media file paths from API responses for no-download sessions."""
+    """Remove original media file paths and URLs from API responses for no-download sessions."""
     for message in messages:
         media = message.get("media")
         if isinstance(media, dict):
             media["file_path"] = None
+            media["url"] = None
             media["downloaded"] = False
             media["no_download"] = True
         media_items = message.get("media_items")
@@ -962,13 +1049,19 @@ def _strip_original_media_paths(messages: list[dict]) -> None:
             for item in media_items:
                 if isinstance(item, dict):
                     item["file_path"] = None
+                    item["url"] = None
                     item["downloaded"] = False
                     item["no_download"] = True
 
 
 def _export_chat_metadata(chat: dict) -> dict:
-    """Return the minimal chat metadata needed by JSON exports."""
-    return {key: chat.get(key) for key in ("id", "type", "title", "username")}
+    """Return the minimal chat metadata needed by JSON exports.
+
+    The export FILE keeps the chat id — it is the user's own data leaving the
+    system, not a URL — and gains the ref so an export can be correlated with
+    the viewer's addressing.
+    """
+    return {key: chat.get(key) for key in ("id", "ref", "type", "title", "username")}
 
 
 # Setup paths
@@ -1003,16 +1096,15 @@ _thumb_cache_dir: Path | None = None
 
 
 def _checked_media_path(path: str) -> str:
-    """Return the single media path string used for BOTH the ACL and the file read.
+    """The traversal predicate every media-file path must pass before a read.
 
-    The folder segment IS the authorization key (_enforce_media_acl reads
-    parts[0] as the chat id), so the string that is authorized has to be the
-    string that selects bytes on disk. A traversal segment breaks exactly that:
-    the ASGI server percent-decodes before routing, so ``%2e%2e`` reaches the
-    route as a real ``..`` and lets the ACL read one folder while the filesystem
-    reads another. Every media route funnels its request path through here
-    first, and passes the returned value on unchanged, so the two can never
-    disagree again.
+    Historically the folder segment WAS the authorization key (the pre-8.0
+    path ACL read parts[0] as the chat id), and a traversal segment let the
+    ACL read one folder while the filesystem read another: the ASGI server
+    percent-decodes before routing, so ``%2e%2e`` reaches a route as a real
+    ``..``. Authorization is row-mediated now, but the predicate still bounds
+    every path that reaches the disk — avatar files funnel through here, and
+    _media_relative_path applies the same rule to media rows' file_path.
     """
     if path.startswith("/") or ".." in path.split("/"):
         raise HTTPException(status_code=403, detail="Access denied")
@@ -1046,84 +1138,66 @@ def _inline_media_type(filename: str) -> str | None:
     return None
 
 
-# Thumbnail endpoint MUST be defined before the catch-all /media/{path:path} route
-@app.get("/media/thumb/{size}/{folder:path}/{filename}")
-async def serve_thumbnail(size: int, folder: str, filename: str, user: UserContext = Depends(require_auth)):
-    """Serve on-demand generated thumbnails with auth and path traversal protection."""
-    if not _media_root:
-        raise HTTPException(status_code=404, detail="Media directory not configured")
+def _parse_media_key(media_key: str) -> tuple[int, str] | None:
+    """Split the URL's ``{message_id}_{type}`` media key, or None when malformed.
 
-    # Traversal check FIRST: an "avatars/../<chat>" folder would otherwise skip
-    # the no_download rule below on its way to another chat's media.
-    requested = _checked_media_path(f"{folder}/{filename}")
-    folder, _, filename = requested.rpartition("/")
-    if not folder:
-        raise HTTPException(status_code=403, detail="Access denied")
-
-    if user.no_download and not folder.startswith("avatars/"):
-        raise HTTPException(status_code=403, detail="Downloads disabled for this account")
-
-    # `requested` is now the ONLY path string in this handler: it is what the ACL
-    # below authorizes and, split back into folder/filename, what ensure_thumbnail
-    # reads. ensure_thumbnail resolves it and bounds it at the media root, so a
-    # symlink cannot take it outside either.
-    # Early ACL check on requested path (prevents existence leakage).
-    # Member avatars (avatars/users/) are gated by a visible-membership probe.
-    member_ok = await _avatar_user_visible_member(requested, user)
-    _enforce_media_acl(requested, user, thumbnail=True, member_ok=member_ok)
-
-    from .thumbnails import ensure_thumbnail, resolve_cache_dir
-
-    global _thumb_cache_dir
-    if _thumb_cache_dir is None:
-        _thumb_cache_dir = resolve_cache_dir(_media_root)
-
-    result = await ensure_thumbnail(_media_root, size, folder, filename, cache_dir=_thumb_cache_dir)
-    if not result:
-        raise HTTPException(status_code=404, detail="Thumbnail not available")
-
-    thumb_path, resolved_folder = result
-    # Secondary ACL on resolved path if it differs (prevents bypass via legacy fallback)
-    if resolved_folder != folder:
-        resolved = f"{resolved_folder}/{filename}"
-        resolved_member_ok = await _avatar_user_visible_member(resolved, user)
-        _enforce_media_acl(resolved, user, thumbnail=True, member_ok=resolved_member_ok)
-
-    # Access-controlled bytes: private, so a shared proxy cache can never hand
-    # one viewer's thumbnail to another.
-    return FileResponse(thumb_path, media_type="image/webp", headers={"Cache-Control": "private, max-age=86400"})
+    The type may itself contain underscores (``video_note``), so the split is
+    on the FIRST separator only — mirroring how the storage key
+    ``{chat_id}_{message_id}_{type}`` is built by the writers.
+    """
+    message_part, _, type_part = media_key.partition("_")
+    if not type_part:
+        return None
+    try:
+        message_id = int(message_part)
+    except ValueError:
+        return None
+    return message_id, type_part
 
 
-@app.get("/media/{path:path}")
-async def serve_media(path: str, download: int = Query(0), user: UserContext = Depends(require_auth)):
-    """Serve media files with authentication, path traversal protection, and no_download enforcement."""
-    if not _media_root:
-        raise HTTPException(status_code=404, detail="Media directory not configured")
+def _media_relative_path(file_path: str | None) -> str | None:
+    """Normalize a media row's file_path to a media-root-relative path, or None.
 
-    # Reject path traversal and absolute paths before anything else reads the
-    # path — the no_download rule below tests a prefix, and a prefix means
-    # nothing until the path is known to stay in the folder it names.
-    path = _checked_media_path(path)
+    Same rules the gallery has always applied before building URLs: absolute
+    paths must live under the media root (older archives stored them absolute),
+    and the result must pass the traversal predicate _checked_media_path
+    enforces — a row whose path cannot be proven to stay inside the root serves
+    nothing.
+    """
+    if not file_path:
+        return None
+    path = file_path
+    if path.startswith("/"):
+        if not _media_root:
+            return None
+        media_root_str = str(_media_root) + "/"
+        if not path.startswith(media_root_str):
+            return None
+        path = path[len(media_root_str) :]
+    if path.startswith("/") or ".." in path.split("/"):
+        return None
+    return path
 
-    # Server-side download restriction. Original media bytes are not served to
-    # no-download users because a direct GET is indistinguishable from browser
-    # inline rendering once the URL is known. Avatars stay available for UI chrome.
-    if user.no_download and not path.startswith("avatars/"):
-        raise HTTPException(status_code=403, detail="Downloads disabled for this account")
 
-    # Construct and resolve path, then verify it stays within media root
-    candidate = _media_root / path
+def _resolve_media_file(relative_path: str):
+    """Resolve a root-relative media path to a real file inside the media root.
+
+    Same containment contract as the pre-8.0 serve path: resolve(strict=True),
+    the legacy positive/negative folder fallback for pre-v4.0.5 archives, and
+    the is_relative_to bound that keeps a symlink from escaping the root.
+    Returns the resolved Path or None.
+    """
+    candidate = _media_root / relative_path
     try:
         resolved = candidate.resolve(strict=True)
     except OSError, ValueError:
         # Legacy fallback: pre-v4.0.5 paths used positive IDs, disk uses negative marked IDs.
         # Try alternate folder names: X→-X (basic group), X→-100X (channel/supergroup)
-        parts = path.split("/", 1)
+        parts = relative_path.split("/", 1)
         resolved = None
         if len(parts) == 2:
             folder, rest = parts
-            alt_folders = legacy_folder_alternates(folder)
-            for alt in alt_folders:
+            for alt in legacy_folder_alternates(folder):
                 try:
                     resolved = (_media_root / alt / rest).resolve(strict=True)
                     logger.debug("Legacy fallback: served media via alternate folder resolution")
@@ -1131,25 +1205,171 @@ async def serve_media(path: str, download: int = Query(0), user: UserContext = D
                 except OSError, ValueError, RuntimeError:
                     continue
         if resolved is None:
-            raise HTTPException(status_code=404, detail="File not found")
+            return None
     if not resolved.is_relative_to(_media_root):
-        raise HTTPException(status_code=403, detail="Access denied")
-
-    # ACL uses the original request path (chat folder), not the resolved symlink
-    # target — symlinks into _shared/ don't carry chat folder context.
-    # Member avatars (avatars/users/) are gated by a visible-membership probe.
-    member_ok = await _avatar_user_visible_member(path, user)
-    _enforce_media_acl(path, user, member_ok=member_ok)
-
+        return None
     if not resolved.is_file():
+        return None
+    return resolved
+
+
+async def _entitled_media_row(chat: ChatContext, media_key: str) -> dict:
+    """Media row for an already-entitled chat + URL key, or the uniform 404.
+
+    The row lookup IS the authorization for the bytes: the storage key is
+    reconstructed as ``{chat_id}_{message_id}_{type}`` from the resolved chat,
+    so a key can only ever select media belonging to the chat the ref named.
+    A malformed key and a missing row answer identically.
+    """
+    parsed = _parse_media_key(media_key)
+    row = None
+    if parsed is not None:
+        message_id, media_type = parsed
+        row = await db.get_media_by_id(f"{chat.chat_id}_{message_id}_{media_type}", account_id=chat.account_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="File not found")
+    return row
+
+
+def _avatar_file_response(avatar_path: str):
+    """Serve an avatars/ file with the containment and caching avatars always had."""
+    checked = _checked_media_path(avatar_path)
+    try:
+        resolved = (_media_root / checked).resolve(strict=True)
+    except OSError, ValueError:
+        raise HTTPException(status_code=404, detail="File not found")
+    if not resolved.is_relative_to(_media_root) or not resolved.is_file():
+        raise HTTPException(status_code=404, detail="File not found")
+    # Avatars are content-addressed (…_{photo_id}.jpg) and change rarely; keep
+    # the long private TTL so avatar URLs are not refetched on every page.
+    return FileResponse(resolved, headers={"Cache-Control": "private, max-age=86400"})
+
+
+# Sender resolution for /media/avatar/{chat_ref}/{message_id}: one indexed
+# message lookup per (chat, message), cached briefly so a page of avatars does
+# not re-query per request.
+_sender_lookup_cache: dict[tuple[int, int, int], tuple[float, int | None]] = {}
+_SENDER_LOOKUP_CACHE_TTL_SECONDS = 300
+
+
+async def _message_sender_id(chat: ChatContext, message_id: int) -> int | None:
+    key = (chat.account_id, chat.chat_id, message_id)
+    cached = _sender_lookup_cache.get(key)
+    if cached is not None and time.monotonic() - cached[0] <= _SENDER_LOOKUP_CACHE_TTL_SECONDS:
+        return cached[1]
+    sender_id = await db.get_message_sender_id(chat.chat_id, message_id, account_id=chat.account_id)
+    _sender_lookup_cache[key] = (time.monotonic(), sender_id)
+    return sender_id
+
+
+# Route order matters only for /media/avatar/{chat_ref}: it shares the
+# two-segment shape with /media/{chat_ref}/{media_key}, and registration order
+# is what makes the literal win. A real ref can never collide with the literal
+# — token_urlsafe(16) is always 22 characters.
+@app.get("/media/thumb/{size}/{chat_ref}/{media_key}")
+async def serve_thumbnail(
+    size: int,
+    media_key: str,
+    chat: ChatContext = Depends(require_chat),
+    user: UserContext = Depends(require_auth),
+):
+    """Serve on-demand generated thumbnails, addressed by chat ref + media key."""
+    if not _media_root:
+        raise HTTPException(status_code=404, detail="Media directory not configured")
+
+    if user.no_download:
+        raise HTTPException(status_code=403, detail="Downloads disabled for this account")
+
+    row = await _entitled_media_row(chat, media_key)
+    relative = _media_relative_path(row.get("file_path"))
+    if relative is None:
+        raise HTTPException(status_code=404, detail="Thumbnail not available")
+    folder, _, filename = relative.rpartition("/")
+    if not folder:
+        raise HTTPException(status_code=404, detail="Thumbnail not available")
+
+    from .thumbnails import ensure_thumbnail, resolve_cache_dir
+
+    global _thumb_cache_dir
+    if _thumb_cache_dir is None:
+        _thumb_cache_dir = resolve_cache_dir(_media_root)
+
+    # ensure_thumbnail resolves the path and bounds it at the media root, so a
+    # symlink cannot take the read outside it; authorization is the media row.
+    result = await ensure_thumbnail(_media_root, size, folder, filename, cache_dir=_thumb_cache_dir)
+    if not result:
+        raise HTTPException(status_code=404, detail="Thumbnail not available")
+
+    thumb_path, _resolved_folder = result
+    # Access-controlled bytes: private, so a shared proxy cache can never hand
+    # one viewer's thumbnail to another.
+    return FileResponse(thumb_path, media_type="image/webp", headers={"Cache-Control": "private, max-age=86400"})
+
+
+@app.get("/media/avatar/{chat_ref}/{message_id}")
+async def serve_sender_avatar(message_id: int, chat: ChatContext = Depends(require_chat)):
+    """Serve the avatar of the sender of one message in an entitled chat.
+
+    Addressed by (chat ref, message id) so no user id appears in the URL — for
+    a private chat the peer's user id IS the chat id. Being entitled to the
+    chat is the membership proof: the sender is resolved from the message row,
+    which replaces the old visible-membership probe. Available for no-download
+    accounts like every avatar (UI chrome, not archive content).
+    """
+    if not _media_root:
+        raise HTTPException(status_code=404, detail="Media directory not configured")
+
+    sender_id = await _message_sender_id(chat, message_id)
+    if not sender_id or sender_id <= 0:
+        raise HTTPException(status_code=404, detail="File not found")
+    avatar_path = _get_cached_avatar_path(sender_id, "private")
+    if not avatar_path:
+        raise HTTPException(status_code=404, detail="File not found")
+    return _avatar_file_response(avatar_path)
+
+
+@app.get("/media/avatar/{chat_ref}")
+async def serve_chat_avatar(chat: ChatContext = Depends(require_chat)):
+    """Serve a chat's avatar, addressed by its ref alone."""
+    if not _media_root:
+        raise HTTPException(status_code=404, detail="Media directory not configured")
+
+    avatar_path = _get_cached_avatar_path(chat.chat_id, chat.type or "private")
+    if not avatar_path:
+        raise HTTPException(status_code=404, detail="File not found")
+    return _avatar_file_response(avatar_path)
+
+
+@app.get("/media/{chat_ref}/{media_key}")
+async def serve_media(
+    media_key: str,
+    download: int = Query(0),
+    chat: ChatContext = Depends(require_chat),
+    user: UserContext = Depends(require_auth),
+):
+    """Serve original media bytes, addressed by chat ref + ``{message_id}_{type}`` key.
+
+    The bytes are selected THROUGH the media row (its file_path is the storage
+    location; nothing moved on disk), and the resolved path still passes the
+    same traversal/symlink containment the path-addressed route enforced.
+    """
+    if not _media_root:
+        raise HTTPException(status_code=404, detail="Media directory not configured")
+
+    # Server-side download restriction. Original media bytes are not served to
+    # no-download users because a direct GET is indistinguishable from browser
+    # inline rendering once the URL is known. Avatars have their own routes.
+    if user.no_download:
+        raise HTTPException(status_code=403, detail="Downloads disabled for this account")
+
+    row = await _entitled_media_row(chat, media_key)
+    relative = _media_relative_path(row.get("file_path"))
+    if relative is None:
+        raise HTTPException(status_code=404, detail="File not found")
+    resolved = _resolve_media_file(relative)
+    if resolved is None:
         raise HTTPException(status_code=404, detail="File not found")
 
-    # Avatars are content-addressed (…_{photo_id}.jpg) and change rarely — let
-    # them cache like serve_thumbnail's output so avatar URLs aren't refetched on
-    # every page. The Cache-Control is set on the response after construction so
-    # the FileResponse(resolved) call is unchanged; the containment check above
-    # (reject ../absolute, resolve strict, is_relative_to media root) is the
-    # actual path-traversal protection.
     # ?download=1 forces a save instead of inline rendering. The saved name is the
     # DISPLAY name, not the storage name: on disk every file carries a uniqueness
     # prefix (``<file_id>_holiday.jpg``), and Media.file_name holds that same
@@ -1175,7 +1395,7 @@ async def serve_media(path: str, download: int = Query(0), user: UserContext = D
     inline_type = _inline_media_type(resolved.name)
     response = FileResponse(resolved, media_type=inline_type or "application/octet-stream")
     if download or inline_type is None:
-        download_name = media_display_filename(path.rsplit("/", 1)[-1])
+        download_name = media_display_filename(row.get("file_name") or resolved.name)
         quoted = quote(download_name)
         response.headers["Content-Disposition"] = (
             f"attachment; filename*=utf-8''{quoted}"
@@ -1183,9 +1403,8 @@ async def serve_media(path: str, download: int = Query(0), user: UserContext = D
             else f'attachment; filename="{download_name}"'
         )
     # Every byte this route serves is access-controlled, so no shared cache may
-    # store it. Avatars keep their long browser TTL; the rest stays as cacheable
-    # per-browser as it was, just never in a proxy that skips the ACL.
-    response.headers["Cache-Control"] = "private, max-age=86400" if path.startswith("avatars/") else "private"
+    # store it — never a proxy that skips the entitlement.
+    response.headers["Cache-Control"] = "private"
     return response
 
 
@@ -1406,16 +1625,19 @@ async def login(request: Request):
             # 600k-round PBKDF2: off the event loop, or one login attempt stalls
             # every other request, WebSocket frame and health check on the way.
             if await asyncio.to_thread(_verify_password, password, viewer["salt"], viewer["password_hash"]):
-                allowed = None
-                if viewer["allowed_chat_ids"]:
-                    try:
-                        allowed = set(json.loads(viewer["allowed_chat_ids"]))
-                    except json.JSONDecodeError, TypeError:
-                        logger.warning("Corrupted allowed_chat_ids for viewer %s, denying login", username)
-                        raise HTTPException(status_code=403, detail="Invalid viewer scope")
+                # v8.0.0 grant columns only; an unreadable grant logs the viewer
+                # in with the EMPTY grant (sees nothing) — fail-closed without
+                # turning a data problem into a login oracle.
+                allowed_accounts, allowed_chat_refs = _grants_from_row(viewer)
 
                 viewer_no_download = bool(viewer.get("no_download", 0))
-                token = await _create_session(username, "viewer", allowed, no_download=viewer_no_download)
+                token = await _create_session(
+                    username,
+                    "viewer",
+                    allowed_accounts=allowed_accounts,
+                    allowed_chat_refs=allowed_chat_refs,
+                    no_download=viewer_no_download,
+                )
                 response = JSONResponse({"success": True, "role": "viewer", "username": username})
                 response.set_cookie(
                     key=AUTH_COOKIE_NAME,
@@ -1444,7 +1666,7 @@ async def login(request: Request):
     if secrets.compare_digest(username, VIEWER_USERNAME) and secrets.compare_digest(password, VIEWER_PASSWORD):
         if viewer_only:
             raise HTTPException(status_code=401, detail="Invalid credentials")
-        token = await _create_session(username, "master", None)
+        token = await _create_session(username, "master")
         response = JSONResponse({"success": True, "role": "master", "username": username})
         response.set_cookie(
             key=AUTH_COOKIE_NAME,
@@ -1558,20 +1780,17 @@ async def auth_via_token(request: Request):
         )
         raise HTTPException(status_code=401, detail="Invalid or expired token")
 
-    allowed = None
-    if token_record["allowed_chat_ids"]:
-        try:
-            allowed = set(json.loads(token_record["allowed_chat_ids"]))
-        except json.JSONDecodeError, TypeError:
-            logger.warning("Corrupted allowed_chat_ids for share token %s, denying login", token_record["id"])
-            raise HTTPException(status_code=403, detail="Invalid token scope")
+    # v8.0.0 grant columns only; an unreadable grant authenticates into the
+    # EMPTY grant (sees nothing). The legacy allowed_chat_ids is never read.
+    allowed_accounts, allowed_chat_refs = _grants_from_row(token_record)
 
     token_no_download = bool(token_record.get("no_download", 0))
     token_label = token_record.get("label") or f"token:{token_record['id']}"
     session_token = await _create_session(
         username=f"token:{token_label}",
         role="token",
-        allowed_chat_ids=allowed,
+        allowed_accounts=allowed_accounts,
+        allowed_chat_refs=allowed_chat_refs,
         no_download=token_no_download,
         source_token_id=token_record["id"],
     )
@@ -1690,36 +1909,12 @@ _avatar_cache: dict[int, str | None] = {}
 _avatar_cache_time: datetime | None = None
 AVATAR_CACHE_TTL_SECONDS = 300  # 5 minutes
 
-# Cache avatar membership verdicts to avoid a DB probe per avatar request.
-# Keyed by (avatar_user_id, frozenset(user_chat_ids)) — the verdict depends on
-# both. Mirrors the avatar-path cache's TTL sweep.
-_avatar_member_cache: dict[tuple[int, frozenset[int]], bool] = {}
-_avatar_member_cache_time: datetime | None = None
-AVATAR_MEMBER_CACHE_TTL_SECONDS = 300  # 5 minutes
 
-
-def _encode_media_path(path: str) -> str:
-    """Percent-encode each segment of a media path, keeping "/" separators intact.
-
-    Media filenames come from Telegram document names, so they can contain "#"
-    or "?" — unencoded, those truncate the URL into a fragment/query and the
-    request never reaches /media/{path:path} (#258). Encoding per segment (rather
-    than the whole string) keeps the folder/filename structure routable; Starlette
-    decodes the path before the traversal guard in serve_media sees it.
-
-    Applied to avatar paths too, even though ``_find_avatar_path`` builds them
-    from ``{chat_id}_{photo_id}.jpg`` and cannot itself produce a reserved
-    character: the name is whatever the glob found on disk, so encoding keeps a
-    single rule for everything served under /media/ rather than two.
-
-    The viewer builds the same URLs client-side with ``encodeURIComponent`` per
-    segment. The two agree on every character that matters here (both encode
-    "#", "?", "/" and space) and differ only on ``!*'()``, which ``quote`` escapes
-    and ``encodeURIComponent`` leaves literal — both spellings decode to the same
-    path server-side, so they resolve to the same file and differ only as cache
-    keys.
-    """
-    return "/".join(quote(segment, safe="") for segment in path.split("/"))
+def _encode_media_key(media_key: str) -> str:
+    """Percent-encode a URL media key. The key is ``{message_id}_{type}`` — both
+    server-minted — but the single rule keeps every /media/ URL builder safe
+    even if a type ever grows a reserved character."""
+    return quote(media_key, safe="")
 
 
 def _get_cached_avatar_path(chat_id: int, chat_type: str) -> str | None:
@@ -1744,78 +1939,40 @@ def _get_cached_avatar_path(chat_id: int, chat_type: str) -> str | None:
     return avatar_path
 
 
-def _sender_avatar_url(sender_id: int | None) -> str | None:
-    """Resolve a per-message member avatar URL from files ALREADY on disk.
+def _attach_message_payload_urls(messages: list, chat: ChatContext) -> None:
+    """Give message payloads their ref-addressed URLs; no chat id survives in any URL.
 
-    A member avatar exists only when a prior backup happened to download it
-    (in practice because the sender is also a 1:1 contact). Proactive
-    member-avatar download is intentionally deferred (slice 2b) — it is
-    flood-sensitive, so nothing here fetches arbitrary member photos. The
-    initials circle in the viewer is the always-available render; a served
-    file is a bonus. Returns None when no file is present.
-
-    User ids are positive and map to avatars/users/ (same folder + naming as a
-    private chat with that id), so the shared avatar cache resolves them with
-    no collision against negative group/channel chat ids.
+    - ``media.id`` is rewritten from the storage key to the chat-free URL key
+      ``{message_id}_{type}`` (the ref in the route scopes it), and ``media.url``
+      is added — the viewer must build no /media/ URL from file_path anymore.
+    - ``sender_avatar_url`` becomes ``/media/avatar/{ref}/{message_id}``, present
+      only when the sender's avatar file is already on disk. A member avatar
+      exists only when a prior backup happened to download it (proactive
+      download stays deferred — flood-sensitive); the initials circle is the
+      always-available render, a served file is a bonus.
     """
-    if not sender_id or sender_id <= 0:
-        return None
-    avatar_path = _get_cached_avatar_path(sender_id, "private")
-    return f"/media/{_encode_media_path(avatar_path)}" if avatar_path else None
-
-
-async def _avatar_user_visible_member(path: str, user: UserContext) -> bool:
-    """Pre-resolve whether an avatars/users/ path is for a visible member.
-
-    Runs the SELECT-only membership probe for the avatars/users/{user_id}_...
-    case only, so the sync _enforce_media_acl can stay signature-stable. A user
-    avatar is allowed iff the requested user has spoken in a chat the viewer is
-    authorized for. Returns True (no DB hit) when the id is already directly
-    allowed (a 1:1 chat the viewer can see); returns False (no DB hit) for every
-    other path and for unrestricted viewers (the ACL short-circuits anyway). On
-    any DB error the probe fails CLOSED (returns False → the avatar is denied).
-    Never logs ids.
-    """
-    parts = path.split("/")
-    if len(parts) < 3 or parts[0] != "avatars" or parts[1] != "users":
-        return False
-    user_chat_ids = get_user_chat_ids(user)
-    if user_chat_ids is None:
-        return False
-    name = parts[2].rsplit(".", 1)[0] if "." in parts[2] else parts[2]
-    try:
-        avatar_user_id = int(name.split("_")[0])
-    except ValueError:
-        return False
-    if avatar_user_id in user_chat_ids:
-        # Directly allowed as a 1:1 chat — no membership probe needed.
-        return True
-
-    # Cache the DB verdict (short TTL) so repeated avatar requests on a page
-    # don't each run the membership probe.
-    global _avatar_member_cache_time
-    now = datetime.utcnow()
-    if (
-        _avatar_member_cache_time
-        and (now - _avatar_member_cache_time).total_seconds() > AVATAR_MEMBER_CACHE_TTL_SECONDS
-    ):
-        _avatar_member_cache.clear()
-        _avatar_member_cache_time = None
-    cache_key = (avatar_user_id, frozenset(user_chat_ids))
-    if cache_key in _avatar_member_cache:
-        return _avatar_member_cache[cache_key]
-
-    try:
-        verdict = await db.sender_has_message_in_chats(avatar_user_id, user_chat_ids)
-    except Exception as exc:
-        # Fail closed: a transient DB error must deny the avatar (403), never
-        # surface as an uncaught 500. Log the exception class only (no ids).
-        logger.warning("Avatar membership probe failed (%s); denying avatar", exc.__class__.__name__)
-        return False
-    _avatar_member_cache[cache_key] = verdict
-    if _avatar_member_cache_time is None:
-        _avatar_member_cache_time = now
-    return verdict
+    prefix = f"{chat.chat_id}_"
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        sender_id = message.get("sender_id")
+        message["sender_avatar_url"] = (
+            f"/media/avatar/{chat.ref}/{message.get('id')}"
+            if sender_id and sender_id > 0 and _get_cached_avatar_path(sender_id, "private")
+            else None
+        )
+        media = message.get("media")
+        if not isinstance(media, dict):
+            continue
+        media_key = None
+        raw_id = media.get("id")
+        if isinstance(raw_id, str) and raw_id.startswith(prefix):
+            media_key = raw_id[len(prefix) :]
+            media["id"] = media_key
+        if media_key and _media_relative_path(media.get("file_path")):
+            media["url"] = f"/media/{chat.ref}/{_encode_media_key(media_key)}"
+        else:
+            media["url"] = None
 
 
 @app.get("/api/chats")
@@ -1835,12 +1992,12 @@ async def get_chats(
     v6.2.0: Added archived and folder_id filters.
     """
     try:
-        user_chat_ids = get_user_chat_ids(user)
         # If user has chat restrictions, we need to load all matching chats
+        # (entitlements are ref/account-based, so filtering happens here).
         # Otherwise, use pagination
-        if user_chat_ids is not None:
+        if _user_is_restricted(user):
             chats = await db.get_all_chats(search=search, archived=archived, folder_id=folder_id)
-            chats = [c for c in chats if c["id"] in user_chat_ids]
+            chats = [c for c in chats if _chat_visible(user, c)]
             total = len(chats)
             # Apply pagination after filtering
             chats = chats[offset : offset + limit]
@@ -1850,14 +2007,12 @@ async def get_chats(
             )
             total = await db.get_chat_count(search=search, archived=archived, folder_id=folder_id)
 
-        # Add avatar URLs using cache
+        # Ref-addressed avatar URLs; the avatar bytes route re-resolves at serve
+        # time, this only decides whether the viewer renders an <img> at all.
         for chat in chats:
             try:
                 avatar_path = _get_cached_avatar_path(chat["id"], chat.get("type", "private"))
-                if avatar_path:
-                    chat["avatar_url"] = f"/media/{_encode_media_path(avatar_path)}"
-                else:
-                    chat["avatar_url"] = None
+                chat["avatar_url"] = f"/media/avatar/{chat['ref']}" if avatar_path else None
             except Exception as e:
                 logger.error(f"Error finding avatar for a chat: {e}")
                 chat["avatar_url"] = None
@@ -1876,9 +2031,9 @@ async def get_chats(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@app.get("/api/chats/{chat_id}/messages")
+@app.get("/api/chats/{chat_ref}/messages")
 async def get_messages(
-    chat_id: int,
+    chat: ChatContext = Depends(require_chat),
     user: UserContext = Depends(require_auth),
     limit: int = Query(50, ge=1, le=500),
     offset: int = Query(0, ge=0),
@@ -1901,10 +2056,6 @@ async def get_messages(
 
     Cursor-based pagination is preferred for infinite scroll.
     """
-    user_chat_ids = get_user_chat_ids(user)
-    if user_chat_ids is not None and chat_id not in user_chat_ids:
-        raise HTTPException(status_code=403, detail="Access denied")
-
     # Parse before_date if provided
     parsed_before_date = None
     if before_date:
@@ -1918,7 +2069,7 @@ async def get_messages(
 
     try:
         messages = await db.get_messages_paginated(
-            chat_id=chat_id,
+            chat_id=chat.chat_id,
             limit=limit,
             offset=offset,
             search=search,
@@ -1926,17 +2077,12 @@ async def get_messages(
             before_id=before_id,
             after_id=after_id,
             topic_id=topic_id,
+            account_id=chat.account_id,
         )
-        # Slice 2a: attach a member-avatar URL inferred from files already on
-        # disk (globbed via the shared avatar cache). Null when absent — the
-        # viewer falls back to the initials circle. No new DB column; proactive
-        # member-avatar download stays deferred (slice 2b, flood-sensitive).
         # get_messages_paginated returns a list of message dicts; guard so an
         # unexpected shape can never turn a read into a 500.
         if isinstance(messages, list):
-            for message in messages:
-                if isinstance(message, dict):
-                    message["sender_avatar_url"] = _sender_avatar_url(message.get("sender_id"))
+            _attach_message_payload_urls(messages, chat)
         if user.no_download:
             _strip_original_media_paths(messages)
         return messages
@@ -1947,20 +2093,17 @@ async def get_messages(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@app.get("/api/chats/{chat_id}/messages/{message_id}/versions")
+@app.get("/api/chats/{chat_ref}/messages/{message_id}/versions")
 async def get_message_versions(
-    chat_id: int,
     message_id: int,
-    user: UserContext = Depends(require_auth),
+    chat: ChatContext = Depends(require_chat),
     limit: int = Query(100, ge=1, le=500),
 ):
     """Get preserved previous versions for a message."""
-    user_chat_ids = get_user_chat_ids(user)
-    if user_chat_ids is not None and chat_id not in user_chat_ids:
-        raise HTTPException(status_code=403, detail="Access denied")
-
     try:
-        return await db.get_message_versions(chat_id=chat_id, message_id=message_id, limit=limit)
+        return await db.get_message_versions(
+            chat_id=chat.chat_id, message_id=message_id, limit=limit, account_id=chat.account_id
+        )
     except Exception as e:
         logger.error(f"Error fetching message versions: {e}", exc_info=True)
         if _is_db_connection_error(e):
@@ -1968,15 +2111,16 @@ async def get_message_versions(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@app.get("/api/chats/{chat_id}/pinned")
-async def get_pinned_messages(chat_id: int, user: UserContext = Depends(require_auth)):
+@app.get("/api/chats/{chat_ref}/pinned")
+async def get_pinned_messages(chat: ChatContext = Depends(require_chat), user: UserContext = Depends(require_auth)):
     """Get all pinned messages for a chat, ordered by date descending (newest first)."""
-    user_chat_ids = get_user_chat_ids(user)
-    if user_chat_ids is not None and chat_id not in user_chat_ids:
-        raise HTTPException(status_code=403, detail="Access denied")
-
     try:
-        pinned_messages = await db.get_pinned_messages(chat_id)
+        pinned_messages = await db.get_pinned_messages(chat.chat_id, account_id=chat.account_id)
+        # Same renderer as the message list, so the same ref-addressed URLs.
+        if isinstance(pinned_messages, list):
+            _attach_message_payload_urls(pinned_messages, chat)
+        if user.no_download:
+            _strip_original_media_paths(pinned_messages)
         return pinned_messages  # Returns empty list if no pinned messages
     except Exception as e:
         logger.error(f"Error fetching pinned messages: {e}", exc_info=True)
@@ -1985,27 +2129,24 @@ async def get_pinned_messages(chat_id: int, user: UserContext = Depends(require_
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@app.get("/api/chats/{chat_id}/media")
+@app.get("/api/chats/{chat_ref}/media")
 async def get_chat_media(
-    chat_id: int,
     types: str = Query(default=""),
     limit: int = Query(default=50, ge=1, le=200),
     before_id: str = Query(default=""),
     after_id: str = Query(default=""),
+    chat: ChatContext = Depends(require_chat),
     user: UserContext = Depends(require_auth),
 ):
     """Get paginated media items for a chat, with optional type filtering.
 
     ``before_id`` pages BACKWARD (older) and ``after_id`` pages FORWARD (newer);
-    both are the same opaque composite media-id token. They are mutually
-    exclusive — asking for a page both before X and after Y has no meaning here,
-    so it is rejected instead of silently honouring one. An unresolvable or
-    foreign token yields an empty page in either direction (#266).
+    both are the CHAT-FREE ``{message_id}_{type}`` key this endpoint returns as
+    each item's ``id`` — the chat id no longer rides in the query string. They
+    are mutually exclusive — asking for a page both before X and after Y has no
+    meaning here, so it is rejected instead of silently honouring one. An
+    unresolvable or foreign token yields an empty page in either direction (#266).
     """
-    allowed = get_user_chat_ids(user)
-    if allowed is not None and chat_id not in allowed:
-        raise HTTPException(status_code=403, detail="Access denied")
-
     if not db:
         raise HTTPException(status_code=503, detail="Database not available")
 
@@ -2014,41 +2155,37 @@ async def get_chat_media(
 
     media_types = [t.strip() for t in types.split(",") if t.strip()] or None
 
+    # The adapter's cursor is the storage key; the URL token is its chat-free
+    # suffix. An old-format (full) token reconstructs to a key that resolves to
+    # no row, which is the same empty page a deleted cursor yields.
+    key_prefix = f"{chat.chat_id}_"
+
     try:
         result = await db.get_media_paginated(
-            chat_id,
+            chat.chat_id,
             media_types=media_types,
             limit=limit,
-            before_id=before_id or None,
-            after_id=after_id or None,
+            before_id=f"{key_prefix}{before_id}" if before_id else None,
+            after_id=f"{key_prefix}{after_id}" if after_id else None,
+            account_id=chat.account_id,
         )
         for item in result["items"]:
-            file_path = item.get("file_path", "") or ""
-            # Strip media root prefix for absolute paths stored in DB
-            if _media_root and file_path.startswith("/"):
-                media_root_str = str(_media_root) + "/"
-                if file_path.startswith(media_root_str):
-                    file_path = file_path[len(media_root_str) :]
-                else:
-                    item["thumb_url"] = None
-                    item.pop("file_path", None)
-                    continue
-            if ".." in file_path.split("/") or file_path.startswith("/"):
+            media_key = None
+            raw_id = item.get("id")
+            if isinstance(raw_id, str) and raw_id.startswith(key_prefix):
+                media_key = raw_id[len(key_prefix) :]
+                item["id"] = media_key
+
+            relative = _media_relative_path(item.get("file_path", "") or "")
+            if relative is None or media_key is None:
                 item["thumb_url"] = None
                 item.pop("file_path", None)
                 continue
 
-            parts = file_path.split("/", 1)
-            if len(parts) == 2:
-                # The split only gates on "has a folder component" and reads the
-                # extension; the URL below re-uses ``file_path`` itself, which is
-                # exactly ``folder/filename``.
-                filename = parts[1]
-                ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
-                if ext in THUMBNAIL_EXTENSIONS:
-                    item["thumb_url"] = f"/media/thumb/200/{_encode_media_path(file_path)}"
-                else:
-                    item["thumb_url"] = None
+            filename = relative.rsplit("/", 1)[-1]
+            ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+            if ext in THUMBNAIL_EXTENSIONS:
+                item["thumb_url"] = f"/media/thumb/200/{chat.ref}/{_encode_media_key(media_key)}"
             else:
                 item["thumb_url"] = None
 
@@ -2059,7 +2196,7 @@ async def get_chat_media(
                 # lights up the gallery's own placeholder instead.
                 item["thumb_url"] = None
             else:
-                item["media_url"] = f"/media/{_encode_media_path(file_path)}"
+                item["media_url"] = f"/media/{chat.ref}/{_encode_media_key(media_key)}"
 
         return result
     except Exception as e:
@@ -2069,21 +2206,14 @@ async def get_chat_media(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@app.get("/api/chats/{chat_id}/media/counts")
-async def get_chat_media_counts(
-    chat_id: int,
-    user: UserContext = Depends(require_auth),
-):
+@app.get("/api/chats/{chat_ref}/media/counts")
+async def get_chat_media_counts(chat: ChatContext = Depends(require_chat)):
     """Get media type counts for a chat."""
-    allowed = get_user_chat_ids(user)
-    if allowed is not None and chat_id not in allowed:
-        raise HTTPException(status_code=403, detail="Access denied")
-
     if not db:
         raise HTTPException(status_code=503, detail="Database not available")
 
     try:
-        counts = await db.get_media_counts(chat_id)
+        counts = await db.get_media_counts(chat.chat_id, account_id=chat.account_id)
         return counts
     except Exception as e:
         logger.error(f"Error fetching media counts: {e}", exc_info=True)
@@ -2099,8 +2229,8 @@ async def get_folders(user: UserContext = Depends(require_auth)):
     v6.2.0: Returns user-created Telegram folders (dialog filters).
     """
     try:
-        user_chat_ids = get_user_chat_ids(user)
-        folders = await db.get_all_folders(allowed_chat_ids=user_chat_ids)
+        visible_chat_ids = await _visible_chat_id_set(user)
+        folders = await db.get_all_folders(allowed_chat_ids=visible_chat_ids)
         return {"folders": folders}
     except Exception as e:
         logger.error(f"Error fetching folders: {e}", exc_info=True)
@@ -2109,18 +2239,14 @@ async def get_folders(user: UserContext = Depends(require_auth)):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@app.get("/api/chats/{chat_id}/topics")
-async def get_chat_topics(chat_id: int, user: UserContext = Depends(require_auth)):
+@app.get("/api/chats/{chat_ref}/topics")
+async def get_chat_topics(chat: ChatContext = Depends(require_chat)):
     """Get forum topics for a chat.
 
     v6.2.0: Returns topic list with message counts for forum-enabled chats.
     """
-    user_chat_ids = get_user_chat_ids(user)
-    if user_chat_ids is not None and chat_id not in user_chat_ids:
-        raise HTTPException(status_code=403, detail="Access denied")
-
     try:
-        topics = await db.get_forum_topics(chat_id)
+        topics = await db.get_forum_topics(chat.chat_id, account_id=chat.account_id)
         return {"topics": topics}
     except Exception as e:
         logger.error(f"Error fetching topics: {e}", exc_info=True)
@@ -2137,10 +2263,9 @@ async def get_archived_count(user: UserContext = Depends(require_auth)):
     Respects DISPLAY_CHAT_IDS so restricted viewers only see relevant archived chats.
     """
     try:
-        user_chat_ids = get_user_chat_ids(user)
-        if user_chat_ids is not None:
+        if _user_is_restricted(user):
             all_archived = await db.get_all_chats(archived=True)
-            count = sum(1 for c in all_archived if c["id"] in user_chat_ids)
+            count = sum(1 for c in all_archived if _chat_visible(user, c))
         else:
             count = await db.get_archived_chat_count()
         return {"count": count}
@@ -2158,7 +2283,7 @@ async def get_stats(user: UserContext = Depends(require_auth)):
         stats = await db.get_cached_statistics()
 
         # Filter per-chat stats to only chats the user can access
-        user_chat_ids = get_user_chat_ids(user)
+        user_chat_ids = await _visible_chat_id_set(user)
         per_chat = stats.get("per_chat_message_counts", {})
         if user_chat_ids is not None and per_chat:
             # JSON keys are strings after json.loads(), user_chat_ids are ints
@@ -2247,7 +2372,7 @@ async def push_subscribe(request: Request, user: UserContext = Depends(require_a
     - endpoint: Push service URL
     - keys.p256dh: Client public key (base64)
     - keys.auth: Auth secret (base64)
-    - chat_id: Optional chat ID for chat-specific subscriptions
+    - chat_ref: Optional chat ref for chat-specific subscriptions
     """
     if not push_manager or not push_manager.is_enabled:
         raise HTTPException(status_code=400, detail="Push notifications not enabled. Set PUSH_NOTIFICATIONS=full")
@@ -2259,10 +2384,15 @@ async def push_subscribe(request: Request, user: UserContext = Depends(require_a
         keys = data.get("keys", {})
         p256dh = keys.get("p256dh")
         auth = keys.get("auth")
-        chat_id = data.get("chat_id")
+        chat_ref = data.get("chat_ref")
 
         if not endpoint or not p256dh or not auth:
             raise HTTPException(status_code=400, detail="Missing required subscription data")
+
+        # The 7.x field is refused rather than ignored: silently dropping a
+        # scoping request would store a GLOBAL subscription — a widening.
+        if data.get("chat_id") is not None:
+            raise HTTPException(status_code=400, detail="chat_id is no longer accepted; send chat_ref")
 
         from .push import validate_push_endpoint
 
@@ -2278,26 +2408,27 @@ async def push_subscribe(request: Request, user: UserContext = Depends(require_a
             logger.warning("Rejected push subscription with invalid endpoint")
             raise HTTPException(status_code=400, detail="Invalid subscription endpoint")
 
-        if chat_id:
-            user_chat_ids = get_user_chat_ids(user)
-            if user_chat_ids is not None and chat_id not in user_chat_ids:
-                raise HTTPException(status_code=403, detail="Access denied to this chat")
+        # A chat-scoped subscription resolves + entitles through the SAME
+        # resolver as every route: forbidden/unknown/malformed refs 404 alike.
+        chat_ctx: ChatContext | None = None
+        if chat_ref:
+            chat_ctx = await _resolve_chat_ref(str(chat_ref), user)
 
         user_agent = request.headers.get("user-agent", "")[:500]
-        user_chat_ids_list = get_user_chat_ids(user)
 
         success = await push_manager.subscribe(
             endpoint=endpoint,
             p256dh=p256dh,
             auth=auth,
-            chat_id=chat_id,
+            chat_id=chat_ctx.chat_id if chat_ctx else None,
             user_agent=user_agent,
             username=user.username,
-            allowed_chat_ids=list(user_chat_ids_list) if user_chat_ids_list is not None else None,
+            allowed_accounts=sorted(user.allowed_accounts) if user.allowed_accounts is not None else None,
+            allowed_chat_refs=sorted(user.allowed_chat_refs) if user.allowed_chat_refs is not None else None,
         )
 
         if success:
-            return {"status": "subscribed", "chat_id": chat_id}
+            return {"status": "subscribed", "chat_ref": chat_ctx.ref if chat_ctx else None}
         else:
             raise HTTPException(status_code=500, detail="Failed to store subscription")
 
@@ -2402,43 +2533,43 @@ async def internal_push(request: Request):
         return {"status": "error", "detail": "Internal push processing failed"}
 
 
-# Cache chat stats to avoid re-running 3 aggregate queries on every chat open
-_chat_stats_cache: dict[int, tuple[float, dict]] = {}
+# Cache chat stats to avoid re-running 3 aggregate queries on every chat open.
+# Keyed by (account_id, chat_id): a chat id alone repeats across accounts.
+_chat_stats_cache: dict[tuple[int, int], tuple[float, dict]] = {}
 CHAT_STATS_CACHE_TTL_SECONDS = 60
 
 
-def _get_cached_chat_stats(chat_id: int) -> dict | None:
-    """Return cached stats for chat_id if still fresh, else None."""
-    entry = _chat_stats_cache.get(chat_id)
+def _get_cached_chat_stats(key: tuple[int, int]) -> dict | None:
+    """Return cached stats for (account_id, chat_id) if still fresh, else None."""
+    entry = _chat_stats_cache.get(key)
     if entry is None:
         return None
     cached_at, stats = entry
     if time.monotonic() - cached_at > CHAT_STATS_CACHE_TTL_SECONDS:
-        _chat_stats_cache.pop(chat_id, None)
+        _chat_stats_cache.pop(key, None)
         return None
     return stats
 
 
-def _set_cached_chat_stats(chat_id: int, stats: dict) -> None:
-    _chat_stats_cache[chat_id] = (time.monotonic(), stats)
+def _set_cached_chat_stats(key: tuple[int, int], stats: dict) -> None:
+    _chat_stats_cache[key] = (time.monotonic(), stats)
 
 
-@app.get("/api/chats/{chat_id}/stats")
-async def get_chat_stats(chat_id: int, user: UserContext = Depends(require_auth)):
-    """Get statistics for a specific chat (message count, media files, size)."""
-    # ACL check runs unconditionally, before any cache lookup, so a cache hit
-    # never bypasses access control.
-    user_chat_ids = get_user_chat_ids(user)
-    if user_chat_ids is not None and chat_id not in user_chat_ids:
-        raise HTTPException(status_code=403, detail="Access denied")
+@app.get("/api/chats/{chat_ref}/stats")
+async def get_chat_stats(chat: ChatContext = Depends(require_chat)):
+    """Get statistics for a specific chat (message count, media files, size).
 
-    cached = _get_cached_chat_stats(chat_id)
+    Resolution + entitlement run in the dependency, before any cache lookup, so
+    a cache hit never bypasses access control.
+    """
+    cache_key = (chat.account_id, chat.chat_id)
+    cached = _get_cached_chat_stats(cache_key)
     if cached is not None:
         return cached
 
     try:
-        stats = await db.get_chat_stats(chat_id)
-        _set_cached_chat_stats(chat_id, stats)
+        stats = await db.get_chat_stats(chat.chat_id, account_id=chat.account_id)
+        _set_cached_chat_stats(cache_key, stats)
         return stats
     except Exception as e:
         logger.error(f"Error getting chat stats: {e}", exc_info=True)
@@ -2447,9 +2578,9 @@ async def get_chat_stats(chat_id: int, user: UserContext = Depends(require_auth)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@app.get("/api/chats/{chat_id}/messages/by-date")
+@app.get("/api/chats/{chat_ref}/messages/by-date")
 async def get_message_by_date(
-    chat_id: int,
+    chat: ChatContext = Depends(require_chat),
     user: UserContext = Depends(require_auth),
     date: str = Query(..., description="Date in YYYY-MM-DD format"),
     timezone: str = Query(None, description="Timezone for date interpretation (e.g., 'Europe/Madrid')"),
@@ -2459,10 +2590,6 @@ async def get_message_by_date(
     Find the first message on or after a specific date for navigation.
     Used by the date picker to jump to a specific date.
     """
-    user_chat_ids = get_user_chat_ids(user)
-    if user_chat_ids is not None and chat_id not in user_chat_ids:
-        raise HTTPException(status_code=403, detail="Access denied")
-
     if timezone is not None:
         if len(timezone) > 255:
             raise HTTPException(status_code=400, detail="Invalid timezone")
@@ -2493,11 +2620,16 @@ async def get_message_by_date(
         raise HTTPException(status_code=400, detail="Invalid date format. Use YYYY-MM-DD")
 
     try:
-        message = await db.find_message_by_date_with_joins(chat_id, target_date, topic_id)
+        message = await db.find_message_by_date_with_joins(
+            chat.chat_id, target_date, topic_id, account_id=chat.account_id
+        )
 
         if not message:
             raise HTTPException(status_code=404, detail="No messages found for this date")
 
+        _attach_message_payload_urls([message], chat)
+        if user.no_download:
+            _strip_original_media_paths([message])
         return message
     except HTTPException:
         raise
@@ -2508,19 +2640,14 @@ async def get_message_by_date(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@app.get("/api/chats/{chat_id}/messages/dates")
+@app.get("/api/chats/{chat_ref}/messages/dates")
 async def get_message_dates(
-    chat_id: int,
-    user: UserContext = Depends(require_auth),
+    chat: ChatContext = Depends(require_chat),
     month: str = Query(..., description="Month in YYYY-MM format"),
     timezone: str = Query(..., description="IANA timezone"),
     topic_id: int | None = None,
 ):
     """Return the local calendar dates containing messages in a month."""
-    user_chat_ids = get_user_chat_ids(user)
-    if user_chat_ids is not None and chat_id not in user_chat_ids:
-        raise HTTPException(status_code=403, detail="Access denied")
-
     try:
         month_start = datetime.strptime(month, "%Y-%m")
     except OverflowError, ValueError:
@@ -2569,7 +2696,7 @@ async def get_message_dates(
         raise HTTPException(status_code=400, detail="Invalid month format. Use YYYY-MM")
 
     try:
-        dates = await db.get_message_dates(chat_id, day_ranges, topic_id)
+        dates = await db.get_message_dates(chat.chat_id, day_ranges, topic_id, account_id=chat.account_id)
         return JSONResponse(
             content={
                 "month": month,
@@ -2586,31 +2713,30 @@ async def get_message_dates(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
-@app.get("/api/chats/{chat_id}/export")
-async def export_chat(chat_id: int, user: UserContext = Depends(require_auth)):
+@app.get("/api/chats/{chat_ref}/export")
+async def export_chat(chat: ChatContext = Depends(require_chat), user: UserContext = Depends(require_auth)):
     """Export chat history to JSON."""
     if user.no_download:
         raise HTTPException(status_code=403, detail="Downloads disabled for this account")
-    user_chat_ids = get_user_chat_ids(user)
-    if user_chat_ids is not None and chat_id not in user_chat_ids:
-        raise HTTPException(status_code=403, detail="Access denied")
 
     try:
-        chat = await db.get_chat_by_id(chat_id)
-        if not chat:
+        chat_row = await db.get_chat_by_id(chat.chat_id, account_id=chat.account_id)
+        if not chat_row:
             raise HTTPException(status_code=404, detail="Chat not found")
 
-        chat_name = chat.get("title") or chat.get("username") or str(chat_id)
+        # The download filename never falls back to the chat id: the saved name
+        # lands in filesystem listings, which are the same surface as a URL.
+        chat_name = chat_row.get("title") or chat_row.get("username") or chat.ref
         # Sanitize filename
         safe_name = "".join(c for c in chat_name if c.isalnum() or c in (" ", "-", "_")).strip()
         filename = f"{safe_name}_export.json"
 
         async def iter_json():
             yield "{\n"
-            yield f'  "chat": {json.dumps(_export_chat_metadata(chat), ensure_ascii=False, default=str)},\n'
+            yield f'  "chat": {json.dumps(_export_chat_metadata(chat_row), ensure_ascii=False, default=str)},\n'
             yield '  "messages": [\n'
             first = True
-            async for msg in db.get_messages_for_export(chat_id):
+            async for msg in db.get_messages_for_export(chat.chat_id, account_id=chat.account_id):
                 if not first:
                     yield ",\n"
                 first = False
@@ -2621,7 +2747,7 @@ async def export_chat(chat_id: int, user: UserContext = Depends(require_auth)):
             # so it must never be materialized into a single list/dumps here.
             yield '  "message_versions": [\n'
             first_version = True
-            async for version in db.iter_message_versions_for_export(chat_id):
+            async for version in db.iter_message_versions_for_export(chat.chat_id, account_id=chat.account_id):
                 if not first_version:
                     yield ",\n"
                 first_version = False
@@ -2650,6 +2776,45 @@ async def export_chat(chat_id: int, user: UserContext = Depends(require_auth)):
 # ============================================================================
 
 
+def _reject_legacy_grant_key(data: dict) -> None:
+    """Refuse a 7.x ``allowed_chat_ids`` in an admin write, loudly.
+
+    Ignoring it would create/leave the identity UNRESTRICTED — a widening the
+    caller did not ask for. The error names the replacement so an old client
+    fails toward the fix, not toward full access.
+    """
+    if "allowed_chat_ids" in data:
+        raise HTTPException(status_code=400, detail="allowed_chat_ids is no longer accepted; send allowed_chat_refs")
+
+
+def _refs_grant_json(value) -> str | None:
+    """Validate an ``allowed_chat_refs`` payload: None, or a list of ref strings."""
+    if value is None:
+        return None
+    if not isinstance(value, list) or not all(isinstance(ref, str) and 0 < len(ref) <= 64 for ref in value):
+        raise HTTPException(status_code=400, detail="Invalid chat ref format")
+    return json.dumps(sorted(set(value)))
+
+
+def _accounts_grant_json(value) -> str | None:
+    """Validate an ``allowed_accounts`` payload: None, or a list of account ids."""
+    if value is None:
+        return None
+    if not isinstance(value, list):
+        raise HTTPException(status_code=400, detail="Invalid account id format")
+    try:
+        accounts = sorted({int(account) for account in value})
+    except TypeError, ValueError:
+        raise HTTPException(status_code=400, detail="Invalid account id format")
+    return json.dumps(accounts)
+
+
+def _grant_list(raw: str | None, element_type: type) -> list | None:
+    """Render a stored grant column for an admin response (unreadable → [], as enforced)."""
+    parsed = parse_entitlement_column(raw, element_type)
+    return sorted(parsed) if parsed is not None else None
+
+
 @app.get("/api/admin/viewers")
 async def list_viewers(user: UserContext = Depends(require_master)):
     """List all viewer accounts."""
@@ -2660,7 +2825,8 @@ async def list_viewers(user: UserContext = Depends(require_master)):
             {
                 "id": v["id"],
                 "username": v["username"],
-                "allowed_chat_ids": json.loads(v["allowed_chat_ids"]) if v["allowed_chat_ids"] else None,
+                "allowed_accounts": _grant_list(v.get("allowed_accounts"), int),
+                "allowed_chat_refs": _grant_list(v.get("allowed_chat_refs"), str),
                 "is_active": v["is_active"],
                 "no_download": v.get("no_download", 0),
                 "created_by": v["created_by"],
@@ -2679,9 +2845,9 @@ async def create_viewer(request: Request, user: UserContext = Depends(require_ma
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid JSON")
 
+    _reject_legacy_grant_key(data)
     username = data.get("username", "").strip()
     password = data.get("password", "").strip()
-    allowed_chat_ids = data.get("allowed_chat_ids")
     is_active = 1 if data.get("is_active", 1) else 0
     viewer_no_download = 1 if data.get("no_download", 0) else 0
 
@@ -2699,18 +2865,19 @@ async def create_viewer(request: Request, user: UserContext = Depends(require_ma
     salt = secrets.token_hex(32)
     password_hash = await asyncio.to_thread(_hash_password, password, salt)
 
-    chat_ids_json = None
-    if allowed_chat_ids is not None:
-        try:
-            chat_ids_json = json.dumps([int(cid) for cid in allowed_chat_ids])
-        except ValueError, TypeError:
-            raise HTTPException(status_code=400, detail="Invalid chat ID format")
+    accounts_json = _accounts_grant_json(data.get("allowed_accounts"))
+    refs_json = _refs_grant_json(data.get("allowed_chat_refs"))
+    restricted = accounts_json is not None or refs_json is not None
 
     account = await db.create_viewer_account(
         username=username,
         password_hash=password_hash,
         salt=salt,
-        allowed_chat_ids=chat_ids_json,
+        # Rollback tombstone: "[]" denies under a 7.x binary too; never NULL
+        # for a restricted viewer. 8.0 code does not read this column.
+        allowed_chat_ids="[]" if restricted else None,
+        allowed_accounts=accounts_json,
+        allowed_chat_refs=refs_json,
         created_by=user.username,
         is_active=is_active,
         no_download=viewer_no_download,
@@ -2727,7 +2894,8 @@ async def create_viewer(request: Request, user: UserContext = Depends(require_ma
     return {
         "id": account["id"],
         "username": account["username"],
-        "allowed_chat_ids": json.loads(chat_ids_json) if chat_ids_json else None,
+        "allowed_accounts": _grant_list(accounts_json, int),
+        "allowed_chat_refs": _grant_list(refs_json, str),
         "is_active": account["is_active"],
         "no_download": account["no_download"],
     }
@@ -2741,6 +2909,7 @@ async def update_viewer(viewer_id: int, request: Request, user: UserContext = De
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid JSON")
 
+    _reject_legacy_grant_key(data)
     existing = await db.get_viewer_account(viewer_id)
     if not existing:
         raise HTTPException(status_code=404, detail="Viewer not found")
@@ -2754,15 +2923,17 @@ async def update_viewer(viewer_id: int, request: Request, user: UserContext = De
         updates["password_hash"] = await asyncio.to_thread(_hash_password, pwd, salt)
         updates["salt"] = salt
 
-    if "allowed_chat_ids" in data:
-        allowed = data["allowed_chat_ids"]
-        if allowed is None:
-            updates["allowed_chat_ids"] = None
-        else:
-            try:
-                updates["allowed_chat_ids"] = json.dumps([int(cid) for cid in allowed])
-            except ValueError, TypeError:
-                raise HTTPException(status_code=400, detail="Invalid chat ID format")
+    if "allowed_accounts" in data:
+        updates["allowed_accounts"] = _accounts_grant_json(data["allowed_accounts"])
+    if "allowed_chat_refs" in data:
+        updates["allowed_chat_refs"] = _refs_grant_json(data["allowed_chat_refs"])
+    if "allowed_accounts" in data or "allowed_chat_refs" in data:
+        # Keep the rollback tombstone in step with the FINAL grant state, so a
+        # viewer widened to unrestricted loses the "[]" and a narrowed one
+        # gains it (checking the reverse of the create path).
+        final_accounts = updates.get("allowed_accounts", existing.get("allowed_accounts"))
+        final_refs = updates.get("allowed_chat_refs", existing.get("allowed_chat_refs"))
+        updates["allowed_chat_ids"] = "[]" if (final_accounts is not None or final_refs is not None) else None
 
     if "is_active" in data:
         updates["is_active"] = 1 if data["is_active"] else 0
@@ -2787,7 +2958,8 @@ async def update_viewer(viewer_id: int, request: Request, user: UserContext = De
     return {
         "id": account["id"],
         "username": account["username"],
-        "allowed_chat_ids": json.loads(account["allowed_chat_ids"]) if account["allowed_chat_ids"] else None,
+        "allowed_accounts": _grant_list(account.get("allowed_accounts"), int),
+        "allowed_chat_refs": _grant_list(account.get("allowed_chat_refs"), str),
         "is_active": account["is_active"],
     }
 
@@ -2826,6 +2998,8 @@ async def admin_list_chats(user: UserContext = Depends(require_master)):
         result.append(
             {
                 "id": c["id"],
+                "ref": c.get("ref"),
+                "account_id": c.get("account_id"),
                 "title": title,
                 "type": c.get("type"),
                 "username": c.get("username"),
@@ -2865,7 +3039,8 @@ async def list_tokens(user: UserContext = Depends(require_master)):
                 "id": t["id"],
                 "label": t["label"],
                 "created_by": t["created_by"],
-                "allowed_chat_ids": json.loads(t["allowed_chat_ids"]) if t["allowed_chat_ids"] else None,
+                "allowed_accounts": _grant_list(t.get("allowed_accounts"), int),
+                "allowed_chat_refs": _grant_list(t.get("allowed_chat_refs"), str),
                 "is_revoked": t["is_revoked"],
                 "no_download": t["no_download"],
                 "expires_at": t["expires_at"],
@@ -2885,8 +3060,9 @@ async def create_token(request: Request, user: UserContext = Depends(require_mas
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid JSON")
 
+    _reject_legacy_grant_key(data)
     label = (data.get("label") or "").strip() or None
-    allowed_chat_ids = data.get("allowed_chat_ids")
+    allowed_chat_refs = data.get("allowed_chat_refs")
     no_download = 1 if data.get("no_download") else 0
     expires_at = None
     if data.get("expires_at"):
@@ -2895,13 +3071,10 @@ async def create_token(request: Request, user: UserContext = Depends(require_mas
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid expires_at format. Use ISO 8601.")
 
-    if not allowed_chat_ids or not isinstance(allowed_chat_ids, list):
-        raise HTTPException(status_code=400, detail="allowed_chat_ids is required (list of chat IDs)")
-
-    try:
-        chat_ids_json = json.dumps([int(cid) for cid in allowed_chat_ids])
-    except ValueError, TypeError:
-        raise HTTPException(status_code=400, detail="Invalid chat ID format")
+    # A share token is ALWAYS scoped: no refs, no token.
+    if not allowed_chat_refs or not isinstance(allowed_chat_refs, list):
+        raise HTTPException(status_code=400, detail="allowed_chat_refs is required (list of chat refs)")
+    refs_json = _refs_grant_json(allowed_chat_refs)
 
     # Generate token: 32 bytes = 64 hex chars
     plaintext_token = secrets.token_hex(32)
@@ -2913,7 +3086,9 @@ async def create_token(request: Request, user: UserContext = Depends(require_mas
         token_hash=token_hash,
         token_salt=salt,
         created_by=user.username,
-        allowed_chat_ids=chat_ids_json,
+        # NOT NULL rollback tombstone: under a 7.x binary this token grants nothing.
+        allowed_chat_ids="[]",
+        allowed_chat_refs=refs_json,
         no_download=no_download,
         expires_at=expires_at,
     )
@@ -2930,7 +3105,7 @@ async def create_token(request: Request, user: UserContext = Depends(require_mas
         "id": token_record["id"],
         "label": token_record["label"],
         "token": plaintext_token,  # Only returned once at creation time
-        "allowed_chat_ids": json.loads(chat_ids_json),
+        "allowed_chat_refs": _grant_list(refs_json, str),
         "no_download": token_record["no_download"],
         "expires_at": token_record["expires_at"],
         "created_at": token_record["created_at"],
@@ -2939,23 +3114,22 @@ async def create_token(request: Request, user: UserContext = Depends(require_mas
 
 @app.put("/api/admin/tokens/{token_id}")
 async def update_token(token_id: int, request: Request, user: UserContext = Depends(require_master)):
-    """Update a share token (label, allowed_chat_ids, is_revoked, no_download)."""
+    """Update a share token (label, allowed_chat_refs, is_revoked, no_download)."""
     try:
         data = await request.json()
     except Exception:
         raise HTTPException(status_code=400, detail="Invalid JSON")
 
+    _reject_legacy_grant_key(data)
     updates = {}
     if "label" in data:
         updates["label"] = (data["label"] or "").strip() or None
-    if "allowed_chat_ids" in data:
-        allowed = data["allowed_chat_ids"]
-        if allowed is None or not isinstance(allowed, list):
-            raise HTTPException(status_code=400, detail="allowed_chat_ids must be a list")
-        try:
-            updates["allowed_chat_ids"] = json.dumps([int(cid) for cid in allowed])
-        except ValueError, TypeError:
-            raise HTTPException(status_code=400, detail="Invalid chat ID format")
+    if "allowed_chat_refs" in data:
+        allowed = data["allowed_chat_refs"]
+        if allowed is None or not isinstance(allowed, list) or not allowed:
+            raise HTTPException(status_code=400, detail="allowed_chat_refs must be a non-empty list")
+        updates["allowed_chat_refs"] = _refs_grant_json(allowed)
+        updates["allowed_chat_ids"] = "[]"  # keep the rollback tombstone denying
     if "is_revoked" in data:
         updates["is_revoked"] = 1 if data["is_revoked"] else 0
     if "no_download" in data:
@@ -2969,7 +3143,7 @@ async def update_token(token_id: int, request: Request, user: UserContext = Depe
         raise HTTPException(status_code=404, detail="Token not found")
 
     # Invalidate all active sessions from this token when scope/access changes
-    scope_changed = any(k in updates for k in ("is_revoked", "allowed_chat_ids", "no_download"))
+    scope_changed = any(k in updates for k in ("is_revoked", "allowed_chat_refs", "no_download"))
     if scope_changed:
         await _invalidate_token_sessions(token_id)
 
@@ -2984,7 +3158,7 @@ async def update_token(token_id: int, request: Request, user: UserContext = Depe
     return {
         "id": updated["id"],
         "label": updated["label"],
-        "allowed_chat_ids": json.loads(updated["allowed_chat_ids"]) if updated["allowed_chat_ids"] else None,
+        "allowed_chat_refs": _grant_list(updated.get("allowed_chat_refs"), str),
         "is_revoked": updated["is_revoked"],
         "no_download": updated["no_download"],
         "expires_at": updated["expires_at"],
@@ -3100,9 +3274,7 @@ async def websocket_endpoint(websocket: WebSocket):
         await websocket.close(code=4001, reason=exc.detail)
         return
 
-    ws_user_chat_ids = get_user_chat_ids(user_ctx)
-
-    await ws_manager.connect(websocket, allowed_chat_ids=ws_user_chat_ids)
+    await ws_manager.connect(websocket, user_ctx)
 
     try:
         while True:
@@ -3110,18 +3282,24 @@ async def websocket_endpoint(websocket: WebSocket):
             action = data.get("action")
 
             if action == "subscribe":
-                chat_id = data.get("chat_id")
-                if chat_id:
-                    if ws_manager.subscribe(websocket, chat_id):
-                        await websocket.send_json({"type": "subscribed", "chat_id": chat_id})
+                chat_ref = data.get("chat_ref")
+                if isinstance(chat_ref, str) and chat_ref:
+                    # The SAME resolver + entitlement as every HTTP route (the
+                    # parity requirement): unknown, malformed and forbidden refs
+                    # are denied identically, and a DB outage denies too.
+                    try:
+                        await _resolve_chat_ref(chat_ref, user_ctx)
+                    except HTTPException:
+                        await websocket.send_json({"type": "subscribe_denied", "chat_ref": chat_ref})
                     else:
-                        await websocket.send_json({"type": "subscribe_denied", "chat_id": chat_id})
+                        ws_manager.subscribe(websocket, chat_ref)
+                        await websocket.send_json({"type": "subscribed", "chat_ref": chat_ref})
 
             elif action == "unsubscribe":
-                chat_id = data.get("chat_id")
-                if chat_id:
-                    ws_manager.unsubscribe(websocket, chat_id)
-                    await websocket.send_json({"type": "unsubscribed", "chat_id": chat_id})
+                chat_ref = data.get("chat_ref")
+                if isinstance(chat_ref, str) and chat_ref:
+                    ws_manager.unsubscribe(websocket, chat_ref)
+                    await websocket.send_json({"type": "unsubscribed", "chat_ref": chat_ref})
 
             elif action == "ping":
                 await websocket.send_json({"type": "pong"})
@@ -3139,27 +3317,42 @@ async def websocket_endpoint(websocket: WebSocket):
 
 
 async def broadcast_new_message(chat_id: int, message: dict):
-    """Broadcast a new message to subscribed clients."""
-    await ws_manager.broadcast_to_chat(chat_id, {"type": "new_message", "chat_id": chat_id, "message": message})
+    """Broadcast a new message to subscribed clients (frames are ref-addressed)."""
+    chat = await _broadcast_chat_row(chat_id)
+    if chat is None:
+        return
+    await ws_manager.broadcast_to_chat(chat, {"type": "new_message", "chat_ref": chat["ref"], "message": message})
 
 
 async def broadcast_message_edit(chat_id: int, message_id: int, new_text: str, edit_date: str):
-    """Broadcast a message edit to subscribed clients."""
+    """Broadcast a message edit to subscribed clients (frames are ref-addressed)."""
+    chat = await _broadcast_chat_row(chat_id)
+    if chat is None:
+        return
     await ws_manager.broadcast_to_chat(
-        chat_id,
-        {"type": "edit", "chat_id": chat_id, "message_id": message_id, "new_text": new_text, "edit_date": edit_date},
+        chat,
+        {
+            "type": "edit",
+            "chat_ref": chat["ref"],
+            "message_id": message_id,
+            "new_text": new_text,
+            "edit_date": edit_date,
+        },
     )
 
 
 async def broadcast_message_delete(
     chat_id: int, message_id: int, deletion_mode: str = "hard", deleted_at: str | None = None
 ) -> None:
-    """Broadcast a message deletion to subscribed clients."""
+    """Broadcast a message deletion to subscribed clients (frames are ref-addressed)."""
+    chat = await _broadcast_chat_row(chat_id)
+    if chat is None:
+        return
     await ws_manager.broadcast_to_chat(
-        chat_id,
+        chat,
         {
             "type": "delete",
-            "chat_id": chat_id,
+            "chat_ref": chat["ref"],
             "message_id": message_id,
             "deletion_mode": deletion_mode,
             "deleted_at": deleted_at,

--- a/src/web/push.py
+++ b/src/web/push.py
@@ -20,6 +20,7 @@ from py_vapid import Vapid
 from py_vapid.utils import b64urlencode
 from pywebpush import WebPushException, webpush
 
+from ..db.adapter import parse_entitlement_column
 from ..message_utils import utcnow_naive
 
 logger = logging.getLogger(__name__)
@@ -202,7 +203,8 @@ class PushNotificationManager:
         chat_id: int | None = None,
         user_agent: str | None = None,
         username: str | None = None,
-        allowed_chat_ids: list[int] | None = None,
+        allowed_accounts: list[int] | None = None,
+        allowed_chat_refs: list[str] | None = None,
     ) -> bool:
         """
         Store a push subscription with user ownership.
@@ -211,10 +213,16 @@ class PushNotificationManager:
             endpoint: Push service URL
             p256dh: Client public key (base64)
             auth: Auth secret (base64)
-            chat_id: Optional chat ID for chat-specific subscriptions
+            chat_id: Optional resolved chat ID for chat-specific subscriptions
+                (the API takes a chat_ref; the caller resolves it before this)
             user_agent: Browser user agent for debugging
             username: The authenticated user who created this subscription
-            allowed_chat_ids: Snapshot of the user's allowed chats (None = master/all access)
+            allowed_accounts: Snapshot of the user's account grant (None = all)
+            allowed_chat_refs: Snapshot of the user's chat-ref grant (None = all)
+
+        The legacy ``allowed_chat_ids`` column is written as a rollback
+        tombstone only — "[]" for a restricted subscriber so a 7.x binary
+        denies, NULL for an unrestricted one. 8.0 code never reads it.
 
         Returns:
             True if subscription was stored successfully
@@ -224,7 +232,10 @@ class PushNotificationManager:
 
             from src.db.models import PushSubscription
 
-            allowed_json = json.dumps(allowed_chat_ids) if allowed_chat_ids is not None else None
+            accounts_json = json.dumps(allowed_accounts) if allowed_accounts is not None else None
+            refs_json = json.dumps(allowed_chat_refs) if allowed_chat_refs is not None else None
+            restricted = accounts_json is not None or refs_json is not None
+            legacy_tombstone = "[]" if restricted else None
 
             async with self.db.db_manager.async_session_factory() as session:
                 result = await session.execute(select(PushSubscription).where(PushSubscription.endpoint == endpoint))
@@ -236,7 +247,9 @@ class PushNotificationManager:
                     existing.chat_id = chat_id
                     existing.user_agent = user_agent
                     existing.username = username
-                    existing.allowed_chat_ids = allowed_json
+                    existing.allowed_chat_ids = legacy_tombstone
+                    existing.allowed_accounts = accounts_json
+                    existing.allowed_chat_refs = refs_json
                     existing.last_used_at = utcnow_naive()
                 else:
                     sub = PushSubscription(
@@ -246,7 +259,9 @@ class PushNotificationManager:
                         chat_id=chat_id,
                         user_agent=user_agent,
                         username=username,
-                        allowed_chat_ids=allowed_json,
+                        allowed_chat_ids=legacy_tombstone,
+                        allowed_accounts=accounts_json,
+                        allowed_chat_refs=refs_json,
                         created_at=utcnow_naive(),
                     )
                     session.add(sub)
@@ -279,13 +294,23 @@ class PushNotificationManager:
             logger.error(f"Failed to remove push subscription: {e}")
             return False
 
-    async def get_subscriptions(self, chat_id: int | None = None) -> list[dict[str, Any]]:
+    async def get_subscriptions(
+        self,
+        chat_id: int | None = None,
+        *,
+        account_id: int | None = None,
+        chat_ref: str | None = None,
+    ) -> list[dict[str, Any]]:
         """
-        Get push subscriptions for a given chat, filtered by per-user permissions.
+        Get push subscriptions entitled to a given chat, fail-closed.
 
-        Only returns subscriptions where:
-        - The user is master (allowed_chat_ids is NULL) and subscribed globally or to this chat
-        - The user is a viewer whose allowed_chat_ids includes this chat_id
+        ``chat_id`` narrows to subscriptions whose TOPIC is this chat (or
+        global); ``account_id``/``chat_ref`` are the chat's identity for the
+        entitlement check against the v8.0.0 grant columns. The legacy
+        ``allowed_chat_ids`` column is never read — a subscription whose grant
+        exists only there (or cannot be parsed) receives nothing, exactly like
+        the viewer's own resolver. Without a chat context only unrestricted
+        subscriptions qualify.
         """
         try:
             from sqlalchemy import or_, select
@@ -303,13 +328,17 @@ class PushNotificationManager:
 
                 filtered = []
                 for sub in subs:
-                    if sub.allowed_chat_ids is not None:
-                        try:
-                            user_chats = json.loads(sub.allowed_chat_ids)
-                            if chat_id not in user_chats:
-                                continue
-                        except json.JSONDecodeError, TypeError:
-                            continue
+                    accounts = parse_entitlement_column(sub.allowed_accounts, int)
+                    refs = parse_entitlement_column(sub.allowed_chat_refs, str)
+                    # Deny-only legacy guard, the twin of main._grants_from_row:
+                    # a legacy grant with BOTH new columns NULL is an unconverted
+                    # 7.x restriction and must deny, never widen.
+                    if accounts is None and refs is None and sub.allowed_chat_ids is not None:
+                        continue
+                    if accounts is not None and account_id not in accounts:
+                        continue
+                    if refs is not None and chat_ref not in refs:
+                        continue
                     filtered.append({"endpoint": sub.endpoint, "keys": {"p256dh": sub.p256dh, "auth": sub.auth}})
 
                 return filtered
@@ -326,6 +355,9 @@ class PushNotificationManager:
         data: dict[str, Any] | None = None,
         icon: str | None = None,
         tag: str | None = None,
+        *,
+        account_id: int | None = None,
+        chat_ref: str | None = None,
     ) -> int:
         """
         Send push notification to all relevant subscribers.
@@ -333,10 +365,13 @@ class PushNotificationManager:
         Args:
             title: Notification title
             body: Notification body text
-            chat_id: Optional chat ID to filter subscribers
+            chat_id: Optional chat ID to filter subscribers (topic match only —
+                it never reaches the payload; the ref is the outward identity)
             data: Additional data to include in notification
             icon: URL for notification icon
             tag: Tag for notification grouping/replacement
+            account_id: The chat's account, for the entitlement filter
+            chat_ref: The chat's opaque ref, for the entitlement filter and tag
 
         Returns:
             Number of notifications successfully sent
@@ -344,7 +379,7 @@ class PushNotificationManager:
         if not self.is_enabled:
             return 0
 
-        subscriptions = await self.get_subscriptions(chat_id)
+        subscriptions = await self.get_subscriptions(chat_id, account_id=account_id, chat_ref=chat_ref)
 
         if not subscriptions:
             return 0
@@ -353,7 +388,7 @@ class PushNotificationManager:
             "title": title,
             "body": body,
             "icon": icon or "/static/favicon.ico",
-            "tag": tag or f"telegram-archive-{chat_id or 'all'}",
+            "tag": tag or f"telegram-archive-{chat_ref or 'all'}",
             "data": data or {},
             "timestamp": utcnow_naive().isoformat(),
         }
@@ -411,17 +446,28 @@ class PushNotificationManager:
         return sent
 
     async def notify_new_message(
-        self, chat_id: int, chat_title: str, sender_name: str, message_text: str, message_id: int
+        self,
+        chat_id: int,
+        chat_ref: str,
+        chat_title: str,
+        sender_name: str,
+        message_text: str,
+        message_id: int,
+        *,
+        account_id: int | None = None,
     ) -> int:
         """
         Send notification for a new message.
 
         Args:
-            chat_id: The chat ID where the message was posted
+            chat_id: The chat ID where the message was posted (topic filter only)
+            chat_ref: The chat's opaque ref — the ONLY chat identity that enters
+                the payload, its URL, and the grouping tag
             chat_title: Display name of the chat
             sender_name: Name of the message sender
             message_text: Preview of the message text
             message_id: ID of the message (for click navigation)
+            account_id: The chat's account, for the entitlement filter
 
         Returns:
             Number of notifications sent
@@ -438,11 +484,13 @@ class PushNotificationManager:
             chat_id=chat_id,
             data={
                 "type": "new_message",
-                "chat_id": chat_id,
+                "chat_ref": chat_ref,
                 "message_id": message_id,
-                "url": f"/?chat={chat_id}&msg={message_id}",
+                "url": f"/?chat={chat_ref}&msg={message_id}",
             },
-            tag=f"chat-{chat_id}",  # Group by chat, replace previous
+            tag=f"chat-{chat_ref}",  # Group by chat, replace previous
+            account_id=account_id,
+            chat_ref=chat_ref,
         )
 
 

--- a/src/web/static/sw.js
+++ b/src/web/static/sw.js
@@ -103,9 +103,9 @@ self.addEventListener('notificationclick', (event) => {
     if (data.url) {
         url = data.url;
     } else if (data.chat_ref) {
-        url = `/?chat=${data.chat_ref}`;
+        url = `/?chat=${encodeURIComponent(data.chat_ref)}`;
         if (data.message_id) {
-            url += `&msg=${data.message_id}`;
+            url += `&msg=${encodeURIComponent(data.message_id)}`;
         }
     }
     

--- a/src/web/static/sw.js
+++ b/src/web/static/sw.js
@@ -96,12 +96,14 @@ self.addEventListener('notificationclick', (event) => {
     
     notification.close();
     
-    // Determine the URL to open
+    // Determine the URL to open. The fallback builds the same ref-addressed
+    // deep link the server sends in data.url — the chat's opaque ref, never
+    // the chat id, so no chat id reaches browser history or access logs.
     let url = '/';
     if (data.url) {
         url = data.url;
-    } else if (data.chat_id) {
-        url = `/?chat=${data.chat_id}`;
+    } else if (data.chat_ref) {
+        url = `/?chat=${data.chat_ref}`;
         if (data.message_id) {
             url += `&msg=${data.message_id}`;
         }

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -2841,7 +2841,7 @@
                     topics.value = []
                     topicsError.value = ''
                     try {
-                        const res = await fetch(`/api/chats/${chatRef}/topics`, { credentials: 'include' })
+                        const res = await fetch(`/api/chats/${encodeURIComponent(chatRef)}/topics`, { credentials: 'include' })
                         if (requestSeq !== topicsRequestSeq) return
                         if (res.ok) {
                             const data = await res.json()
@@ -3885,7 +3885,7 @@
                         })
                         if (lastItem) params.set('before_id', lastItem.id)
 
-                        const res = await fetch(`/api/chats/${requestChatRef}/media?${params}`, {
+                        const res = await fetch(`/api/chats/${encodeURIComponent(requestChatRef)}/media?${params}`, {
                             credentials: 'include'
                         })
                         if (!stillCurrent()) return
@@ -3917,7 +3917,7 @@
                     // previous chat's numbers.
                     const requestChatRef = selectedChat.value.ref
                     try {
-                        const res = await fetch(`/api/chats/${requestChatRef}/media/counts`, {
+                        const res = await fetch(`/api/chats/${encodeURIComponent(requestChatRef)}/media/counts`, {
                             credentials: 'include'
                         })
                         if (res.ok) {
@@ -4026,7 +4026,7 @@
                         const topicParam = topicId == null ? '' : `&topic_id=${topicId}`
                         // before_id is an exclusive bound, so +1 keeps the target itself as the
                         // newest row of the history half of the window.
-                        const res = await fetch(`/api/chats/${selectedChat.value.ref}/messages?before_id=${messageId + 1}&limit=${windowLimit}${topicParam}`, {
+                        const res = await fetch(`/api/chats/${encodeURIComponent(selectedChat.value.ref)}/messages?before_id=${messageId + 1}&limit=${windowLimit}${topicParam}`, {
                             credentials: 'include'
                         })
                         if (!isCurrentIntent()) return
@@ -4043,7 +4043,7 @@
                         let afterRows = []
                         let afterFetchComplete = false
                         try {
-                            const afterRes = await fetch(`/api/chats/${selectedChat.value.ref}/messages?after_id=${messageId}&limit=${windowLimit}${topicParam}`, {
+                            const afterRes = await fetch(`/api/chats/${encodeURIComponent(selectedChat.value.ref)}/messages?after_id=${messageId}&limit=${windowLimit}${topicParam}`, {
                                 credentials: 'include'
                             })
                             if (!isCurrentIntent()) return
@@ -4301,7 +4301,7 @@
                 // Load all pinned messages for a chat
                 const loadPinnedMessages = async (chatRef) => {
                     try {
-                        const res = await fetch(`/api/chats/${chatRef}/pinned`, {
+                        const res = await fetch(`/api/chats/${encodeURIComponent(chatRef)}/pinned`, {
                             credentials: 'include'
                         })
                         if (res.ok) {
@@ -4355,7 +4355,7 @@
 
                 const loadChatStats = async (chatRef) => {
                     try {
-                        const res = await fetch(`/api/chats/${chatRef}/stats`, {
+                        const res = await fetch(`/api/chats/${encodeURIComponent(chatRef)}/stats`, {
                             credentials: 'include'
                         })
                         if (res.ok) {
@@ -5371,7 +5371,7 @@
                     clearMessageVersionsRecord(messageVersionsErrors, key)
 
                     try {
-                        const res = await fetch(`/api/chats/${chatRef}/messages/${msg.id}/versions?limit=100`, {
+                        const res = await fetch(`/api/chats/${encodeURIComponent(chatRef)}/messages/${encodeURIComponent(msg.id)}/versions?limit=100`, {
                             credentials: 'include'
                         })
                         if (!res.ok) {
@@ -5990,7 +5990,7 @@
                     audioQueueAbort?.abort()
                     const controller = new AbortController()
                     audioQueueAbort = controller
-                    const res = await fetch(`/api/chats/${chatRef}/media?${params}`, {
+                    const res = await fetch(`/api/chats/${encodeURIComponent(chatRef)}/media?${params}`, {
                         credentials: 'include',
                         signal: controller.signal
                     })
@@ -6948,7 +6948,7 @@
                     try {
                         let res
                         if (adminEditingId.value) {
-                            res = await fetch(`/api/admin/viewers/${adminEditingId.value}`, {
+                            res = await fetch(`/api/admin/viewers/${encodeURIComponent(adminEditingId.value)}`, {
                                 method: 'PUT', credentials: 'include',
                                 headers: { 'Content-Type': 'application/json' },
                                 body: JSON.stringify(body)
@@ -6985,7 +6985,7 @@
                 const deleteViewer = async (viewer) => {
                     if (!confirm(`Delete viewer "${viewer.username}"?`)) return
                     try {
-                        await fetch(`/api/admin/viewers/${viewer.id}`, {
+                        await fetch(`/api/admin/viewers/${encodeURIComponent(viewer.id)}`, {
                             method: 'DELETE', credentials: 'include'
                         })
                         await loadAdminViewers()
@@ -7046,7 +7046,7 @@
                 const revokeToken = async (token) => {
                     if (!confirm(`Revoke token "${token.label || token.id}"?`)) return
                     try {
-                        await fetch(`/api/admin/tokens/${token.id}`, {
+                        await fetch(`/api/admin/tokens/${encodeURIComponent(token.id)}`, {
                             method: 'PUT', credentials: 'include',
                             headers: { 'Content-Type': 'application/json' },
                             body: JSON.stringify({ is_revoked: true })
@@ -7058,7 +7058,7 @@
                 const deleteToken = async (token) => {
                     if (!confirm(`Permanently delete token "${token.label || token.id}"?`)) return
                     try {
-                        await fetch(`/api/admin/tokens/${token.id}`, {
+                        await fetch(`/api/admin/tokens/${encodeURIComponent(token.id)}`, {
                             method: 'DELETE', credentials: 'include'
                         })
                         await loadAdminTokens()

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -4435,7 +4435,7 @@
                     try {
                         // Get latest messages (just first page)
                         // v6.2.12: Include topic_id filter when viewing a forum topic
-                        let refreshUrl = `/api/chats/${selectedChat.value.ref}/messages?limit=50&offset=0`
+                        let refreshUrl = `/api/chats/${encodeURIComponent(selectedChat.value.ref)}/messages?limit=50&offset=0`
                         const topicId = activeTopicId()
                         if (topicId != null) {
                             refreshUrl += `&topic_id=${topicId}`
@@ -4527,7 +4527,7 @@
                     loading.value = true
                     try {
                         const limit = 50
-                        let url = `/api/chats/${selectedChat.value.ref}/messages?limit=${limit}`
+                        let url = `/api/chats/${encodeURIComponent(selectedChat.value.ref)}/messages?limit=${limit}`
 
                         // v6.2.0: Add topic_id filter if the displayed pane is scoped to a topic.
                         const topicId = activeTopicId()
@@ -4552,7 +4552,7 @@
                         if (messageSearchQuery.value) {
                             // Search still uses offset for simplicity
                             const offset = page.value * limit
-                            url = `/api/chats/${selectedChat.value.ref}/messages?limit=${limit}&offset=${offset}`
+                            url = `/api/chats/${encodeURIComponent(selectedChat.value.ref)}/messages?limit=${limit}&offset=${offset}`
                             url += `&search=${encodeURIComponent(messageSearchQuery.value)}`
                             // Also pass topic_id for search within a topic
                             if (topicId != null) {
@@ -4649,7 +4649,7 @@
                     try {
                         const limit = 50
                         const res = await fetch(
-                            `/api/chats/${chatRef}/messages?after_id=${newestMessageId}&limit=${limit}${topicParam}`,
+                            `/api/chats/${encodeURIComponent(chatRef)}/messages?after_id=${newestMessageId}&limit=${limit}${topicParam}`,
                             { credentials: 'include' }
                         )
                         if (requestSeq !== newerLoadRequestSeq || chatVersion !== myVersion ||
@@ -5118,7 +5118,7 @@
 
                 const exportChat = () => {
                     if (!selectedChat.value) return
-                    const url = `/api/chats/${selectedChat.value.ref}/export`
+                    const url = `/api/chats/${encodeURIComponent(selectedChat.value.ref)}/export`
                     window.open(url, '_blank')
                 }
 
@@ -6667,7 +6667,7 @@
                     calendarAvailabilityLoading.value = true
                     calendarAvailabilityError.value = ''
                     try {
-                        let url = `/api/chats/${chatRef}/messages/dates?month=${monthKey}&timezone=${encodeURIComponent(timezone)}`
+                        let url = `/api/chats/${encodeURIComponent(chatRef)}/messages/dates?month=${monthKey}&timezone=${encodeURIComponent(timezone)}`
                         if (topicId != null) {
                             url += `&topic_id=${topicId}`
                         }
@@ -6822,7 +6822,7 @@
                         // Fetch message for the selected date
                         // Pass timezone so backend can convert the displayed date to correct UTC bounds
                         const tz = encodeURIComponent(viewerTimezone.value)
-                        let dateUrl = `/api/chats/${chatRefAtStart}/messages/by-date?date=${selectedDateAtStart}&timezone=${tz}`
+                        let dateUrl = `/api/chats/${encodeURIComponent(chatRefAtStart)}/messages/by-date?date=${selectedDateAtStart}&timezone=${tz}`
                         if (topicIdAtStart != null) {
                             dateUrl += `&topic_id=${topicIdAtStart}`
                         }

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -756,13 +756,13 @@
                                 <template v-if="statsData && statsData.backup_in_progress">A backup is currently running — topics appear once it finishes.</template>
                                 <template v-else>If this group uses Topics, they’ll appear after the next full backup completes.</template>
                             </span>
-                            <button @click="selectTopic(topicsNavEntry.chat || { id: topicsNavEntry.chatId, is_forum: true }, { id: 'all', title: 'All messages' })"
+                            <button @click="selectTopic(topicsNavEntry.chat || { ref: topicsNavEntry.chatRef, is_forum: true }, { id: 'all', title: 'All messages' })"
                                 class="mt-1 px-3 py-1.5 text-xs rounded-full bg-tg-active hover:bg-blue-600 text-white transition">
                                 View all messages
                             </button>
                         </div>
                         <div v-else v-for="topic in topics" :key="topic.id"
-                            @click="selectTopic(topicsNavEntry.chat || { id: topicsNavEntry.chatId, is_forum: true }, topic)"
+                            @click="selectTopic(topicsNavEntry.chat || { ref: topicsNavEntry.chatRef, is_forum: true }, topic)"
                             class="p-3 cursor-pointer hover:bg-tg-hover transition-colors flex items-center gap-3 border-b border-gray-700/30"
                             :class="{'bg-tg-active': selectedPaneTopic?.id === topic.id}">
                             <!-- Topic icon -->
@@ -840,9 +840,9 @@
                             </div>
 
                             <!-- Chat items -->
-                            <div v-for="chat in filteredChats" :key="chat.id" @click="selectChat(chat)"
+                            <div v-for="chat in filteredChats" :key="chat.ref" @click="selectChat(chat)"
                                 class="p-3 cursor-pointer hover:bg-tg-hover transition-colors flex items-center gap-3"
-                                :class="{'bg-tg-active': selectedChat?.id === chat.id}">
+                                :class="{'bg-tg-active': selectedChat?.ref === chat.ref}">
                                 <!-- Avatar -->
                                 <div
                                     class="w-12 h-12 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center text-lg font-bold text-white shrink-0 overflow-hidden relative">
@@ -1908,7 +1908,7 @@
                                 <label class="text-xs text-gray-400 block mb-1">Allowed Chats (none selected = access to all chats)</label>
                                 <div class="flex flex-wrap gap-1 bg-gray-700 rounded p-2 max-h-32 overflow-y-auto">
                                     <label v-for="chat in adminChats" :key="chat.id" class="flex items-center gap-1 text-xs text-gray-300 bg-gray-600 rounded px-2 py-1 cursor-pointer hover:bg-gray-500">
-                                        <input type="checkbox" :value="chat.id" v-model="adminViewerForm.allowed_chat_ids" class="rounded" />
+                                        <input type="checkbox" :value="chat.ref" v-model="adminViewerForm.allowed_chat_refs" class="rounded" />
                                         {{ chat.title || chat.id }}
                                     </label>
                                 </div>
@@ -1934,10 +1934,13 @@
                                 <div class="flex-1">
                                     <div class="text-sm text-white font-medium">{{ viewer.username }}</div>
                                     <div class="text-xs text-gray-400">
-                                        <template v-if="viewer.allowed_chat_ids && viewer.allowed_chat_ids.length">
-                                            {{ viewer.allowed_chat_ids.map(id => { const c = adminChats.find(ch => ch.id === id); return c ? c.title : id }).join(', ') }}
+                                        <template v-if="viewer.allowed_chat_refs && viewer.allowed_chat_refs.length">
+                                            {{ viewer.allowed_chat_refs.map(r => { const c = adminChats.find(ch => ch.ref === r); return c ? c.title : r }).join(', ') }}
                                         </template>
+                                        <!-- [] is an ENFORCED empty grant (deny everything), not "all chats" -->
+                                        <template v-else-if="viewer.allowed_chat_refs">No chats (empty grant)</template>
                                         <template v-else>All chats</template>
+                                        <template v-if="viewer.allowed_accounts"> · Accounts: {{ viewer.allowed_accounts.length ? viewer.allowed_accounts.join(', ') : 'none' }}</template>
                                         · {{ viewer.is_active ? 'Active' : 'Inactive' }}
                                         <template v-if="viewer.no_download"> · <span class="text-amber-400">No DL</span></template>
                                     </div>
@@ -1963,7 +1966,7 @@
                                 <label class="text-xs text-gray-400 block mb-1">Allowed Chats (required — tokens must be scoped)</label>
                                 <div class="flex flex-wrap gap-1 bg-gray-700 rounded p-2 max-h-32 overflow-y-auto">
                                     <label v-for="chat in adminChats" :key="chat.id" class="flex items-center gap-1 text-xs text-gray-300 bg-gray-600 rounded px-2 py-1 cursor-pointer hover:bg-gray-500">
-                                        <input type="checkbox" :value="chat.id" v-model="adminTokenForm.allowed_chat_ids" class="rounded" />
+                                        <input type="checkbox" :value="chat.ref" v-model="adminTokenForm.allowed_chat_refs" class="rounded" />
                                         {{ chat.title || chat.id }}
                                     </label>
                                 </div>
@@ -2002,9 +2005,12 @@
                                     <div class="flex-1">
                                         <div class="text-sm text-white font-medium">{{ token.label || `Token #${token.id}` }}</div>
                                         <div class="text-xs text-gray-400">
-                                            <template v-if="token.allowed_chat_ids && token.allowed_chat_ids.length">
-                                                {{ token.allowed_chat_ids.map(id => { const c = adminChats.find(ch => ch.id === id); return c ? c.title : id }).join(', ') }}
+                                            <template v-if="token.allowed_chat_refs && token.allowed_chat_refs.length">
+                                                {{ token.allowed_chat_refs.map(r => { const c = adminChats.find(ch => ch.ref === r); return c ? c.title : r }).join(', ') }}
                                             </template>
+                                            <!-- an unreadable stored grant renders as [] and denies everything -->
+                                            <template v-else>No chats (empty grant)</template>
+                                            <template v-if="token.allowed_accounts"> · Accounts: {{ token.allowed_accounts.length ? token.allowed_accounts.join(', ') : 'none' }}</template>
                                             · Used {{ token.use_count || 0 }}x
                                             <template v-if="token.last_used_at"> · Last: {{ new Date(token.last_used_at).toLocaleDateString() }}</template>
                                             <template v-if="token.expires_at"> · Exp: {{ new Date(token.expires_at).toLocaleDateString() }}</template>
@@ -2826,7 +2832,7 @@
                     }
                 }
 
-                const loadTopics = async (chatId) => {
+                const loadTopics = async (chatRef) => {
                     const requestSeq = ++topicsRequestSeq
                     loadingTopics.value = true
                     // Drop the previous chat's rows up front: a failure or a lost race
@@ -2835,7 +2841,7 @@
                     topics.value = []
                     topicsError.value = ''
                     try {
-                        const res = await fetch(`/api/chats/${chatId}/topics`, { credentials: 'include' })
+                        const res = await fetch(`/api/chats/${chatRef}/topics`, { credentials: 'include' })
                         if (requestSeq !== topicsRequestSeq) return
                         if (res.ok) {
                             const data = await res.json()
@@ -2856,7 +2862,7 @@
 
                 const retryLoadTopics = () => {
                     const nav = topicsNavEntry.value
-                    if (nav) loadTopics(nav.chatId)
+                    if (nav) loadTopics(nav.chatRef)
                 }
 
                 const selectFolder = (folderId) => {
@@ -2875,8 +2881,8 @@
 
                 const openForumTopics = async (chat) => {
                     // v6.2.12: Store full chat object so selectTopic can use it for display name
-                    navigateTo({ type: 'topics', chatId: chat.id, chatName: getChatName(chat), chat: chat })
-                    await loadTopics(chat.id)
+                    navigateTo({ type: 'topics', chatRef: chat.ref, chatName: getChatName(chat), chat: chat })
+                    await loadTopics(chat.ref)
                 }
 
                 const selectTopic = async (chat, topic) => {
@@ -2886,7 +2892,7 @@
                     loading.value = false
 
                     // Push topic chat view onto nav stack
-                    navStack.value.push({ type: 'chat', chatId: chat.id, topicId: topic.id, topicTitle: topic.title })
+                    navStack.value.push({ type: 'chat', chatRef: chat.ref, topicId: topic.id, topicTitle: topic.title })
                     selectedChat.value = chat
                     selectedPaneTopic.value = topic
                     messages.value = []
@@ -2900,7 +2906,7 @@
                     showMediaGallery.value = false
                     await loadMessages()
                     if (chatVersion !== myVersion) return
-                    await loadChatStats(chat.id)
+                    await loadChatStats(chat.ref)
                     await nextTick()
                     if (chatVersion !== myVersion) return
                     scrollToBottom()
@@ -3161,22 +3167,24 @@
                     loadingStats.value = false
                 }
 
-                // Resolve the chat a notification points at. The sidebar holds one page of
-                // 50 NON-archived chats, so looking the id up there alone silently fails
+                // Resolve the chat a notification points at (by its opaque ref — the only
+                // chat identity notifications carry now). The sidebar holds one page of
+                // 50 NON-archived chats, so looking the ref up there alone silently fails
                 // for every archived chat (a notification is fired for those too) and for
                 // anything past the first page. Fall back to one wider lookup — no
                 // archived filter, so archived chats are included — before giving up.
-                const resolveChatById = async (chatId) => {
-                    const known = chats.value.find(c => c.id === chatId)
+                const resolveChatById = async (chatRef) => {
+                    const known = chats.value.find(c => c.ref === chatRef)
                     if (known) return known
                     try {
                         const res = await fetch('/api/chats?limit=1000', { credentials: 'include' })
                         if (res.ok) {
                             const data = await res.json()
-                            return (data.chats || []).find(c => c.id === chatId) || null
+                            return (data.chats || []).find(c => c.ref === chatRef) || null
                         }
                     } catch (e) {
-                        // No identifiers in the message: the chat id is PII.
+                        // No identifiers in the message, out of habit: the ref is opaque,
+                        // but log-shape stability is worth keeping.
                         console.error('Failed to resolve the notification target chat')
                     }
                     return null
@@ -3185,8 +3193,8 @@
                 // Open what a notification points at, or say so instead of doing nothing.
                 // Returns whether the chat was opened, so the caller can decide to keep a
                 // deep link in the URL and let a refresh retry it.
-                const openNotificationTarget = async (chatId, messageId) => {
-                    const targetChat = await resolveChatById(chatId)
+                const openNotificationTarget = async (chatRef, messageId) => {
+                    const targetChat = await resolveChatById(chatRef)
                     if (!targetChat) {
                         showToast('Could not open that chat')
                         return false
@@ -3208,9 +3216,9 @@
                 const flushPendingNotificationClick = async () => {
                     notificationClickReady = true
                     if (!pendingNotificationClick) return
-                    const { chatId, messageId } = pendingNotificationClick
+                    const { chatRef, messageId } = pendingNotificationClick
                     pendingNotificationClick = null
-                    await openNotificationTarget(chatId, messageId)
+                    await openNotificationTarget(chatRef, messageId)
                 }
 
                 // Auth check on mount
@@ -3226,15 +3234,15 @@
                     // to handle.
                     const onServiceWorkerMessage = async (event) => {
                         if (event.data?.type !== 'NOTIFICATION_CLICK') return
-                        const { chat_id, message_id } = event.data.data || {}
-                        if (!chat_id) return
-                        // No identifiers in the log line: chat and message ids are PII.
+                        const { chat_ref, message_id } = event.data.data || {}
+                        if (!chat_ref) return
+                        // No identifiers in the log line: message ids are PII.
                         console.log('[Notification] Click received')
                         if (!notificationClickReady) {
-                            pendingNotificationClick = { chatId: chat_id, messageId: message_id }
+                            pendingNotificationClick = { chatRef: chat_ref, messageId: message_id }
                             return
                         }
-                        await openNotificationTarget(chat_id, message_id)
+                        await openNotificationTarget(chat_ref, message_id)
                     }
                     if ('serviceWorker' in navigator) {
                         navigator.serviceWorker.addEventListener('message', onServiceWorkerMessage)
@@ -3296,17 +3304,17 @@
                                 await loadArchivedCount()
                                 setupInfiniteScroll()
 
-                                // Handle deep link from push notification
+                                // Handle deep link from push notification. /?chat= carries the
+                                // chat's opaque ref, so the chat id stays out of browser history.
                                 const urlParams = new URLSearchParams(window.location.search)
-                                const chatIdParam = urlParams.get('chat')
+                                const chatRefParam = urlParams.get('chat')
                                 const msgIdParam = urlParams.get('msg')
 
-                                if (chatIdParam) {
-                                    const chatId = parseInt(chatIdParam)
+                                if (chatRefParam) {
                                     const msgId = msgIdParam ? parseInt(msgIdParam) : null
-                                    // No identifiers in the log line: chat and message ids are PII.
+                                    // No identifiers in the log line: message ids are PII.
                                     console.log('[Notification] Deep linking to a chat')
-                                    const opened = await openNotificationTarget(chatId, msgId)
+                                    const opened = await openNotificationTarget(chatRefParam, msgId)
                                     // Clean URL without reload to prevent re-navigation on refresh —
                                     // but only once the link actually opened, so a failed one stays
                                     // retryable by refresh instead of being scrubbed away.
@@ -3367,7 +3375,7 @@
                             if (selectedChat.value) {
                                 socket.send(JSON.stringify({
                                     action: 'subscribe',
-                                    chat_id: selectedChat.value.id
+                                    chat_ref: selectedChat.value.ref
                                 }))
                             }
                         }
@@ -3399,7 +3407,7 @@
                     switch (data.type) {
                         case 'new_message':
                             // Add to messages if we're viewing that chat/topic (deduplicate by ID)
-                            if (selectedChat.value?.id === data.chat_id && data.message?.id != null && messageBelongsToCurrentTopic(data.message)) {
+                            if (selectedChat.value?.ref === data.chat_ref && data.message?.id != null && messageBelongsToCurrentTopic(data.message)) {
                                 if (viewingPinnedWindow.value || messageSearchQuery.value) {
                                     // Mirror the realtime-poll guard (#213): a detached jump window
                                     // must not grow live-tail rows (the near-bottom autoscroll below
@@ -3429,13 +3437,13 @@
                             break
 
                         case 'edit':
-                            if (data.chat_id != null && selectedChat.value?.id !== data.chat_id) {
+                            if (data.chat_ref != null && selectedChat.value?.ref !== data.chat_ref) {
                                 break
                             }
-                            // Update message text in current view
-                            const editMsg = messages.value.find(m =>
-                                m.id === data.message_id && (data.chat_id == null || m.chat_id === data.chat_id)
-                            )
+                            // Update message text in current view. Message rows carry no ref,
+                            // but every row in the pane belongs to selectedChat, and the guard
+                            // above already matched the frame's chat_ref against it.
+                            const editMsg = messages.value.find(m => m.id === data.message_id)
                             if (editMsg) {
                                 const previousText = editMsg.text
                                 editMsg.text = data.new_text
@@ -3454,34 +3462,28 @@
                             // Live reaction update (#219). The 3s poll already merges
                             // reactions via upsertMessages, so this is just the instant
                             // path; wholesale-replace to match the server's aggregate.
-                            if (data.chat_id != null && selectedChat.value?.id !== data.chat_id) {
+                            if (data.chat_ref != null && selectedChat.value?.ref !== data.chat_ref) {
                                 break
                             }
-                            const reactionMsg = messages.value.find(m =>
-                                m.id === data.message_id && (data.chat_id == null || m.chat_id === data.chat_id)
-                            )
+                            const reactionMsg = messages.value.find(m => m.id === data.message_id)
                             if (reactionMsg) {
                                 reactionMsg.reactions = data.reactions || []
                             }
                             break
 
                         case 'delete':
-                            if (data.chat_id != null && selectedChat.value?.id !== data.chat_id) {
+                            if (data.chat_ref != null && selectedChat.value?.ref !== data.chat_ref) {
                                 break
                             }
                             if (data.deletion_mode === 'soft') {
-                                const deleteMsg = messages.value.find(m =>
-                                    m.id === data.message_id && (data.chat_id == null || m.chat_id === data.chat_id)
-                                )
+                                const deleteMsg = messages.value.find(m => m.id === data.message_id)
                                 if (deleteMsg) {
                                     deleteMsg.is_deleted = 1
                                     deleteMsg.deleted_at = data.deleted_at
                                 }
                             } else {
                                 // Remove from current view
-                                const deleteIdx = messages.value.findIndex(m =>
-                                    m.id === data.message_id && (data.chat_id == null || m.chat_id === data.chat_id)
-                                )
+                                const deleteIdx = messages.value.findIndex(m => m.id === data.message_id)
                                 if (deleteIdx !== -1) {
                                     messages.value.splice(deleteIdx, 1)
                                 }
@@ -3490,8 +3492,8 @@
 
                         case 'pin':
                             // Reload pinned messages when pin/unpin happens in current chat
-                            if (selectedChat.value?.id === data.chat_id) {
-                                loadPinnedMessages(data.chat_id)
+                            if (selectedChat.value?.ref === data.chat_ref) {
+                                loadPinnedMessages(data.chat_ref)
                             }
                             break
 
@@ -3717,14 +3719,14 @@
                     // Skip if push is enabled (service worker handles it)
                     if (pushEnabled.value && pushSubscribed.value) return
 
-                    const chatName = chats.value.find(c => c.id === data.chat_id)?.title || 'New Message'
+                    const chatName = chats.value.find(c => c.ref === data.chat_ref)?.title || 'New Message'
                     const body = data.message?.text?.substring(0, 100) || 'New message received'
 
                     new Notification(chatName, {
                         body: body,
                         icon: '/static/favicon.ico',
-                        tag: `chat-${data.chat_id}`,
-                        data: { chat_id: data.chat_id }
+                        tag: `chat-${data.chat_ref}`,
+                        data: { chat_ref: data.chat_ref }
                     })
                 }
 
@@ -3768,14 +3770,14 @@
                         if (oldChat) {
                             ws.send(JSON.stringify({
                                 action: 'unsubscribe',
-                                chat_id: oldChat.id
+                                chat_ref: oldChat.ref
                             }))
                         }
                         // Subscribe to new chat
                         if (newChat) {
                             ws.send(JSON.stringify({
                                 action: 'subscribe',
-                                chat_id: newChat.id
+                                chat_ref: newChat.ref
                             }))
                         }
                     }
@@ -3858,13 +3860,13 @@
                     // the (already cleared) list, so the grid filled with the wrong type's
                     // items and stayed that way: both the skeleton and the empty state only
                     // render while the list is empty, and no request for the visible tab was
-                    // ever issued. The chat id and tab are pinned too, because a response can
+                    // ever issued. The chat ref and tab are pinned too, because a response can
                     // also outlive the view it was requested for.
                     const requestSeq = ++mediaGalleryRequestSeq
-                    const requestChatId = selectedChat.value.id
+                    const requestChatRef = selectedChat.value.ref
                     const requestTab = mediaGalleryTab.value
                     const stillCurrent = () => requestSeq === mediaGalleryRequestSeq &&
-                        selectedChat.value?.id === requestChatId &&
+                        selectedChat.value?.ref === requestChatRef &&
                         mediaGalleryTab.value === requestTab
                     mediaGalleryLoading.value = true
                     try {
@@ -3883,7 +3885,7 @@
                         })
                         if (lastItem) params.set('before_id', lastItem.id)
 
-                        const res = await fetch(`/api/chats/${requestChatId}/media?${params}`, {
+                        const res = await fetch(`/api/chats/${requestChatRef}/media?${params}`, {
                             credentials: 'include'
                         })
                         if (!stillCurrent()) return
@@ -3913,14 +3915,14 @@
                     // Same staleness as the item list: these counts are the tab badges, so a
                     // response that outlived its chat would label this chat's tabs with the
                     // previous chat's numbers.
-                    const requestChatId = selectedChat.value.id
+                    const requestChatRef = selectedChat.value.ref
                     try {
-                        const res = await fetch(`/api/chats/${requestChatId}/media/counts`, {
+                        const res = await fetch(`/api/chats/${requestChatRef}/media/counts`, {
                             credentials: 'include'
                         })
                         if (res.ok) {
                             const data = await res.json()
-                            if (selectedChat.value?.id !== requestChatId) return
+                            if (selectedChat.value?.ref !== requestChatRef) return
                             mediaGalleryCounts.value = {
                                 photos: (data.photo || 0) + (data.video || 0) + (data.animation || 0),
                                 voice: (data.voice || 0) + (data.audio || 0),
@@ -3952,6 +3954,9 @@
                         const mapped = mediaList.map(m => ({
                             media: {
                                 type: m.type,
+                                // The server-built URL is the only way to the bytes now;
+                                // file_path stays as display data (getMediaDisplayName).
+                                url: m.media_url || null,
                                 file_path: m.file_path,
                                 file_name: m.file_name,
                                 width: m.width,
@@ -4021,7 +4026,7 @@
                         const topicParam = topicId == null ? '' : `&topic_id=${topicId}`
                         // before_id is an exclusive bound, so +1 keeps the target itself as the
                         // newest row of the history half of the window.
-                        const res = await fetch(`/api/chats/${selectedChat.value.id}/messages?before_id=${messageId + 1}&limit=${windowLimit}${topicParam}`, {
+                        const res = await fetch(`/api/chats/${selectedChat.value.ref}/messages?before_id=${messageId + 1}&limit=${windowLimit}${topicParam}`, {
                             credentials: 'include'
                         })
                         if (!isCurrentIntent()) return
@@ -4038,7 +4043,7 @@
                         let afterRows = []
                         let afterFetchComplete = false
                         try {
-                            const afterRes = await fetch(`/api/chats/${selectedChat.value.id}/messages?after_id=${messageId}&limit=${windowLimit}${topicParam}`, {
+                            const afterRes = await fetch(`/api/chats/${selectedChat.value.ref}/messages?after_id=${messageId}&limit=${windowLimit}${topicParam}`, {
                                 credentials: 'include'
                             })
                             if (!isCurrentIntent()) return
@@ -4105,7 +4110,7 @@
                 watch(showMediaGallery, async (val) => {
                     if (val) {
                         galleryReturnState = {
-                            chatId: selectedChat.value?.id ?? null,
+                            chatRef: selectedChat.value?.ref ?? null,
                             scrollTop: messagesContainer.value ? messagesContainer.value.scrollTop : 0,
                             focusElement: document.activeElement instanceof HTMLElement ? document.activeElement : null
                         }
@@ -4127,7 +4132,7 @@
                             await nextTick()
                             setupMessagesScrollObserver()
                             // Restore reading position + focus for a plain close in the same chat.
-                            if (returnState && returnState.chatId === (selectedChat.value?.id ?? null)) {
+                            if (returnState && returnState.chatRef === (selectedChat.value?.ref ?? null)) {
                                 if (messagesContainer.value) {
                                     messagesContainer.value.scrollTop = returnState.scrollTop
                                 }
@@ -4294,9 +4299,9 @@
                 })
 
                 // Load all pinned messages for a chat
-                const loadPinnedMessages = async (chatId) => {
+                const loadPinnedMessages = async (chatRef) => {
                     try {
-                        const res = await fetch(`/api/chats/${chatId}/pinned`, {
+                        const res = await fetch(`/api/chats/${chatRef}/pinned`, {
                             credentials: 'include'
                         })
                         if (res.ok) {
@@ -4305,16 +4310,16 @@
                             // outlived its chat would pin the previous chat's message
                             // over this one until the next switch — and a stale
                             // failure below would wipe this chat's banner instead.
-                            if (selectedChat.value?.id !== chatId) return
+                            if (selectedChat.value?.ref !== chatRef) return
                             pinnedMessages.value = Array.isArray(data) ? data : []
                             currentPinnedIndex.value = 0  // Start with newest
                         } else {
-                            if (selectedChat.value?.id !== chatId) return
+                            if (selectedChat.value?.ref !== chatRef) return
                             pinnedMessages.value = []
                         }
                     } catch (e) {
                         console.error('Failed to load pinned messages:', e)
-                        if (selectedChat.value?.id !== chatId) return
+                        if (selectedChat.value?.ref !== chatRef) return
                         pinnedMessages.value = []
                     }
                 }
@@ -4348,9 +4353,9 @@
                     showPinnedOnly.value = false
                 }
 
-                const loadChatStats = async (chatId) => {
+                const loadChatStats = async (chatRef) => {
                     try {
-                        const res = await fetch(`/api/chats/${chatId}/stats`, {
+                        const res = await fetch(`/api/chats/${chatRef}/stats`, {
                             credentials: 'include'
                         })
                         if (res.ok) {
@@ -4358,12 +4363,12 @@
                             // Stats never auto-refresh, so a response that outlived its
                             // chat would show the previous chat's counts in this chat's
                             // header until the next switch.
-                            if (selectedChat.value?.id !== chatId) return
+                            if (selectedChat.value?.ref !== chatRef) return
                             chatStats.value = data
                         }
                     } catch (e) {
                         console.error('Failed to load chat stats:', e)
-                        if (selectedChat.value?.id !== chatId) return
+                        if (selectedChat.value?.ref !== chatRef) return
                         chatStats.value = null
                     }
                 }
@@ -4393,8 +4398,8 @@
                     showMediaGallery.value = false  // Exit media gallery when changing chat
                     await loadMessages()
                     if (chatVersion !== myVersion) return  // Another chat was selected, abort
-                    await loadChatStats(chat.id)  // Load stats for this chat
-                    await loadPinnedMessages(chat.id)  // Load pinned messages for this chat
+                    await loadChatStats(chat.ref)  // Load stats for this chat
+                    await loadPinnedMessages(chat.ref)  // Load pinned messages for this chat
                     await nextTick()
                     if (chatVersion !== myVersion) return
                     scrollToBottom()
@@ -4430,7 +4435,7 @@
                     try {
                         // Get latest messages (just first page)
                         // v6.2.12: Include topic_id filter when viewing a forum topic
-                        let refreshUrl = `/api/chats/${selectedChat.value.id}/messages?limit=50&offset=0`
+                        let refreshUrl = `/api/chats/${selectedChat.value.ref}/messages?limit=50&offset=0`
                         const topicId = activeTopicId()
                         if (topicId != null) {
                             refreshUrl += `&topic_id=${topicId}`
@@ -4522,7 +4527,7 @@
                     loading.value = true
                     try {
                         const limit = 50
-                        let url = `/api/chats/${selectedChat.value.id}/messages?limit=${limit}`
+                        let url = `/api/chats/${selectedChat.value.ref}/messages?limit=${limit}`
 
                         // v6.2.0: Add topic_id filter if the displayed pane is scoped to a topic.
                         const topicId = activeTopicId()
@@ -4547,7 +4552,7 @@
                         if (messageSearchQuery.value) {
                             // Search still uses offset for simplicity
                             const offset = page.value * limit
-                            url = `/api/chats/${selectedChat.value.id}/messages?limit=${limit}&offset=${offset}`
+                            url = `/api/chats/${selectedChat.value.ref}/messages?limit=${limit}&offset=${offset}`
                             url += `&search=${encodeURIComponent(messageSearchQuery.value)}`
                             // Also pass topic_id for search within a topic
                             if (topicId != null) {
@@ -4637,18 +4642,18 @@
 
                     const requestSeq = ++newerLoadRequestSeq
                     const myVersion = chatVersion
-                    const chatId = selectedChat.value.id
+                    const chatRef = selectedChat.value.ref
                     const topicId = activeTopicId()
                     const topicParam = topicId == null ? '' : `&topic_id=${topicId}`
                     loadingNewer.value = true
                     try {
                         const limit = 50
                         const res = await fetch(
-                            `/api/chats/${chatId}/messages?after_id=${newestMessageId}&limit=${limit}${topicParam}`,
+                            `/api/chats/${chatRef}/messages?after_id=${newestMessageId}&limit=${limit}${topicParam}`,
                             { credentials: 'include' }
                         )
                         if (requestSeq !== newerLoadRequestSeq || chatVersion !== myVersion ||
-                            selectedChat.value?.id !== chatId || activeTopicId() !== topicId) return
+                            selectedChat.value?.ref !== chatRef || activeTopicId() !== topicId) return
                         if (!res.ok) {
                             if (res.status === 401) {
                                 isAuthenticated.value = false
@@ -4658,7 +4663,7 @@
 
                         const data = await res.json()
                         if (requestSeq !== newerLoadRequestSeq || chatVersion !== myVersion ||
-                            selectedChat.value?.id !== chatId || activeTopicId() !== topicId) return
+                            selectedChat.value?.ref !== chatRef || activeTopicId() !== topicId) return
                         const newMessages = data.messages || data
                         newerLoadError.value = ''
                         upsertMessages(newMessages)
@@ -4678,7 +4683,7 @@
                         }
                     } catch (e) {
                         if (requestSeq === newerLoadRequestSeq && chatVersion === myVersion &&
-                            selectedChat.value?.id === chatId && activeTopicId() === topicId) {
+                            selectedChat.value?.ref === chatRef && activeTopicId() === topicId) {
                             newerLoadError.value = 'Could not load newer messages.'
                         }
                         console.error('Failed to load newer messages', e)
@@ -4722,12 +4727,12 @@
                         clearTimeout(messageSearchDebounceTimer)
                     }
                     const queryAtInput = messageSearchQuery.value
-                    const chatIdAtInput = selectedChat.value?.id ?? null
+                    const chatRefAtInput = selectedChat.value?.ref ?? null
                     messageSearchDebounceTimer = setTimeout(() => {
                         messageSearchDebounceTimer = null
                         // A chat/topic switch clears the box and rebuilds the pane while the
                         // timer is pending; running the old query then would wipe the new view.
-                        if ((selectedChat.value?.id ?? null) !== chatIdAtInput) return
+                        if ((selectedChat.value?.ref ?? null) !== chatRefAtInput) return
                         if (messageSearchQuery.value !== queryAtInput) return
                         searchMessages()
                     }, 300) // 300ms debounce, same as the sidebar search
@@ -5113,7 +5118,7 @@
 
                 const exportChat = () => {
                     if (!selectedChat.value) return
-                    const url = `/api/chats/${selectedChat.value.id}/export`
+                    const url = `/api/chats/${selectedChat.value.ref}/export`
                     window.open(url, '_blank')
                 }
 
@@ -5354,8 +5359,10 @@
                 }
 
                 const loadMessageVersions = async (msg) => {
-                    const chatId = msg.chat_id ?? selectedChat.value?.id
-                    if (!chatId || msg.id == null) return
+                    // The URL wants the chat's ref; message rows carry only chat_id (data),
+                    // and every row this panel opens for belongs to the selected chat.
+                    const chatRef = selectedChat.value?.ref
+                    if (!chatRef || msg.id == null) return
 
                     const key = messageVersionsKey(msg)
                     const requestSeq = (messageVersionsRequestSeq.value[key] || 0) + 1
@@ -5364,7 +5371,7 @@
                     clearMessageVersionsRecord(messageVersionsErrors, key)
 
                     try {
-                        const res = await fetch(`/api/chats/${chatId}/messages/${msg.id}/versions?limit=100`, {
+                        const res = await fetch(`/api/chats/${chatRef}/messages/${msg.id}/versions?limit=100`, {
                             credentials: 'include'
                         })
                         if (!res.ok) {
@@ -5495,18 +5502,11 @@
                 }
 
                 const getMediaUrl = (msg) => {
-                    if (!msg.media?.file_path) return ''
-                    // Extract folder and filename from the stored path
-                    // media_path is like: /data/backups/media/35258041/filename.jpg
-                    // We need to extract: /media/35258041/filename.jpg
-                    const parts = msg.media?.file_path.split(/[/\\]/)
-                    const filename = parts.pop()
-                    const folder = parts.pop()  // Get the folder from the path, not from chat_id
-                    // #258: encode each SEGMENT on its own. A filename containing '#' or
-                    // '?' is otherwise cut by the browser (fragment / query) before the
-                    // request is even sent. Encoding the assembled path instead would
-                    // escape the '/' separators, so it must stay per-segment.
-                    return `/media/${encodeURIComponent(folder)}/${encodeURIComponent(filename)}`
+                    // Server-built, ref-addressed URL (/media/{chat_ref}/{media_key}) or
+                    // null. file_path is display data only — building a /media/ URL from
+                    // it would put the chat id back into requests and access logs, which
+                    // is exactly what the ref exists to prevent.
+                    return msg.media?.url || ''
                 }
 
                 const getMediaDisplayName = (media) => {
@@ -5546,10 +5546,9 @@
                 }
 
                 const handleImageError = (event, msg) => {
-                    // Log the event, never the URL: it is /media/<chat id>/<file id>_<the
-                    // sender's own filename>, i.e. exactly the identifiers the project
-                    // keeps out of logs, and the console buffer travels in screenshots,
-                    // screen shares and browser bug reports.
+                    // Log the event, never the URL: it is /media/<chat ref>/<message id>_
+                    // <type> — the message id is PII, and the console buffer travels in
+                    // screenshots, screen shares and browser bug reports.
                     console.error('Failed to load image')
                     // Show placeholder instead of broken image
                     const img = event.target
@@ -5566,8 +5565,8 @@
                 }
 
                 const handleMediaError = (event, msg) => {
-                    // Same rule as handleImageError: the media URL carries the chat id and
-                    // the sender's original filename, so log the event only.
+                    // Same rule as handleImageError: the media URL carries the message id,
+                    // so log the event only.
                     console.error('Failed to load media')
                     // Flag the row and let the template swap in the placeholder. Writing
                     // the placeholder in with innerHTML destroyed the <video>, its <source>
@@ -5753,37 +5752,39 @@
 
                 const audioMessageChatId = (msg) => msg.chat_id ?? selectedChat.value?.id ?? null
 
-                // #266: the media endpoint's cursor is a composite media id, and it is
-                // what lets the queue page in both directions from a track the endpoint
-                // has never returned — the window-seeded queue — instead of first
-                // walking backwards from the newest item to reach it.
+                // #266: the media endpoint's cursor is the chat-free `{message_id}_{type}`
+                // key it returns as each item's id, and it is what lets the queue page in
+                // both directions from a track the endpoint has never returned — the
+                // window-seeded queue — instead of first walking backwards from the
+                // newest item to reach it.
                 //
                 // #268: PREFER the id the payload already carries. Both message paths
-                // that feed this view select Media.id into `media.id`
-                // (get_messages_paginated / get_pinned_messages), and the no_download
-                // strip only blanks file_path, so the authoritative cursor is in hand
-                // and never has to be guessed.
+                // that feed this view deliver that key as `media.id`, and the
+                // no_download strip only blanks file_path/url, so the authoritative
+                // cursor is in hand and never has to be guessed.
                 //
                 // The rebuild below is only a FALLBACK, for a payload that predates
-                // that field or a writer that omits it. It reproduces the shape the
-                // capture path writes, `{chat}_{message}_{type}` — which is NOT the
-                // only shape in use (the importer writes `import_{chat}_{message}`), so
-                // guessing it is exactly how a legacy/imported archive ended up with a
-                // cursor the server cannot resolve. An unresolvable cursor answers with
-                // an empty page, which every caller here already reads as "nothing more
-                // that way", so the fallback degrades quietly rather than erroring.
+                // that field or a writer that omits it. The server reconstructs the
+                // storage key from it — which is NOT the only shape in use (the
+                // importer writes `import_{chat}_{message}`), so guessing is exactly
+                // how a legacy/imported archive ended up with a cursor the server
+                // cannot resolve. An unresolvable cursor answers with an empty page,
+                // which every caller here already reads as "nothing more that way",
+                // so the fallback degrades quietly rather than erroring.
                 const audioMessageMediaId = (msg) => {
                     const delivered = msg?.media?.id
                     if (delivered) return String(delivered)
-                    const chatId = audioMessageChatId(msg)
                     const type = msg?.media?.type
-                    if (chatId == null || msg?.id == null || !type) return null
-                    return `${chatId}_${msg.id}_${type}`
+                    if (msg?.id == null || !type) return null
+                    return `${msg.id}_${type}`
                 }
 
                 const audioTrackFromMessage = (msg) => ({
                     id: msg.id,
                     chatId: audioMessageChatId(msg),
+                    // The ref addresses every queue-page request; chatId stays as the
+                    // in-memory identity the queue compares tracks by.
+                    chatRef: selectedChat.value?.ref ?? null,
                     mediaId: audioMessageMediaId(msg),
                     chatName: selectedChat.value ? getChatName(selectedChat.value) : '',
                     url: getMediaUrl(msg),
@@ -5975,7 +5976,7 @@
                 // a response to land on a player the user has already closed.
                 let audioQueueAbort = null
 
-                const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') => {
+                const fetchAudioQueuePage = async (chatRef, kind, cursor, direction = 'older') => {
                     const params = new URLSearchParams({
                         types: audioQueueTypes(kind),
                         limit: String(AUDIO_QUEUE_PAGE_SIZE),
@@ -5989,7 +5990,7 @@
                     audioQueueAbort?.abort()
                     const controller = new AbortController()
                     audioQueueAbort = controller
-                    const res = await fetch(`/api/chats/${chatId}/media?${params}`, {
+                    const res = await fetch(`/api/chats/${chatRef}/media?${params}`, {
                         credentials: 'include',
                         signal: controller.signal
                     })
@@ -6003,9 +6004,10 @@
                     return await res.json()
                 }
 
-                const audioTrackFromMediaItem = (item, kind, chatName) => ({
+                const audioTrackFromMediaItem = (item, kind, chatName, chatRef) => ({
                     id: item.message_id,
                     chatId: item.chat_id,
+                    chatRef,
                     // Authoritative cursor, straight from the endpoint — unlike the one
                     // audioMessageMediaId has to rebuild for a window-seeded track.
                     mediaId: item.id ?? null,
@@ -6021,7 +6023,7 @@
                     // no_download viewers get no media_url, and paths outside the media
                     // root are stripped server-side: an entry with no URL is unplayable.
                     .filter(item => item && item.media_url && item.message_id != null)
-                    .map(item => audioTrackFromMediaItem(item, track.kind, track.chatName))
+                    .map(item => audioTrackFromMediaItem(item, track.kind, track.chatName, track.chatRef))
 
                 const audioTrackTime = (track) => {
                     const ms = Date.parse(track.date || '')
@@ -6086,7 +6088,7 @@
                     let data
                     let forward = null
                     try {
-                        data = await fetchAudioQueuePage(track.chatId, track.kind, track.mediaId, 'older')
+                        data = await fetchAudioQueuePage(track.chatRef, track.kind, track.mediaId, 'older')
                         if (!(Array.isArray(data?.items) ? data.items : []).length && !data?.has_more) {
                             // #268: an empty backward page has two causes that LOOK
                             // identical — the track is the oldest audio of its kind, or
@@ -6097,7 +6099,7 @@
                             // resolves. That matters because handing the oldest track to
                             // the walk makes it traverse the WHOLE chat backwards to
                             // reach it, which is the cost #266 exists to remove.
-                            forward = await fetchAudioQueuePage(track.chatId, track.kind, track.mediaId, 'newer')
+                            forward = await fetchAudioQueuePage(track.chatRef, track.kind, track.mediaId, 'newer')
                         }
                     } catch (e) {
                         // A page that fails to load is not a bad anchor, and retrying it
@@ -6169,7 +6171,7 @@
                     // Playback advances forward in time while the endpoint pages
                     // backwards from the newest item, so paging back until the playing
                     // track shows up puts EVERY possible next track in hand.
-                    if (!track || track.chatId == null || noDownload.value) return
+                    if (!track || track.chatRef == null || noDownload.value) return
                     // #266: with a usable anchor none of that walking is needed — both
                     // directions extend on demand instead. Only a track whose media id
                     // cannot be rebuilt, or that this archive cannot resolve, falls
@@ -6184,7 +6186,7 @@
                     let foundPlaying = false
                     try {
                         for (let page = 0; page < AUDIO_QUEUE_MAX_PAGES; page++) {
-                            const data = await fetchAudioQueuePage(track.chatId, track.kind, cursor, 'older')
+                            const data = await fetchAudioQueuePage(track.chatRef, track.kind, cursor, 'older')
                             const items = Array.isArray(data?.items) ? data.items : []
                             if (!items.length) {
                                 // An empty page is NOT self-evidently "exhausted": it has
@@ -6297,7 +6299,7 @@
                         const seenCursors = new Set([audioQueueCursorNewer])
                         while (true) {
                             const data = await fetchAudioQueuePage(
-                                track.chatId, track.kind, audioQueueCursorNewer, 'newer')
+                                track.chatRef, track.kind, audioQueueCursorNewer, 'newer')
                             if (requestId !== audioQueueRequestId || !audioQueueBelongsToTrack(track)) return 'aborted'
                             const items = Array.isArray(data?.items) ? data.items : []
                             if (!items.length) {
@@ -6345,7 +6347,7 @@
                     audioQueueFetching = true
                     let data
                     try {
-                        data = await fetchAudioQueuePage(track.chatId, track.kind, audioQueueCursor, 'older')
+                        data = await fetchAudioQueuePage(track.chatRef, track.kind, audioQueueCursor, 'older')
                     } catch (e) {
                         // A transport failure is NOT the end of the queue. Collapsing the
                         // two makes "previous" restart the track on a 401/403/429 as if
@@ -6631,18 +6633,18 @@
                     document.body.classList.toggle('audio-player-open', !!track && !noDownload.value)
                 })
 
-                const calendarAvailabilityKey = (chatId, topicId, timezone, monthKey) => {
-                    return `${chatId}:${topicId ?? 'all'}:${timezone}:${monthKey}`
+                const calendarAvailabilityKey = (chatRef, topicId, timezone, monthKey) => {
+                    return `${chatRef}:${topicId ?? 'all'}:${timezone}:${monthKey}`
                 }
 
                 const loadCalendarAvailability = async (year, month) => {
                     if (!selectedChat.value) return
 
-                    const chatId = selectedChat.value.id
+                    const chatRef = selectedChat.value.ref
                     const topicId = activeTopicId()
                     const timezone = viewerTimezone.value
                     const monthKey = `${year}-${String(month + 1).padStart(2, '0')}`
-                    const cacheKey = calendarAvailabilityKey(chatId, topicId, timezone, monthKey)
+                    const cacheKey = calendarAvailabilityKey(chatRef, topicId, timezone, monthKey)
                     calendarAvailabilityActiveKey = cacheKey
                     const cachedDates = calendarAvailabilityCache.get(cacheKey)
                     if (cachedDates) {
@@ -6665,13 +6667,13 @@
                     calendarAvailabilityLoading.value = true
                     calendarAvailabilityError.value = ''
                     try {
-                        let url = `/api/chats/${chatId}/messages/dates?month=${monthKey}&timezone=${encodeURIComponent(timezone)}`
+                        let url = `/api/chats/${chatRef}/messages/dates?month=${monthKey}&timezone=${encodeURIComponent(timezone)}`
                         if (topicId != null) {
                             url += `&topic_id=${topicId}`
                         }
                         const res = await fetch(url, { credentials: 'include' })
                         if (requestSeq !== calendarAvailabilityRequestSeq || chatVersion !== myVersion ||
-                            selectedChat.value?.id !== chatId || activeTopicId() !== topicId) return
+                            selectedChat.value?.ref !== chatRef || activeTopicId() !== topicId) return
                         if (!res.ok) {
                             if (res.status === 401) isAuthenticated.value = false
                             throw new Error(`Calendar availability fetch failed: ${res.status}`)
@@ -6679,7 +6681,7 @@
 
                         const data = await res.json()
                         if (requestSeq !== calendarAvailabilityRequestSeq || chatVersion !== myVersion ||
-                            selectedChat.value?.id !== chatId || activeTopicId() !== topicId) return
+                            selectedChat.value?.ref !== chatRef || activeTopicId() !== topicId) return
                         const dates = new Set(
                             Array.isArray(data.dates)
                                 ? data.dates.filter(date => typeof date === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(date))
@@ -6692,7 +6694,7 @@
                         if (flatpickrInstance) flatpickrInstance.redraw()
                     } catch (e) {
                         if (requestSeq !== calendarAvailabilityRequestSeq || chatVersion !== myVersion ||
-                            selectedChat.value?.id !== chatId || activeTopicId() !== topicId ||
+                            selectedChat.value?.ref !== chatRef || activeTopicId() !== topicId ||
                             calendarAvailabilityActiveKey !== cacheKey) return
                         // Availability is advisory: an endpoint failure must leave every day selectable.
                         calendarAvailableDates.value = null
@@ -6808,8 +6810,8 @@
                 const jumpToDate = async () => {
                     if (!selectedChat.value || !selectedDate.value) return
 
-                    // Capture chat ID to detect if user switches chats during async operations
-                    const chatIdAtStart = selectedChat.value.id
+                    // Capture the chat's ref to detect if user switches chats during async operations
+                    const chatRefAtStart = selectedChat.value.ref
                     const topicIdAtStart = activeTopicId()
                     const dateRequestVersion = chatVersion
                     const selectedDateAtStart = selectedDate.value
@@ -6820,13 +6822,13 @@
                         // Fetch message for the selected date
                         // Pass timezone so backend can convert the displayed date to correct UTC bounds
                         const tz = encodeURIComponent(viewerTimezone.value)
-                        let dateUrl = `/api/chats/${chatIdAtStart}/messages/by-date?date=${selectedDateAtStart}&timezone=${tz}`
+                        let dateUrl = `/api/chats/${chatRefAtStart}/messages/by-date?date=${selectedDateAtStart}&timezone=${tz}`
                         if (topicIdAtStart != null) {
                             dateUrl += `&topic_id=${topicIdAtStart}`
                         }
                         const res = await fetch(dateUrl, { credentials: 'include' })
                         if (jumpRequestSeq !== dateJumpRequestSeq || chatVersion !== dateRequestVersion ||
-                            selectedChat.value?.id !== chatIdAtStart ||
+                            selectedChat.value?.ref !== chatRefAtStart ||
                             activeTopicId() !== topicIdAtStart) return
 
                         if (!res.ok) {
@@ -6840,7 +6842,7 @@
 
                         const message = await res.json()
                         if (jumpRequestSeq !== dateJumpRequestSeq || chatVersion !== dateRequestVersion ||
-                            selectedChat.value?.id !== chatIdAtStart ||
+                            selectedChat.value?.ref !== chatRefAtStart ||
                             activeTopicId() !== topicIdAtStart) return
                         const messageLocalDate = moment.utc(message.date).tz(viewerTimezone.value).format('YYYY-MM-DD')
                         if (!selectedDateHadAvailability && messageLocalDate !== selectedDateAtStart) {
@@ -6849,7 +6851,7 @@
                         closeDatePicker(false)
 
                         // Abort if user switched chats while waiting for response
-                        if (!selectedChat.value || selectedChat.value.id !== chatIdAtStart) {
+                        if (!selectedChat.value || selectedChat.value.ref !== chatRefAtStart) {
                             return
                         }
 
@@ -6858,7 +6860,7 @@
                         if (existingIndex !== -1) {
                             await nextTick()
                             if (jumpRequestSeq !== dateJumpRequestSeq || chatVersion !== dateRequestVersion ||
-                                selectedChat.value?.id !== chatIdAtStart || activeTopicId() !== topicIdAtStart) return
+                                selectedChat.value?.ref !== chatRefAtStart || activeTopicId() !== topicIdAtStart) return
                             scrollToMessage(message.id)
                             return
                         }
@@ -6886,13 +6888,13 @@
                 const adminChats = ref([])
                 const adminAuditLogs = ref([])
                 const adminAuditAction = ref('')
-                const adminViewerForm = ref({ username: '', password: '', allowed_chat_ids: [], is_active: true, no_download: false })
+                const adminViewerForm = ref({ username: '', password: '', allowed_chat_refs: [], is_active: true, no_download: false })
                 const adminEditingId = ref(null)
                 const adminError = ref('')
                 const adminActiveTab = ref('viewers')
                 // v7.2.0: Share tokens
                 const adminTokens = ref([])
-                const adminTokenForm = ref({ label: '', allowed_chat_ids: [], no_download: false, expires_at: '' })
+                const adminTokenForm = ref({ label: '', allowed_chat_refs: [], no_download: false, expires_at: '' })
                 const adminTokenError = ref('')
                 const adminNewToken = ref('')
                 const adminNewTokenUrl = computed(() => {
@@ -6933,11 +6935,13 @@
 
                 const saveViewer = async () => {
                     adminError.value = ''
-                    const chatIds = adminViewerForm.value.allowed_chat_ids
+                    const chatRefs = adminViewerForm.value.allowed_chat_refs
                     const body = {
                         username: adminViewerForm.value.username,
                         password: adminViewerForm.value.password,
-                        allowed_chat_ids: (chatIds && chatIds.length > 0) ? chatIds : null,
+                        // null = unrestricted. allowed_accounts has no editor yet (phase
+                        // 5); the PUT is partial, so omitting it leaves it untouched.
+                        allowed_chat_refs: (chatRefs && chatRefs.length > 0) ? chatRefs : null,
                         is_active: adminViewerForm.value.is_active ? 1 : 0,
                         no_download: adminViewerForm.value.no_download ? 1 : 0
                     }
@@ -6961,7 +6965,7 @@
                             adminError.value = err.detail || 'Failed to save'
                             return
                         }
-                        adminViewerForm.value = { username: '', password: '', allowed_chat_ids: [], is_active: true, no_download: false }
+                        adminViewerForm.value = { username: '', password: '', allowed_chat_refs: [], is_active: true, no_download: false }
                         adminEditingId.value = null
                         await loadAdminViewers()
                     } catch (e) { adminError.value = 'Network error' }
@@ -6972,7 +6976,7 @@
                     adminViewerForm.value = {
                         username: viewer.username,
                         password: '',
-                        allowed_chat_ids: viewer.allowed_chat_ids ? [...viewer.allowed_chat_ids] : [],
+                        allowed_chat_refs: viewer.allowed_chat_refs ? [...viewer.allowed_chat_refs] : [],
                         is_active: !!viewer.is_active,
                         no_download: !!viewer.no_download
                     }
@@ -6990,7 +6994,7 @@
 
                 const cancelEdit = () => {
                     adminEditingId.value = null
-                    adminViewerForm.value = { username: '', password: '', allowed_chat_ids: [], is_active: true, no_download: false }
+                    adminViewerForm.value = { username: '', password: '', allowed_chat_refs: [], is_active: true, no_download: false }
                     adminError.value = ''
                 }
 
@@ -7005,8 +7009,8 @@
                 const createToken = async () => {
                     adminTokenError.value = ''
                     adminNewToken.value = ''
-                    const chatIds = adminTokenForm.value.allowed_chat_ids
-                    if (!chatIds || chatIds.length === 0) {
+                    const chatRefs = adminTokenForm.value.allowed_chat_refs
+                    if (!chatRefs || chatRefs.length === 0) {
                         adminTokenError.value = 'Select at least one chat'
                         return
                     }
@@ -7017,7 +7021,7 @@
                     }
                     const body = {
                         label: adminTokenForm.value.label || null,
-                        allowed_chat_ids: chatIds,
+                        allowed_chat_refs: chatRefs,
                         no_download: !!adminTokenForm.value.no_download,
                         expires_at: expiresUtc,
                     }
@@ -7034,7 +7038,7 @@
                         }
                         const data = await res.json()
                         adminNewToken.value = data.token
-                        adminTokenForm.value = { label: '', allowed_chat_ids: [], no_download: false, expires_at: '' }
+                        adminTokenForm.value = { label: '', allowed_chat_refs: [], no_download: false, expires_at: '' }
                         await loadAdminTokens()
                     } catch (e) { adminTokenError.value = 'Network error' }
                 }

--- a/tests/test_calendar_frontend_behavior.py
+++ b/tests/test_calendar_frontend_behavior.py
@@ -104,7 +104,7 @@ const ref = value => ({ value });
 const loadingNewer = ref(false);
 const newerLoadError = ref('');
 const hasMoreNewer = ref(true);
-const selectedChat = ref({ id: 77, ref: '77' });
+const selectedChat = ref({ id: 77, ref: 'opaque-cal-a' });
 const isAuthenticated = ref(true);
 const viewingPinnedWindow = ref(true);
 const loadNewerSentinel = ref({});
@@ -151,8 +151,8 @@ const console = { error: () => {} };
     await loadNewerMessages();
 
     assert.deepEqual(requestedUrls, [
-        '/api/chats/77/messages?after_id=100&limit=50&topic_id=9',
-        '/api/chats/77/messages?after_id=150&limit=50&topic_id=9',
+        '/api/chats/opaque-cal-a/messages?after_id=100&limit=50&topic_id=9',
+        '/api/chats/opaque-cal-a/messages?after_id=150&limit=50&topic_id=9',
     ]);
     assert.equal(newestMessageId, 152);
     assert.equal(hasMoreNewer.value, false);
@@ -187,7 +187,7 @@ const ref = value => ({ value });
 const loadingNewer = ref(false);
 const newerLoadError = ref('');
 const hasMoreNewer = ref(true);
-const selectedChat = ref({ id: 88, ref: '88' });
+const selectedChat = ref({ id: 88, ref: 'opaque-cal-b' });
 const isAuthenticated = ref(true);
 const viewingPinnedWindow = ref(true);
 const loadNewerSentinel = ref({});
@@ -257,7 +257,7 @@ def test_jump_to_date_cancellation_and_latest_intent_win() -> None:
             "const assert = require('node:assert/strict');",
             """
 const ref = value => ({ value });
-const selectedChat = ref({ id: 99, ref: '99' });
+const selectedChat = ref({ id: 99, ref: 'opaque-cal-c' });
 const selectedDate = ref('2026-01-10');
 const calendarAvailableDates = ref(new Set(['2026-01-10', '2026-01-11', '2026-01-12']));
 const viewerTimezone = ref('Europe/Madrid');
@@ -328,9 +328,9 @@ const response = (id, date) => ({
     assert.deepEqual(
         deferredFetches.map(request => request.url),
         [
-            '/api/chats/99/messages/by-date?date=2026-01-10&timezone=Europe%2FMadrid&topic_id=44',
-            '/api/chats/99/messages/by-date?date=2026-01-11&timezone=Europe%2FMadrid&topic_id=44',
-            '/api/chats/99/messages/by-date?date=2026-01-12&timezone=Europe%2FMadrid&topic_id=44',
+            '/api/chats/opaque-cal-c/messages/by-date?date=2026-01-10&timezone=Europe%2FMadrid&topic_id=44',
+            '/api/chats/opaque-cal-c/messages/by-date?date=2026-01-11&timezone=Europe%2FMadrid&topic_id=44',
+            '/api/chats/opaque-cal-c/messages/by-date?date=2026-01-12&timezone=Europe%2FMadrid&topic_id=44',
         ],
     );
     for (const request of deferredFetches) {

--- a/tests/test_calendar_frontend_behavior.py
+++ b/tests/test_calendar_frontend_behavior.py
@@ -104,7 +104,7 @@ const ref = value => ({ value });
 const loadingNewer = ref(false);
 const newerLoadError = ref('');
 const hasMoreNewer = ref(true);
-const selectedChat = ref({ id: 77 });
+const selectedChat = ref({ id: 77, ref: '77' });
 const isAuthenticated = ref(true);
 const viewingPinnedWindow = ref(true);
 const loadNewerSentinel = ref({});
@@ -187,7 +187,7 @@ const ref = value => ({ value });
 const loadingNewer = ref(false);
 const newerLoadError = ref('');
 const hasMoreNewer = ref(true);
-const selectedChat = ref({ id: 88 });
+const selectedChat = ref({ id: 88, ref: '88' });
 const isAuthenticated = ref(true);
 const viewingPinnedWindow = ref(true);
 const loadNewerSentinel = ref({});
@@ -257,7 +257,7 @@ def test_jump_to_date_cancellation_and_latest_intent_win() -> None:
             "const assert = require('node:assert/strict');",
             """
 const ref = value => ({ value });
-const selectedChat = ref({ id: 99 });
+const selectedChat = ref({ id: 99, ref: '99' });
 const selectedDate = ref('2026-01-10');
 const calendarAvailableDates = ref(new Set(['2026-01-10', '2026-01-11', '2026-01-12']));
 const viewerTimezone = ref('Europe/Madrid');

--- a/tests/test_chat_ref_acl.py
+++ b/tests/test_chat_ref_acl.py
@@ -588,7 +588,8 @@ async def test_websocket_restricted_socket_sees_only_entitled_events(viewer_app)
 
         # Delivery re-check: force a subscription the grant does not cover
         # (a stale subscription from before a narrowing) …
-        server_socket = next(iter(web_main.ws_manager.active_connections))
+        # Exactly one live socket by construction; unpacking fails loudly otherwise.
+        [server_socket] = list(web_main.ws_manager.active_connections)
         web_main.ws_manager.active_connections[server_socket].add(archive.ref_b)
 
         # … broadcast for the forbidden chat FIRST, then the entitled one.

--- a/tests/test_chat_ref_acl.py
+++ b/tests/test_chat_ref_acl.py
@@ -1,0 +1,731 @@
+"""The phase-4 fail-closed entitlement matrix, on a real migrated 8.0 database.
+
+Every chat-scoped viewer route resolves its ``{chat_ref}`` through ONE shared
+dependency, and that dependency is the whole access-control story — so this
+file pins its behaviour end to end, on a database built by ``alembic upgrade
+head`` (never ``create_all``) and driven through the real FastAPI app, on both
+supported backends:
+
+- NULL grants see everything; a set grant sees exactly the set; the EMPTY set
+  denies everything.
+- A grant that cannot be read (bad JSON, wrong shape, wrong element type)
+  parses to the empty set: authentication still succeeds, the session just
+  sees nothing — fail-closed without a login oracle.
+- The legacy 7.x ``allowed_chat_ids`` column is NEVER read as a grant. A row
+  where it is populated while both 8.0 columns are NULL is an unconverted
+  restriction and gets the empty grant; a populated legacy column can never
+  override an 8.0 deny.
+- Unknown, malformed and forbidden refs answer with the SAME status and body:
+  nothing distinguishes "exists but not yours" from "does not exist".
+- Media bytes ride the same resolver; a forbidden ref is indistinguishable
+  from a nonexistent one there too, and cursors/ids are chat-free (#266).
+- The WebSocket subscribe path uses the same resolver, and delivery re-checks
+  the grant per socket — parity with HTTP is a hard requirement.
+- No stored audit row, no server log line, and no URL the server mints or
+  serves carries a chat id; the ref is the only chat identity that travels.
+
+The chat ids seeded here (900777001 / 900777002) are deliberately distinctive
+so the "never appears" assertions are a grep, not a guess.
+"""
+
+import json
+import logging
+import os
+import secrets
+import tempfile
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+import sqlalchemy as sa
+from alembic.config import Config as AlembicConfig
+from conftest import NO_POSTGRES_REASON
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import NullPool
+from starlette.testclient import TestClient
+
+from alembic import command
+
+os.environ.setdefault("BACKUP_PATH", tempfile.mkdtemp(prefix="ta_test_chat_ref_"))
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Chat, Media, Message
+from src.web import main as web_main
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Distinctive on purpose: the PII assertions grep every stored/logged string
+# for these digits, so they must be unmistakable for anything else.
+CHAT_A_ID = 900777001
+CHAT_B_ID = 900777002
+SENDER_ID = 900777801
+
+MASTER_USERNAME = "matrix-master"
+MASTER_PASSWORD = "master-pass@test/value"  # obvious fake
+VIEWER_PASSWORD = "matrix-pass@test/value"  # obvious fake
+
+UNIFORM_404 = {"detail": "Chat not found"}
+
+
+def _upgrade_to_head(url: str) -> None:
+    """Run this tree's real Alembic environment against ``url`` (sync or async)."""
+    config = AlembicConfig()
+    config.set_main_option("script_location", str(REPO_ROOT / "alembic"))
+    config.set_main_option("sqlalchemy.url", url)
+    previous = os.environ.get("DATABASE_URL")
+    os.environ["DATABASE_URL"] = url
+    try:
+        command.upgrade(config, "head")
+    finally:
+        if previous is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = previous
+
+
+def _seed(sync_url: str, media_root: Path) -> dict[int, str]:
+    """Two chats under account 1 (the row migration 022 seeds), messages, media.
+
+    Returns {chat_id: ref} — the refs the ORM minted on INSERT, which are the
+    only chat identity the tests put in URLs from here on.
+    """
+    (media_root / str(CHAT_A_ID)).mkdir(parents=True, exist_ok=True)
+    (media_root / str(CHAT_A_ID) / "2_photo.jpg").write_bytes(b"ref-jpg")
+    (media_root / str(CHAT_A_ID) / "3_clip.mp4").write_bytes(b"ref-mp4")
+
+    engine = sa.create_engine(sync_url)
+    try:
+        with Session(engine) as session:
+            session.add(Chat(account_id=1, id=CHAT_A_ID, type="private", first_name="Alpha", username="matrix_alpha"))
+            session.add(Chat(account_id=1, id=CHAT_B_ID, type="private", first_name="Beta", username="matrix_beta"))
+            start = datetime(2026, 4, 1, 9, 0, 0)
+            session.add(Message(account_id=1, id=1, chat_id=CHAT_A_ID, date=start, text="alpha hello"))
+            session.add(
+                Message(
+                    account_id=1,
+                    id=2,
+                    chat_id=CHAT_A_ID,
+                    date=start + timedelta(minutes=1),
+                    text="alpha photo",
+                    sender_id=SENDER_ID,
+                )
+            )
+            session.add(
+                Message(account_id=1, id=3, chat_id=CHAT_A_ID, date=start + timedelta(minutes=2), text="alpha clip")
+            )
+            session.add(Message(account_id=1, id=1, chat_id=CHAT_B_ID, date=start + timedelta(hours=1), text="beta"))
+            session.add(
+                Media(
+                    account_id=1,
+                    id=f"{CHAT_A_ID}_2_photo",
+                    message_id=2,
+                    chat_id=CHAT_A_ID,
+                    type="photo",
+                    file_path=f"{CHAT_A_ID}/2_photo.jpg",
+                    file_name="2_photo.jpg",
+                    file_size=7,
+                    mime_type="image/jpeg",
+                    downloaded=1,
+                )
+            )
+            session.add(
+                Media(
+                    account_id=1,
+                    id=f"{CHAT_A_ID}_3_video",
+                    message_id=3,
+                    chat_id=CHAT_A_ID,
+                    type="video",
+                    file_path=f"{CHAT_A_ID}/3_clip.mp4",
+                    file_name="3_clip.mp4",
+                    file_size=7,
+                    mime_type="video/mp4",
+                    downloaded=1,
+                )
+            )
+            session.commit()
+        with engine.connect() as conn:
+            rows = conn.execute(sa.text("SELECT id, ref FROM chats")).fetchall()
+    finally:
+        engine.dispose()
+    return dict(rows)
+
+
+@pytest.fixture(scope="module", params=("sqlite", "postgresql"))
+def ref_archive(request, tmp_path_factory, postgres_server_url, make_postgres_database):
+    """A migration-built, seeded 8.0 database per backend, plus its media root."""
+    media_root = tmp_path_factory.mktemp(f"chatref-media-{request.param}").resolve()
+    if request.param == "postgresql":
+        if not postgres_server_url:
+            pytest.skip(NO_POSTGRES_REASON)
+        async_url, sync_url = make_postgres_database("telegram_archive_pytest_chatref")
+    else:
+        db_path = tmp_path_factory.mktemp("chatref-db") / "archive.db"
+        sync_url = f"sqlite:///{db_path}"
+        async_url = f"sqlite+aiosqlite:///{db_path}"
+    # alembic/env.py builds an ASYNC engine from the URL it is given, so the
+    # upgrade takes the async URL; seeding uses a plain sync engine.
+    _upgrade_to_head(async_url)
+    refs = _seed(sync_url, media_root)
+    return SimpleNamespace(
+        backend=request.param,
+        async_url=async_url,
+        media_root=media_root,
+        ref_a=refs[CHAT_A_ID],
+        ref_b=refs[CHAT_B_ID],
+    )
+
+
+def _null_pool_manager(async_url: str) -> DatabaseManager:
+    """A DatabaseManager whose engine never pools connections.
+
+    The WebSocket tests drive the app through Starlette's TestClient, whose
+    portal runs a DIFFERENT event loop from pytest's. A pooled asyncpg
+    connection binds to the loop it was created on, so pooling across the two
+    breaks; NullPool gives every operation a fresh connection on whatever loop
+    is current, which also makes disposal loop-safe. ``hide_parameters`` stays
+    on exactly as in production (the PII rule for engine error text).
+    """
+    manager = DatabaseManager(async_url)
+    manager.engine = create_async_engine(manager.database_url, poolclass=NullPool, hide_parameters=True)
+    manager.async_session_factory = async_sessionmaker(manager.engine, class_=AsyncSession, expire_on_commit=False)
+    return manager
+
+
+@pytest.fixture
+async def viewer_app(ref_archive):
+    """The real app wired to the migrated database, auth on, state restored after."""
+    manager = _null_pool_manager(ref_archive.async_url)
+    adapter = DatabaseAdapter(manager)
+
+    saved = {
+        "db": web_main.db,
+        "auth_enabled": web_main.AUTH_ENABLED,
+        "allow_anonymous": web_main.ALLOW_ANONYMOUS_VIEWER,
+        "viewer_username": web_main.VIEWER_USERNAME,
+        "viewer_password": web_main.VIEWER_PASSWORD,
+        "sessions": dict(web_main._sessions),
+        "login_attempts": dict(web_main._login_attempts),
+        "display_chat_ids": web_main.config.display_chat_ids,
+        "media_path": web_main.config.media_path,
+        "media_root": web_main._media_root,
+        "avatar_cache": dict(web_main._avatar_cache),
+        "avatar_cache_time": web_main._avatar_cache_time,
+        "chat_stats_cache": dict(web_main._chat_stats_cache),
+        "broadcast_chat_cache": dict(web_main._broadcast_chat_cache),
+        "sender_lookup_cache": dict(web_main._sender_lookup_cache),
+    }
+    web_main.db = adapter
+    web_main.AUTH_ENABLED = True
+    web_main.ALLOW_ANONYMOUS_VIEWER = False
+    web_main.VIEWER_USERNAME = MASTER_USERNAME
+    web_main.VIEWER_PASSWORD = MASTER_PASSWORD
+    web_main._sessions.clear()
+    web_main._login_attempts.clear()
+    web_main.config.display_chat_ids = set()
+    web_main.config.media_path = str(ref_archive.media_root)
+    web_main._media_root = ref_archive.media_root
+    web_main._avatar_cache.clear()
+    web_main._avatar_cache_time = None
+    web_main._chat_stats_cache.clear()
+    web_main._broadcast_chat_cache.clear()
+    web_main._sender_lookup_cache.clear()
+
+    try:
+        yield SimpleNamespace(adapter=adapter, archive=ref_archive)
+    finally:
+        web_main.db = saved["db"]
+        web_main.AUTH_ENABLED = saved["auth_enabled"]
+        web_main.ALLOW_ANONYMOUS_VIEWER = saved["allow_anonymous"]
+        web_main.VIEWER_USERNAME = saved["viewer_username"]
+        web_main.VIEWER_PASSWORD = saved["viewer_password"]
+        web_main._sessions.clear()
+        web_main._sessions.update(saved["sessions"])
+        web_main._login_attempts.clear()
+        web_main._login_attempts.update(saved["login_attempts"])
+        web_main.config.display_chat_ids = saved["display_chat_ids"]
+        web_main.config.media_path = saved["media_path"]
+        web_main._media_root = saved["media_root"]
+        web_main._avatar_cache.clear()
+        web_main._avatar_cache.update(saved["avatar_cache"])
+        web_main._avatar_cache_time = saved["avatar_cache_time"]
+        web_main._chat_stats_cache.clear()
+        web_main._chat_stats_cache.update(saved["chat_stats_cache"])
+        web_main._broadcast_chat_cache.clear()
+        web_main._broadcast_chat_cache.update(saved["broadcast_chat_cache"])
+        web_main._sender_lookup_cache.clear()
+        web_main._sender_lookup_cache.update(saved["sender_lookup_cache"])
+        await manager.close()
+
+
+def _client(app=None) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app or web_main.app), base_url="http://test")
+
+
+async def _login_viewer(
+    client: AsyncClient,
+    adapter: DatabaseAdapter,
+    *,
+    allowed_chat_ids: str | None = None,
+    allowed_accounts: str | None = None,
+    allowed_chat_refs: str | None = None,
+) -> str:
+    """Create a viewer account with EXACTLY these stored grant columns, log in.
+
+    The grants deliberately go through the database and the real login flow, so
+    what is enforced is what a real deployment enforces — a row shaped by 8.0
+    writers, by migration 022, or by a bypassed migration (the legacy cases).
+    """
+    username = f"matrix-viewer-{secrets.token_hex(4)}"
+    salt = secrets.token_hex(8)
+    password_hash = web_main._hash_password(VIEWER_PASSWORD, salt)
+    await adapter.create_viewer_account(
+        username=username,
+        password_hash=password_hash,
+        salt=salt,
+        allowed_chat_ids=allowed_chat_ids,
+        allowed_accounts=allowed_accounts,
+        allowed_chat_refs=allowed_chat_refs,
+        created_by="test",
+        is_active=1,
+    )
+    resp = await client.post("/api/login", json={"username": username, "password": VIEWER_PASSWORD})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["role"] == "viewer"
+    return username
+
+
+async def _visible_chat_ids(client: AsyncClient) -> list[int]:
+    resp = await client.get("/api/chats")
+    assert resp.status_code == 200, resp.text
+    return sorted(chat["id"] for chat in resp.json()["chats"])
+
+
+def _fresh_unknown_ref() -> str:
+    """Well-formed (22-char urlsafe) but guaranteed absent from the database."""
+    return secrets.token_urlsafe(16)
+
+
+# ============================================================================
+# (a) NULL grants: unrestricted
+# ============================================================================
+
+
+async def test_null_grants_see_every_chat(viewer_app):
+    archive = viewer_app.archive
+    async with _client() as client:
+        await _login_viewer(client, viewer_app.adapter)
+        assert await _visible_chat_ids(client) == [CHAT_A_ID, CHAT_B_ID]
+        for ref in (archive.ref_a, archive.ref_b):
+            resp = await client.get(f"/api/chats/{ref}/messages")
+            assert resp.status_code == 200, resp.text
+        # The chat payload carries ref + account_id, and its avatar URL — the
+        # only chat identity handed to the frontend for URLs is the ref.
+        chats = (await client.get("/api/chats")).json()["chats"]
+        by_id = {chat["id"]: chat for chat in chats}
+        assert by_id[CHAT_A_ID]["ref"] == archive.ref_a
+        assert by_id[CHAT_A_ID]["account_id"] == 1
+
+
+# ============================================================================
+# (b) A ref grant, and the no-oracle rule
+# ============================================================================
+
+
+async def test_ref_grant_sees_only_that_ref_and_denials_are_uniform(viewer_app):
+    archive = viewer_app.archive
+    async with _client() as client:
+        await _login_viewer(client, viewer_app.adapter, allowed_chat_refs=json.dumps([archive.ref_a]))
+        assert await _visible_chat_ids(client) == [CHAT_A_ID]
+
+        allowed = await client.get(f"/api/chats/{archive.ref_a}/messages")
+        assert allowed.status_code == 200, allowed.text
+        assert [message["id"] for message in allowed.json()] == [3, 2, 1]
+
+        # Forbidden-but-existing, well-formed-unknown, and garbage must be
+        # indistinguishable: same status, same body, for every candidate.
+        outcomes = set()
+        for candidate in (archive.ref_b, _fresh_unknown_ref(), "AAAA", "!" * 22, "0"):
+            resp = await client.get(f"/api/chats/{candidate}/messages")
+            outcomes.add((resp.status_code, resp.text))
+        assert len(outcomes) == 1, outcomes
+        status, body = outcomes.pop()
+        assert status == 404
+        assert json.loads(body) == UNIFORM_404
+
+
+# ============================================================================
+# (c) An account grant that matches no chats
+# ============================================================================
+
+
+async def test_account_grant_for_an_absent_account_sees_nothing(viewer_app):
+    archive = viewer_app.archive
+    async with _client() as client:
+        await _login_viewer(client, viewer_app.adapter, allowed_accounts=json.dumps([2]))
+        assert await _visible_chat_ids(client) == []
+        for ref in (archive.ref_a, archive.ref_b):
+            resp = await client.get(f"/api/chats/{ref}/messages")
+            assert (resp.status_code, resp.json()) == (404, UNIFORM_404)
+
+
+# ============================================================================
+# (d) Unparseable grants deny — after a SUCCESSFUL login
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    "grant_columns",
+    [
+        {"allowed_chat_refs": "{not json"},
+        {"allowed_chat_refs": '"a-string-not-a-list"'},
+        {"allowed_chat_refs": "[1, 2]"},  # wrong element type: refs are strings
+        {"allowed_accounts": "{not json"},
+        {"allowed_accounts": '["one"]'},  # wrong element type: accounts are ints
+        {"allowed_accounts": "[true]"},  # bool is NOT an account id
+    ],
+)
+async def test_unparseable_grant_authenticates_into_the_empty_grant(viewer_app, grant_columns):
+    archive = viewer_app.archive
+    async with _client() as client:
+        # Login must SUCCEED (a corrupt grant is not a login oracle)…
+        await _login_viewer(client, viewer_app.adapter, **grant_columns)
+        # …into a session that sees nothing at all.
+        assert await _visible_chat_ids(client) == []
+        resp = await client.get(f"/api/chats/{archive.ref_a}/messages")
+        assert (resp.status_code, resp.json()) == (404, UNIFORM_404)
+
+
+# ============================================================================
+# (e) The EMPTY grant denies everything
+# ============================================================================
+
+
+async def test_empty_list_grant_denies_everything(viewer_app):
+    archive = viewer_app.archive
+    async with _client() as client:
+        await _login_viewer(client, viewer_app.adapter, allowed_chat_refs="[]")
+        assert await _visible_chat_ids(client) == []
+        resp = await client.get(f"/api/chats/{archive.ref_a}/messages")
+        assert (resp.status_code, resp.json()) == (404, UNIFORM_404)
+
+
+# ============================================================================
+# (f) The legacy column is rollback data, never a grant
+# ============================================================================
+
+
+async def test_legacy_column_alone_is_an_unconverted_restriction_and_denies(viewer_app):
+    """Both 8.0 columns NULL + a populated legacy grant = migration bypassed.
+
+    Under 7.x this row could read chat A; reading it that way today would be
+    the fail-open this design exists to prevent. It must see NOTHING.
+    """
+    archive = viewer_app.archive
+    async with _client() as client:
+        await _login_viewer(client, viewer_app.adapter, allowed_chat_ids=json.dumps([CHAT_A_ID, CHAT_B_ID]))
+        assert await _visible_chat_ids(client) == []
+        for candidate in (archive.ref_a, archive.ref_b):
+            resp = await client.get(f"/api/chats/{candidate}/messages")
+            assert (resp.status_code, resp.json()) == (404, UNIFORM_404)
+
+
+async def test_legacy_column_cannot_override_an_explicit_deny(viewer_app):
+    """New columns say deny (empty), legacy says allow-everything: still deny."""
+    archive = viewer_app.archive
+    async with _client() as client:
+        await _login_viewer(
+            client,
+            viewer_app.adapter,
+            allowed_chat_ids=json.dumps([CHAT_A_ID, CHAT_B_ID]),
+            allowed_chat_refs="[]",
+        )
+        assert await _visible_chat_ids(client) == []
+        resp = await client.get(f"/api/chats/{archive.ref_a}/messages")
+        assert (resp.status_code, resp.json()) == (404, UNIFORM_404)
+
+
+# ============================================================================
+# (g) Media through a forbidden ref is indistinguishable from nonexistent
+# ============================================================================
+
+
+async def test_media_via_forbidden_ref_is_indistinguishable(viewer_app):
+    archive = viewer_app.archive
+    async with _client() as client:
+        # Granted chat B only; the media lives in chat A.
+        await _login_viewer(client, viewer_app.adapter, allowed_chat_refs=json.dumps([archive.ref_b]))
+        outcomes = set()
+        for candidate in (archive.ref_a, _fresh_unknown_ref()):
+            resp = await client.get(f"/media/{candidate}/2_photo")
+            outcomes.add((resp.status_code, resp.text))
+            thumb = await client.get(f"/media/thumb/200/{candidate}/2_photo")
+            outcomes.add((thumb.status_code, thumb.text))
+        assert len(outcomes) == 1, outcomes
+        status, body = outcomes.pop()
+        assert status == 404
+        assert json.loads(body) == UNIFORM_404
+
+    async with _client() as control:
+        # Control: the same URL with the grant serves the actual bytes — the
+        # 404s above are entitlement, not brokenness.
+        await _login_viewer(control, viewer_app.adapter, allowed_chat_refs=json.dumps([archive.ref_a]))
+        resp = await control.get(f"/media/{archive.ref_a}/2_photo")
+        assert resp.status_code == 200
+        assert resp.content == b"ref-jpg"
+        assert resp.headers["cache-control"] == "private"
+
+
+async def test_media_ids_and_cursors_are_chat_free(viewer_app):
+    """Gallery ids round-trip as cursors; a 7.x full-composite token yields an
+    empty page (#266 semantics) instead of resolving anything."""
+    archive = viewer_app.archive
+    async with _client() as client:
+        await _login_viewer(client, viewer_app.adapter, allowed_chat_refs=json.dumps([archive.ref_a]))
+        page = await client.get(f"/api/chats/{archive.ref_a}/media")
+        assert page.status_code == 200, page.text
+        items = page.json()["items"]
+        assert [item["id"] for item in items] == ["3_video", "2_photo"]
+        assert items[1]["media_url"] == f"/media/{archive.ref_a}/2_photo"
+
+        older = await client.get(f"/api/chats/{archive.ref_a}/media", params={"before_id": "3_video"})
+        assert [item["id"] for item in older.json()["items"]] == ["2_photo"]
+
+        legacy = await client.get(f"/api/chats/{archive.ref_a}/media", params={"before_id": f"{CHAT_A_ID}_3_video"})
+        assert legacy.status_code == 200
+        assert legacy.json()["items"] == []
+
+
+# ============================================================================
+# DISPLAY_CHAT_IDS binds every role, master included
+# ============================================================================
+
+
+async def test_display_chat_ids_binds_master_too(viewer_app):
+    archive = viewer_app.archive
+    web_main.config.display_chat_ids = {CHAT_B_ID}
+    async with _client() as client:
+        resp = await client.post("/api/login", json={"username": MASTER_USERNAME, "password": MASTER_PASSWORD})
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["role"] == "master"
+        assert await _visible_chat_ids(client) == [CHAT_B_ID]
+        hidden = await client.get(f"/api/chats/{archive.ref_a}/messages")
+        assert (hidden.status_code, hidden.json()) == (404, UNIFORM_404)
+        shown = await client.get(f"/api/chats/{archive.ref_b}/messages")
+        assert shown.status_code == 200, shown.text
+
+
+# ============================================================================
+# Database down: 503, with no per-chat signal
+# ============================================================================
+
+
+async def test_db_down_answers_503_identically_for_any_ref(viewer_app):
+    archive = viewer_app.archive
+    async with _client() as client:
+        await _login_viewer(client, viewer_app.adapter)
+        web_main.db = None
+        try:
+            outcomes = set()
+            for candidate in (archive.ref_a, _fresh_unknown_ref()):
+                resp = await client.get(f"/api/chats/{candidate}/messages")
+                outcomes.add((resp.status_code, resp.text))
+        finally:
+            web_main.db = viewer_app.adapter
+        assert len(outcomes) == 1, outcomes
+        assert outcomes.pop()[0] == 503
+
+
+# ============================================================================
+# (h) WebSocket parity: same resolver on subscribe, re-check at delivery
+# ============================================================================
+
+
+async def test_websocket_restricted_socket_sees_only_entitled_events(viewer_app):
+    """Subscribe parity AND delivery parity over a real socket.
+
+    The subscribe gate rides the same resolver as HTTP (uniform denial for
+    forbidden/unknown/malformed/DB-down), and delivery re-checks the socket's
+    grant — a subscription that somehow outlives its grant still delivers
+    nothing (a prior audit found exactly this gap once).
+
+    TestClient runs the app on its own portal loop; the fixture's NullPool
+    engine is what makes the database usable from there and from pytest's
+    loop in the same test.
+    """
+    archive = viewer_app.archive
+    token = f"ws-{secrets.token_hex(8)}"
+    web_main._sessions[token] = web_main.SessionData(
+        username="ws-viewer", role="viewer", allowed_chat_refs={archive.ref_a}, created_at=time.time()
+    )
+    client = TestClient(web_main.app, raise_server_exceptions=False)
+    client.cookies.set("viewer_auth", token)
+
+    with client.websocket_connect("/ws/updates") as socket:
+        socket.send_json({"action": "subscribe", "chat_ref": archive.ref_a})
+        assert socket.receive_json() == {"type": "subscribed", "chat_ref": archive.ref_a}
+
+        # Forbidden-but-existing, well-formed-unknown, malformed: one denial.
+        for candidate in (archive.ref_b, _fresh_unknown_ref(), "AAAA"):
+            socket.send_json({"action": "subscribe", "chat_ref": candidate})
+            assert socket.receive_json() == {"type": "subscribe_denied", "chat_ref": candidate}
+
+        # DB down: the same uniform denial, even for the entitled ref.
+        web_main.db = None
+        try:
+            socket.send_json({"action": "subscribe", "chat_ref": archive.ref_a})
+            assert socket.receive_json() == {"type": "subscribe_denied", "chat_ref": archive.ref_a}
+        finally:
+            web_main.db = viewer_app.adapter
+
+        # Delivery re-check: force a subscription the grant does not cover
+        # (a stale subscription from before a narrowing) …
+        server_socket = next(iter(web_main.ws_manager.active_connections))
+        web_main.ws_manager.active_connections[server_socket].add(archive.ref_b)
+
+        # … broadcast for the forbidden chat FIRST, then the entitled one.
+        socket.portal.call(web_main.broadcast_new_message, CHAT_B_ID, {"id": 9, "text": "beta-secret"})
+        socket.portal.call(web_main.broadcast_new_message, CHAT_A_ID, {"id": 4, "text": "alpha-public"})
+
+        # The first (and only) frame is the entitled chat's, ref-addressed.
+        frame = socket.receive_json()
+        assert frame["type"] == "new_message"
+        assert frame["chat_ref"] == archive.ref_a
+        assert "chat_id" not in frame
+        assert frame["message"]["id"] == 4
+
+
+# ============================================================================
+# (i) Stored rows and logs speak refs, never chat ids
+# ============================================================================
+
+
+class _PathRecorder:
+    """Wraps the app and records scope['path'] — exactly what an access log logs."""
+
+    def __init__(self, app):
+        self.app = app
+        self.paths: list[str] = []
+
+    async def __call__(self, scope, receive, send):
+        if scope["type"] == "http":
+            self.paths.append(scope["path"])
+        await self.app(scope, receive, send)
+
+
+class _CaptureHandler(logging.Handler):
+    """Captures every formatted record from every logger at INFO and up.
+
+    INFO is production's level (main.py's basicConfig): the claim under test is
+    what a real deployment's log stream carries, exc_info tracebacks included
+    (the formatter appends them, which is exactly where a leak would hide).
+    """
+
+    def __init__(self):
+        super().__init__(level=logging.INFO)
+        self.lines: list[str] = []
+        self.setFormatter(logging.Formatter("%(name)s %(levelname)s %(message)s"))
+
+    def emit(self, record):
+        self.lines.append(self.format(record))
+
+
+async def test_stored_rows_and_logs_carry_the_ref_and_never_the_chat_id(viewer_app):
+    """Drive a full chat-scoped workload and grep every surface.
+
+    Surfaces: every request path the app saw (the access-log line), every log
+    record any logger emitted, every audit row as stored, and the grant/session
+    rows the flows wrote. The ref must be present where a chat identity is
+    needed; the distinctive chat id digits must appear in NONE of them.
+    """
+    archive = viewer_app.archive
+    adapter = viewer_app.adapter
+    recorder = _PathRecorder(web_main.app)
+    capture = _CaptureHandler()
+    root = logging.getLogger()
+    previous_level = root.level
+    root.addHandler(capture)
+    root.setLevel(logging.INFO)
+    try:
+        async with _client(app=recorder) as client:
+            # Master: admin flows that persist grants + audit rows.
+            resp = await client.post("/api/login", json={"username": MASTER_USERNAME, "password": MASTER_PASSWORD})
+            assert resp.status_code == 200, resp.text
+            created = await client.post(
+                "/api/admin/tokens", json={"label": "matrix-share", "allowed_chat_refs": [archive.ref_a]}
+            )
+            assert created.status_code == 200, created.text
+            share_token = created.json()["token"]
+            assert created.json()["allowed_chat_refs"] == [archive.ref_a]
+
+        async with _client(app=recorder) as viewer:
+            # Viewer: the chat-scoped read workload, ref-addressed throughout.
+            await _login_viewer(viewer, adapter, allowed_chat_refs=json.dumps([archive.ref_a]))
+            messages = await viewer.get(f"/api/chats/{archive.ref_a}/messages")
+            assert messages.status_code == 200, messages.text
+            with_media = next(m for m in messages.json() if m["id"] == 2)
+            # The URLs the server mints are the access-log surface of the NEXT
+            # request: they must be ref-addressed, chat-id-free.
+            assert with_media["media"]["id"] == "2_photo"
+            assert with_media["media"]["url"] == f"/media/{archive.ref_a}/2_photo"
+            media = await viewer.get(with_media["media"]["url"])
+            assert media.status_code == 200
+            forbidden = await viewer.get(f"/api/chats/{archive.ref_b}/messages")
+            assert forbidden.status_code == 404
+            export = await viewer.get(f"/api/chats/{archive.ref_a}/export")
+            assert export.status_code == 200
+
+        async with _client(app=recorder) as token_client:
+            # Token auth: writes a session row whose grant is ref-based.
+            resp = await token_client.post("/auth/token", json={"token": share_token})
+            assert resp.status_code == 200, resp.text
+    finally:
+        root.removeHandler(capture)
+        root.setLevel(previous_level)
+
+    needles = (str(CHAT_A_ID), str(CHAT_B_ID))
+
+    # 1. The access-log surface: the ref addressed the chats; no path carried an id.
+    assert any(archive.ref_a in path for path in recorder.paths)
+    for path in recorder.paths:
+        for needle in needles:
+            assert needle not in path, path
+
+    # 2. Every log record from every logger, formatted.
+    logged = "\n".join(capture.lines)
+    for needle in needles:
+        assert needle not in logged
+
+    # 3. Audit rows as STORED: real workload rows exist, and no column of any
+    #    row renders the chat id.
+    audit_rows = await adapter.get_audit_logs(limit=500)
+    actions = {row["action"] for row in audit_rows}
+    assert "login_success" in actions
+    assert any(action.startswith("token_created") for action in actions)
+    rendered = json.dumps(audit_rows, default=str)
+    for needle in needles:
+        assert needle not in rendered
+
+    # 4. The stored grant rows: refs where a chat identity is needed, the "[]"
+    #    tombstone (never ids) in the legacy column.
+    token_rows = await adapter.get_all_viewer_tokens()
+    share_row = next(row for row in token_rows if row["label"] == "matrix-share")
+    assert archive.ref_a in (share_row["allowed_chat_refs"] or "")
+    assert share_row["allowed_chat_ids"] == "[]"
+    for needle in needles:
+        assert needle not in json.dumps(share_row, default=str)
+
+    session_rows = await adapter.load_all_sessions()
+    token_sessions = [row for row in session_rows if row["role"] == "token"]
+    assert token_sessions, "token auth wrote no session row"
+    for row in token_sessions:
+        assert archive.ref_a in (row["allowed_chat_refs"] or "")
+        assert row["allowed_chat_ids"] == "[]"

--- a/tests/test_database_viewer.py
+++ b/tests/test_database_viewer.py
@@ -118,6 +118,10 @@ class TestAsyncDatabaseAdapter(unittest.TestCase):
             "insert_messages_batch",
             "get_reactions",
             "reconcile_reactions",
+            # Phase 4 (chat-ref viewer) surface
+            "get_chat_by_ref",
+            "get_media_by_id",
+            "get_message_sender_id",
         ]
 
         for method in required_methods:

--- a/tests/test_frontend_audit_fixes.py
+++ b/tests/test_frontend_audit_fixes.py
@@ -190,7 +190,7 @@ def test_media_gallery_tab_switch_supersedes_the_in_flight_page() -> None:
             "const assert = require('node:assert/strict');",
             """
 const ref = value => ({ value });
-const selectedChat = ref({ id: 7 });
+const selectedChat = ref({ id: 7, ref: 'ref-chat-7' });
 const mediaGalleryTab = ref('photos');
 const mediaGalleryItems = ref([]);
 const mediaGalleryLoading = ref(false);
@@ -259,7 +259,8 @@ def test_media_gallery_response_that_outlived_its_chat_is_discarded() -> None:
             "const assert = require('node:assert/strict');",
             """
 const ref = value => ({ value });
-const selectedChat = ref({ id: 111 });
+// Chats are URL-addressed by their opaque ref; the id is payload data only.
+const selectedChat = ref({ id: 111, ref: 'ref-chat-111' });
 const mediaGalleryTab = ref('photos');
 const mediaGalleryItems = ref([]);
 const mediaGalleryLoading = ref(false);
@@ -282,9 +283,9 @@ const flush = () => new Promise(resolve => setImmediate(resolve));
 (async () => {
     loadMediaGallery();
     await flush();
-    assert.ok(requests[0].url.startsWith('/api/chats/111/media?'), requests[0].url);
+    assert.ok(requests[0].url.startsWith('/api/chats/ref-chat-111/media?'), requests[0].url);
 
-    selectedChat.value = { id: 222 };
+    selectedChat.value = { id: 222, ref: 'ref-chat-222' };
     requests[0].settle({ ok: true, json: async () => ({ items: [{ id: 'from-111' }], has_more: true }) });
     await flush();
     assert.deepEqual(mediaGalleryItems.value, [], "chat 111's media landed in chat 222");
@@ -320,8 +321,9 @@ def test_notification_deep_link_resolves_a_chat_outside_the_loaded_page() -> Non
             """
 const ref = value => ({ value });
 // The sidebar page: 50 non-archived chats, none of them the notification's target.
-const chats = ref(Array.from({ length: 50 }, (_, index) => ({ id: 1000 + index, title: 'chat' })));
-const archived = { id: -1009999, title: 'archived chat', is_archived: true };
+// Notifications address chats by their opaque ref (chat ids stay out of URLs).
+const chats = ref(Array.from({ length: 50 }, (_, index) => ({ id: 1000 + index, ref: `ref${1000 + index}`, title: 'chat' })));
+const archived = { id: -1009999, ref: 'archivedTargetRef', title: 'archived chat', is_archived: true };
 const opened = [];
 const scrolled = [];
 const toasts = [];
@@ -340,7 +342,7 @@ const fetch = async url => {
             _extract_const_arrow_function(html, "openNotificationTarget", asynchronous=True),
             """
 (async () => {
-    const wasOpened = await openNotificationTarget(-1009999, 4242);
+    const wasOpened = await openNotificationTarget('archivedTargetRef', 4242);
     assert.equal(wasOpened, true, 'the deep link silently failed');
     assert.deepEqual(opened, [-1009999]);
     assert.deepEqual(scrolled, [4242]);
@@ -352,12 +354,12 @@ const fetch = async url => {
 
     // A chat in the loaded page needs no request at all.
     requested.length = 0;
-    assert.equal(await openNotificationTarget(1003, null), true);
+    assert.equal(await openNotificationTarget('ref1003', null), true);
     assert.deepEqual(requested, []);
     assert.deepEqual(scrolled, [4242]);
 
     // Genuinely unresolvable: say so instead of doing nothing.
-    const missing = await openNotificationTarget(-1, 7);
+    const missing = await openNotificationTarget('noSuchRefAnywhere', 7);
     assert.equal(missing, false);
     assert.equal(toasts.length, 1, 'a failed deep link stayed silent');
     assert.deepEqual(opened, [-1009999, 1003]);
@@ -376,10 +378,10 @@ def test_failed_deep_link_keeps_the_url_so_a_refresh_retries() -> None:
     """The URL is scrubbed only once the chat actually opened."""
     html = INDEX_HTML.read_text(encoding="utf-8")
 
-    start = html.index("const chatIdParam = urlParams.get('chat')")
+    start = html.index("const chatRefParam = urlParams.get('chat')")
     block = html[start : html.index("window.history.replaceState({}, '', '/')", start) + 80]
 
-    assert "const opened = await openNotificationTarget(chatId, msgId)" in block
+    assert "const opened = await openNotificationTarget(chatRefParam, msgId)" in block
     assert "if (opened) {" in block
     assert block.index("if (opened) {") < block.index("window.history.replaceState({}, '', '/')")
 
@@ -398,7 +400,7 @@ def test_notification_click_listener_is_not_gated_on_an_active_controller() -> N
     listener_body = _without_comments(html[listener_start : html.index("finishInitialization()", listener_start)])
     assert "if ('serviceWorker' in navigator) {" in listener_body
     assert "navigator.serviceWorker.controller" not in listener_body
-    assert "await openNotificationTarget(chat_id, message_id)" in listener_body
+    assert "await openNotificationTarget(chat_ref, message_id)" in listener_body
 
 
 # --------------------------------------------------------------------------------------
@@ -708,7 +710,7 @@ def test_notification_click_during_startup_is_parked_and_replayed_once() -> None
 let pendingNotificationClick = null;
 let notificationClickReady = false;
 const opened = [];
-const openNotificationTarget = async (chatId, messageId) => { opened.push([chatId, messageId]); return true; };
+const openNotificationTarget = async (chatRef, messageId) => { opened.push([chatRef, messageId]); return true; };
 const console = { log: () => {} };
 """,
             _extract_const_arrow_function(html, "flushPendingNotificationClick", asynchronous=True),
@@ -716,7 +718,8 @@ const console = { log: () => {} };
             """
 (async () => {
     // Before initialization is done: the click is parked, not acted on and not lost.
-    await onServiceWorkerMessage({ data: { type: 'NOTIFICATION_CLICK', data: { chat_id: -100123, message_id: 55 } } });
+    // Push payloads carry the chat's opaque ref — never a chat id.
+    await onServiceWorkerMessage({ data: { type: 'NOTIFICATION_CLICK', data: { chat_ref: 'parkedRef', message_id: 55 } } });
     assert.deepEqual(opened, [], 'acted on a click before the app could open a chat');
 
     // Non-clicks and payloads without a chat must not park anything.
@@ -726,13 +729,13 @@ const console = { log: () => {} };
 
     // Initialization finishes: the parked click replays exactly once.
     await flushPendingNotificationClick();
-    assert.deepEqual(opened, [[-100123, 55]], 'the parked click was dropped');
+    assert.deepEqual(opened, [['parkedRef', 55]], 'the parked click was dropped');
     await flushPendingNotificationClick();
-    assert.deepEqual(opened, [[-100123, 55]], 'the parked click replayed twice');
+    assert.deepEqual(opened, [['parkedRef', 55]], 'the parked click replayed twice');
 
     // From now on clicks are handled directly.
-    await onServiceWorkerMessage({ data: { type: 'NOTIFICATION_CLICK', data: { chat_id: 7 } } });
-    assert.deepEqual(opened, [[-100123, 55], [7, undefined]]);
+    await onServiceWorkerMessage({ data: { type: 'NOTIFICATION_CLICK', data: { chat_ref: 'directRef' } } });
+    assert.deepEqual(opened, [['parkedRef', 55], ['directRef', undefined]]);
 })().catch(error => {
     process.stderr.write(`${error.stack}\\n`);
     process.exitCode = 1;
@@ -1086,7 +1089,8 @@ def test_chat_stats_response_that_outlived_its_chat_is_discarded() -> None:
             "const assert = require('node:assert/strict');",
             """
 const ref = value => ({ value });
-const selectedChat = ref({ id: 111 });
+// Loaders address and guard by the chat's opaque ref, not its id.
+const selectedChat = ref({ ref: 'ref-111' });
 const chatStats = ref(null);
 const console = { error: () => {} };
 """,
@@ -1094,15 +1098,15 @@ const console = { error: () => {} };
             _extract_const_arrow_function(html, "loadChatStats", asynchronous=True),
             """
 (async () => {
-    loadChatStats(111);
+    loadChatStats('ref-111');
     await flush();
-    assert.ok(requests[0].url.startsWith('/api/chats/111/stats'), requests[0].url);
+    assert.ok(requests[0].url.startsWith('/api/chats/ref-111/stats'), requests[0].url);
 
     // The user switches chats while chat 111's stats are still in flight
     // (selectChat resets the panel and issues the new chat's request).
-    selectedChat.value = { id: 222 };
+    selectedChat.value = { ref: 'ref-222' };
     chatStats.value = null;
-    loadChatStats(222);
+    loadChatStats('ref-222');
     await flush();
 
     respond(1, { message_count: 5 });
@@ -1116,11 +1120,11 @@ const console = { error: () => {} };
         "chat 111's stats landed in chat 222's header");
 
     // A stale network error must not blank the header either.
-    loadChatStats(222);
+    loadChatStats('ref-222');
     await flush();
-    selectedChat.value = { id: 333 };
+    selectedChat.value = { ref: 'ref-333' };
     chatStats.value = null;
-    loadChatStats(333);
+    loadChatStats('ref-333');
     await flush();
     respond(3, { message_count: 7 });
     await flush();
@@ -1130,18 +1134,18 @@ const console = { error: () => {} };
         "chat 222's network error blanked chat 333's header");
 
     // The CURRENT chat's failure still clears: the guard must not pin stale numbers.
-    loadChatStats(333);
+    loadChatStats('ref-333');
     await flush();
     fail(4);
     await flush();
     assert.equal(chatStats.value, null, 'a live network error no longer clears the header');
 
     // A stale HTTP failure must not blank the header either.
-    loadChatStats(333);
+    loadChatStats('ref-333');
     await flush();
-    selectedChat.value = { id: 444 };
+    selectedChat.value = { ref: 'ref-444' };
     chatStats.value = null;
-    loadChatStats(444);
+    loadChatStats('ref-444');
     await flush();
     respond(6, { message_count: 9 });
     await flush();
@@ -1153,7 +1157,7 @@ const console = { error: () => {} };
     // A CURRENT chat's non-ok response leaves the header as it was: unlike the
     // pinned banner, loadChatStats has no else-branch write — only a network
     // error clears the header.
-    loadChatStats(444);
+    loadChatStats('ref-444');
     await flush();
     respondError(7, 500);
     await flush();
@@ -1186,7 +1190,8 @@ def test_pinned_messages_response_that_outlived_its_chat_is_discarded() -> None:
             "const assert = require('node:assert/strict');",
             """
 const ref = value => ({ value });
-const selectedChat = ref({ id: 111 });
+// Loaders address and guard by the chat's opaque ref, not its id.
+const selectedChat = ref({ ref: 'ref-111' });
 const pinnedMessages = ref([]);
 const currentPinnedIndex = ref(0);
 const console = { error: () => {} };
@@ -1195,15 +1200,15 @@ const console = { error: () => {} };
             _extract_const_arrow_function(html, "loadPinnedMessages", asynchronous=True),
             """
 (async () => {
-    loadPinnedMessages(111);
+    loadPinnedMessages('ref-111');
     await flush();
-    assert.ok(requests[0].url.startsWith('/api/chats/111/pinned'), requests[0].url);
+    assert.ok(requests[0].url.startsWith('/api/chats/ref-111/pinned'), requests[0].url);
 
     // Chat switch while 111's request is in flight (selectChat's resets).
-    selectedChat.value = { id: 222 };
+    selectedChat.value = { ref: 'ref-222' };
     pinnedMessages.value = [];
     currentPinnedIndex.value = 0;
-    loadPinnedMessages(222);
+    loadPinnedMessages('ref-222');
     await flush();
 
     respond(1, [{ id: 'pin-222-newest' }, { id: 'pin-222-older' }]);
@@ -1219,12 +1224,12 @@ const console = { error: () => {} };
     assert.equal(currentPinnedIndex.value, 1, 'a stale response reset the banner cycle');
 
     // A stale HTTP failure must not wipe the current chat's banner.
-    loadPinnedMessages(222);
+    loadPinnedMessages('ref-222');
     await flush();
-    selectedChat.value = { id: 333 };
+    selectedChat.value = { ref: 'ref-333' };
     pinnedMessages.value = [];
     currentPinnedIndex.value = 0;
-    loadPinnedMessages(333);
+    loadPinnedMessages('ref-333');
     await flush();
     respond(3, [{ id: 'pin-333' }]);
     await flush();
@@ -1234,11 +1239,11 @@ const console = { error: () => {} };
         "chat 222's failed request wiped chat 333's banner");
 
     // A stale network error must not wipe it either.
-    loadPinnedMessages(333);
+    loadPinnedMessages('ref-333');
     await flush();
-    selectedChat.value = { id: 444 };
+    selectedChat.value = { ref: 'ref-444' };
     pinnedMessages.value = [];
-    loadPinnedMessages(444);
+    loadPinnedMessages('ref-444');
     await flush();
     respond(5, [{ id: 'pin-444' }]);
     await flush();
@@ -1248,14 +1253,14 @@ const console = { error: () => {} };
         "chat 333's network error wiped chat 444's banner");
 
     // The CURRENT chat's failures still clear: the guard must not pin a stale banner.
-    loadPinnedMessages(444);
+    loadPinnedMessages('ref-444');
     await flush();
     respondError(6, 500);
     await flush();
     assert.deepEqual(pinnedMessages.value, [], 'a live failed reload no longer clears the banner');
 
     pinnedMessages.value = [{ id: 'left-behind' }];
-    loadPinnedMessages(444);
+    loadPinnedMessages('ref-444');
     await flush();
     fail(7);
     await flush();

--- a/tests/test_frontend_audit_fixes.py
+++ b/tests/test_frontend_audit_fixes.py
@@ -1274,3 +1274,50 @@ const console = { error: () => {} };
     )
 
     _run_node(script)
+
+
+def test_interpolated_fetch_paths_encode_their_segments() -> None:
+    """A ref-shaped value can never smuggle a path separator into a fetch URL.
+
+    Every chat-scoped URL builder wraps its interpolated segments in
+    encodeURIComponent, so even a hostile deep-link value like ``../admin``
+    reaches the server as one opaque path segment (``..%2Fadmin``) instead of
+    stepping the request onto another route (CodeQL js/request-forgery).
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    script = "\n".join(
+        [
+            '"use strict";',
+            "const assert = require('node:assert/strict');",
+            """
+const ref = value => ({ value });
+const selectedChat = ref({ id: 111, ref: '../admin' });
+const messageVersionsByMessage = ref({});
+const messageVersionsErrors = ref({});
+const messageVersionsRequestSeq = ref({});
+const messageVersionsLoading = ref({});
+const isAuthenticated = ref(true);
+const console = { error: () => {} };
+const urls = [];
+const fetch = async (url) => { urls.push(url); return { ok: false, status: 500, json: async () => ({}) }; };
+const messageVersionsKey = msg => String(msg.id);
+const setMessageVersionsRecord = (store, key, value) => { store.value = { ...store.value, [key]: value }; };
+const clearMessageVersionsRecord = (store, key) => { const next = { ...store.value }; delete next[key]; store.value = next; };
+""",
+            _extract_const_arrow_function(html, "loadMessageVersions", asynchronous=True),
+            """
+(async () => {
+    await loadMessageVersions({ id: 7 });
+    assert.equal(urls.length, 1, 'expected exactly one request');
+    assert.ok(urls[0].includes('..%2Fadmin'), `separator not encoded: ${urls[0]}`);
+    assert.ok(!/\\/\\.\\.\\//.test(urls[0]), `raw dot-dot segment survived: ${urls[0]}`);
+})().catch(error => {
+    process.stderr.write(`${error.stack}\\n`);
+    process.exitCode = 1;
+});
+""",
+        ]
+    )
+
+    _run_node(script)

--- a/tests/test_frontend_audit_fixes.py
+++ b/tests/test_frontend_audit_fixes.py
@@ -1321,3 +1321,18 @@ const clearMessageVersionsRecord = (store, key) => { const next = { ...store.val
     )
 
     _run_node(script)
+
+
+def test_every_chat_scoped_url_interpolation_is_encoded() -> None:
+    """The encoding invariant is enforced by scan, not sampled by one builder.
+
+    Any ``/api/chats/${...}`` interpolation whose first expression is not
+    ``encodeURIComponent(`` can smuggle a path separator; a new builder added
+    without the wrapper fails here by construction.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    violations = [
+        html[max(0, m.start() - 40) : m.start() + 60]
+        for m in re.finditer(r"/api/chats/\$\{(?!encodeURIComponent\()", html)
+    ]
+    assert violations == [], f"unencoded chat-scoped interpolations: {violations}"

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -1413,7 +1413,7 @@ def test_audio_queue_pages_the_media_endpoint_with_a_capped_cursor_walk():
     html = INDEX_HTML.read_text(encoding="utf-8")
 
     fetch_body = _setup_slice(html, "const fetchAudioQueuePage = async (chatRef, kind, cursor, direction = 'older') =>")
-    assert "`/api/chats/${chatRef}/media?${params}`" in fetch_body
+    assert "`/api/chats/${encodeURIComponent(chatRef)}/media?${params}`" in fetch_body
     assert "types: audioQueueTypes(kind)," in fetch_body
     assert "limit: String(AUDIO_QUEUE_PAGE_SIZE)," in fetch_body
     # One cursor shape, two directions: before_id walks older, after_id newer.

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -604,7 +604,7 @@ def test_gallery_close_restores_reading_position_and_focus():
     assert "galleryReturnState = null" in jump_body
     # Restore happens after the observer reconnect, inside the same guarded block.
     assert watcher_body.index("setupMessagesScrollObserver()") < watcher_body.index(
-        "returnState.chatId === (selectedChat.value?.id ?? null)"
+        "returnState.chatRef === (selectedChat.value?.ref ?? null)"
     )
 
 
@@ -697,8 +697,9 @@ def test_reaction_ws_case_patches_message_reactions():
     assert "case 'reaction':" in ws_body
     reaction_start = ws_body.index("case 'reaction':")
     reaction_body = ws_body[reaction_start : ws_body.index("case 'delete':", reaction_start)]
-    # Same chat-scope guard as the 'edit' case, wholesale-replace the reactions array.
-    assert "selectedChat.value?.id !== data.chat_id" in reaction_body
+    # Same chat-scope guard as the 'edit' case (ref-addressed frames since v8.0),
+    # wholesale-replace the reactions array.
+    assert "selectedChat.value?.ref !== data.chat_ref" in reaction_body
     assert "reactionMsg.reactions = data.reactions" in reaction_body
     # The reactions block renders the aggregate shape the server sends.
     assert 'v-for="reaction in msg.reactions"' in html
@@ -800,7 +801,7 @@ def test_calendar_availability_is_topic_scoped_stale_safe_and_fail_open():
 
     availability_start = html.index("const loadCalendarAvailability = async (year, month) =>")
     availability_body = html[availability_start : html.index("const openDatePicker", availability_start)]
-    assert "calendarAvailabilityKey(chatId, topicId, timezone, monthKey)" in availability_body
+    assert "calendarAvailabilityKey(chatRef, topicId, timezone, monthKey)" in availability_body
     assert "url += `&topic_id=${topicId}`" in availability_body
     assert availability_body.count("requestSeq !== calendarAvailabilityRequestSeq") >= 2
     assert "calendarAvailableDates.value = null" in availability_body
@@ -1393,7 +1394,7 @@ def test_audio_auto_advance_does_not_drive_pagination():
 # --- Pagination-aware audio queue (#254) ---------------------------------------
 
 _AUDIO_QUEUE_DECLARATIONS = (
-    "const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') =>",
+    "const fetchAudioQueuePage = async (chatRef, kind, cursor, direction = 'older') =>",
     "const seedAudioQueueAroundTrack = async (track) =>",
     "const extendAudioQueueFromMedia = async (track) =>",
     "const extendAudioQueueNewer = async () =>",
@@ -1411,8 +1412,8 @@ def test_audio_queue_pages_the_media_endpoint_with_a_capped_cursor_walk():
     """
     html = INDEX_HTML.read_text(encoding="utf-8")
 
-    fetch_body = _setup_slice(html, "const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') =>")
-    assert "`/api/chats/${chatId}/media?${params}`" in fetch_body
+    fetch_body = _setup_slice(html, "const fetchAudioQueuePage = async (chatRef, kind, cursor, direction = 'older') =>")
+    assert "`/api/chats/${chatRef}/media?${params}`" in fetch_body
     assert "types: audioQueueTypes(kind)," in fetch_body
     assert "limit: String(AUDIO_QUEUE_PAGE_SIZE)," in fetch_body
     # One cursor shape, two directions: before_id walks older, after_id newer.
@@ -1424,7 +1425,7 @@ def test_audio_queue_pages_the_media_endpoint_with_a_capped_cursor_walk():
 
     extend_body = _setup_slice(html, "const extendAudioQueueFromMedia = async (track) =>")
     assert "for (let page = 0; page < AUDIO_QUEUE_MAX_PAGES; page++)" in extend_body
-    assert "await fetchAudioQueuePage(track.chatId, track.kind, cursor, 'older')" in extend_body
+    assert "await fetchAudioQueuePage(track.chatRef, track.kind, cursor, 'older')" in extend_body
     assert "cursor = items[items.length - 1].id" in extend_body
     # Stop as soon as the playing track is in hand, or nothing older is left.
     assert "items.some(item => item.message_id === track.id)" in extend_body
@@ -1435,7 +1436,7 @@ def test_audio_queue_pages_the_media_endpoint_with_a_capped_cursor_walk():
 
     # "Previous" at the head of the queue pages one more time from the same cursor.
     older_body = _setup_slice(html, "const extendAudioQueueOlder = async () =>")
-    assert "await fetchAudioQueuePage(track.chatId, track.kind, audioQueueCursor, 'older')" in older_body
+    assert "await fetchAudioQueuePage(track.chatRef, track.kind, audioQueueCursor, 'older')" in older_body
     prev_body = _setup_slice(html, "const playPrevAudio = async () =>")
     assert "await extendAudioQueueOlder()" in prev_body
     assert "seekAudioTo(0)" in prev_body
@@ -1484,7 +1485,7 @@ def test_audio_queue_extension_never_drives_message_pagination():
 
     # The queue holds copied descriptors, so emptying messages.value on a chat
     # switch cannot invalidate it.
-    item_body = _setup_slice(html, "const audioTrackFromMediaItem = (item, kind, chatName) =>")
+    item_body = _setup_slice(html, "const audioTrackFromMediaItem = (item, kind, chatName, chatRef) =>")
     assert "id: item.message_id," in item_body
     assert "chatId: item.chat_id," in item_body
     assert "url: item.media_url || ''," in item_body
@@ -1569,17 +1570,17 @@ def test_audio_queue_keeps_voice_and_music_on_separate_types():
     # direction — a forward page that dropped the kind would roll a voice run
     # into music the moment auto-advance left the seeded window.
     extend_body = _setup_slice(html, "const extendAudioQueueFromMedia = async (track) =>")
-    assert "fetchAudioQueuePage(track.chatId, track.kind, cursor, 'older')" in extend_body
+    assert "fetchAudioQueuePage(track.chatRef, track.kind, cursor, 'older')" in extend_body
     older_body = _setup_slice(html, "const extendAudioQueueOlder = async () =>")
-    assert "fetchAudioQueuePage(track.chatId, track.kind, audioQueueCursor, 'older')" in older_body
+    assert "fetchAudioQueuePage(track.chatRef, track.kind, audioQueueCursor, 'older')" in older_body
     seed_body = _setup_slice(html, "const seedAudioQueueAroundTrack = async (track) =>")
-    assert "fetchAudioQueuePage(track.chatId, track.kind, track.mediaId, 'older')" in seed_body
+    assert "fetchAudioQueuePage(track.chatRef, track.kind, track.mediaId, 'older')" in seed_body
     newer_body = _setup_slice(html, "const extendAudioQueueNewer = async () =>")
-    assert "track.chatId, track.kind, audioQueueCursorNewer, 'newer')" in newer_body
+    assert "track.chatRef, track.kind, audioQueueCursorNewer, 'newer')" in newer_body
 
     # Fetched descriptors inherit that kind, so a merged queue stays single-class.
     tracks_body = _setup_slice(html, "const audioTracksFromMediaItems = (items, track) =>")
-    assert "audioTrackFromMediaItem(item, track.kind, track.chatName)" in tracks_body
+    assert "audioTrackFromMediaItem(item, track.kind, track.chatName, track.chatRef)" in tracks_body
 
 
 def test_audio_queue_in_flight_flag_cannot_leak():
@@ -1624,7 +1625,7 @@ class TestAudioQueuePagingOutcomes(unittest.TestCase):
         same falsy result as an exhausted cursor and "previous" restarted the
         current track as though the oldest message had been reached.
         """
-        fetch_body = self._slice("const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') =>")
+        fetch_body = self._slice("const fetchAudioQueuePage = async (chatRef, kind, cursor, direction = 'older') =>")
         self.assertIn("error.status = res.status", fetch_body)
         # Stale pages are aborted rather than landing on a closed player.
         self.assertIn("new AbortController()", fetch_body)
@@ -1754,7 +1755,7 @@ class TestAudioQueueHoleGuard(unittest.TestCase):
         prelude = """
 const noDownload = { value: false }
 const audioQueue = { value: [] }
-const audioTrack = { value: { chatId: 7, kind: 'voice' } }
+const audioTrack = { value: { chatId: 7, chatRef: 'r7', kind: 'voice' } }
 const audioTrackFromMediaItem = (item, kind, chatName) => ({
     id: item.message_id, chatId: item.chat_id, kind, chatName,
     date: item.message_date, url: item.media_url,
@@ -1782,8 +1783,8 @@ const scenario = async (pages) => {
     audioQueueHasOlder = false
     // The seeded window queue around the playing track, which the guard
     // protects when the walk cannot be trusted.
-    audioQueue.value = [{ id: 999, chatId: 7, kind: 'voice', date: '2026-07-09T00:00:00' }]
-    await extendAudioQueueFromMedia({ chatId: 7, kind: 'voice', id: 999, chatName: 'c' })
+    audioQueue.value = [{ id: 999, chatId: 7, chatRef: 'r7', kind: 'voice', date: '2026-07-09T00:00:00' }]
+    await extendAudioQueueFromMedia({ chatId: 7, chatRef: 'r7', kind: 'voice', id: 999, chatName: 'c' })
     return {
         cursor: audioQueueCursor,
         hasOlder: audioQueueHasOlder,
@@ -1880,7 +1881,7 @@ _AUDIO_QUEUE_EXEC_DECLARATIONS = (
     # (request id, fetch seq, both cursors, both has-more flags, fetching), which
     # is why none of them may be re-declared in a prelude.
     "const AUDIO_QUEUE_MAX_PAGES = ",
-    "const audioTrackFromMediaItem = (item, kind, chatName) =>",
+    "const audioTrackFromMediaItem = (item, kind, chatName, chatRef) =>",
     "const audioTracksFromMediaItems = (items, track) =>",
     "const audioTrackTime = (track) =>",
     "const mergeAudioQueue = (tracks) =>",
@@ -1897,7 +1898,7 @@ const audioTrack = { value: null }
 let PAGES = []
 let REPEAT = null
 const REQUESTED = []
-const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') => {
+const fetchAudioQueuePage = async (chatRef, kind, cursor, direction = 'older') => {
     REQUESTED.push([cursor ?? null, direction])
     return PAGES.shift() ?? REPEAT ?? { items: [], has_more: false }
 }
@@ -1911,7 +1912,7 @@ const mediaItem = (n) => ({
 // page of these adds NOTHING even though it was a perfectly successful fetch.
 const unplayableItem = (n) => ({ ...mediaItem(n), media_url: '' })
 const seedTrack = (n) => ({
-    id: n, chatId: 7, kind: 'voice', mediaId: `m${n}`,
+    id: n, chatId: 7, chatRef: 'r7', kind: 'voice', mediaId: `m${n}`,
     date: `2026-07-01T00:00:${String(n).padStart(2, '0')}`, url: `/media/${n}.ogg`,
 })
 """
@@ -1938,7 +1939,7 @@ class TestAudioQueueExtendsInTheDirectionOfTravel(unittest.TestCase):
     def test_forward_paging_uses_the_after_id_cursor(self) -> None:
         """The endpoint pages backward by default; forward needs the #266 cursor."""
         fetch_body = _setup_slice(
-            self.html, "const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') =>"
+            self.html, "const fetchAudioQueuePage = async (chatRef, kind, cursor, direction = 'older') =>"
         )
         self.assertIn("params.set(direction === 'newer' ? 'after_id' : 'before_id', cursor)", fetch_body)
         # One cursor per request: before_id and after_id are mutually exclusive
@@ -1985,7 +1986,7 @@ const scenario = async (pages, repeat) => {
     audioQueueCursor = null
     audioQueueHasOlder = false
     audioQueue.value = [seedTrack(10)]
-    audioTrack.value = { chatId: 7, kind: 'voice', id: 10, chatName: 'c', mediaId: 'm10' }
+    audioTrack.value = { chatId: 7, chatRef: 'r7', kind: 'voice', id: 10, chatName: 'c', mediaId: 'm10' }
     audioQueueCursorNewer = audioQueueEdgeMediaId(true)
     audioQueueHasNewer = true
     const outcome = await extendAudioQueueNewer()
@@ -2068,7 +2069,7 @@ const scenario = async (track, pages) => {
     audioQueueCursorNewer = null
     audioQueueHasNewer = false
     audioQueue.value = [seedTrack(500)]
-    audioTrack.value = { chatId: 7, kind: 'voice', id: 500, chatName: 'c' }
+    audioTrack.value = { chatId: 7, chatRef: 'r7', kind: 'voice', id: 500, chatName: 'c' }
     await extendAudioQueueFromMedia(track)
     return {
         cursor: audioQueueCursor,
@@ -2080,7 +2081,7 @@ const scenario = async (track, pages) => {
     }
 };
 (async () => {
-    const anchored = { chatId: 7, kind: 'voice', id: 500, chatName: 'c', mediaId: 'm500' };
+    const anchored = { chatId: 7, chatRef: 'r7', kind: 'voice', id: 500, chatName: 'c', mediaId: 'm500' };
     // The endpoint answers a backward page newest-first.
     const seeded = await scenario(anchored, [
         { items: [mediaItem(499), mediaItem(498)], has_more: true },
@@ -2100,7 +2101,7 @@ const scenario = async (track, pages) => {
         { items: [mediaItem(501), mediaItem(502)], has_more: true },
     ]);
     // No id to anchor on at all -> straight to the walk.
-    const noAnchor = await scenario({ chatId: 7, kind: 'voice', id: 500, chatName: 'c' }, [
+    const noAnchor = await scenario({ chatId: 7, chatRef: 'r7', kind: 'voice', id: 500, chatName: 'c' }, [
         { items: [mediaItem(501), mediaItem(500)], has_more: false },
     ]);
     console.log(JSON.stringify({ seeded, unresolvable, oldestOfItsKind, noAnchor }));
@@ -2152,18 +2153,20 @@ const scenario = async (track, pages) => {
 
     def test_media_id_is_carried_on_every_descriptor(self) -> None:
         """A cursor the queue cannot name is a queue that cannot page."""
-        item_body = _setup_slice(self.html, "const audioTrackFromMediaItem = (item, kind, chatName) =>")
+        item_body = _setup_slice(self.html, "const audioTrackFromMediaItem = (item, kind, chatName, chatRef) =>")
         self.assertIn("mediaId: item.id ?? null,", item_body)
 
         msg_body = _setup_slice(self.html, "const audioTrackFromMessage = (msg) =>")
         self.assertIn("mediaId: audioMessageMediaId(msg),", msg_body)
 
         # #268: taken from the payload first — the rebuild is only the fallback.
+        # v8.0: the cursor is the CHAT-FREE `{message_id}_{type}` key, so the
+        # rebuild no longer needs (or embeds) the chat id.
         built = _setup_slice(self.html, "const audioMessageMediaId = (msg) =>")
         self.assertIn("const delivered = msg?.media?.id", built)
-        self.assertLess(built.index("msg?.media?.id"), built.index("`${chatId}_${msg.id}_${type}`"))
-        self.assertIn("return `${chatId}_${msg.id}_${type}`", built)
-        self.assertIn("if (chatId == null || msg?.id == null || !type) return null", built)
+        self.assertLess(built.index("msg?.media?.id"), built.index("`${msg.id}_${type}`"))
+        self.assertIn("return `${msg.id}_${type}`", built)
+        self.assertIn("if (msg?.id == null || !type) return null", built)
 
     @unittest.skipUnless(NODE, "node is required to execute the helper")
     def test_rebuilt_media_id_executed(self) -> None:
@@ -2179,11 +2182,13 @@ const selectedChat = { value: null }
 const cases = [
     { id: 12, chat_id: -100, media: { type: 'voice' } },
     { id: 12, chat_id: -100, media: {} },
+    // v8.0: the rebuilt cursor is chat-free, so a missing chat_id no longer
+    // matters — the ref in the request path is what scopes it.
     { id: 12, media: { type: 'voice' } },
 ]
 """,
         )
-        self.assertEqual(out, ["-100_12_voice", None, None])
+        self.assertEqual(out, ["12_voice", None, "12_voice"])
 
     @unittest.skipUnless(NODE, "node is required to execute the helper")
     def test_delivered_media_id_wins_over_the_rebuild_executed(self) -> None:
@@ -2209,18 +2214,19 @@ const cases = [
             prelude="""
 const selectedChat = { value: null }
 const cases = [
-    // Imported archive: the rebuild would have produced "-100_12_voice".
+    // Imported archive: the rebuild would have produced "12_voice".
     { id: 12, chat_id: -100, media: { id: 'import_-100_12', type: 'voice' } },
-    // Capture path: same shape as the rebuild, still taken from the payload.
+    // A payload predating the v8.0 chat-free rewrite: delivered verbatim, and
+    // the server answers the empty page it answers for any unresolvable cursor.
     { id: 12, chat_id: -100, media: { id: '-100_12_voice', type: 'voice' } },
     // Numeric ids survive the trip as cursor strings.
     { id: 12, chat_id: -100, media: { id: 4242, type: 'voice' } },
-    // No id delivered -> the documented best-effort rebuild.
+    // No id delivered -> the documented best-effort (chat-free) rebuild.
     { id: 12, chat_id: -100, media: { type: 'voice' } },
 ]
 """,
         )
-        self.assertEqual(out, ["import_-100_12", "-100_12_voice", "4242", "-100_12_voice"])
+        self.assertEqual(out, ["import_-100_12", "-100_12_voice", "4242", "12_voice"])
 
     @unittest.skipUnless(NODE, "node is required to execute the helper")
     def test_forward_walk_stops_on_a_cursor_it_has_already_asked_from(self) -> None:
@@ -2239,7 +2245,7 @@ const cases = [
 const noDownload = { value: false }
 const audioError = { value: '' }
 const audioQueue = { value: [] }
-const audioTrack = { value: { chatId: 7, kind: 'voice', id: 10 } }
+const audioTrack = { value: { chatId: 7, chatRef: 'r7', kind: 'voice', id: 10 } }
 const REQUESTED = []
 let CALLS = 0
 // Downloaded but unplayable for this viewer, so no page ever adds a track and
@@ -2268,7 +2274,7 @@ const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'newer') =>
             self.html,
             (
                 "const AUDIO_QUEUE_MAX_PAGES = ",
-                "const audioTrackFromMediaItem = (item, kind, chatName) =>",
+                "const audioTrackFromMediaItem = (item, kind, chatName, chatRef) =>",
                 "const audioTracksFromMediaItems = (items, track) =>",
                 "const audioTrackTime = (track) =>",
                 "const mergeAudioQueue = (tracks) =>",
@@ -2303,7 +2309,7 @@ const unseenMessageCount = { value: 0 }
 const messageWindowIsContiguous = { value: false }
 const isAuthenticated = { value: true }
 const messageSearchQuery = { value: '' }
-const selectedChat = { value: { id: 7, title: 'chat' } }
+const selectedChat = { value: { id: 7, ref: 'r7', title: 'chat' } }
 let oldestMessageCursor = null
 let loadFailureStreak = 0
 let newestMessageId = null
@@ -2572,7 +2578,7 @@ const REQUESTED = []
 // A faithful stand-in for get_media_paginated: an opaque cursor resolved
 // against the table, paged away from it in the requested direction, answering
 // an unresolvable cursor with an empty page in EITHER direction.
-const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') => {
+const fetchAudioQueuePage = async (chatRef, kind, cursor, direction = 'older') => {
     REQUESTED.push([cursor ?? null, direction])
     const at = cursor ? MEDIA.findIndex(m => m.id === cursor) : -1
     if (cursor && at < 0) return { items: [], has_more: false }
@@ -2651,7 +2657,7 @@ const run = async ({ search = '', topic = null, pinnedIds = null, rowIds }, clic
                 "const audioTrackFromMessage = (msg) =>",
                 "const audioQueueSeedIsContiguous = () =>",
                 "const buildAudioQueue = (msg) =>",
-                "const audioTrackFromMediaItem = (item, kind, chatName) =>",
+                "const audioTrackFromMediaItem = (item, kind, chatName, chatRef) =>",
                 "const audioTracksFromMediaItems = (items, track) =>",
                 "const audioTrackTime = (track) =>",
                 "const mergeAudioQueue = (tracks) =>",
@@ -2719,7 +2725,7 @@ const audioQueue = { value: [] }
 const audioTrack = { value: null }
 const audioAutoAdvanceHalted = { value: false }
 let audioConsecutiveFailures = 0
-const selectedChat = { value: { id: 7, title: 'chat' } }
+const selectedChat = { value: { id: 7, ref: 'r7', title: 'chat' } }
 // The clicked row comes from a SPARSE view (search results), which is what
 // leaves the queue one entry long until the anchored seed lands.
 const messageView = { value: { contiguous: false } }
@@ -2803,7 +2809,7 @@ const MEDIA = Array.from({ length: 12 }, (_, i) => mediaRow(i + 1))
 // The seed page is held until RELEASE is called: everything that happens in
 // between happens while the fetch is genuinely in flight.
 let RELEASE = null
-const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') => {
+const fetchAudioQueuePage = async (chatRef, kind, cursor, direction = 'older') => {
     REQUESTED.push([cursor ?? null, direction])
     if (direction === 'older' && !RELEASE) {
         return new Promise(resolve => { RELEASE = () => resolve(answerPage(MEDIA, cursor, direction)) })
@@ -2849,7 +2855,7 @@ const scenario = async (duringHold) => {
     //    THAT track and replay 2.
     const switched = await scenario(() => {
         audioTrack.value = {
-            id: 1, chatId: 7, kind: 'voice', chatName: 'chat',
+            id: 1, chatId: 7, chatRef: 'r7', kind: 'voice', chatName: 'chat',
             mediaId: 'm1', url: '/media/1.ogg', date: stamp(1),
         }
     })
@@ -2868,7 +2874,7 @@ const scenario = async (duringHold) => {
                 "const audioTrackFromMessage = (msg) =>",
                 "const audioQueueSeedIsContiguous = () =>",
                 "const buildAudioQueue = (msg) =>",
-                "const audioTrackFromMediaItem = (item, kind, chatName) =>",
+                "const audioTrackFromMediaItem = (item, kind, chatName, chatRef) =>",
                 "const audioTracksFromMediaItems = (items, track) =>",
                 "const audioTrackTime = (track) =>",
                 "const mergeAudioQueue = (tracks) =>",
@@ -2940,7 +2946,7 @@ const MEDIA = Array.from({ length: 12 }, (_, i) => {
     const row = mediaRow(i + 1)
     return (i + 1 >= 9 && i + 1 <= 11) ? { ...row, media_url: '' } : row
 })
-const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') => {
+const fetchAudioQueuePage = async (chatRef, kind, cursor, direction = 'older') => {
     REQUESTED.push([cursor ?? null, direction])
     return answerPage(MEDIA, cursor, direction)
 }
@@ -2999,7 +3005,7 @@ const scenario = async ({ contiguous, visible, clicked }) => {
                 "const audioTrackFromMessage = (msg) =>",
                 "const audioQueueSeedIsContiguous = () =>",
                 "const buildAudioQueue = (msg) =>",
-                "const audioTrackFromMediaItem = (item, kind, chatName) =>",
+                "const audioTrackFromMediaItem = (item, kind, chatName, chatRef) =>",
                 "const audioTracksFromMediaItems = (items, track) =>",
                 "const audioTrackTime = (track) =>",
                 "const mergeAudioQueue = (tracks) =>",
@@ -3069,7 +3075,7 @@ const viewingPinnedWindow = ref(false)
 const unseenMessageCount = ref(0)
 const isAuthenticated = ref(true)
 const messageSearchQuery = ref('')
-const selectedChat = ref({ id: 7, title: 'chat' })
+const selectedChat = ref({ id: 7, ref: 'r7', title: 'chat' })
 const selectedPaneTopic = ref(null)
 const pinnedMessages = ref([])
 const showPinnedOnly = ref(false)
@@ -3139,7 +3145,7 @@ const PLAYED = []
 const loadAudioTrack = (track) => { audioTrack.value = track; PLAYED.push(track.id) }
 const MEDIA_PAGE = 3
 const REQUESTED = []
-const fetchAudioQueuePage = async (chatId, kind, cursor, direction = 'older') => {
+const fetchAudioQueuePage = async (chatRef, kind, cursor, direction = 'older') => {
     REQUESTED.push([cursor ?? null, direction])
     const table = SERVER.map(n => ({
         id: `m${n}`, message_id: n, chat_id: 7,
@@ -3224,7 +3230,7 @@ _APPEND_DECLARATIONS = (
     "const audioTrackFromMessage = (msg) =>",
     "const audioQueueSeedIsContiguous = () =>",
     "const buildAudioQueue = (msg) =>",
-    "const audioTrackFromMediaItem = (item, kind, chatName) =>",
+    "const audioTrackFromMediaItem = (item, kind, chatName, chatRef) =>",
     "const audioTracksFromMediaItems = (items, track) =>",
     "const audioTrackTime = (track) =>",
     "const mergeAudioQueue = (tracks) =>",
@@ -3386,13 +3392,13 @@ class TestAppendsCannotPunchAHoleInTheWindow(unittest.TestCase):
     await openChat([1, 2, 3])
     // The socket was down while 4..12 were archived; on reconnect it delivers 12.
     SERVER = Array.from({ length: 12 }, (_, i) => i + 1)
-    handleWebSocketMessage({ type: 'new_message', chat_id: 7, message: messageRow(12) })
+    handleWebSocketMessage({ type: 'new_message', chat_ref: 'r7', message: messageRow(12) })
     const afterGap = windowState()
     const playback = await playFrom(3)
     // The live case: the pane is the tail and the frame is the next message.
     await openChat([1, 2, 3])
     SERVER = [1, 2, 3, 4]
-    handleWebSocketMessage({ type: 'new_message', chat_id: 7, message: messageRow(4) })
+    handleWebSocketMessage({ type: 'new_message', chat_ref: 'r7', message: messageRow(4) })
     emit(JSON.stringify({ afterGap, playback, live: windowState() }))
 })();
 """)
@@ -3553,19 +3559,25 @@ const cases = [
 
 
 class TestMediaUrlEncoding(unittest.TestCase):
-    """#258: '#' or '?' in a filename truncated the URL inside the browser."""
+    """#258's successor: the client never assembles a /media/ URL at all.
+
+    v8.0 removed the client-side URL builder — the server hands ref-addressed
+    URLs (media.url, media_url, thumb_url, avatar_url, sender_avatar_url) and
+    the client uses them verbatim, so a filename can no longer truncate a URL
+    and the chat id never enters a request path.
+    """
 
     @classmethod
     def setUpClass(cls) -> None:
         cls.html = INDEX_HTML.read_text(encoding="utf-8")
 
-    def test_get_media_url_encodes_each_segment(self) -> None:
+    def test_get_media_url_returns_the_server_url_verbatim(self) -> None:
         body = _setup_slice(self.html, "const getMediaUrl = (msg) =>")
-        self.assertIn("encodeURIComponent(folder)", body)
-        self.assertIn("encodeURIComponent(filename)", body)
-        # Per-segment only: encoding the assembled path would escape the '/'.
-        self.assertNotIn("encodeURIComponent(`/media/", body)
-        self.assertNotIn("encodeURI(`/media/", body)
+        self.assertIn("return msg.media?.url || ''", body)
+        # The old file_path builder must stay deleted: rebuilding from file_path
+        # would put the chat id back into requests and access logs.
+        self.assertNotIn("file_path", _code_only(body))
+        self.assertNotIn("`/media/${", body)
 
     def test_server_provided_urls_are_not_encoded_again(self) -> None:
         """media_url / thumb_url / avatar_url arrive already encoded server-side."""
@@ -4188,24 +4200,24 @@ class TestAudioBubbleDownload(unittest.TestCase):
         """``getMediaUrl(msg)`` in the ``v-if`` is NOT a dead term.
 
         The bubble renders on ``isAudioFile(msg)``, which is satisfied by
-        ``media.type`` alone — and a media row exists with ``type`` set but NO
-        ``file_path`` whenever the file was never written: an oversized voice
+        ``media.type`` alone — and a media row exists with ``type`` set but no
+        downloadable file whenever the file was never written: an oversized voice
         note (``_process_media`` returns ``downloaded: False`` with no path once
         it exceeds ``MAX_MEDIA_SIZE``) or a row still queued for the pending
-        -media retry loop (``downloaded=0``, ``file_path`` NULL). The adapter
-        emits ``msg.media`` for every row whose ``media_type`` is set, so those
-        rows reach the client verbatim and ``getMediaUrl`` returns ``''``.
+        -media retry loop (``downloaded=0``, ``file_path`` NULL). v8.0: the
+        SERVER expresses that as ``media.url: null`` (no local file, or a
+        no_download session), and ``getMediaUrl`` returns ``''`` for it.
 
         Without the term the anchor would render ``href="?download=1"`` — a link
         to the viewer page itself, offered as if the audio were downloadable.
         """
         rows = [
-            # Oversized voice note: typed, never written.
-            {"id": 1, "media": {"id": "7_1_voice", "type": "voice", "file_path": None}},
+            # Oversized voice note: typed, never written -> the server sends url null.
+            {"id": 1, "media": {"id": "1_voice", "type": "voice", "url": None}},
             # Pending download of an audio document, name known, file not there.
-            {"id": 2, "media": {"id": "7_2_audio", "type": "audio", "file_name": "note.ogg", "file_path": None}},
-            # Downloaded: both terms true, anchor renders.
-            {"id": 3, "media": {"id": "7_3_voice", "type": "voice", "file_path": "/data/media/7/7_3_voice.ogg"}},
+            {"id": 2, "media": {"id": "2_audio", "type": "audio", "file_name": "note.ogg", "url": None}},
+            # Downloaded: both terms true, anchor renders the server's ref URL.
+            {"id": 3, "media": {"id": "3_voice", "type": "voice", "url": "/media/audioChatRef07AB/3_voice"}},
         ]
         verdicts = _run_setup_helpers(
             self.html,
@@ -4222,7 +4234,7 @@ class TestAudioBubbleDownload(unittest.TestCase):
             [
                 [True, ""],
                 [True, ""],
-                [True, "/media/7/7_3_voice.ogg"],
+                [True, "/media/audioChatRef07AB/3_voice"],
             ],
         )
 

--- a/tests/test_media_download_disposition.py
+++ b/tests/test_media_download_disposition.py
@@ -1,10 +1,11 @@
-"""Tests for #261 (?download=1 forces attachment) and #258 (URL percent-encoding).
+"""Tests for #261 (?download=1 forces attachment) and #258 (URL round-tripping).
 
 Both defects made a media file unreachable or unsaveable from the viewer:
 - serve_media accepted a ``download`` query param and ignored it, so the gallery's
   download button just opened/played the file inline.
-- Server-built media URLs were plain f-strings, so a Telegram filename containing
-  "#" or "?" produced a URL that truncated into a fragment/query.
+- Server-built media URLs used to carry the filename and needed per-segment
+  percent-encoding; since v8.0 the URL is ``/media/{chat_ref}/{message_id}_{type}``
+  resolved through the media row, so the filename never enters a URL at all.
 """
 
 import importlib
@@ -29,6 +30,8 @@ ANON_ENV = {
     "ALLOW_ANONYMOUS_VIEWER": "true",
 }
 
+CHAT_REF = "dispositionRef1001AB0A"
+
 
 def _reload_main(media_root=None):
     """Reload src.web.main under anonymous auth and return (client, module)."""
@@ -41,6 +44,20 @@ def _reload_main(media_root=None):
     return TestClient(main_mod.app, raise_server_exceptions=False), main_mod
 
 
+def _wire_chat_and_media(main_mod, filename: str, chat_id: int = -1001, folder: str | None = None):
+    """Point the mock db at one chat (ref CHAT_REF) holding one media row."""
+    main_mod.db.get_chat_by_ref = AsyncMock(
+        return_value={"id": chat_id, "account_id": 1, "ref": CHAT_REF, "type": "channel"}
+    )
+    main_mod.db.get_media_by_id = AsyncMock(
+        return_value={
+            "id": f"{chat_id}_5_photo",
+            "file_path": f"{folder or chat_id}/{filename}",
+            "file_name": filename,
+        }
+    )
+
+
 class TestDownloadDisposition:
     """#261: ?download=1 must emit Content-Disposition: attachment."""
 
@@ -51,10 +68,9 @@ class TestDownloadDisposition:
             with open(os.path.join(chat_dir, filename), "wb") as handle:
                 handle.write(b"bytes")
             with patch.dict(os.environ, ANON_ENV):
-                client, _ = _reload_main(media_root=tmpdir)
-                from urllib.parse import quote
-
-                return client.get(f"/media/-1001/{quote(filename, safe='')}{query}")
+                client, main_mod = _reload_main(media_root=tmpdir)
+                _wire_chat_and_media(main_mod, filename)
+                return client.get(f"/media/{CHAT_REF}/5_photo{query}")
 
     def test_download_flag_sets_attachment_disposition(self) -> None:
         resp = self._serve("clip.mp4", "?download=1")
@@ -163,26 +179,31 @@ class TestDownloadDisposition:
                 {"VIEWER_USERNAME": "admin", "VIEWER_PASSWORD": "test@value/here", "SECURE_COOKIES": "false"},
             ):
                 client, main_mod = _reload_main(media_root=tmpdir)
+                _wire_chat_and_media(main_mod, "photo.jpg")
                 main_mod.AUTH_ENABLED = True
                 token = "no-download-token"
                 main_mod._sessions[token] = main_mod.SessionData(username="viewer1", role="viewer", no_download=True)
-                resp = client.get("/media/-1001/photo.jpg?download=1", cookies={"viewer_auth": token})
+                resp = client.get(f"/media/{CHAT_REF}/5_photo?download=1", cookies={"viewer_auth": token})
                 assert resp.status_code == 403
 
 
 class TestMediaUrlEncoding:
-    """#258: server-built media URLs must percent-encode each path segment."""
+    """#258's successor: media URLs are ref+key addressed, so the filename —
+    the only attacker-influenced string — never enters a URL. What remains to
+    pin is that key URLs are encoded defensively and that a hostile filename
+    still round-trips URL → row → bytes."""
 
-    def test_encode_helper_escapes_reserved_chars_per_segment(self) -> None:
+    def test_encode_helper_escapes_reserved_chars(self) -> None:
         with patch.dict(os.environ, ANON_ENV):
             _, main_mod = _reload_main()
-        encoded = main_mod._encode_media_path("-1001/we#1 who are? .jpg")
-        assert encoded == "-1001/we%231%20who%20are%3F%20.jpg"
-        assert encoded.count("/") == 1, "path separators must survive"
+        # Server-minted keys are untouched; a reserved character would be escaped.
+        assert main_mod._encode_media_key("5_video_note") == "5_video_note"
+        assert main_mod._encode_media_key("5_a#b?c") == "5_a%23b%3Fc"
 
-    def test_gallery_urls_encode_hash_and_question_mark(self) -> None:
+    def test_gallery_urls_carry_the_key_not_the_filename(self) -> None:
         with patch.dict(os.environ, ANON_ENV):
             client, main_mod = _reload_main()
+            _wire_chat_and_media(main_mod, "we#1 who? are.jpg")
             main_mod.db.get_media_paginated = AsyncMock(
                 return_value={
                     "items": [
@@ -198,17 +219,20 @@ class TestMediaUrlEncoding:
                     "has_more": False,
                 }
             )
-            resp = client.get("/api/chats/-1001/media")
+            resp = client.get(f"/api/chats/{CHAT_REF}/media")
 
         assert resp.status_code == 200
         item = resp.json()["items"][0]
-        assert item["media_url"] == "/media/-1001/we%231%20who%3F%20are.jpg"
-        assert item["thumb_url"] == "/media/thumb/200/-1001/we%231%20who%3F%20are.jpg"
+        assert item["id"] == "5_photo"
+        assert item["media_url"] == f"/media/{CHAT_REF}/5_photo"
+        assert item["thumb_url"] == f"/media/thumb/200/{CHAT_REF}/5_photo"
+        assert "we%231" not in item["media_url"] and "#" not in item["media_url"]
 
-    def test_plain_filenames_are_unchanged(self) -> None:
-        """Existing URLs must not shift — the gallery and tests round-trip them."""
+    def test_plain_filenames_produce_the_same_key_urls(self) -> None:
+        """The URL shape is filename-independent — the gallery round-trips item.id."""
         with patch.dict(os.environ, ANON_ENV):
             client, main_mod = _reload_main()
+            _wire_chat_and_media(main_mod, "photo_123.jpg")
             main_mod.db.get_media_paginated = AsyncMock(
                 return_value={
                     "items": [
@@ -224,32 +248,41 @@ class TestMediaUrlEncoding:
                     "has_more": False,
                 }
             )
-            resp = client.get("/api/chats/-1001/media")
+            resp = client.get(f"/api/chats/{CHAT_REF}/media")
 
         item = resp.json()["items"][0]
-        assert item["media_url"] == "/media/-1001/photo_123.jpg"
-        assert item["thumb_url"] == "/media/thumb/200/-1001/photo_123.jpg"
+        assert item["media_url"] == f"/media/{CHAT_REF}/5_photo"
+        assert item["thumb_url"] == f"/media/thumb/200/{CHAT_REF}/5_photo"
 
-    def test_chat_avatar_url_is_encoded(self) -> None:
+    def test_chat_avatar_url_is_ref_addressed(self) -> None:
+        """The avatar URL names the chat's ref only — never the on-disk avatar file."""
         with patch.dict(os.environ, ANON_ENV):
             client, main_mod = _reload_main()
-            main_mod.db.get_all_chats = AsyncMock(return_value=[{"id": -1001, "title": "Chat A", "type": "channel"}])
+            main_mod.db.get_all_chats = AsyncMock(
+                return_value=[{"id": -1001, "account_id": 1, "ref": CHAT_REF, "title": "Chat A", "type": "channel"}]
+            )
             main_mod.db.get_chat_count = AsyncMock(return_value=1)
             main_mod.db.get_archived_chat_count = AsyncMock(return_value=0)
             with patch.object(main_mod, "_get_cached_avatar_path", return_value="avatars/chats/-1001_a#b.jpg"):
                 resp = client.get("/api/chats")
 
         assert resp.status_code == 200
-        assert resp.json()["chats"][0]["avatar_url"] == "/media/avatars/chats/-1001_a%23b.jpg"
+        assert resp.json()["chats"][0]["avatar_url"] == f"/media/avatar/{CHAT_REF}"
 
-    def test_sender_avatar_url_is_encoded(self) -> None:
+    def test_sender_avatar_url_is_ref_and_message_addressed(self) -> None:
+        """Message payloads point at /media/avatar/{ref}/{message_id}: no user id,
+        no filename (for a private chat the peer's user id IS the chat id)."""
         with patch.dict(os.environ, ANON_ENV):
             _, main_mod = _reload_main()
+        chat = main_mod.ChatContext(account_id=1, chat_id=-1001, ref=CHAT_REF, type="channel")
+        message = {"id": 7, "sender_id": 42}
         with patch.object(main_mod, "_get_cached_avatar_path", return_value="avatars/users/42_a?b.jpg"):
-            assert main_mod._sender_avatar_url(42) == "/media/avatars/users/42_a%3Fb.jpg"
+            main_mod._attach_message_payload_urls([message], chat)
+        assert message["sender_avatar_url"] == f"/media/avatar/{CHAT_REF}/7"
 
-    def test_encoded_thumb_url_routes_with_decoded_segments(self) -> None:
-        """The encoded thumb URL must still match /media/thumb/{size}/{folder:path}/{filename}."""
+    def test_thumb_url_resolves_folder_and_filename_from_the_row(self) -> None:
+        """The key URL routes, and ensure_thumbnail receives the ROW's on-disk
+        folder/filename — hostile characters and all — never URL segments."""
         ensure = AsyncMock(return_value=None)
         with (
             tempfile.TemporaryDirectory() as tmpdir,
@@ -257,16 +290,16 @@ class TestMediaUrlEncoding:
             patch("src.web.thumbnails.ensure_thumbnail", ensure),
         ):
             client, main_mod = _reload_main(media_root=tmpdir)
-            encoded = main_mod._encode_media_path("-1001/we#1 who? are.jpg")
-            resp = client.get(f"/media/thumb/200/{encoded}")
+            _wire_chat_and_media(main_mod, "we#1 who? are.jpg")
+            resp = client.get(f"/media/thumb/200/{CHAT_REF}/5_photo")
 
         assert resp.status_code == 404, "route matched but no thumbnail exists — 404 is the expected miss"
         assert ensure.await_count == 1
         _, size, folder, filename = ensure.await_args[0]
         assert (size, folder, filename) == (200, "-1001", "we#1 who? are.jpg")
 
-    def test_encoded_url_round_trips_through_serve_media(self) -> None:
-        """The encoded URL must resolve back to the same file on disk."""
+    def test_hostile_filename_round_trips_through_serve_media(self) -> None:
+        """A filename full of reserved characters is reachable through its key URL."""
         with tempfile.TemporaryDirectory() as tmpdir:
             chat_dir = os.path.join(tmpdir, "-1001")
             os.makedirs(chat_dir)
@@ -274,8 +307,8 @@ class TestMediaUrlEncoding:
                 handle.write(b"jpegbytes")
             with patch.dict(os.environ, ANON_ENV):
                 client, main_mod = _reload_main(media_root=tmpdir)
-                encoded = main_mod._encode_media_path("-1001/we#1 who? are.jpg")
-                resp = client.get(f"/media/{encoded}")
+                _wire_chat_and_media(main_mod, "we#1 who? are.jpg")
+                resp = client.get(f"/media/{CHAT_REF}/5_photo")
 
         assert resp.status_code == 200
         assert resp.content == b"jpegbytes"

--- a/tests/test_media_page.py
+++ b/tests/test_media_page.py
@@ -16,6 +16,10 @@ pytest.importorskip("fastapi")
 
 from fastapi.testclient import TestClient
 
+MEDIA_CHAT_REF = "opaque-media-a"
+# Every ref the mock resolver recognizes; anything else - numeric ids included - is nothing.
+KNOWN_CHAT_REFS = {MEDIA_CHAT_REF, "mediaChatRef01001ABC"}
+
 
 @pytest.fixture(autouse=True)
 def _reset_auth_module():
@@ -36,11 +40,13 @@ def _make_mock_db():
             {"id": -1001, "account_id": 1, "ref": "mediaChatRef01001ABC", "title": "Chat A", "type": "channel"},
         ]
     )
-    # Echo any requested ref back as chat -1001, so both the anonymous tests
-    # (which use "-1001" as the URL segment) and the restricted-viewer tests
-    # (which grant a realistic ref) resolve to the same chat.
+    # Resolve ONLY the known opaque ref to chat -1001; any other segment —
+    # a numeric chat id included — resolves to nothing, exactly like the real
+    # resolver, so a route that wrongly accepted legacy ids would fail here.
     db.get_chat_by_ref = AsyncMock(
-        side_effect=lambda ref, **kwargs: {"id": -1001, "account_id": 1, "ref": ref, "type": "channel"}
+        side_effect=lambda ref, **kwargs: (
+            {"id": -1001, "account_id": 1, "ref": ref, "type": "channel"} if ref in KNOWN_CHAT_REFS else None
+        )
     )
     db.get_chat_count = AsyncMock(return_value=1)
     db.get_cached_statistics = AsyncMock(return_value={"total_chats": 1})
@@ -143,19 +149,19 @@ class TestMediaEndpointAuth:
 
     def test_requires_authentication(self, auth_env):
         client, _, _ = _get_client()
-        resp = client.get("/api/chats/-1001/media")
+        resp = client.get("/api/chats/opaque-media-a/media")
         assert resp.status_code == 401
 
     def test_works_when_authenticated(self, auth_env):
         client, _, _ = _get_client()
         login_resp = client.post("/api/login", json={"username": "admin", "password": "testpass123"})
         cookie = login_resp.cookies.get("viewer_auth")
-        resp = client.get("/api/chats/-1001/media", cookies={"viewer_auth": cookie})
+        resp = client.get("/api/chats/opaque-media-a/media", cookies={"viewer_auth": cookie})
         assert resp.status_code == 200
 
     def test_works_anonymous_mode(self, anon_env):
         client, _, _ = _get_client()
-        resp = client.get("/api/chats/-1001/media")
+        resp = client.get("/api/chats/opaque-media-a/media")
         assert resp.status_code == 200
 
 
@@ -164,7 +170,7 @@ class TestMediaPaginated:
 
     def test_returns_media_items(self, anon_env):
         client, _, mock_db = _get_client()
-        resp = client.get("/api/chats/-1001/media")
+        resp = client.get("/api/chats/opaque-media-a/media")
         assert resp.status_code == 200
         data = resp.json()
         assert "items" in data
@@ -175,7 +181,7 @@ class TestMediaPaginated:
 
     def test_passes_types_filter(self, anon_env):
         client, _, mock_db = _get_client()
-        resp = client.get("/api/chats/-1001/media?types=photo,video")
+        resp = client.get("/api/chats/opaque-media-a/media?types=photo,video")
         assert resp.status_code == 200
         mock_db.get_media_paginated.assert_called_once_with(
             -1001,
@@ -188,7 +194,7 @@ class TestMediaPaginated:
 
     def test_passes_limit(self, anon_env):
         client, _, mock_db = _get_client()
-        resp = client.get("/api/chats/-1001/media?limit=20")
+        resp = client.get("/api/chats/opaque-media-a/media?limit=20")
         assert resp.status_code == 200
         mock_db.get_media_paginated.assert_called_once_with(
             -1001,
@@ -202,7 +208,7 @@ class TestMediaPaginated:
     def test_passes_before_id(self, anon_env):
         """The chat-free cursor is reconstructed into the storage key server-side."""
         client, _, mock_db = _get_client()
-        resp = client.get("/api/chats/-1001/media?before_id=90_photo")
+        resp = client.get("/api/chats/opaque-media-a/media?before_id=90_photo")
         assert resp.status_code == 200
         mock_db.get_media_paginated.assert_called_once_with(
             -1001,
@@ -219,7 +225,7 @@ class TestMediaPaginated:
         old-format full-composite token reconstructs to a key that resolves to
         no row (an empty page, never someone else's page)."""
         client, _, mock_db = _get_client()
-        resp = client.get("/api/chats/-1001/media?after_id=2428_voice")
+        resp = client.get("/api/chats/opaque-media-a/media?after_id=2428_voice")
         assert resp.status_code == 200
         mock_db.get_media_paginated.assert_called_once_with(
             -1001,
@@ -234,7 +240,7 @@ class TestMediaPaginated:
         """A 7.x cursor ("-1001_2428_voice") gains a second chat prefix and can
         only ever miss — the #266 empty-page semantics."""
         client, _, mock_db = _get_client()
-        resp = client.get("/api/chats/-1001/media?after_id=-1001_2428_voice")
+        resp = client.get("/api/chats/opaque-media-a/media?after_id=-1001_2428_voice")
         assert resp.status_code == 200
         called_after = mock_db.get_media_paginated.call_args.kwargs["after_id"]
         assert called_after == "-1001_-1001_2428_voice"
@@ -242,14 +248,14 @@ class TestMediaPaginated:
     def test_before_id_and_after_id_are_mutually_exclusive(self, anon_env):
         """#266: asking for both directions at once is rejected, not silently halved."""
         client, _, mock_db = _get_client()
-        resp = client.get("/api/chats/-1001/media?before_id=a&after_id=b")
+        resp = client.get("/api/chats/opaque-media-a/media?before_id=a&after_id=b")
         assert resp.status_code == 400
         assert "mutually exclusive" in resp.json()["detail"]
         mock_db.get_media_paginated.assert_not_called()
 
     def test_empty_types_means_all(self, anon_env):
         client, _, mock_db = _get_client()
-        resp = client.get("/api/chats/-1001/media")
+        resp = client.get("/api/chats/opaque-media-a/media")
         assert resp.status_code == 200
         mock_db.get_media_paginated.assert_called_once_with(
             -1001,
@@ -262,10 +268,10 @@ class TestMediaPaginated:
 
     def test_items_include_thumb_url(self, anon_env):
         client, _, _ = _get_client()
-        resp = client.get("/api/chats/-1001/media")
+        resp = client.get("/api/chats/opaque-media-a/media")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["items"][0]["thumb_url"] == "/media/thumb/200/-1001/100_photo"
+        assert data["items"][0]["thumb_url"] == "/media/thumb/200/opaque-media-a/100_photo"
 
     def test_no_download_strips_media_url(self, auth_env):
         import src.web.main as main_mod
@@ -306,7 +312,7 @@ class TestMediaCounts:
 
     def test_returns_counts(self, anon_env):
         client, _, _ = _get_client()
-        resp = client.get("/api/chats/-1001/media/counts")
+        resp = client.get("/api/chats/opaque-media-a/media/counts")
         assert resp.status_code == 200
         data = resp.json()
         assert data["photo"] == 10
@@ -372,7 +378,7 @@ class TestMediaPathValidation:
             }
         )
         client, _, _ = _get_client(mock_db)
-        resp = client.get("/api/chats/-1001/media")
+        resp = client.get("/api/chats/opaque-media-a/media")
         assert resp.status_code == 200
         data = resp.json()
         assert data["items"][0]["thumb_url"] is None
@@ -404,7 +410,7 @@ class TestMediaPathValidation:
             }
         )
         client, _, _ = _get_client(mock_db)
-        resp = client.get("/api/chats/-1001/media")
+        resp = client.get("/api/chats/opaque-media-a/media")
         assert resp.status_code == 200
         data = resp.json()
         assert data["items"][0]["thumb_url"] is None
@@ -412,10 +418,10 @@ class TestMediaPathValidation:
 
     def test_valid_path_includes_media_url(self, anon_env):
         client, _, _ = _get_client()
-        resp = client.get("/api/chats/-1001/media")
+        resp = client.get("/api/chats/opaque-media-a/media")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["items"][0]["media_url"] == "/media/-1001/100_photo"
+        assert data["items"][0]["media_url"] == "/media/opaque-media-a/100_photo"
 
 
 class TestMediaACL:
@@ -453,3 +459,15 @@ class TestMediaACL:
         mock_db.get_chat_by_ref = AsyncMock(return_value=None)
         missing = client.get("/api/chats/mediaChatRef01001ABC/media", cookies={"viewer_auth": cookie})
         assert (missing.status_code, missing.json()) == (404, forbidden_body)
+
+
+class TestLegacyIdSegmentsAreDead:
+    """A numeric chat id where a ref belongs resolves to nothing, hence 404."""
+
+    def test_numeric_segment_is_not_a_chat(self, auth_env) -> None:
+        client, _main, mock_db = _get_client()
+        _login(client)
+        resp = client.get("/api/chats/-1001/media")
+        assert resp.status_code == 404
+        mock_db.get_chat_by_ref.assert_awaited()
+        assert mock_db.get_chat_by_ref.await_args.args[0] == "-1001"

--- a/tests/test_media_page.py
+++ b/tests/test_media_page.py
@@ -2,9 +2,15 @@
 
 import json
 import os
+import tempfile
 from unittest.mock import AsyncMock, patch
 
 import pytest
+
+# Self-contained bootstrap (same pattern as test_media_download_disposition.py):
+# _get_client reloads src.web.main, whose Config creates BACKUP_PATH — defaulting
+# to the read-only "/data" and erroring this module when it runs on its own.
+os.environ.setdefault("BACKUP_PATH", tempfile.mkdtemp(prefix="ta_test_backup_"))
 
 pytest.importorskip("fastapi")
 
@@ -27,8 +33,14 @@ def _make_mock_db():
     db = AsyncMock()
     db.get_all_chats = AsyncMock(
         return_value=[
-            {"id": -1001, "title": "Chat A", "type": "channel"},
+            {"id": -1001, "account_id": 1, "ref": "mediaChatRef01001ABC", "title": "Chat A", "type": "channel"},
         ]
+    )
+    # Echo any requested ref back as chat -1001, so both the anonymous tests
+    # (which use "-1001" as the URL segment) and the restricted-viewer tests
+    # (which grant a realistic ref) resolve to the same chat.
+    db.get_chat_by_ref = AsyncMock(
+        side_effect=lambda ref, **kwargs: {"id": -1001, "account_id": 1, "ref": ref, "type": "channel"}
     )
     db.get_chat_count = AsyncMock(return_value=1)
     db.get_cached_statistics = AsyncMock(return_value={"total_chats": 1})
@@ -42,12 +54,12 @@ def _make_mock_db():
     db.get_session = AsyncMock(return_value=None)
     db.save_session = AsyncMock()
     db.delete_session = AsyncMock()
-    # Media-specific mocks
+    # Media-specific mocks (storage key id: "{chat_id}_{message_id}_{type}")
     db.get_media_paginated = AsyncMock(
         return_value={
             "items": [
                 {
-                    "id": "file_abc123",
+                    "id": "-1001_100_photo",
                     "message_id": 100,
                     "chat_id": -1001,
                     "type": "photo",
@@ -158,7 +170,8 @@ class TestMediaPaginated:
         assert "items" in data
         assert "has_more" in data
         assert len(data["items"]) == 1
-        assert data["items"][0]["id"] == "file_abc123"
+        # The storage key is rewritten to the chat-free URL key.
+        assert data["items"][0]["id"] == "100_photo"
 
     def test_passes_types_filter(self, anon_env):
         client, _, mock_db = _get_client()
@@ -170,6 +183,7 @@ class TestMediaPaginated:
             limit=50,
             before_id=None,
             after_id=None,
+            account_id=1,
         )
 
     def test_passes_limit(self, anon_env):
@@ -182,24 +196,30 @@ class TestMediaPaginated:
             limit=20,
             before_id=None,
             after_id=None,
+            account_id=1,
         )
 
     def test_passes_before_id(self, anon_env):
+        """The chat-free cursor is reconstructed into the storage key server-side."""
         client, _, mock_db = _get_client()
-        resp = client.get("/api/chats/-1001/media?before_id=abc")
+        resp = client.get("/api/chats/-1001/media?before_id=90_photo")
         assert resp.status_code == 200
         mock_db.get_media_paginated.assert_called_once_with(
             -1001,
             media_types=None,
             limit=50,
-            before_id="abc",
+            before_id="-1001_90_photo",
             after_id=None,
+            account_id=1,
         )
 
     def test_passes_after_id(self, anon_env):
-        """#266: the forward cursor reaches the adapter as the same opaque string."""
+        """#266: the forward cursor is the CHAT-FREE key the endpoint returned as
+        item.id; the chat id is re-attached from the resolved chat, so an
+        old-format full-composite token reconstructs to a key that resolves to
+        no row (an empty page, never someone else's page)."""
         client, _, mock_db = _get_client()
-        resp = client.get("/api/chats/-1001/media?after_id=-1001_2428_voice")
+        resp = client.get("/api/chats/-1001/media?after_id=2428_voice")
         assert resp.status_code == 200
         mock_db.get_media_paginated.assert_called_once_with(
             -1001,
@@ -207,7 +227,17 @@ class TestMediaPaginated:
             limit=50,
             before_id=None,
             after_id="-1001_2428_voice",
+            account_id=1,
         )
+
+    def test_old_full_composite_cursor_reconstructs_to_no_row(self, anon_env):
+        """A 7.x cursor ("-1001_2428_voice") gains a second chat prefix and can
+        only ever miss — the #266 empty-page semantics."""
+        client, _, mock_db = _get_client()
+        resp = client.get("/api/chats/-1001/media?after_id=-1001_2428_voice")
+        assert resp.status_code == 200
+        called_after = mock_db.get_media_paginated.call_args.kwargs["after_id"]
+        assert called_after == "-1001_-1001_2428_voice"
 
     def test_before_id_and_after_id_are_mutually_exclusive(self, anon_env):
         """#266: asking for both directions at once is rejected, not silently halved."""
@@ -227,6 +257,7 @@ class TestMediaPaginated:
             limit=50,
             before_id=None,
             after_id=None,
+            account_id=1,
         )
 
     def test_items_include_thumb_url(self, anon_env):
@@ -234,7 +265,7 @@ class TestMediaPaginated:
         resp = client.get("/api/chats/-1001/media")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["items"][0]["thumb_url"] == "/media/thumb/200/-1001/photo_123.jpg"
+        assert data["items"][0]["thumb_url"] == "/media/thumb/200/-1001/100_photo"
 
     def test_no_download_strips_media_url(self, auth_env):
         import src.web.main as main_mod
@@ -248,7 +279,8 @@ class TestMediaPaginated:
                 "username": "restricted",
                 "password_hash": pw_hash,
                 "salt": salt,
-                "allowed_chat_ids": json.dumps([-1001]),
+                "allowed_chat_ids": "[]",  # rollback tombstone; the grant is the refs column
+                "allowed_chat_refs": json.dumps(["mediaChatRef01001ABC"]),
                 "is_active": 1,
                 "no_download": 1,
                 "created_by": "admin",
@@ -260,11 +292,13 @@ class TestMediaPaginated:
 
         login_resp = client.post("/api/login", json={"username": "restricted", "password": "vpass"})
         cookie = login_resp.cookies.get("viewer_auth")
-        resp = client.get("/api/chats/-1001/media", cookies={"viewer_auth": cookie})
+        resp = client.get("/api/chats/mediaChatRef01001ABC/media", cookies={"viewer_auth": cookie})
         assert resp.status_code == 200
         data = resp.json()
         assert "media_url" not in data["items"][0]
         assert "file_path" not in data["items"][0]
+        # serve_thumbnail refuses derived bytes for these accounts too.
+        assert data["items"][0]["thumb_url"] is None
 
 
 class TestMediaCounts:
@@ -282,6 +316,7 @@ class TestMediaCounts:
         assert data["document"] == 8
 
     def test_forbidden_for_restricted_user(self, auth_env):
+        """A chat outside the viewer's ref grant answers the uniform 404."""
         import src.web.main as main_mod
 
         mock_db = _make_mock_db()
@@ -293,7 +328,8 @@ class TestMediaCounts:
                 "username": "restricted",
                 "password_hash": pw_hash,
                 "salt": salt,
-                "allowed_chat_ids": json.dumps([-1002]),
+                "allowed_chat_ids": "[]",
+                "allowed_chat_refs": json.dumps(["someOtherChatRef1002"]),
                 "is_active": 1,
                 "created_by": "admin",
                 "created_at": "2026-01-01T00:00:00",
@@ -304,8 +340,8 @@ class TestMediaCounts:
 
         login_resp = client.post("/api/login", json={"username": "restricted", "password": "vpass"})
         cookie = login_resp.cookies.get("viewer_auth")
-        resp = client.get("/api/chats/-1001/media/counts", cookies={"viewer_auth": cookie})
-        assert resp.status_code == 403
+        resp = client.get("/api/chats/mediaChatRef01001ABC/media/counts", cookies={"viewer_auth": cookie})
+        assert resp.status_code == 404
 
 
 class TestMediaPathValidation:
@@ -317,7 +353,7 @@ class TestMediaPathValidation:
             return_value={
                 "items": [
                     {
-                        "id": "file_evil",
+                        "id": "-1001_1_photo",
                         "message_id": 1,
                         "chat_id": -1001,
                         "type": "photo",
@@ -341,6 +377,7 @@ class TestMediaPathValidation:
         data = resp.json()
         assert data["items"][0]["thumb_url"] is None
         assert "file_path" not in data["items"][0]
+        assert "media_url" not in data["items"][0]
 
     def test_absolute_path_gets_null_thumb_url(self, anon_env):
         mock_db = _make_mock_db()
@@ -348,7 +385,7 @@ class TestMediaPathValidation:
             return_value={
                 "items": [
                     {
-                        "id": "file_abs",
+                        "id": "-1001_2_photo",
                         "message_id": 2,
                         "chat_id": -1001,
                         "type": "photo",
@@ -378,13 +415,14 @@ class TestMediaPathValidation:
         resp = client.get("/api/chats/-1001/media")
         assert resp.status_code == 200
         data = resp.json()
-        assert data["items"][0]["media_url"] == "/media/-1001/photo_123.jpg"
+        assert data["items"][0]["media_url"] == "/media/-1001/100_photo"
 
 
 class TestMediaACL:
     """Tests for media access control list enforcement."""
 
-    def test_forbidden_chat_returns_403(self, auth_env):
+    def test_forbidden_chat_answers_the_uniform_404(self, auth_env):
+        """A chat outside the ref grant is indistinguishable from a nonexistent one."""
         import src.web.main as main_mod
 
         mock_db = _make_mock_db()
@@ -396,7 +434,8 @@ class TestMediaACL:
                 "username": "restricted",
                 "password_hash": pw_hash,
                 "salt": salt,
-                "allowed_chat_ids": json.dumps([-1002]),
+                "allowed_chat_ids": "[]",
+                "allowed_chat_refs": json.dumps(["someOtherChatRef1002"]),
                 "is_active": 1,
                 "created_by": "admin",
                 "created_at": "2026-01-01T00:00:00",
@@ -407,5 +446,10 @@ class TestMediaACL:
 
         login_resp = client.post("/api/login", json={"username": "restricted", "password": "vpass"})
         cookie = login_resp.cookies.get("viewer_auth")
-        resp = client.get("/api/chats/-1001/media", cookies={"viewer_auth": cookie})
-        assert resp.status_code == 403
+        resp = client.get("/api/chats/mediaChatRef01001ABC/media", cookies={"viewer_auth": cookie})
+        assert resp.status_code == 404
+        forbidden_body = resp.json()
+
+        mock_db.get_chat_by_ref = AsyncMock(return_value=None)
+        missing = client.get("/api/chats/mediaChatRef01001ABC/media", cookies={"viewer_auth": cookie})
+        assert (missing.status_code, missing.json()) == (404, forbidden_body)

--- a/tests/test_multi_user_auth.py
+++ b/tests/test_multi_user_auth.py
@@ -27,13 +27,16 @@ def _reset_auth_module():
 
 def _make_mock_db():
     db = AsyncMock()
+    # v8.0.0 chat rows always carry account_id and the opaque ref — the
+    # entitlement filter and the payload builders read both.
     db.get_all_chats = AsyncMock(
         return_value=[
-            {"id": -1001, "title": "Chat A", "type": "channel"},
-            {"id": -1002, "title": "Chat B", "type": "channel"},
-            {"id": -1003, "title": "Chat C", "type": "channel"},
+            {"id": -1001, "account_id": 1, "ref": "refchatAchatAchatAchat", "title": "Chat A", "type": "channel"},
+            {"id": -1002, "account_id": 1, "ref": "refchatBchatBchatBchat", "title": "Chat B", "type": "channel"},
+            {"id": -1003, "account_id": 1, "ref": "refchatCchatCchatCchat", "title": "Chat C", "type": "channel"},
         ]
     )
+    db.get_chat_by_ref = AsyncMock(return_value=None)
     db.get_chat_count = AsyncMock(return_value=3)
     db.get_cached_statistics = AsyncMock(return_value={"total_chats": 3, "total_messages": 100})
     db.get_metadata = AsyncMock(return_value=None)
@@ -192,7 +195,10 @@ class TestViewerLogin:
                 "username": "viewer1",
                 "password_hash": pw_hash,
                 "salt": salt,
-                "allowed_chat_ids": json.dumps([-1001]),
+                # 8.0 shape: the grant lives in allowed_chat_refs; the legacy
+                # column holds only the "[]" rollback tombstone.
+                "allowed_chat_ids": "[]",
+                "allowed_chat_refs": json.dumps(["refchatAchatAchatAchat"]),
                 "is_active": 1,
                 "created_by": "admin",
                 "created_at": "2026-01-01T00:00:00",
@@ -231,7 +237,9 @@ class TestPerUserFiltering:
                 "username": "restricted",
                 "password_hash": pw_hash,
                 "salt": salt,
-                "allowed_chat_ids": json.dumps([-1001]),
+                # 8.0 grant: one chat by REF; the legacy column is a tombstone.
+                "allowed_chat_ids": "[]",
+                "allowed_chat_refs": json.dumps(["refchatAchatAchatAchat"]),
                 "is_active": 1,
                 "created_by": "admin",
                 "created_at": "2026-01-01T00:00:00",
@@ -244,6 +252,9 @@ class TestPerUserFiltering:
         cookie = login_resp.cookies.get("viewer_auth")
         resp = client.get("/api/chats", cookies={"viewer_auth": cookie})
         assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert [chat["id"] for chat in data["chats"]] == [-1001]
 
 
 class TestRateLimiting:
@@ -374,7 +385,12 @@ class TestMediaAuth:
 
     def test_media_requires_auth(self, auth_env):
         client, _, _ = _get_client()
+        # A 7.x id-addressed one-segment path no longer routes at all: it dies
+        # 404 at routing, BEFORE auth even runs.
         resp = client.get("/media/test.jpg")
+        assert resp.status_code == 404
+        # The ref-addressed shape routes, and without a session it is refused.
+        resp = client.get("/media/aaaaaaaaaaaaaaaaaaaaaa/1_photo")
         assert resp.status_code == 401
 
     def test_path_traversal_blocked(self, auth_env):

--- a/tests/test_sender_avatars.py
+++ b/tests/test_sender_avatars.py
@@ -178,7 +178,9 @@ class TestAvatarFillContrast(unittest.TestCase):
 
 
 class TestSenderAvatarUrl(unittest.TestCase):
-    """US-211: per-message sender_avatar_url resolved from on-disk files."""
+    """US-211 as reshaped by v8.0: per-message sender_avatar_url points at
+    /media/avatar/{chat_ref}/{message_id} — present only when the sender's
+    avatar file is already on disk, and carrying no user id in the URL."""
 
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
@@ -186,6 +188,7 @@ class TestSenderAvatarUrl(unittest.TestCase):
         web_main.config.media_path = self.temp_dir.name
         web_main._avatar_cache.clear()
         web_main._avatar_cache_time = None
+        self.chat = web_main.ChatContext(account_id=1, chat_id=-1001, ref="senderAvatarRef001AB", type="group")
 
     def tearDown(self):
         web_main.config.media_path = self.original_media_path
@@ -198,124 +201,84 @@ class TestSenderAvatarUrl(unittest.TestCase):
         with open(path, "w", encoding="utf-8") as avatar_file:
             avatar_file.write("x")
 
+    def _attached(self, message: dict) -> dict:
+        web_main._attach_message_payload_urls([message], self.chat)
+        return message
+
     def test_present_when_file_globs(self):
         user_id = 555000111
         avatars_dir = os.path.join(self.temp_dir.name, "avatars", "users")
         self._touch_avatar(os.path.join(avatars_dir, f"{user_id}_42.jpg"))
 
-        self.assertEqual(
-            web_main._sender_avatar_url(user_id),
-            f"/media/avatars/users/{user_id}_42.jpg",
-        )
+        message = self._attached({"id": 7, "sender_id": user_id})
+        self.assertEqual(message["sender_avatar_url"], "/media/avatar/senderAvatarRef001AB/7")
+        # The proof of the phase: neither the user id nor a filename in the URL.
+        self.assertNotIn(str(user_id), message["sender_avatar_url"])
 
     def test_null_when_absent(self):
-        self.assertIsNone(web_main._sender_avatar_url(999888777))
+        message = self._attached({"id": 7, "sender_id": 999888777})
+        self.assertIsNone(message["sender_avatar_url"])
 
     def test_null_for_missing_or_non_user_sender(self):
-        self.assertIsNone(web_main._sender_avatar_url(None))
+        self.assertIsNone(self._attached({"id": 7, "sender_id": None})["sender_avatar_url"])
         # Negative ids are channels/groups, never a users/ avatar.
-        self.assertIsNone(web_main._sender_avatar_url(-1001234))
+        self.assertIsNone(self._attached({"id": 7, "sender_id": -1001234})["sender_avatar_url"])
 
 
-class TestMemberAvatarAcl(unittest.TestCase):
-    """US-211: ACL fix — member avatars for visible members are served."""
+class TestSenderResolution(unittest.TestCase):
+    """US-211's successor: the membership probe is gone. Entitlement to the chat
+    is the membership proof, and the sender is resolved from the MESSAGE row
+    (_message_sender_id), so no arbitrary user id can be probed at all."""
 
     def setUp(self):
-        web_main._avatar_member_cache.clear()
-        web_main._avatar_member_cache_time = None
+        web_main._sender_lookup_cache.clear()
+        self.chat = web_main.ChatContext(account_id=1, chat_id=-1001, ref="senderLookupRef001AB", type="group")
 
     def tearDown(self):
-        web_main._avatar_member_cache.clear()
-        web_main._avatar_member_cache_time = None
+        web_main._sender_lookup_cache.clear()
 
-    def _viewer(self):
-        return web_main.UserContext(username="viewer", role="viewer", allowed_chat_ids={-1001})
-
-    def test_user_avatar_allowed_when_member_ok(self):
-        """A user who spoke in a visible chat: served (no raise)."""
-        user = self._viewer()
-        web_main._enforce_media_acl("avatars/users/555_9.jpg", user, member_ok=True)
-
-    def test_user_avatar_blocked_when_not_member(self):
-        """A user not in any visible chat: 403."""
-        user = self._viewer()
-        with self.assertRaises(web_main.HTTPException) as ctx:
-            web_main._enforce_media_acl("avatars/users/555_9.jpg", user, member_ok=False)
-        self.assertEqual(ctx.exception.status_code, 403)
-
-    def test_chat_avatar_behavior_unchanged(self):
-        """avatars/chats/ still gates purely on the allowed chat id."""
-        user = self._viewer()
-        # Allowed chat id in the filename -> served.
-        web_main._enforce_media_acl("avatars/chats/-1001_7.jpg", user)
-        # Different chat id -> blocked, regardless of member_ok.
-        with self.assertRaises(web_main.HTTPException) as ctx:
-            web_main._enforce_media_acl("avatars/chats/-1009_7.jpg", user, member_ok=True)
-        self.assertEqual(ctx.exception.status_code, 403)
-
-    def test_one_to_one_contact_avatar_allowed_without_probe(self):
-        """A user whose id is itself a visible (private) chat is served directly."""
-        user = web_main.UserContext(username="v", role="viewer", allowed_chat_ids={555})
-        web_main._enforce_media_acl("avatars/users/555_9.jpg", user, member_ok=False)
-
-    def test_membership_probe_only_hits_db_for_user_avatars(self):
-        """_avatar_user_visible_member queries membership only for avatars/users/."""
-        user = self._viewer()
-        probe = AsyncMock(return_value=True)
+    def _with_db(self, lookup):
         original_db = web_main.db
-        web_main.db = type("D", (), {"sender_has_message_in_chats": staticmethod(probe)})()
+        web_main.db = type("D", (), {"get_message_sender_id": staticmethod(lookup)})()
+        return original_db
+
+    def test_sender_resolved_from_the_message_row(self):
+        """The db lookup receives the resolved chat's identity, never URL input."""
+        lookup = AsyncMock(return_value=555)
+        original_db = self._with_db(lookup)
         try:
-            # User avatar for a non-1:1 user -> DB probe decides.
-            allowed = asyncio.run(web_main._avatar_user_visible_member("avatars/users/555_9.jpg", user))
-            self.assertTrue(allowed)
-            probe.assert_awaited_once()
-
-            # Chat avatar -> never probes the DB.
-            probe.reset_mock()
-            self.assertFalse(asyncio.run(web_main._avatar_user_visible_member("avatars/chats/-1001_9.jpg", user)))
-            probe.assert_not_awaited()
-
-            # Regular media -> never probes the DB.
-            self.assertFalse(asyncio.run(web_main._avatar_user_visible_member("-1001/photo.jpg", user)))
-            probe.assert_not_awaited()
+            self.assertEqual(asyncio.run(web_main._message_sender_id(self.chat, 9)), 555)
+            lookup.assert_awaited_once_with(-1001, 9, account_id=1)
         finally:
             web_main.db = original_db
 
-    def test_membership_probe_skips_db_for_one_to_one_contact(self):
-        """A user id already in the viewer's chat set needs no DB probe."""
-        user = web_main.UserContext(username="v", role="viewer", allowed_chat_ids={555})
-        probe = AsyncMock(return_value=False)
-        original_db = web_main.db
-        web_main.db = type("D", (), {"sender_has_message_in_chats": staticmethod(probe)})()
-        try:
-            self.assertTrue(asyncio.run(web_main._avatar_user_visible_member("avatars/users/555_9.jpg", user)))
-            probe.assert_not_awaited()
-        finally:
-            web_main.db = original_db
-
-    def test_membership_probe_is_cached_across_requests(self):
-        """The DB probe runs once per (user, chat-set); repeats hit the cache."""
-        user = self._viewer()
-        probe = AsyncMock(return_value=True)
-        original_db = web_main.db
-        web_main.db = type("D", (), {"sender_has_message_in_chats": staticmethod(probe)})()
+    def test_sender_lookup_is_cached_across_requests(self):
+        """The row lookup runs once per (account, chat, message); repeats hit the cache."""
+        lookup = AsyncMock(return_value=555)
+        original_db = self._with_db(lookup)
         try:
             for _ in range(3):
-                self.assertTrue(asyncio.run(web_main._avatar_user_visible_member("avatars/users/555_9.jpg", user)))
-            probe.assert_awaited_once()
+                self.assertEqual(asyncio.run(web_main._message_sender_id(self.chat, 9)), 555)
+            lookup.assert_awaited_once()
         finally:
             web_main.db = original_db
 
-    def test_membership_probe_fails_closed_on_db_error(self):
-        """A DB error in the probe denies the avatar (False) and is NOT cached."""
-        user = self._viewer()
-        probe = AsyncMock(side_effect=RuntimeError("db down"))
-        original_db = web_main.db
-        web_main.db = type("D", (), {"sender_has_message_in_chats": staticmethod(probe)})()
+    def test_missing_sender_is_cached_as_none(self):
+        """A message without a sender resolves (and caches) None — the route 404s."""
+        lookup = AsyncMock(return_value=None)
+        original_db = self._with_db(lookup)
         try:
-            self.assertFalse(asyncio.run(web_main._avatar_user_visible_member("avatars/users/555_9.jpg", user)))
-            # Not cached: a transient failure must be retried, not stuck for the TTL.
-            self.assertEqual(web_main._avatar_member_cache, {})
+            self.assertIsNone(asyncio.run(web_main._message_sender_id(self.chat, 9)))
+        finally:
+            web_main.db = original_db
+
+    def test_cache_is_scoped_by_message(self):
+        """Different messages never share a cached sender."""
+        lookup = AsyncMock(side_effect=[555, 777])
+        original_db = self._with_db(lookup)
+        try:
+            self.assertEqual(asyncio.run(web_main._message_sender_id(self.chat, 1)), 555)
+            self.assertEqual(asyncio.run(web_main._message_sender_id(self.chat, 2)), 777)
         finally:
             web_main.db = original_db
 
@@ -441,73 +404,110 @@ class TestSenderHasMessageInChats:
 
 @unittest.skipUnless(_HTTPX_AVAILABLE, "httpx not available")
 class TestMemberAvatarAclEndpoint(unittest.IsolatedAsyncioTestCase):
-    """FIX 4b: ACL allow/block through the REAL /media endpoint."""
+    """FIX 4b reshaped: avatar allow/deny through the REAL v8.0 avatar routes.
+
+    /media/avatar/{chat_ref}[/{message_id}] — entitlement to the chat is the
+    membership proof; the sender comes from the message row; user-id-addressed
+    avatar URLs no longer exist, so no arbitrary user can even be probed.
+    """
+
+    VISIBLE_REF = "visibleChatRef0500AB"
+    OTHER_REF = "otherChatRef00999ABC"
 
     def setUp(self):
         self.temp_dir = tempfile.TemporaryDirectory()
         root = Path(self.temp_dir.name)
         (root / "avatars" / "users").mkdir(parents=True)
         (root / "avatars" / "chats").mkdir(parents=True)
-        (root / "avatars" / "users" / "42_1.jpg").write_bytes(b"x")  # member
-        (root / "avatars" / "users" / "77_1.jpg").write_bytes(b"x")  # non-member
+        (root / "avatars" / "users" / "42_1.jpg").write_bytes(b"x")  # sender of msg 1
         (root / "avatars" / "chats" / "-500_1.jpg").write_bytes(b"x")  # visible chat
         (root / "avatars" / "chats" / "-999_1.jpg").write_bytes(b"x")  # other chat
 
         self._saved_root = web_main._media_root
+        self._saved_media_path = web_main.config.media_path
         self._saved_db = web_main.db
         self._saved_display = web_main.config.display_chat_ids
         web_main._media_root = root.resolve()
+        web_main.config.media_path = self.temp_dir.name  # avatar lookup root
         web_main.config.display_chat_ids = set()
-        web_main._avatar_member_cache.clear()
-        web_main._avatar_member_cache_time = None
+        web_main._avatar_cache.clear()
+        web_main._avatar_cache_time = None
+        web_main._sender_lookup_cache.clear()
 
-        # Restricted viewer authorized only for chat -500.
-        viewer = web_main.UserContext(username="v", role="viewer", allowed_chat_ids={-500})
+        # Restricted viewer authorized only for the visible chat's ref.
+        viewer = web_main.UserContext(username="v", role="viewer", allowed_chat_refs={self.VISIBLE_REF})
         web_main.app.dependency_overrides[web_main.require_auth] = lambda: viewer
 
-        # Membership probe: user 42 spoke in -500, user 77 did not.
-        async def _probe(user_id, chat_ids):
-            return user_id == 42 and -500 in set(chat_ids)
+        chats = {
+            self.VISIBLE_REF: {"id": -500, "account_id": 1, "ref": self.VISIBLE_REF, "type": "group"},
+            self.OTHER_REF: {"id": -999, "account_id": 1, "ref": self.OTHER_REF, "type": "group"},
+        }
+
+        async def _by_ref(ref, **kwargs):
+            return chats.get(ref)
+
+        # Message 1 in the visible chat was sent by user 42; message 2 has no sender.
+        async def _sender(chat_id, message_id, account_id=None):
+            if chat_id == -500 and message_id == 1:
+                return 42
+            return None
 
         self.mock_db = AsyncMock()
-        self.mock_db.sender_has_message_in_chats = AsyncMock(side_effect=_probe)
+        self.mock_db.get_chat_by_ref = AsyncMock(side_effect=_by_ref)
+        self.mock_db.get_message_sender_id = AsyncMock(side_effect=_sender)
         web_main.db = self.mock_db
 
     def tearDown(self):
         web_main.app.dependency_overrides.pop(web_main.require_auth, None)
         web_main._media_root = self._saved_root
+        web_main.config.media_path = self._saved_media_path
         web_main.db = self._saved_db
         web_main.config.display_chat_ids = self._saved_display
-        web_main._avatar_member_cache.clear()
-        web_main._avatar_member_cache_time = None
+        web_main._avatar_cache.clear()
+        web_main._avatar_cache_time = None
+        web_main._sender_lookup_cache.clear()
         self.temp_dir.cleanup()
 
     def _client(self):
         return AsyncClient(transport=ASGITransport(app=web_main.app), base_url="http://test")
 
     async def test_member_avatar_allowed(self):
+        """The avatar of a message's sender in an entitled chat is served."""
         async with self._client() as client:
-            resp = await client.get("/media/avatars/users/42_1.jpg")
+            resp = await client.get(f"/media/avatar/{self.VISIBLE_REF}/1")
         self.assertEqual(resp.status_code, 200)
+        self.assertIn("private", resp.headers.get("cache-control", ""))
 
-    async def test_non_member_avatar_blocked(self):
+    async def test_unknown_message_or_forbidden_chat_blocked(self):
+        """No sender resolvable → 404; a chat outside the grant → the SAME 404."""
         async with self._client() as client:
-            resp = await client.get("/media/avatars/users/77_1.jpg")
-        self.assertEqual(resp.status_code, 403)
+            no_sender = await client.get(f"/media/avatar/{self.VISIBLE_REF}/2")
+            forbidden = await client.get(f"/media/avatar/{self.OTHER_REF}/1")
+        self.assertEqual(no_sender.status_code, 404)
+        self.assertEqual(forbidden.status_code, 404)
 
     async def test_chat_avatar_visible_allowed_and_other_blocked(self):
         async with self._client() as client:
-            ok = await client.get("/media/avatars/chats/-500_1.jpg")
-            blocked = await client.get("/media/avatars/chats/-999_1.jpg")
+            ok = await client.get(f"/media/avatar/{self.VISIBLE_REF}")
+            blocked = await client.get(f"/media/avatar/{self.OTHER_REF}")
         self.assertEqual(ok.status_code, 200)
-        self.assertEqual(blocked.status_code, 403)
+        self.assertEqual(blocked.status_code, 404)
 
-    async def test_db_error_fails_closed_403_not_500(self):
-        """A DB error in the membership probe denies the avatar (403), never 500."""
-        self.mock_db.sender_has_message_in_chats = AsyncMock(side_effect=RuntimeError("db down"))
+    async def test_legacy_user_addressed_avatar_url_is_gone(self):
+        """The old /media/avatars/users/{id}_... shape 404s at routing — user ids
+        are simply unaddressable now."""
         async with self._client() as client:
             resp = await client.get("/media/avatars/users/42_1.jpg")
-        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 404)
+
+    async def test_db_error_fails_closed_no_bytes(self):
+        """A DB error in the sender lookup serves no bytes: a connection-shaped
+        error answers 503 (the redacting handler's split), never the avatar."""
+        self.mock_db.get_message_sender_id = AsyncMock(side_effect=OSError("db down"))
+        async with self._client() as client:
+            resp = await client.get(f"/media/avatar/{self.VISIBLE_REF}/1")
+        self.assertEqual(resp.status_code, 503)
+        self.assertNotEqual(resp.content, b"x")
 
 
 @unittest.skipUnless(_HTTPX_AVAILABLE, "httpx not available")
@@ -533,6 +533,9 @@ class TestMessagesEndpointAvatarWiring(unittest.IsolatedAsyncioTestCase):
         web_main.app.dependency_overrides[web_main.require_auth] = lambda: viewer
 
         self.mock_db = AsyncMock()
+        self.mock_db.get_chat_by_ref = AsyncMock(
+            return_value={"id": -500, "account_id": 1, "ref": "wiringChatRef0500ABC", "type": "group"}
+        )
         self.mock_db.get_messages_paginated = AsyncMock(
             return_value=[
                 {"id": 1, "sender_id": 42, "chat_id": -500},
@@ -555,10 +558,11 @@ class TestMessagesEndpointAvatarWiring(unittest.IsolatedAsyncioTestCase):
 
     async def test_sender_avatar_url_present_when_file_globs_and_null_when_absent(self):
         async with self._client() as client:
-            resp = await client.get("/api/chats/-500/messages")
+            resp = await client.get("/api/chats/wiringChatRef0500ABC/messages")
         self.assertEqual(resp.status_code, 200)
         by_id = {m["id"]: m for m in resp.json()}
-        self.assertEqual(by_id[1]["sender_avatar_url"], "/media/avatars/users/42_1.jpg")
+        # Ref+message addressed: no user id, no filename in the URL.
+        self.assertEqual(by_id[1]["sender_avatar_url"], "/media/avatar/wiringChatRef0500ABC/1")
         self.assertIsNone(by_id[2]["sender_avatar_url"])
 
 

--- a/tests/test_v720_features.py
+++ b/tests/test_v720_features.py
@@ -160,7 +160,8 @@ class TestTokenCRUD:
             "token_hash": "h",
             "token_salt": "s",
             "created_by": "admin",
-            "allowed_chat_ids": json.dumps([-1001]),
+            "allowed_chat_ids": "[]",  # rollback tombstone
+            "allowed_chat_refs": json.dumps(["v720ChatRef01001ABCD"]),
             "is_revoked": 0,
             "no_download": 0,
             "expires_at": None,
@@ -170,7 +171,7 @@ class TestTokenCRUD:
         }
         resp = client.post(
             "/api/admin/tokens",
-            json={"label": "my-token", "allowed_chat_ids": [-1001]},
+            json={"label": "my-token", "allowed_chat_refs": ["v720ChatRef01001ABCD"]},
             cookies={"viewer_auth": cookie},
         )
         assert resp.status_code == 200
@@ -317,16 +318,30 @@ class TestNoDownload:
         # Master should not have no_download
         assert data.get("no_download") is False or data.get("no_download") is None or not data.get("no_download")
 
+    def _restricted_token_row(self):
+        """A no_download token whose grant lives in the v8.0 refs column."""
+        return {
+            "id": 10,
+            "label": "restricted-tok",
+            "allowed_chat_ids": "[]",  # rollback tombstone
+            "allowed_chat_refs": json.dumps(["v720ChatRef01001ABCD"]),
+            "no_download": 1,
+        }
+
+    def _wire_media(self, db):
+        db.get_chat_by_ref = AsyncMock(
+            return_value={"id": -1001, "account_id": 1, "ref": "v720ChatRef01001ABCD", "type": "channel"}
+        )
+        db.get_media_by_id = AsyncMock(
+            return_value={"id": "-1001_5_photo", "file_path": "-1001/photo.jpg", "file_name": "photo.jpg"}
+        )
+
     def test_no_download_blocks_explicit_download(self, auth_env, tmp_path):
         """no_download users cannot explicitly download files (download=1)."""
         client, mod, db = _get_client()
         # Create a token session with no_download=True
-        db.verify_viewer_token.return_value = {
-            "id": 10,
-            "label": "restricted-tok",
-            "allowed_chat_ids": json.dumps([-1001]),
-            "no_download": 1,
-        }
+        db.verify_viewer_token.return_value = self._restricted_token_row()
+        self._wire_media(db)
         resp = client.post("/auth/token", json={"token": "validtoken"})
         assert resp.status_code == 200
         cookie = resp.cookies.get("viewer_auth")
@@ -340,18 +355,14 @@ class TestNoDownload:
         mod._media_root = tmp_path / "media"
 
         # Explicit download should be blocked
-        resp = client.get("/media/-1001/photo.jpg?download=1", cookies={"viewer_auth": cookie})
+        resp = client.get("/media/v720ChatRef01001ABCD/5_photo?download=1", cookies={"viewer_auth": cookie})
         assert resp.status_code == 403
 
     def test_no_download_blocks_original_media_without_download_param(self, auth_env, tmp_path):
         """no_download users cannot fetch original bytes by omitting download=1."""
         client, mod, db = _get_client()
-        db.verify_viewer_token.return_value = {
-            "id": 10,
-            "label": "restricted-tok",
-            "allowed_chat_ids": json.dumps([-1001]),
-            "no_download": 1,
-        }
+        db.verify_viewer_token.return_value = self._restricted_token_row()
+        self._wire_media(db)
         resp = client.post("/auth/token", json={"token": "validtoken"})
         cookie = resp.cookies.get("viewer_auth")
 
@@ -361,22 +372,18 @@ class TestNoDownload:
         mod._media_root = tmp_path / "media"
 
         # Inline request (no download param) is still a direct byte fetch.
-        resp = client.get("/media/-1001/photo.jpg", cookies={"viewer_auth": cookie})
+        resp = client.get("/media/v720ChatRef01001ABCD/5_photo", cookies={"viewer_auth": cookie})
         assert resp.status_code == 403
 
     def test_no_download_blocks_export(self, auth_env):
         """no_download users cannot export chat history."""
         client, mod, db = _get_client()
-        db.verify_viewer_token.return_value = {
-            "id": 10,
-            "label": "restricted-tok",
-            "allowed_chat_ids": json.dumps([-1001]),
-            "no_download": 1,
-        }
+        db.verify_viewer_token.return_value = self._restricted_token_row()
+        self._wire_media(db)
         resp = client.post("/auth/token", json={"token": "validtoken"})
         cookie = resp.cookies.get("viewer_auth")
 
-        resp = client.get("/api/chats/-1001/export", cookies={"viewer_auth": cookie})
+        resp = client.get("/api/chats/v720ChatRef01001ABCD/export", cookies={"viewer_auth": cookie})
         assert resp.status_code == 403
 
 
@@ -444,12 +451,13 @@ class TestTokenRevocation:
         db.delete_sessions_by_source_token_id.assert_called_with(7)
 
     def test_update_token_scope_invalidates_sessions(self, auth_env):
-        """Changing a token's allowed_chat_ids should invalidate sessions."""
+        """Changing a token's allowed_chat_refs should invalidate sessions."""
         client, mod, db = _get_client()
         db.verify_viewer_token.return_value = {
             "id": 8,
             "label": "scoped",
-            "allowed_chat_ids": json.dumps([-1001]),
+            "allowed_chat_ids": "[]",
+            "allowed_chat_refs": json.dumps(["v720ChatRef01001ABCD"]),
             "no_download": 0,
         }
         resp = client.post("/auth/token", json={"token": "validtoken"})
@@ -460,14 +468,15 @@ class TestTokenRevocation:
         db.update_viewer_token.return_value = {
             "id": 8,
             "label": "scoped",
-            "allowed_chat_ids": json.dumps([-1002]),
+            "allowed_chat_ids": "[]",
+            "allowed_chat_refs": json.dumps(["someOtherRef01002ABC"]),
             "is_revoked": 0,
             "no_download": 0,
             "expires_at": None,
         }
         resp = client.put(
             "/api/admin/tokens/8",
-            json={"allowed_chat_ids": [-1002]},
+            json={"allowed_chat_refs": ["someOtherRef01002ABC"]},
             cookies={"viewer_auth": cookie},
         )
         assert resp.status_code == 200

--- a/tests/test_viewer_acl_hardening.py
+++ b/tests/test_viewer_acl_hardening.py
@@ -7,7 +7,8 @@ Each class pins one defect found by the security audit of src/web/main.py:
   VIEWER_PASSWORD were configured together.
 - The thumbnail route authorized the raw request string while the file lookup
   used the joined path, so a percent-encoded ".." read another chat's media and
-  bypassed no_download.
+  bypassed no_download. (Phase 4 media URLs are single-segment ref + key, so the
+  URL variant now dies at routing; the row's file_path is the surface left.)
 - broadcast_to_chat iterated the live connection dict across awaits.
 - Archived .html/.svg documents were served inline as same-origin documents.
 - Access-controlled media carried Cache-Control: public.
@@ -61,7 +62,16 @@ def _mock_db():
     db.delete_session = AsyncMock()
     db.create_audit_log = AsyncMock()
     db.get_viewer_by_username = AsyncMock(return_value=None)
+    # Phase 4: chat-scoped routes resolve their {chat_ref} through these two
+    # reads. None = "no such chat/media", the fail-closed default.
+    db.get_chat_by_ref = AsyncMock(return_value=None)
+    db.get_media_by_id = AsyncMock(return_value=None)
     return db
+
+
+def _chat_row(chat_id: int, ref: str, chat_type: str = "channel") -> dict:
+    """A chats row dict of the shape get_chat_by_ref returns."""
+    return {"id": chat_id, "account_id": 1, "ref": ref, "type": chat_type}
 
 
 # ============================================================================
@@ -118,17 +128,23 @@ class TestWebSocketAuthWithProxyAndPassword(unittest.TestCase):
 
     def test_authenticated_viewer_socket_keeps_its_chat_acl(self):
         """A restricted viewer must not be able to subscribe outside its allowed set."""
+        allowed_ref = "wsAllowedRefwsAllowedR"
+        forbidden_ref = "wsForbiddenRwsForbidde"
+        # BOTH refs resolve to real chats: the denial below is entitlement,
+        # not unknownness — and the two are indistinguishable on the wire.
+        rows = {allowed_ref: _chat_row(1, allowed_ref), forbidden_ref: _chat_row(2, forbidden_ref)}
+        web_main.db.get_chat_by_ref = AsyncMock(side_effect=lambda ref, **kwargs: rows.get(ref))
         token = "acl-ws-session"
         web_main._sessions[token] = web_main.SessionData(
-            username="v1", role="viewer", allowed_chat_ids={1, 2}, created_at=time.time()
+            username="v1", role="viewer", allowed_chat_refs={allowed_ref}, created_at=time.time()
         )
         self.client.cookies.set("viewer_auth", token)
 
         with self.client.websocket_connect("/ws/updates") as socket:
-            socket.send_json({"action": "subscribe", "chat_id": 1})
-            self.assertEqual({"type": "subscribed", "chat_id": 1}, socket.receive_json())
-            socket.send_json({"action": "subscribe", "chat_id": 999})
-            self.assertEqual({"type": "subscribe_denied", "chat_id": 999}, socket.receive_json())
+            socket.send_json({"action": "subscribe", "chat_ref": allowed_ref})
+            self.assertEqual({"type": "subscribed", "chat_ref": allowed_ref}, socket.receive_json())
+            socket.send_json({"action": "subscribe", "chat_ref": forbidden_ref})
+            self.assertEqual({"type": "subscribe_denied", "chat_ref": forbidden_ref}, socket.receive_json())
 
     def test_proxy_header_still_authenticates(self):
         """Control: the proxy path itself is untouched and still connects."""
@@ -138,13 +154,22 @@ class TestWebSocketAuthWithProxyAndPassword(unittest.TestCase):
 
 
 # ============================================================================
-# Thumbnail route: percent-encoded ".." (the ACL string must be the read string)
+# Media traversal (the ref-addressed routes must keep the containment absolute)
 # ============================================================================
 
 
 @_skip_unless_web
 class TestThumbnailPathTraversal(unittest.IsolatedAsyncioTestCase):
-    """`%2e%2e` arrives decoded, so the folder the ACL reads must be the folder served."""
+    """Traversal died at the URL; it must stay dead in the DB row too.
+
+    Phase 4 media URLs are ``/media/{chat_ref}/{media_key}`` — single segments,
+    so an encoded ``..`` can no longer splice extra path components into the
+    request: those URLs stop matching any route at all. What CAN still carry a
+    traversal is the media row's ``file_path`` (database content), because the
+    bytes are now selected through the row. Both surfaces must refuse.
+    """
+
+    ALLOWED_REF = "thumbAllowedRefthumbAl"
 
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
@@ -156,6 +181,9 @@ class TestThumbnailPathTraversal(unittest.IsolatedAsyncioTestCase):
         web_main._thumb_cache_dir = Path(self.tmp.name) / "thumbs"
         web_main.AUTH_ENABLED = True
         web_main.db = _mock_db()
+        web_main.db.get_chat_by_ref = AsyncMock(
+            side_effect=lambda ref, **kwargs: _chat_row(-1001, self.ALLOWED_REF) if ref == self.ALLOWED_REF else None
+        )
         web_main._sessions.clear()
 
     def tearDown(self):
@@ -173,50 +201,82 @@ class TestThumbnailPathTraversal(unittest.IsolatedAsyncioTestCase):
     def _client(self):
         return AsyncClient(transport=ASGITransport(app=web_main.app), base_url="http://test")
 
-    async def test_encoded_dot_dot_cannot_reach_a_forbidden_chat(self):
-        """The exploit: authorized on -1001, served from -1002."""
-        cookies = self._session("tv-restricted", allowed_chat_ids={-1001})
+    async def test_encoded_dot_dot_urls_no_longer_route_at_all(self):
+        """Every multi-segment traversal spelling dies before any code runs."""
+        cookies = self._session("tv-restricted", allowed_chat_refs={self.ALLOWED_REF})
         generated = AsyncMock(return_value=(Path(self.tmp.name) / "thumb.webp", "-1002"))
         with patch("src.web.thumbnails.ensure_thumbnail", generated):
             async with self._client() as client:
-                resp = await client.get("/media/thumb/200/-1001/%2e%2e/-1002/secret.jpg", cookies=cookies)
-        self.assertEqual(403, resp.status_code)
-        # No file was even looked at: the request never reached generation.
+                for url in (
+                    f"/media/thumb/200/{self.ALLOWED_REF}/%2e%2e/-1002/secret.jpg",
+                    f"/media/thumb/200/{self.ALLOWED_REF}/..%2f-1002/secret.jpg",
+                    "/media/thumb/200/avatars/%2e%2e/-1001/private.jpg",
+                    f"/media/{self.ALLOWED_REF}/%2e%2e/-1002/secret.jpg",
+                ):
+                    resp = await client.get(url, cookies=cookies)
+                    self.assertEqual(404, resp.status_code, url)
+        # No file was even looked at: the requests never reached generation.
         generated.assert_not_awaited()
 
-    async def test_encoded_slash_spelling_is_refused_too(self):
-        """`..%2f` decodes to the same traversal and must fail the same way."""
-        cookies = self._session("tv-restricted-2", allowed_chat_ids={-1001})
-        async with self._client() as client:
-            resp = await client.get("/media/thumb/200/-1001/..%2f-1002/secret.jpg", cookies=cookies)
-        self.assertEqual(403, resp.status_code)
-
-    async def test_encoded_dot_dot_cannot_bypass_no_download(self):
-        """`avatars/..` used to skip the no_download rule on its way to real media."""
-        cookies = self._session("tv-nodl", allowed_chat_ids={-1001}, no_download=True)
+    async def test_a_media_row_carrying_a_traversal_path_serves_nothing(self):
+        """file_path is data; a ``..`` planted there must not select bytes."""
+        cookies = self._session("tv-row", allowed_chat_refs={self.ALLOWED_REF})
+        web_main.db.get_media_by_id = AsyncMock(
+            return_value={"id": "-1001_9_photo", "file_path": "-1001/../-1002/secret.jpg", "file_name": "secret.jpg"}
+        )
         generated = AsyncMock(return_value=(Path(self.tmp.name) / "thumb.webp", "-1001"))
         with patch("src.web.thumbnails.ensure_thumbnail", generated):
             async with self._client() as client:
-                resp = await client.get("/media/thumb/200/avatars/%2e%2e/-1001/private.jpg", cookies=cookies)
+                thumb = await client.get(f"/media/thumb/200/{self.ALLOWED_REF}/9_photo", cookies=cookies)
+                media = await client.get(f"/media/{self.ALLOWED_REF}/9_photo", cookies=cookies)
+        self.assertEqual(404, thumb.status_code)
+        self.assertEqual(404, media.status_code)
+        generated.assert_not_awaited()
+
+    async def test_an_absolute_file_path_outside_the_root_serves_nothing(self):
+        """Absolute stored paths are honoured ONLY under the media root."""
+        cookies = self._session("tv-abs", allowed_chat_refs={self.ALLOWED_REF})
+        outside = Path(self.tmp.name).parent / "outside-secret.jpg"
+        web_main.db.get_media_by_id = AsyncMock(
+            return_value={"id": "-1001_9_photo", "file_path": str(outside), "file_name": "outside-secret.jpg"}
+        )
+        async with self._client() as client:
+            resp = await client.get(f"/media/{self.ALLOWED_REF}/9_photo", cookies=cookies)
+        self.assertEqual(404, resp.status_code)
+
+    async def test_traversal_predicates_themselves_still_hold(self):
+        """The helpers the routes lean on keep refusing ``..`` and absolutes."""
+        with self.assertRaises(web_main.HTTPException):
+            web_main._checked_media_path("../secret.txt")
+        with self.assertRaises(web_main.HTTPException):
+            web_main._checked_media_path("/etc/passwd")
+        self.assertIsNone(web_main._media_relative_path("-1001/../-1002/x.jpg"))
+        self.assertIsNone(web_main._media_relative_path("/not/under/root.jpg"))
+
+    async def test_no_download_cannot_reach_thumbnails(self):
+        """The no_download rule fires before any row or file work."""
+        cookies = self._session("tv-nodl", allowed_chat_refs={self.ALLOWED_REF}, no_download=True)
+        generated = AsyncMock(return_value=(Path(self.tmp.name) / "thumb.webp", "-1001"))
+        with patch("src.web.thumbnails.ensure_thumbnail", generated):
+            async with self._client() as client:
+                resp = await client.get(f"/media/thumb/200/{self.ALLOWED_REF}/9_photo", cookies=cookies)
         self.assertEqual(403, resp.status_code)
         generated.assert_not_awaited()
 
     async def test_clean_path_in_an_allowed_chat_still_serves(self):
-        """Control: the guard denies only requests that were already meant to be denied."""
-        cookies = self._session("tv-allowed", allowed_chat_ids={-1001})
+        """Control: the guards deny only requests that were already meant to be denied."""
+        cookies = self._session("tv-allowed", allowed_chat_refs={self.ALLOWED_REF})
         thumb = Path(self.tmp.name) / "thumb.webp"
         thumb.write_bytes(b"\x00" * 8)
+        web_main.db.get_media_by_id = AsyncMock(
+            return_value={"id": "-1001_9_photo", "file_path": "-1001/9_photo.jpg", "file_name": "9_photo.jpg"}
+        )
         with patch("src.web.thumbnails.ensure_thumbnail", AsyncMock(return_value=(thumb, "-1001"))):
             async with self._client() as client:
-                resp = await client.get("/media/thumb/200/-1001/allowed.jpg", cookies=cookies)
+                resp = await client.get(f"/media/thumb/200/{self.ALLOWED_REF}/9_photo", cookies=cookies)
         self.assertEqual(200, resp.status_code)
-
-    async def test_serve_media_still_refuses_traversal(self):
-        """The sibling route shares the same guard now; it must not have regressed."""
-        cookies = self._session("tv-media", allowed_chat_ids={-1001})
-        async with self._client() as client:
-            resp = await client.get("/media/-1001/%2e%2e/-1002/secret.jpg", cookies=cookies)
-        self.assertEqual(403, resp.status_code)
+        # The row was looked up under the resolved chat's account + storage key.
+        web_main.db.get_media_by_id.assert_awaited_once_with("-1001_9_photo", account_id=1)
 
 
 # ============================================================================
@@ -245,6 +305,15 @@ class _FakeSocket:
 class TestBroadcastSnapshot(unittest.IsolatedAsyncioTestCase):
     """One client leaving must not cancel the event for everyone else."""
 
+    CHAT = {"id": 42, "account_id": 1, "ref": "broadcastRefbroadcastR"}
+
+    def setUp(self):
+        self._saved_display = web_main.config.display_chat_ids
+        web_main.config.display_chat_ids = set()
+
+    def tearDown(self):
+        web_main.config.display_chat_ids = self._saved_display
+
     async def test_disconnect_during_send_still_reaches_the_remaining_clients(self):
         manager = web_main.ConnectionManager()
         leaving = _FakeSocket()
@@ -257,11 +326,12 @@ class TestBroadcastSnapshot(unittest.IsolatedAsyncioTestCase):
             await asyncio.sleep(0)
 
         first = _FakeSocket(on_send=disconnect_mid_broadcast)
+        user = web_main.UserContext(username="v1", role="viewer")
         for socket in (first, leaving, staying):
-            await manager.connect(socket)
-            manager.subscribe(socket, 42)
+            await manager.connect(socket, user)
+            manager.subscribe(socket, self.CHAT["ref"])
 
-        await manager.broadcast_to_chat(42, {"type": "new_message", "chat_id": 42})
+        await manager.broadcast_to_chat(self.CHAT, {"type": "new_message", "chat_ref": self.CHAT["ref"]})
 
         self.assertEqual(1, len(first.received))
         self.assertEqual(1, len(staying.received), "a client after the mutation point missed the broadcast")
@@ -276,8 +346,9 @@ class TestBroadcastSnapshot(unittest.IsolatedAsyncioTestCase):
             await asyncio.sleep(0)
 
         first = _FakeSocket(on_send=disconnect_mid_broadcast)
+        user = web_main.UserContext(username="v1", role="viewer")
         for socket in (first, leaving, staying):
-            await manager.connect(socket)
+            await manager.connect(socket, user)
 
         await manager.broadcast_to_all({"type": "ping"})
 
@@ -293,6 +364,8 @@ class TestBroadcastSnapshot(unittest.IsolatedAsyncioTestCase):
 class TestMediaServingHeaders(unittest.IsolatedAsyncioTestCase):
     """Archived bytes are attacker-named: they must never become a live document."""
 
+    REF = "mediaHdrRefmediaHdrRef"
+
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
         # serve_media compares the resolved file against _media_root, and the
@@ -304,28 +377,46 @@ class TestMediaServingHeaders(unittest.IsolatedAsyncioTestCase):
         (self.root / "avatars" / "chats").mkdir(parents=True)
         (self.root / "avatars" / "chats" / "-1001_7.jpg").write_bytes(b"\xff\xd8\xff")
         self._saved_root = web_main._media_root
+        self._saved_media_path = web_main.config.media_path
         self._saved_auth = web_main.AUTH_ENABLED
         self._saved_anon = web_main.ALLOW_ANONYMOUS_VIEWER
         self._saved_db = web_main.db
         web_main._media_root = self.root
+        web_main.config.media_path = str(self.root)
         web_main.AUTH_ENABLED = False
         web_main.ALLOW_ANONYMOUS_VIEWER = True
         web_main.db = _mock_db()
+        web_main.db.get_chat_by_ref = AsyncMock(
+            side_effect=lambda ref, **kwargs: _chat_row(-1001, self.REF) if ref == self.REF else None
+        )
+        web_main._avatar_cache.clear()
+        web_main._avatar_cache_time = None
+        web_main._avatar_dir_index.clear()
 
     def tearDown(self):
         web_main._media_root = self._saved_root
+        web_main.config.media_path = self._saved_media_path
         web_main.AUTH_ENABLED = self._saved_auth
         web_main.ALLOW_ANONYMOUS_VIEWER = self._saved_anon
         web_main.db = self._saved_db
+        web_main._avatar_cache.clear()
+        web_main._avatar_cache_time = None
+        web_main._avatar_dir_index.clear()
         self.tmp.cleanup()
 
     def _client(self):
         return AsyncClient(transport=ASGITransport(app=web_main.app), base_url="http://test")
 
     async def _get(self, name, query=""):
+        # ``name`` doubles as the URL media key: ``77_report.html`` parses as
+        # message 77, type "report.html", and the media row's file_path picks
+        # the actual bytes — the phase-4 shape, where the row selects the file.
         (self.chat_dir / name).write_bytes(b"<script>archive.exfiltrate()</script>")
+        web_main.db.get_media_by_id = AsyncMock(
+            return_value={"id": f"-1001_{name}", "file_path": f"-1001/{name}", "file_name": name}
+        )
         async with self._client() as client:
-            return await client.get(f"/media/-1001/{name}{query}")
+            return await client.get(f"/media/{self.REF}/{name}{query}")
 
     async def test_archived_html_is_a_download_not_a_document(self):
         resp = await self._get("77_report.html")
@@ -360,20 +451,27 @@ class TestMediaServingHeaders(unittest.IsolatedAsyncioTestCase):
         self.assertNotIn("public", resp.headers["cache-control"])
 
     async def test_avatar_cache_control_is_private(self):
+        # The chat's avatar is addressed by ref alone; the id-addressed
+        # /media/avatars/... shape no longer routes.
         async with self._client() as client:
-            resp = await client.get("/media/avatars/chats/-1001_7.jpg")
+            resp = await client.get(f"/media/avatar/{self.REF}")
+            legacy = await client.get("/media/avatars/chats/-1001_7.jpg")
         self.assertEqual(200, resp.status_code)
         self.assertEqual("private, max-age=86400", resp.headers["cache-control"])
+        self.assertEqual(404, legacy.status_code)
 
     async def test_thumbnail_cache_control_is_private(self):
         thumb = self.root / "thumb.webp"
         thumb.write_bytes(b"\x00" * 8)
+        web_main.db.get_media_by_id = AsyncMock(
+            return_value={"id": "-1001_77_photo", "file_path": "-1001/77_photo.jpg", "file_name": "77_photo.jpg"}
+        )
         saved_cache_dir = web_main._thumb_cache_dir
         web_main._thumb_cache_dir = self.root / "thumbs"
         try:
             with patch("src.web.thumbnails.ensure_thumbnail", AsyncMock(return_value=(thumb, "-1001"))):
                 async with self._client() as client:
-                    resp = await client.get("/media/thumb/200/-1001/77_photo.jpg")
+                    resp = await client.get(f"/media/thumb/200/{self.REF}/77_photo")
         finally:
             web_main._thumb_cache_dir = saved_cache_dir
         self.assertEqual(200, resp.status_code)
@@ -388,8 +486,15 @@ class TestMediaServingHeaders(unittest.IsolatedAsyncioTestCase):
 
 @_skip_unless_web
 class TestExceptionHandlerRedaction(unittest.TestCase):
-    """A media URL is /media/<chat id>/<file id>_<the sender's file name>."""
+    """A media key still ends with the sender's own file name — it must not be logged.
 
+    The chat id has left the URL (the ref addresses the chat), but the media
+    key carries the sender's filename and a hostile client can put ANY string in
+    either segment, so the redaction rule is unchanged: log the route template,
+    never the request values.
+    """
+
+    CHAT_REF = "redactChatRefredactCha"
     CHAT_FOLDER = "-1001234567890"
     FILE_NAME = "555_Maria Invoice.jpg"
 
@@ -405,6 +510,16 @@ class TestExceptionHandlerRedaction(unittest.TestCase):
         web_main.AUTH_ENABLED = False
         web_main.ALLOW_ANONYMOUS_VIEWER = True
         web_main.db = _mock_db()
+        # The failure is planted INSIDE the handler (ensure_thumbnail), so the
+        # resolver and the media row lookup must both succeed first.
+        web_main.db.get_chat_by_ref = AsyncMock(return_value=_chat_row(-1001234567890, self.CHAT_REF))
+        web_main.db.get_media_by_id = AsyncMock(
+            return_value={
+                "id": f"{self.CHAT_FOLDER}_{self.FILE_NAME}",
+                "file_path": f"{self.CHAT_FOLDER}/{self.FILE_NAME}",
+                "file_name": self.FILE_NAME,
+            }
+        )
 
     def tearDown(self):
         web_main._media_root = self._saved_root
@@ -416,7 +531,7 @@ class TestExceptionHandlerRedaction(unittest.TestCase):
 
     def _drive_failing_request(self, failure):
         client = TestClient(web_main.app, raise_server_exceptions=False)
-        url = f"/media/thumb/200/{self.CHAT_FOLDER}/{self.FILE_NAME}"
+        url = f"/media/thumb/200/{self.CHAT_REF}/{self.FILE_NAME}"
         with (
             patch("src.web.thumbnails.ensure_thumbnail", AsyncMock(side_effect=failure)),
             self.assertLogs("src.web.main", level=logging.ERROR) as captured,
@@ -430,16 +545,18 @@ class TestExceptionHandlerRedaction(unittest.TestCase):
         response, logged = self._drive_failing_request(OSError(20, "Not a directory", "/cache/thumbs"))
         self.assertEqual(503, response.status_code)
         self.assertNotIn(self.CHAT_FOLDER, logged)
+        self.assertNotIn(self.CHAT_REF, logged)
         self.assertNotIn("Maria", logged)
         self.assertNotIn("Errno", logged)
-        self.assertIn("/media/thumb/{size}/{folder:path}/{filename}", logged)
+        self.assertIn("/media/thumb/{size}/{chat_ref}/{media_key}", logged)
 
     def test_unhandled_error_branch_logs_no_identifiers(self):
         response, logged = self._drive_failing_request(RuntimeError("thumbnail worker exploded"))
         self.assertEqual(500, response.status_code)
         self.assertNotIn(self.CHAT_FOLDER, logged)
+        self.assertNotIn(self.CHAT_REF, logged)
         self.assertNotIn("Maria", logged)
-        self.assertIn("/media/thumb/{size}/{folder:path}/{filename}", logged)
+        self.assertIn("/media/thumb/{size}/{chat_ref}/{media_key}", logged)
         # The class and message of a non-path exception stay: that is the diagnostic.
         self.assertIn("RuntimeError", logged)
 
@@ -457,6 +574,7 @@ class TestExceptionHandlerRedaction(unittest.TestCase):
         response, logged = self._drive_failing_request(attack)
         self.assertEqual(500, response.status_code)
         self.assertNotIn(self.CHAT_FOLDER, logged)
+        self.assertNotIn(self.CHAT_REF, logged)
         self.assertNotIn("Maria", logged)
         self.assertNotIn("ffmpeg", logged)
         # Debuggability survives redaction: the type names the failure and the
@@ -472,6 +590,7 @@ class TestExceptionHandlerRedaction(unittest.TestCase):
         response, logged = self._drive_failing_request(attack)
         self.assertEqual(503, response.status_code)
         self.assertNotIn(self.CHAT_FOLDER, logged)
+        self.assertNotIn(self.CHAT_REF, logged)
         self.assertNotIn("Maria", logged)
         self.assertNotIn("Errno", logged)
         self.assertIn("FileNotFoundError", logged)
@@ -496,6 +615,7 @@ class TestUnhandledExceptionNeverReachesTheServer(unittest.TestCase):
     propagates out of the ASGI app), and leak nothing.
     """
 
+    CHAT_REF = "reraiseChatRefreraiseC"
     CHAT_FOLDER = "-1001234567890"
     FILE_NAME = "555_Maria Invoice.jpg"
 
@@ -511,6 +631,16 @@ class TestUnhandledExceptionNeverReachesTheServer(unittest.TestCase):
         web_main.AUTH_ENABLED = False
         web_main.ALLOW_ANONYMOUS_VIEWER = True
         web_main.db = _mock_db()
+        # Resolve the ref and the media row so the request reaches the planted
+        # ensure_thumbnail failure — the row's file_path is the PII-bearing path.
+        web_main.db.get_chat_by_ref = AsyncMock(return_value=_chat_row(-1001234567890, self.CHAT_REF))
+        web_main.db.get_media_by_id = AsyncMock(
+            return_value={
+                "id": f"{self.CHAT_FOLDER}_{self.FILE_NAME}",
+                "file_path": f"{self.CHAT_FOLDER}/{self.FILE_NAME}",
+                "file_name": self.FILE_NAME,
+            }
+        )
 
     def tearDown(self):
         web_main._media_root = self._saved_root
@@ -527,7 +657,7 @@ class TestUnhandledExceptionNeverReachesTheServer(unittest.TestCase):
         # with exc_info. So "this call returned a response" == "uvicorn never saw
         # it". Before the middleware, this same call raised the exception.
         client = TestClient(web_main.app, raise_server_exceptions=True)
-        url = f"/media/thumb/200/{self.CHAT_FOLDER}/{self.FILE_NAME}"
+        url = f"/media/thumb/200/{self.CHAT_REF}/{self.FILE_NAME}"
 
         # Capture BOTH 'src.web.main' and 'uvicorn.error' by attaching a handler
         # to the ROOT logger (both propagate there), and FORMAT each record so an
@@ -593,6 +723,8 @@ class TestUnhandledExceptionNeverReachesTheServer(unittest.TestCase):
 class TestNoDownloadGalleryThumbnails(unittest.IsolatedAsyncioTestCase):
     """A URL the route puts in its own response must be fetchable by its recipient."""
 
+    REF = "galleryRefgalleryRefga"
+
     def setUp(self):
         self._saved_db = web_main.db
         self._saved_auth = web_main.AUTH_ENABLED
@@ -603,8 +735,9 @@ class TestNoDownloadGalleryThumbnails(unittest.IsolatedAsyncioTestCase):
         web_main.config.display_chat_ids = set()
         web_main._sessions.clear()
         self.mock_db = _mock_db()
+        self.mock_db.get_chat_by_ref = AsyncMock(return_value=_chat_row(-1001, self.REF))
         self.mock_db.get_media_paginated = AsyncMock(
-            side_effect=lambda *a, **k: {"items": [{"id": 1, "file_path": "-1001/photo_123.jpg"}]}
+            side_effect=lambda *a, **k: {"items": [{"id": "-1001_123_photo", "file_path": "-1001/photo_123.jpg"}]}
         )
         web_main.db = self.mock_db
 
@@ -619,12 +752,12 @@ class TestNoDownloadGalleryThumbnails(unittest.IsolatedAsyncioTestCase):
         web_main._sessions[token] = web_main.SessionData(
             username="v1",
             role="viewer",
-            allowed_chat_ids={-1001},
+            allowed_chat_refs={self.REF},
             no_download=no_download,
             created_at=time.time(),
         )
         async with AsyncClient(transport=ASGITransport(app=web_main.app), base_url="http://test") as client:
-            resp = await client.get("/api/chats/-1001/media", cookies={"viewer_auth": token})
+            resp = await client.get(f"/api/chats/{self.REF}/media", cookies={"viewer_auth": token})
         self.assertEqual(200, resp.status_code)
         return resp.json()["items"][0]
 
@@ -632,10 +765,15 @@ class TestNoDownloadGalleryThumbnails(unittest.IsolatedAsyncioTestCase):
         item = await self._gallery("gal-nodl", no_download=True)
         self.assertIsNone(item["thumb_url"])
         self.assertNotIn("file_path", item)
+        # No original-bytes URL either: no_download strips both.
+        self.assertNotIn("media_url", item)
 
     async def test_ordinary_viewer_still_gets_the_thumbnail_url(self):
         item = await self._gallery("gal-ok", no_download=False)
-        self.assertEqual("/media/thumb/200/-1001/photo_123.jpg", item["thumb_url"])
+        # The gallery id is the chat-free cursor key; both URLs ride the ref.
+        self.assertEqual("123_photo", item["id"])
+        self.assertEqual(f"/media/thumb/200/{self.REF}/123_photo", item["thumb_url"])
+        self.assertEqual(f"/media/{self.REF}/123_photo", item["media_url"])
 
 
 # ============================================================================
@@ -728,7 +866,7 @@ class TestTokenHashingOffTheEventLoop(unittest.IsolatedAsyncioTestCase):
             async with AsyncClient(transport=ASGITransport(app=web_main.app), base_url="http://test") as client:
                 resp = await client.post(
                     "/api/admin/tokens",
-                    json={"label": "backup", "allowed_chat_ids": [-1001]},
+                    json={"label": "backup", "allowed_chat_refs": ["tokenGrantRefTokenGran"]},
                     cookies={"viewer_auth": "master-tok"},
                 )
 
@@ -771,6 +909,9 @@ class TestAvatarLookupScans(unittest.TestCase):
         return path
 
     def test_a_page_of_senders_reads_the_folder_once(self):
+        # _sender_avatar_url is gone (sender avatars are addressed by chat ref +
+        # message id now); the per-sender lookup the page renderer performs is
+        # _get_cached_avatar_path, and it must still cost one directory read.
         sender_ids = list(range(1000, 1030))
         for sender_id in sender_ids:
             self._touch(f"{sender_id}_1.jpg")
@@ -783,9 +924,9 @@ class TestAvatarLookupScans(unittest.TestCase):
             return real_scandir(path)
 
         with patch.object(web_main.os, "scandir", counting_scandir):
-            urls = [web_main._sender_avatar_url(sender_id) for sender_id in sender_ids]
+            paths = [web_main._get_cached_avatar_path(sender_id, "private") for sender_id in sender_ids]
 
-        self.assertEqual([f"/media/avatars/users/{sender_id}_1.jpg" for sender_id in sender_ids], urls)
+        self.assertEqual([f"avatars/users/{sender_id}_1.jpg" for sender_id in sender_ids], paths)
         self.assertEqual(1, len([s for s in scans if str(self.users_dir) in s]))
 
     def test_a_new_avatar_is_picked_up_without_waiting(self):

--- a/tests/test_viewer_on_8_0_schema.py
+++ b/tests/test_viewer_on_8_0_schema.py
@@ -1,14 +1,13 @@
-"""The viewer runs UNTOUCHED on the 8.0 multi-account schema.
+"""The ref-addressed viewer works end to end on the 8.0 multi-account schema.
 
-The 8.0 contract says every adapter method the web viewer calls is
-OPTIONAL-UNSCOPED (``account_id: int | None = None``), so ``src/web/`` needs no
-edits when the primary keys gain ``account_id``. That claim is only worth
-something if it is pinned against the real schema: this suite builds its
-database with ``alembic upgrade head`` from this tree — never
-``Base.metadata.create_all`` — seeds it through the ORM models with
-``account_id=1`` (the row migration 022 itself seeds), and drives the real
-FastAPI app over ASGI with a real ``DatabaseAdapter``. Any viewer route that
-starts requiring ``account_id`` surfaces here as a TypeError-backed 500.
+Phase 4 moved every chat-scoped route onto ``chats.ref``, so this suite drives
+the real routes by ref against the real schema: the database is built with
+``alembic upgrade head`` from this tree — never ``Base.metadata.create_all`` —
+seeded through the ORM models with ``account_id=1`` (the row migration 022
+itself seeds, which also mints each chat's ref), and served by the real FastAPI
+app over ASGI with a real ``DatabaseAdapter``. Any route that breaks on the 8.0
+keys, or any read that starts requiring ``account_id``, surfaces here as a
+TypeError-backed 500.
 
 The deployed MCP server (telegram-archive-mcp, a separate repo) fronts these
 same HTTP endpoints, so this file is also the MCP-surface baseline: no MCP
@@ -194,6 +193,17 @@ class TestViewerOn80Schema(unittest.IsolatedAsyncioTestCase):
         _upgrade_to_head(sync_url)
         _seed(sync_url)
 
+        # The refs the ORM minted on INSERT: the only chat identity URLs carry.
+        engine = sa.create_engine(sync_url)
+        try:
+            with engine.connect() as conn:
+                rows = conn.execute(sa.text("SELECT id, ref FROM chats")).fetchall()
+        finally:
+            engine.dispose()
+        refs = dict(rows)
+        cls.ref_a = refs[CHAT_A]
+        cls.ref_b = refs[CHAT_B]
+
     async def asyncSetUp(self):
         self.manager = DatabaseManager(f"sqlite+aiosqlite:///{self.db_path}")
         await self.manager.init()
@@ -295,18 +305,23 @@ class TestViewerOn80Schema(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(set(by_id), {CHAT_A, CHAT_B})
             self.assertEqual(by_id[CHAT_A]["title"], "Synthetic Alpha")
             self.assertEqual(by_id[CHAT_B]["username"], "synth_beta")
+            # Phase 4 payload additions: the ref the frontend must address
+            # chats by, and the account id carried for phase 5.
+            self.assertEqual(by_id[CHAT_A]["ref"], self.ref_a)
+            self.assertEqual(by_id[CHAT_B]["ref"], self.ref_b)
+            self.assertEqual(by_id[CHAT_A]["account_id"], 1)
             self.assertFalse(data["has_more"])
 
     async def test_message_pagination_offset_and_cursor_agree(self):
         async with self._client() as client:
             await self._login(client)
 
-            resp = await client.get(f"/api/chats/{CHAT_A}/messages", params={"limit": 10})
+            resp = await client.get(f"/api/chats/{self.ref_a}/messages", params={"limit": 10})
             self.assertEqual(resp.status_code, 200, resp.text)
             page1 = resp.json()
             self.assertEqual([m["id"] for m in page1], list(range(30, 20, -1)))
 
-            resp = await client.get(f"/api/chats/{CHAT_A}/messages", params={"limit": 10, "offset": 10})
+            resp = await client.get(f"/api/chats/{self.ref_a}/messages", params={"limit": 10, "offset": 10})
             self.assertEqual(resp.status_code, 200, resp.text)
             page2 = resp.json()
             self.assertEqual([m["id"] for m in page2], list(range(20, 10, -1)))
@@ -314,7 +329,7 @@ class TestViewerOn80Schema(unittest.IsolatedAsyncioTestCase):
             # Cursor mode (the infinite-scroll path) must land on the same rows.
             oldest = page1[-1]
             resp = await client.get(
-                f"/api/chats/{CHAT_A}/messages",
+                f"/api/chats/{self.ref_a}/messages",
                 params={"limit": 10, "before_date": oldest["date"], "before_id": oldest["id"]},
             )
             self.assertEqual(resp.status_code, 200, resp.text)
@@ -323,7 +338,7 @@ class TestViewerOn80Schema(unittest.IsolatedAsyncioTestCase):
     async def test_message_search_returns_only_the_matching_row(self):
         async with self._client() as client:
             await self._login(client)
-            resp = await client.get(f"/api/chats/{CHAT_A}/messages", params={"search": "needle"})
+            resp = await client.get(f"/api/chats/{self.ref_a}/messages", params={"search": "needle"})
             self.assertEqual(resp.status_code, 200, resp.text)
             hits = resp.json()
             self.assertEqual([m["id"] for m in hits], [7])
@@ -340,14 +355,17 @@ class TestViewerOn80Schema(unittest.IsolatedAsyncioTestCase):
         async with self._client() as client:
             await self._login(client)
 
-            resp = await client.get(f"/api/chats/{CHAT_A}/media")
+            resp = await client.get(f"/api/chats/{self.ref_a}/media")
             self.assertEqual(resp.status_code, 200, resp.text)
             items = resp.json()["items"]
             # Exactly one: the seeded downloaded=0 document must stay filtered out.
             self.assertEqual(len(items), 1)
             item = items[0]
-            self.assertEqual(item["id"], f"{CHAT_A}_30_photo")
-            self.assertEqual(item["media_url"], f"/media/{CHAT_A}/30_photo.jpg")
+            # The gallery id is the CHAT-FREE key (it round-trips as the
+            # cursor), and every URL is ref-addressed — no chat id in either.
+            self.assertEqual(item["id"], "30_photo")
+            self.assertEqual(item["media_url"], f"/media/{self.ref_a}/30_photo")
+            self.assertEqual(item["thumb_url"], f"/media/thumb/200/{self.ref_a}/30_photo")
 
             resp = await client.get(item["media_url"])
             self.assertEqual(resp.status_code, 200, resp.text)
@@ -355,11 +373,12 @@ class TestViewerOn80Schema(unittest.IsolatedAsyncioTestCase):
 
             # The message payload nests the same media row and its reaction —
             # the joins that now carry Media.account_id == Message.account_id.
-            resp = await client.get(f"/api/chats/{CHAT_A}/messages", params={"limit": 1})
+            resp = await client.get(f"/api/chats/{self.ref_a}/messages", params={"limit": 1})
             self.assertEqual(resp.status_code, 200, resp.text)
             top = resp.json()[0]
             self.assertEqual(top["id"], 30)
-            self.assertEqual(top["media"]["id"], f"{CHAT_A}_30_photo")
+            self.assertEqual(top["media"]["id"], "30_photo")
+            self.assertEqual(top["media"]["url"], f"/media/{self.ref_a}/30_photo")
             self.assertEqual(top["reactions"], [{"emoji": "\U0001f44d", "count": 2, "user_ids": []}])
 
     def test_every_viewer_read_keeps_account_id_optional(self):
@@ -393,11 +412,11 @@ class TestViewerOn80Schema(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(resp.status_code, 200, resp.text)
             self.assertEqual(resp.json()["folders"], [])
 
-            resp = await client.get(f"/api/chats/{CHAT_A}/topics")
+            resp = await client.get(f"/api/chats/{self.ref_a}/topics")
             self.assertEqual(resp.status_code, 200, resp.text)
             self.assertEqual(resp.json()["topics"], [])
 
-            resp = await client.get(f"/api/chats/{CHAT_A}/pinned")
+            resp = await client.get(f"/api/chats/{self.ref_a}/pinned")
             self.assertEqual(resp.status_code, 200, resp.text)
             self.assertEqual(resp.json(), [])
 
@@ -405,15 +424,15 @@ class TestViewerOn80Schema(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(resp.status_code, 200, resp.text)
             self.assertEqual(resp.json()["count"], 0)
 
-            resp = await client.get(f"/api/chats/{CHAT_A}/media/counts")
+            resp = await client.get(f"/api/chats/{self.ref_a}/media/counts")
             self.assertEqual(resp.status_code, 200, resp.text)
             self.assertEqual(resp.json(), {"photo": 1})
 
-            resp = await client.get(f"/api/chats/{CHAT_A}/messages/30/versions")
+            resp = await client.get(f"/api/chats/{self.ref_a}/messages/30/versions")
             self.assertEqual(resp.status_code, 200, resp.text)
             self.assertEqual(resp.json(), [])
 
-            resp = await client.get(f"/api/chats/{CHAT_A}/stats")
+            resp = await client.get(f"/api/chats/{self.ref_a}/stats")
             self.assertEqual(resp.status_code, 200, resp.text)
             stats = resp.json()
             self.assertEqual(stats["messages"], 30)
@@ -426,22 +445,25 @@ class TestViewerOn80Schema(unittest.IsolatedAsyncioTestCase):
             await self._login(client)
 
             resp = await client.get(
-                f"/api/chats/{CHAT_A}/messages/by-date",
+                f"/api/chats/{self.ref_a}/messages/by-date",
                 params={"date": "2026-03-01", "timezone": "UTC"},
             )
             self.assertEqual(resp.status_code, 200, resp.text)
             self.assertEqual(resp.json()["id"], 1)
 
             resp = await client.get(
-                f"/api/chats/{CHAT_A}/messages/dates",
+                f"/api/chats/{self.ref_a}/messages/dates",
                 params={"month": "2026-03", "timezone": "UTC"},
             )
             self.assertEqual(resp.status_code, 200, resp.text)
             self.assertEqual(resp.json()["dates"], ["2026-03-01"])
 
-            resp = await client.get(f"/api/chats/{CHAT_A}/export")
+            resp = await client.get(f"/api/chats/{self.ref_a}/export")
             self.assertEqual(resp.status_code, 200, resp.text)
             export = json.loads(resp.text)
+            # The export FILE keeps the chat id (the user's own data leaving
+            # the system, not a URL) and gains the ref for correlation.
             self.assertEqual(export["chat"]["id"], CHAT_A)
+            self.assertEqual(export["chat"]["ref"], self.ref_a)
             self.assertEqual(len(export["messages"]), 30)
             self.assertEqual(export["message_versions"], [])

--- a/tests/test_web_coverage.py
+++ b/tests/test_web_coverage.py
@@ -49,11 +49,21 @@ def _skip_unless_push(cls_or_fn):
 
 
 def _mock_db():
-    """Create a mock database adapter with common methods."""
+    """Create a mock database adapter with common methods.
+
+    get_chat_by_ref echoes the requested ref back as an existing chat (id=1,
+    account 1) so ref-addressed routes resolve by default; tests that need an
+    unknown ref or a specific chat identity override it.
+    """
     db = AsyncMock()
     db.get_all_chats = AsyncMock(return_value=[])
     db.get_chat_count = AsyncMock(return_value=0)
     db.get_chat_by_id = AsyncMock(return_value=None)
+    db.get_chat_by_ref = AsyncMock(
+        side_effect=lambda ref, **kwargs: {"id": 1, "account_id": 1, "ref": ref, "type": "group"}
+    )
+    db.get_media_by_id = AsyncMock(return_value=None)
+    db.get_message_sender_id = AsyncMock(return_value=None)
     db.get_messages_paginated = AsyncMock(return_value=[])
     db.get_pinned_messages = AsyncMock(return_value=[])
     db.get_all_folders = AsyncMock(return_value=[])
@@ -137,6 +147,8 @@ class _WebTestBase(unittest.IsolatedAsyncioTestCase):
         web_main._avatar_cache.clear()
         web_main._avatar_cache_time = None
         web_main._chat_stats_cache.clear()
+        web_main._broadcast_chat_cache.clear()
+        web_main._sender_lookup_cache.clear()
 
     def tearDown(self):
         if not _WEB_AVAILABLE:
@@ -153,6 +165,8 @@ class _WebTestBase(unittest.IsolatedAsyncioTestCase):
         web_main._avatar_cache_time = self._saved_avatar_cache_time
         web_main._chat_stats_cache.clear()
         web_main._chat_stats_cache.update(self._saved_chat_stats_cache)
+        web_main._broadcast_chat_cache.clear()
+        web_main._sender_lookup_cache.clear()
         web_main._media_root = self._saved_media_root
         web_main.realtime_listener = self._saved_realtime
 
@@ -305,30 +319,38 @@ class TestServiceWorkerEndpoint(_WebTestBase):
 
 @_skip_unless_web
 class TestServeMedia(_WebTestBase):
-    """Test /media/{path} endpoint."""
+    """Test /media/{chat_ref}/{media_key} endpoint (row-mediated since v8.0)."""
 
     async def test_media_404_when_no_media_root(self):
         """serve_media returns 404 when media directory not configured."""
         web_main._media_root = None
         async with self._client() as client:
-            resp = await client.get("/media/test.jpg")
+            resp = await client.get("/media/someChatRef000000042A/5_photo")
         self.assertEqual(resp.status_code, 404)
 
-    async def test_media_rejects_absolute_path(self):
-        """serve_media returns 403 for absolute path prefix in route."""
+    async def test_media_rejects_poisoned_row_path(self):
+        """A media row whose file_path traverses out of the media root serves nothing.
+
+        The URL can no longer carry a path, so the traversal surface left is the
+        DB row itself; a row that cannot be proven inside the root answers the
+        same 404 as a missing file (tested directly against the handler).
+        """
         with tempfile.TemporaryDirectory() as tmpdir:
             web_main._media_root = web_main.Path(tmpdir)
-            # The path traversal check tests ".." in split("/") or startswith("/")
-            # We test the function directly since httpx normalizes URLs
+            self.mock_db.get_media_by_id = AsyncMock(
+                return_value={"id": "1_5_photo", "file_path": "../etc/passwd", "file_name": "passwd"}
+            )
             from fastapi import HTTPException
 
+            chat = web_main.ChatContext(account_id=1, chat_id=1, ref="poisonedRowRef0000001A", type="group")
             with self.assertRaises(HTTPException) as ctx:
                 await web_main.serve_media(
-                    path="../etc/passwd",
+                    media_key="5_photo",
                     download=0,
+                    chat=chat,
                     user=web_main.UserContext(username="anon", role="master"),
                 )
-            self.assertEqual(ctx.exception.status_code, 403)
+            self.assertEqual(ctx.exception.status_code, 404)
 
     async def test_media_rejects_no_download_with_download_flag(self):
         """serve_media returns 403 when user has no_download and download=1."""
@@ -338,91 +360,92 @@ class TestServeMedia(_WebTestBase):
             token = "nd-token"
             web_main._sessions[token] = web_main.SessionData(username="viewer1", role="viewer", no_download=True)
             async with self._client() as client:
-                resp = await client.get("/media/test.jpg?download=1", cookies={"viewer_auth": token})
+                resp = await client.get(
+                    "/media/someChatRef000000042A/5_photo?download=1", cookies={"viewer_auth": token}
+                )
             self.assertEqual(resp.status_code, 403)
 
     async def test_media_serves_existing_file(self):
-        """serve_media returns FileResponse for existing file."""
+        """serve_media resolves the media row's file_path and serves the bytes."""
         with tempfile.TemporaryDirectory() as tmpdir:
             media_root = web_main.Path(tmpdir).resolve()
             web_main._media_root = media_root
-            # Create file inside a subfolder to ensure path has segments
-            sub_dir = os.path.join(tmpdir, "files")
-            os.makedirs(sub_dir)
-            test_file = os.path.join(sub_dir, "test.txt")
-            with open(test_file, "w") as f:
-                f.write("content")
-            async with self._client() as client:
-                resp = await client.get("/media/files/test.txt")
-            self.assertEqual(resp.status_code, 200)
-
-    async def test_media_404_for_nonexistent_file(self):
-        """serve_media returns 404 for files that don't exist."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            web_main._media_root = web_main.Path(tmpdir)
-            async with self._client() as client:
-                resp = await client.get("/media/nonexistent.jpg")
-            # Path doesn't resolve, so 404
-            self.assertIn(resp.status_code, (403, 404))
-
-    async def test_media_restricts_by_chat_id(self):
-        """serve_media enforces chat-level access for restricted users."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            web_main._media_root = web_main.Path(tmpdir)
-            # Create media file under chat folder
             chat_dir = os.path.join(tmpdir, "123")
             os.makedirs(chat_dir)
-            with open(os.path.join(chat_dir, "photo.jpg"), "w") as f:
-                f.write("img")
+            test_file = os.path.join(chat_dir, "test.txt")
+            with open(test_file, "w") as f:
+                f.write("content")
+            self.mock_db.get_chat_by_ref = AsyncMock(
+                return_value={"id": 123, "account_id": 1, "ref": "servesFileRef000123AB", "type": "group"}
+            )
+            self.mock_db.get_media_by_id = AsyncMock(
+                return_value={"id": "123_5_document", "file_path": "123/test.txt", "file_name": "test.txt"}
+            )
+            async with self._client() as client:
+                resp = await client.get("/media/servesFileRef000123AB/5_document")
+            self.assertEqual(resp.status_code, 200)
+            # The storage key is reconstructed from the resolved chat, not the URL
+            self.mock_db.get_media_by_id.assert_awaited_once_with("123_5_document", account_id=1)
 
+    async def test_media_404_for_nonexistent_file(self):
+        """serve_media returns 404 when the row's file is gone from disk."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            web_main._media_root = web_main.Path(tmpdir)
+            self.mock_db.get_media_by_id = AsyncMock(
+                return_value={"id": "1_5_photo", "file_path": "1/gone.jpg", "file_name": "gone.jpg"}
+            )
+            async with self._client() as client:
+                resp = await client.get("/media/someChatRef000000042A/5_photo")
+            self.assertEqual(resp.status_code, 404)
+
+    async def test_media_restricts_by_chat_ref(self):
+        """serve_media denies a chat outside the session's ref grant — with the
+        SAME 404 an unknown ref gets (no forbidden-vs-nonexistent oracle)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            web_main._media_root = web_main.Path(tmpdir)
             web_main.AUTH_ENABLED = True
             token = "restricted-media"
-            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={999})
+            web_main._sessions[token] = web_main.SessionData(
+                username="v1", role="viewer", allowed_chat_refs={"grantedRef00000000999"}
+            )
             async with self._client() as client:
-                resp = await client.get("/media/123/photo.jpg", cookies={"viewer_auth": token})
-            self.assertEqual(resp.status_code, 403)
-
-    async def test_media_acl_enforced_on_resolved_path_not_url(self):
-        """ACL bypass prevention: user requests positive folder, file resolves to
-        a negative folder the user does NOT have access to — must deny."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            media_root = web_main.Path(tmpdir).resolve()
-            web_main._media_root = media_root
-            # File lives under negative folder -999 (the actual chat folder on disk)
-            denied_dir = os.path.join(tmpdir, "-999")
-            os.makedirs(denied_dir)
-            with open(os.path.join(denied_dir, "secret.jpg"), "w") as f:
-                f.write("secret")
-
-            web_main.AUTH_ENABLED = True
-            token = "acl-bypass-test"
-            # User only has access to chat 555, NOT -999
-            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={555})
-            # Request via positive folder "999" — legacy fallback resolves to "-999"
-            async with self._client() as client:
-                resp = await client.get("/media/999/secret.jpg", cookies={"viewer_auth": token})
-            self.assertEqual(resp.status_code, 403)
+                resp = await client.get("/media/forbiddenRef000000123/5_photo", cookies={"viewer_auth": token})
+                unknown = await client.get("/media/unknownRef00000000xyz/5_photo", cookies={"viewer_auth": token})
+                self.mock_db.get_chat_by_ref = AsyncMock(return_value=None)
+                missing = await client.get("/media/unknownRef00000000xyz/5_photo", cookies={"viewer_auth": token})
+            self.assertEqual(resp.status_code, 404)
+            self.assertEqual((resp.status_code, resp.text), (missing.status_code, missing.text))
+            self.assertEqual((unknown.status_code, unknown.text), (missing.status_code, missing.text))
 
     async def test_media_acl_allows_resolved_path_when_authorized(self):
-        """User with access to the resolved negative chat can access via positive folder."""
+        """The pre-v4.0.5 legacy folder fallback still resolves THROUGH the row:
+        a row recorded with the positive folder serves from the negative one."""
         with tempfile.TemporaryDirectory() as tmpdir:
             media_root = web_main.Path(tmpdir).resolve()
             web_main._media_root = media_root
-            denied_dir = os.path.join(tmpdir, "-999")
-            os.makedirs(denied_dir)
-            with open(os.path.join(denied_dir, "photo.jpg"), "w") as f:
+            on_disk_dir = os.path.join(tmpdir, "-999")
+            os.makedirs(on_disk_dir)
+            with open(os.path.join(on_disk_dir, "photo.jpg"), "w") as f:
                 f.write("img")
 
             web_main.AUTH_ENABLED = True
             token = "acl-allow-test"
-            # User has access to -999 (the resolved folder)
-            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={-999})
+            web_main._sessions[token] = web_main.SessionData(
+                username="v1", role="viewer", allowed_chat_refs={"legacyFolderRef0099AB"}
+            )
+            self.mock_db.get_chat_by_ref = AsyncMock(
+                return_value={"id": -999, "account_id": 1, "ref": "legacyFolderRef0099AB", "type": "group"}
+            )
+            self.mock_db.get_media_by_id = AsyncMock(
+                return_value={"id": "-999_5_photo", "file_path": "999/photo.jpg", "file_name": "photo.jpg"}
+            )
             async with self._client() as client:
-                resp = await client.get("/media/999/photo.jpg", cookies={"viewer_auth": token})
+                resp = await client.get("/media/legacyFolderRef0099AB/5_photo", cookies={"viewer_auth": token})
             self.assertEqual(resp.status_code, 200)
 
     async def test_media_rejects_shared_folder_for_restricted_user(self):
-        """Restricted users cannot fetch deduplicated _shared files directly."""
+        """Direct addressing of _shared dedup files is gone: the first segment is
+        a chat ref now, and '_shared' resolves to no chat."""
         with tempfile.TemporaryDirectory() as tmpdir:
             web_main._media_root = web_main.Path(tmpdir)
             shared_dir = os.path.join(tmpdir, "_shared")
@@ -432,10 +455,13 @@ class TestServeMedia(_WebTestBase):
 
             web_main.AUTH_ENABLED = True
             token = "restricted-shared"
-            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={123})
+            web_main._sessions[token] = web_main.SessionData(
+                username="v1", role="viewer", allowed_chat_refs={"grantedRef00000000123"}
+            )
+            self.mock_db.get_chat_by_ref = AsyncMock(return_value=None)
             async with self._client() as client:
                 resp = await client.get("/media/_shared/secret.jpg", cookies={"viewer_auth": token})
-            self.assertEqual(resp.status_code, 403)
+            self.assertEqual(resp.status_code, 404)
 
     async def test_media_rejects_original_file_for_no_download_user(self):
         """no_download users cannot fetch original media bytes by omitting download=1."""
@@ -449,43 +475,34 @@ class TestServeMedia(_WebTestBase):
             web_main.AUTH_ENABLED = True
             token = "no-download-original"
             web_main._sessions[token] = web_main.SessionData(
-                username="v1", role="viewer", allowed_chat_ids={123}, no_download=True
+                username="v1", role="viewer", allowed_chat_refs={"noDownloadRef00000123"}, no_download=True
             )
             async with self._client() as client:
-                resp = await client.get("/media/123/photo.jpg", cookies={"viewer_auth": token})
+                resp = await client.get("/media/noDownloadRef00000123/5_photo", cookies={"viewer_auth": token})
             self.assertEqual(resp.status_code, 403)
 
     async def test_media_avatar_access_check(self):
-        """serve_media enforces chat-level access for avatar paths."""
+        """/media/avatar/{chat_ref} denies a chat outside the grant with the uniform 404."""
         with tempfile.TemporaryDirectory() as tmpdir:
             web_main._media_root = web_main.Path(tmpdir)
-            avatar_dir = os.path.join(tmpdir, "avatars", "chats")
-            os.makedirs(avatar_dir)
-            with open(os.path.join(avatar_dir, "456_789.jpg"), "w") as f:
-                f.write("avatar")
-
             web_main.AUTH_ENABLED = True
             token = "av-restricted"
-            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={100})
+            web_main._sessions[token] = web_main.SessionData(
+                username="v1", role="viewer", allowed_chat_refs={"grantedRef00000000100"}
+            )
             async with self._client() as client:
-                resp = await client.get("/media/avatars/chats/456_789.jpg", cookies={"viewer_auth": token})
-            self.assertEqual(resp.status_code, 403)
+                resp = await client.get("/media/avatar/forbiddenRef000000456", cookies={"viewer_auth": token})
+            self.assertEqual(resp.status_code, 404)
 
-    async def test_media_avatar_invalid_chat_id_format(self):
-        """serve_media returns 403 for avatar with non-numeric filename."""
+    async def test_sender_avatar_404_when_message_has_no_sender(self):
+        """/media/avatar/{chat_ref}/{message_id} answers 404 when the message
+        resolves to no sender (service message, unknown id)."""
         with tempfile.TemporaryDirectory() as tmpdir:
             web_main._media_root = web_main.Path(tmpdir)
-            avatar_dir = os.path.join(tmpdir, "avatars", "users")
-            os.makedirs(avatar_dir)
-            with open(os.path.join(avatar_dir, "badname.jpg"), "w") as f:
-                f.write("avatar")
-
-            web_main.AUTH_ENABLED = True
-            token = "av-bad"
-            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={100})
+            self.mock_db.get_message_sender_id = AsyncMock(return_value=None)
             async with self._client() as client:
-                resp = await client.get("/media/avatars/users/badname.jpg", cookies={"viewer_auth": token})
-            self.assertEqual(resp.status_code, 403)
+                resp = await client.get("/media/avatar/someChatRef000000100A/77")
+            self.assertEqual(resp.status_code, 404)
 
 
 # ============================================================================
@@ -495,36 +512,46 @@ class TestServeMedia(_WebTestBase):
 
 @_skip_unless_web
 class TestServeThumbnail(_WebTestBase):
-    """Test /media/thumb/{size}/{folder}/{filename} endpoint."""
+    """Test /media/thumb/{size}/{chat_ref}/{media_key} endpoint."""
+
+    def _media_row(self):
+        return {"id": "1_5_photo", "file_path": "123/photo.jpg", "file_name": "photo.jpg"}
 
     async def test_thumbnail_404_when_no_media_root(self):
         """serve_thumbnail returns 404 when media directory not configured."""
         web_main._media_root = None
         async with self._client() as client:
-            resp = await client.get("/media/thumb/200/123/photo.jpg")
+            resp = await client.get("/media/thumb/200/someChatRef000000123A/5_photo")
         self.assertEqual(resp.status_code, 404)
 
-    async def test_thumbnail_restricts_by_chat_id(self):
-        """serve_thumbnail enforces chat-level access for restricted users."""
+    async def test_thumbnail_restricts_by_chat_ref(self):
+        """serve_thumbnail denies a chat outside the ref grant with the uniform 404."""
         with tempfile.TemporaryDirectory() as tmpdir:
             web_main._media_root = web_main.Path(tmpdir)
             web_main.AUTH_ENABLED = True
             token = "th-restrict"
-            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={999})
+            web_main._sessions[token] = web_main.SessionData(
+                username="v1", role="viewer", allowed_chat_refs={"grantedRef00000000999"}
+            )
             async with self._client() as client:
-                resp = await client.get("/media/thumb/200/123/photo.jpg", cookies={"viewer_auth": token})
-            self.assertEqual(resp.status_code, 403)
+                resp = await client.get(
+                    "/media/thumb/200/forbiddenRef000000123/5_photo", cookies={"viewer_auth": token}
+                )
+            self.assertEqual(resp.status_code, 404)
 
     async def test_thumbnail_rejects_shared_folder_for_restricted_user(self):
-        """Restricted users cannot request thumbnails for non-chat media folders."""
+        """'_shared' is not a chat ref: direct thumbnail addressing of dedup files is gone."""
         with tempfile.TemporaryDirectory() as tmpdir:
             web_main._media_root = web_main.Path(tmpdir)
             web_main.AUTH_ENABLED = True
             token = "th-shared"
-            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={123})
+            web_main._sessions[token] = web_main.SessionData(
+                username="v1", role="viewer", allowed_chat_refs={"grantedRef00000000123"}
+            )
+            self.mock_db.get_chat_by_ref = AsyncMock(return_value=None)
             async with self._client() as client:
                 resp = await client.get("/media/thumb/200/_shared/secret.jpg", cookies={"viewer_auth": token})
-            self.assertEqual(resp.status_code, 403)
+            self.assertEqual(resp.status_code, 404)
 
     async def test_thumbnail_rejects_no_download_for_media_bytes(self):
         """no_download users cannot fetch derived thumbnail bytes for media."""
@@ -533,47 +560,41 @@ class TestServeThumbnail(_WebTestBase):
             web_main.AUTH_ENABLED = True
             token = "th-no-download"
             web_main._sessions[token] = web_main.SessionData(
-                username="v1", role="viewer", allowed_chat_ids={123}, no_download=True
+                username="v1", role="viewer", allowed_chat_refs={"noDownloadRef00000123"}, no_download=True
             )
             async with self._client() as client:
-                resp = await client.get("/media/thumb/200/123/photo.jpg", cookies={"viewer_auth": token})
-            self.assertEqual(resp.status_code, 403)
-
-    async def test_thumbnail_avatar_access_check(self):
-        """serve_thumbnail enforces access for avatar thumbnails."""
-        with tempfile.TemporaryDirectory() as tmpdir:
-            web_main._media_root = web_main.Path(tmpdir)
-            web_main.AUTH_ENABLED = True
-            token = "th-av"
-            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={100})
-            async with self._client() as client:
                 resp = await client.get(
-                    "/media/thumb/100/avatars/chats/456_789.jpg",
-                    cookies={"viewer_auth": token},
+                    "/media/thumb/200/noDownloadRef00000123/5_photo", cookies={"viewer_auth": token}
                 )
             self.assertEqual(resp.status_code, 403)
 
-    async def test_thumbnail_avatar_invalid_format(self):
-        """serve_thumbnail returns 403 for avatar with invalid chat ID format."""
+    async def test_thumbnail_legacy_avatar_url_404s_at_routing(self):
+        """The old path-addressed avatar thumbnail shape no longer matches any route."""
         with tempfile.TemporaryDirectory() as tmpdir:
             web_main._media_root = web_main.Path(tmpdir)
-            web_main.AUTH_ENABLED = True
-            token = "th-bad"
-            web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={100})
             async with self._client() as client:
-                resp = await client.get(
-                    "/media/thumb/100/avatars/users/badname.jpg",
-                    cookies={"viewer_auth": token},
-                )
-            self.assertEqual(resp.status_code, 403)
+                resp = await client.get("/media/thumb/100/avatars/chats/456_789.jpg")
+            self.assertEqual(resp.status_code, 404)
+
+    async def test_thumbnail_404_when_row_path_has_no_folder(self):
+        """A media row whose file_path has no folder segment cannot be thumbnailed."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            web_main._media_root = web_main.Path(tmpdir)
+            self.mock_db.get_media_by_id = AsyncMock(
+                return_value={"id": "1_5_photo", "file_path": "bare.jpg", "file_name": "bare.jpg"}
+            )
+            async with self._client() as client:
+                resp = await client.get("/media/thumb/200/someChatRef000000123A/5_photo")
+            self.assertEqual(resp.status_code, 404)
 
     async def test_thumbnail_returns_404_when_not_generated(self):
         """serve_thumbnail returns 404 when thumbnail generation returns None."""
         with tempfile.TemporaryDirectory() as tmpdir:
             web_main._media_root = web_main.Path(tmpdir)
+            self.mock_db.get_media_by_id = AsyncMock(return_value=self._media_row())
             with patch("src.web.thumbnails.ensure_thumbnail", new_callable=AsyncMock, return_value=None):
                 async with self._client() as client:
-                    resp = await client.get("/media/thumb/200/123/photo.jpg")
+                    resp = await client.get("/media/thumb/200/someChatRef000000123A/5_photo")
             self.assertEqual(resp.status_code, 404)
 
     async def test_thumbnail_serves_generated_file(self):
@@ -583,15 +604,20 @@ class TestServeThumbnail(_WebTestBase):
             thumb_file = os.path.join(tmpdir, "thumb.webp")
             with open(thumb_file, "wb") as f:
                 f.write(b"\x00" * 10)
+            self.mock_db.get_media_by_id = AsyncMock(return_value=self._media_row())
             with patch(
                 "src.web.thumbnails.ensure_thumbnail",
                 new_callable=AsyncMock,
                 return_value=(web_main.Path(thumb_file), "123"),
-            ):
+            ) as mock_ensure:
                 async with self._client() as client:
-                    resp = await client.get("/media/thumb/200/123/photo.jpg")
+                    resp = await client.get("/media/thumb/200/someChatRef000000123A/5_photo")
             self.assertEqual(resp.status_code, 200)
             self.assertIn("image/webp", resp.headers.get("content-type", ""))
+            # The folder/filename handed to ensure_thumbnail come from the media
+            # row's file_path, never from the URL.
+            call_args = mock_ensure.call_args[0]
+            self.assertEqual((call_args[2], call_args[3]), ("123", "photo.jpg"))
 
 
 # ============================================================================
@@ -865,7 +891,7 @@ class TestTokenAuthEdgeCases(_WebTestBase):
 
 @_skip_unless_web
 class TestExportEndpoint(_WebTestBase):
-    """Test /api/chats/{chat_id}/export endpoint."""
+    """Test /api/chats/{chat_ref}/export endpoint."""
 
     async def test_export_returns_403_for_no_download_user(self):
         """export_chat returns 403 when user has no_download restriction."""
@@ -873,30 +899,36 @@ class TestExportEndpoint(_WebTestBase):
         token = "nd-export"
         web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", no_download=True)
         async with self._client() as client:
-            resp = await client.get("/api/chats/1/export", cookies={"viewer_auth": token})
+            resp = await client.get("/api/chats/someChatRef000000001A/export", cookies={"viewer_auth": token})
         self.assertEqual(resp.status_code, 403)
 
-    async def test_export_returns_403_for_restricted_chat(self):
-        """export_chat returns 403 when user cannot access the chat."""
+    async def test_export_returns_404_for_restricted_chat(self):
+        """export_chat answers a forbidden ref with the SAME 404 as an unknown one."""
         web_main.AUTH_ENABLED = True
         token = "restricted-export"
-        web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={100})
+        web_main._sessions[token] = web_main.SessionData(
+            username="v1", role="viewer", allowed_chat_refs={"grantedRef00000000100"}
+        )
         async with self._client() as client:
-            resp = await client.get("/api/chats/999/export", cookies={"viewer_auth": token})
-        self.assertEqual(resp.status_code, 403)
+            resp = await client.get("/api/chats/forbiddenRef000000999/export", cookies={"viewer_auth": token})
+        self.assertEqual(resp.status_code, 404)
 
     async def test_export_returns_404_when_chat_not_found(self):
-        """export_chat returns 404 when chat doesn't exist."""
-        self.mock_db.get_chat_by_id = AsyncMock(return_value=None)
+        """export_chat returns 404 when the ref resolves to no chat."""
+        self.mock_db.get_chat_by_ref = AsyncMock(return_value=None)
         async with self._client() as client:
-            resp = await client.get("/api/chats/999/export")
+            resp = await client.get("/api/chats/unknownRef00000000999/export")
         self.assertEqual(resp.status_code, 404)
 
     async def test_export_streams_json_successfully(self):
-        """export_chat streams JSON for a valid chat."""
+        """export_chat streams JSON for a valid chat; the chat object gains the ref."""
+        self.mock_db.get_chat_by_ref = AsyncMock(
+            return_value={"id": 42, "account_id": 1, "ref": "exportChatRef00042AB", "type": "private"}
+        )
         self.mock_db.get_chat_by_id = AsyncMock(
             return_value={
                 "id": 42,
+                "ref": "exportChatRef00042AB",
                 "type": "private",
                 "title": "Test Chat",
                 "username": "testchat",
@@ -905,24 +937,24 @@ class TestExportEndpoint(_WebTestBase):
             }
         )
 
-        async def fake_versions(chat_id):
+        async def fake_versions(chat_id, account_id=None):
             yield {"message_id": 2, "chat_id": 42, "text": "old", "date": "2025-01-01"}
 
         self.mock_db.iter_message_versions_for_export = fake_versions
 
-        async def fake_export(chat_id):
+        async def fake_export(chat_id, account_id=None):
             yield {"id": 1, "text": "hello", "date": "2025-01-01"}
             yield {"id": 2, "text": "world", "date": "2025-01-02"}
 
         self.mock_db.get_messages_for_export = fake_export
 
         async with self._client() as client:
-            resp = await client.get("/api/chats/42/export")
+            resp = await client.get("/api/chats/exportChatRef00042AB/export")
         self.assertEqual(resp.status_code, 200)
         data = json.loads(resp.text)
         self.assertEqual(
             data["chat"],
-            {"id": 42, "type": "private", "title": "Test Chat", "username": "testchat"},
+            {"id": 42, "ref": "exportChatRef00042AB", "type": "private", "title": "Test Chat", "username": "testchat"},
         )
         self.assertNotIn("phone", data["chat"])
         self.assertNotIn("description", data["chat"])
@@ -932,10 +964,10 @@ class TestExportEndpoint(_WebTestBase):
         self.assertEqual(data["message_versions"][0]["text"], "old")
 
     async def test_export_handles_db_error(self):
-        """export_chat returns 500 on db error."""
+        """export_chat returns 500 on db error inside the handler."""
         self.mock_db.get_chat_by_id = AsyncMock(side_effect=RuntimeError("db error"))
         async with self._client() as client:
-            resp = await client.get("/api/chats/1/export")
+            resp = await client.get("/api/chats/someChatRef000000001A/export")
         self.assertEqual(resp.status_code, 500)
 
 
@@ -968,13 +1000,13 @@ class TestAdminViewerUpdateEdgeCases(_MasterTestBase):
             resp = await client.put("/api/admin/viewers/1", json={"password": "short"})
         self.assertEqual(resp.status_code, 400)
 
-    async def test_update_viewer_allowed_chat_ids_null(self):
-        """update_viewer sets allowed_chat_ids to None."""
+    async def test_update_viewer_allowed_chat_refs_null(self):
+        """update_viewer accepts allowed_chat_refs: null (unrestricted)."""
         self.mock_db.get_viewer_account = AsyncMock(return_value={"id": 1, "username": "v1"})
         async with self._client() as client:
             resp = await client.put(
                 "/api/admin/viewers/1",
-                json={"allowed_chat_ids": None},
+                json={"allowed_chat_refs": None},
             )
         self.assertEqual(resp.status_code, 200)
 
@@ -1039,7 +1071,7 @@ class TestAdminTokenEdgeCases(_MasterTestBase):
             resp = await client.post(
                 "/api/admin/tokens",
                 json={
-                    "allowed_chat_ids": [1, 2],
+                    "allowed_chat_refs": ["tokenRefA0000000001AB", "tokenRefB0000000002AB"],
                     "expires_at": "2030-01-01T00:00:00Z",
                 },
             )
@@ -1052,7 +1084,7 @@ class TestAdminTokenEdgeCases(_MasterTestBase):
         async with self._client() as client:
             resp = await client.post(
                 "/api/admin/tokens",
-                json={"allowed_chat_ids": [1], "expires_at": "not-a-date"},
+                json={"allowed_chat_refs": ["tokenRefA0000000001AB"], "expires_at": "not-a-date"},
             )
         self.assertEqual(resp.status_code, 400)
 
@@ -1125,7 +1157,7 @@ class TestAdminTokenEdgeCases(_MasterTestBase):
         async with self._client() as client:
             resp = await client.post(
                 "/api/admin/tokens",
-                json={"allowed_chat_ids": [1], "no_download": True, "label": "nd"},
+                json={"allowed_chat_refs": ["tokenRefA0000000001AB"], "no_download": True, "label": "nd"},
             )
         self.assertEqual(resp.status_code, 200)
 
@@ -1205,11 +1237,32 @@ class TestPushEndpointEdgeCases(_WebTestBase):
                 )
         self.assertEqual(resp.status_code, 500)
 
-    async def test_subscribe_with_chat_id_restricted(self):
-        """push_subscribe returns 403 when user can't access the chat."""
+    async def test_subscribe_with_chat_ref_restricted(self):
+        """push_subscribe answers a forbidden chat_ref with the uniform 404."""
         web_main.AUTH_ENABLED = True
         token = "push-restrict"
-        web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={100})
+        web_main._sessions[token] = web_main.SessionData(
+            username="v1", role="viewer", allowed_chat_refs={"grantedRef00000000100"}
+        )
+        mock_pm = MagicMock()
+        mock_pm.is_enabled = True
+        web_main.push_manager = mock_pm
+        with patch("src.web.push.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("8.8.8.8", 443))]):
+            async with self._client() as client:
+                resp = await client.post(
+                    "/api/push/subscribe",
+                    json={
+                        "endpoint": "https://push.example.com/sub",
+                        "keys": {"p256dh": "k", "auth": "a"},
+                        "chat_ref": "forbiddenRef000000999",
+                    },
+                    cookies={"viewer_auth": token},
+                )
+        self.assertEqual(resp.status_code, 404)
+
+    async def test_subscribe_rejects_legacy_chat_id_field(self):
+        """A 7.x chat_id in the body is refused: silently dropping the scoping
+        request would store a GLOBAL subscription (a widening)."""
         mock_pm = MagicMock()
         mock_pm.is_enabled = True
         web_main.push_manager = mock_pm
@@ -1222,9 +1275,9 @@ class TestPushEndpointEdgeCases(_WebTestBase):
                         "keys": {"p256dh": "k", "auth": "a"},
                         "chat_id": 999,
                     },
-                    cookies={"viewer_auth": token},
                 )
-        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("chat_ref", resp.json()["detail"])
 
     async def test_subscribe_db_connection_error(self):
         """push_subscribe returns 503 on DB connection error."""
@@ -1407,9 +1460,17 @@ class TestCreateSessionWithDb(_WebTestBase):
 
     async def test_creates_session_with_db_persistence(self):
         """_create_session persists session to DB when db is available."""
-        token = await web_main._create_session("admin", "master", allowed_chat_ids={1, 2})
+        token = await web_main._create_session(
+            "admin", "master", allowed_chat_refs={"sessionRefA000000001A", "sessionRefB000000002A"}
+        )
         self.assertIn(token, web_main._sessions)
         self.mock_db.save_session.assert_awaited_once()
+        save_kwargs = self.mock_db.save_session.call_args.kwargs
+        self.assertEqual(
+            json.loads(save_kwargs["allowed_chat_refs"]), ["sessionRefA000000001A", "sessionRefB000000002A"]
+        )
+        # Rollback tombstone: a restricted 8.0 session denies under a 7.x binary too.
+        self.assertEqual(save_kwargs["allowed_chat_ids"], "[]")
 
     async def test_handles_db_save_failure(self):
         """_create_session succeeds even when DB save fails."""
@@ -1642,7 +1703,9 @@ class TestRealtimeNotificationPushNoSender(_WebTestBase):
         mock_pm.is_enabled = True
         mock_pm.notify_new_message = AsyncMock(return_value=1)
         web_main.push_manager = mock_pm
-        self.mock_db.get_chat_by_id = AsyncMock(return_value=None)
+        self.mock_db.get_chat_by_id = AsyncMock(
+            return_value={"id": 42, "account_id": 1, "ref": "pushChatRef0000042AB", "title": None}
+        )
         self.mock_db.get_user_by_id = AsyncMock(return_value=None)
 
         with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock):
@@ -1657,6 +1720,7 @@ class TestRealtimeNotificationPushNoSender(_WebTestBase):
         mock_pm.notify_new_message.assert_awaited_once()
         call_kwargs = mock_pm.notify_new_message.call_args.kwargs
         self.assertEqual(call_kwargs["sender_name"], "")
+        self.assertEqual(call_kwargs["chat_ref"], "pushChatRef0000042AB")
 
     async def test_push_with_no_sender_id(self):
         """Push notification works when message has no sender_id."""
@@ -1664,7 +1728,9 @@ class TestRealtimeNotificationPushNoSender(_WebTestBase):
         mock_pm.is_enabled = True
         mock_pm.notify_new_message = AsyncMock(return_value=1)
         web_main.push_manager = mock_pm
-        self.mock_db.get_chat_by_id = AsyncMock(return_value={"title": "Chat"})
+        self.mock_db.get_chat_by_id = AsyncMock(
+            return_value={"id": 42, "account_id": 1, "ref": "pushChatRef0000042AB", "title": "Chat"}
+        )
 
         with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock):
             await web_main.handle_realtime_notification(
@@ -1679,15 +1745,16 @@ class TestRealtimeNotificationPushNoSender(_WebTestBase):
         call_kwargs = mock_pm.notify_new_message.call_args.kwargs
         self.assertEqual(call_kwargs["sender_name"], "")
 
-    async def test_push_with_no_db(self):
-        """Push notification handles missing db gracefully."""
+    async def test_push_with_no_db_drops_the_event(self):
+        """Without a db the chat id cannot be resolved to its ref, so v8.0 drops
+        the event entirely rather than emit an id-addressed frame or push."""
         mock_pm = MagicMock()
         mock_pm.is_enabled = True
         mock_pm.notify_new_message = AsyncMock(return_value=0)
         web_main.push_manager = mock_pm
         web_main.db = None
 
-        with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock):
+        with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock) as mock_bc:
             await web_main.handle_realtime_notification(
                 {
                     "type": "new_message",
@@ -1696,7 +1763,8 @@ class TestRealtimeNotificationPushNoSender(_WebTestBase):
                 }
             )
 
-        mock_pm.notify_new_message.assert_awaited_once()
+        mock_bc.assert_not_awaited()
+        mock_pm.notify_new_message.assert_not_awaited()
 
 
 # ============================================================================
@@ -1741,12 +1809,16 @@ class TestPushSubscribe(unittest.IsolatedAsyncioTestCase):
             chat_id=42,
             user_agent="TestBrowser",
             username="testuser",
-            allowed_chat_ids=[1, 2, 3],
+            allowed_chat_refs=["subRefA0000000000001A", "subRefB0000000000002A"],
         )
 
         self.assertTrue(result)
         mock_session.add.assert_called_once()
         mock_session.commit.assert_awaited_once()
+        stored = mock_session.add.call_args[0][0]
+        self.assertEqual(json.loads(stored.allowed_chat_refs), ["subRefA0000000000001A", "subRefB0000000000002A"])
+        # Restricted subscriber → legacy column holds the deny-all tombstone.
+        self.assertEqual(stored.allowed_chat_ids, "[]")
 
     async def test_subscribe_updates_existing_subscription(self):
         """subscribe updates existing subscription when endpoint found."""
@@ -1858,6 +1930,8 @@ class TestPushGetSubscriptions(unittest.IsolatedAsyncioTestCase):
         mock_sub.p256dh = "key1"
         mock_sub.auth = "auth1"
         mock_sub.allowed_chat_ids = None  # Master user, no restriction
+        mock_sub.allowed_accounts = None
+        mock_sub.allowed_chat_refs = None
 
         mock_session = AsyncMock()
         mock_result = MagicMock()
@@ -1876,20 +1950,24 @@ class TestPushGetSubscriptions(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result[0]["endpoint"], "https://push.example.com/sub1")
 
     async def test_get_subscriptions_filters_by_allowed_chats(self):
-        """get_subscriptions filters out subs where user can't see the chat."""
+        """get_subscriptions filters out subs whose ref grant excludes the chat."""
         mgr = _make_push_manager()
 
         mock_sub1 = MagicMock()
         mock_sub1.endpoint = "https://push.example.com/allowed"
         mock_sub1.p256dh = "k1"
         mock_sub1.auth = "a1"
-        mock_sub1.allowed_chat_ids = json.dumps([42, 43])
+        mock_sub1.allowed_chat_ids = "[]"  # rollback tombstone, never read as a grant
+        mock_sub1.allowed_accounts = None
+        mock_sub1.allowed_chat_refs = json.dumps(["pushRefAllowed000042A", "pushRefAllowed000043A"])
 
         mock_sub2 = MagicMock()
         mock_sub2.endpoint = "https://push.example.com/denied"
         mock_sub2.p256dh = "k2"
         mock_sub2.auth = "a2"
-        mock_sub2.allowed_chat_ids = json.dumps([100, 200])
+        mock_sub2.allowed_chat_ids = "[]"
+        mock_sub2.allowed_accounts = None
+        mock_sub2.allowed_chat_refs = json.dumps(["pushRefOther000000100"])
 
         mock_session = AsyncMock()
         mock_result = MagicMock()
@@ -1903,12 +1981,12 @@ class TestPushGetSubscriptions(unittest.IsolatedAsyncioTestCase):
         mock_ctx.__aexit__ = AsyncMock(return_value=None)
         mgr.db.db_manager.async_session_factory.return_value = mock_ctx
 
-        result = await mgr.get_subscriptions(chat_id=42)
+        result = await mgr.get_subscriptions(chat_id=42, account_id=1, chat_ref="pushRefAllowed000042A")
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]["endpoint"], "https://push.example.com/allowed")
 
     async def test_get_subscriptions_without_chat_id(self):
-        """get_subscriptions returns all subscriptions when no chat_id."""
+        """get_subscriptions returns unrestricted subscriptions when no chat context."""
         mgr = _make_push_manager()
 
         mock_sub = MagicMock()
@@ -1916,6 +1994,8 @@ class TestPushGetSubscriptions(unittest.IsolatedAsyncioTestCase):
         mock_sub.p256dh = "k"
         mock_sub.auth = "a"
         mock_sub.allowed_chat_ids = None
+        mock_sub.allowed_accounts = None
+        mock_sub.allowed_chat_refs = None
 
         mock_session = AsyncMock()
         mock_result = MagicMock()
@@ -1945,14 +2025,17 @@ class TestPushGetSubscriptions(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(result, [])
 
     async def test_get_subscriptions_handles_corrupted_json(self):
-        """get_subscriptions skips subs with corrupted allowed_chat_ids."""
+        """get_subscriptions skips subs with a corrupted allowed_chat_refs grant
+        (unparseable → the empty grant → receives nothing, fail-closed)."""
         mgr = _make_push_manager()
 
         mock_sub = MagicMock()
         mock_sub.endpoint = "https://push.example.com/bad"
         mock_sub.p256dh = "k"
         mock_sub.auth = "a"
-        mock_sub.allowed_chat_ids = "not valid json {"
+        mock_sub.allowed_chat_ids = None
+        mock_sub.allowed_accounts = None
+        mock_sub.allowed_chat_refs = "not valid json {"
 
         mock_session = AsyncMock()
         mock_result = MagicMock()

--- a/tests/test_web_main.py
+++ b/tests/test_web_main.py
@@ -30,6 +30,16 @@ def _skip_unless_web_main(cls_or_fn):
     return unittest.skipUnless(_WEB_MAIN_AVAILABLE, "web_main import failed (pydantic mismatch)")(cls_or_fn)
 
 
+def _user(role="master", **kwargs):
+    """A UserContext for ConnectionManager tests (v8.0: sockets carry their principal)."""
+    return web_main.UserContext(username="u", role=role, **kwargs)
+
+
+def _chat_row(chat_id, ref, account_id=1):
+    """The resolved chat row shape broadcast_to_chat consumes (id, account_id, ref)."""
+    return {"id": chat_id, "account_id": account_id, "ref": ref, "type": "group"}
+
+
 # ============================================================================
 # ConnectionManager (pure async, no FastAPI dependency beyond WebSocket type)
 # ============================================================================
@@ -45,21 +55,22 @@ class TestConnectionManagerConnect(unittest.IsolatedAsyncioTestCase):
     async def test_connect_adds_websocket(self):
         """connect() adds websocket to active_connections."""
         ws = AsyncMock()
-        await self.mgr.connect(ws)
+        await self.mgr.connect(ws, _user())
         self.assertIn(ws, self.mgr.active_connections)
 
     async def test_connect_initializes_empty_subscription_set(self):
         """connect() creates an empty subscription set for the websocket."""
         ws = AsyncMock()
-        await self.mgr.connect(ws)
+        await self.mgr.connect(ws, _user())
         self.assertEqual(self.mgr.active_connections[ws], set())
 
     async def test_disconnect_removes_websocket(self):
-        """disconnect() removes websocket from active_connections."""
+        """disconnect() removes websocket and its user context."""
         ws = AsyncMock()
-        await self.mgr.connect(ws)
+        await self.mgr.connect(ws, _user())
         self.mgr.disconnect(ws)
         self.assertNotIn(ws, self.mgr.active_connections)
+        self.assertNotIn(ws, self.mgr._contexts)
 
     async def test_disconnect_nonexistent_is_noop(self):
         """disconnect() does not raise for unknown websocket."""
@@ -69,59 +80,73 @@ class TestConnectionManagerConnect(unittest.IsolatedAsyncioTestCase):
 
 @_skip_unless_web_main
 class TestConnectionManagerSubscribe(unittest.IsolatedAsyncioTestCase):
-    """Test ConnectionManager.subscribe and unsubscribe."""
+    """Test ConnectionManager.subscribe and unsubscribe (ref-keyed since v8.0)."""
 
     def setUp(self):
         self.mgr = web_main.ConnectionManager()
+        self._saved_display = web_main.config.display_chat_ids
+        web_main.config.display_chat_ids = set()
 
-    async def test_subscribe_adds_chat_id(self):
-        """subscribe() adds chat_id to connection's subscriptions."""
+    def tearDown(self):
+        web_main.config.display_chat_ids = self._saved_display
+
+    async def test_subscribe_adds_chat_ref(self):
+        """subscribe() adds the chat ref to the connection's subscriptions."""
         ws = AsyncMock()
-        await self.mgr.connect(ws)
-        result = self.mgr.subscribe(ws, 42)
+        await self.mgr.connect(ws, _user())
+        result = self.mgr.subscribe(ws, "refSubscribeAdd0000042")
         self.assertTrue(result)
-        self.assertIn(42, self.mgr.active_connections[ws])
+        self.assertIn("refSubscribeAdd0000042", self.mgr.active_connections[ws])
 
     async def test_subscribe_returns_false_for_unknown_ws(self):
         """subscribe() returns False for unregistered websocket."""
         ws = AsyncMock()
-        result = self.mgr.subscribe(ws, 42)
+        result = self.mgr.subscribe(ws, "refUnknownSocket000042")
         self.assertFalse(result)
 
-    async def test_subscribe_denied_by_acl(self):
-        """subscribe() returns False when chat_id not in allowed set."""
+    async def test_subscription_outside_grant_is_never_delivered(self):
+        """Entitlement moved to the endpoint resolver: subscribe() records the ref,
+        and the delivery re-check in broadcast_to_chat is what keeps a frame from
+        outrunning the grant (e.g. a grant revoked after subscribe)."""
         ws = AsyncMock()
-        await self.mgr.connect(ws, allowed_chat_ids={100, 200})
-        result = self.mgr.subscribe(ws, 999)
-        self.assertFalse(result)
-
-    async def test_subscribe_allowed_by_acl(self):
-        """subscribe() returns True when chat_id is in allowed set."""
-        ws = AsyncMock()
-        await self.mgr.connect(ws, allowed_chat_ids={100, 200})
-        result = self.mgr.subscribe(ws, 100)
+        await self.mgr.connect(ws, _user(role="viewer", allowed_chat_refs={"refGranted0000000100AA"}))
+        result = self.mgr.subscribe(ws, "refForbidden000000999A")
         self.assertTrue(result)
 
-    async def test_subscribe_allowed_when_acl_is_none(self):
-        """subscribe() allows any chat when allowed_chat_ids is None."""
-        ws = AsyncMock()
-        await self.mgr.connect(ws, allowed_chat_ids=None)
-        result = self.mgr.subscribe(ws, 999)
-        self.assertTrue(result)
+        await self.mgr.broadcast_to_chat(_chat_row(999, "refForbidden000000999A"), {"type": "test"})
+        ws.send_json.assert_not_awaited()
 
-    async def test_unsubscribe_removes_chat_id(self):
-        """unsubscribe() removes chat_id from subscriptions."""
+    async def test_subscription_within_grant_is_delivered(self):
+        """A subscription to a ref inside the session's grant receives frames."""
         ws = AsyncMock()
-        await self.mgr.connect(ws)
-        self.mgr.subscribe(ws, 42)
-        self.mgr.unsubscribe(ws, 42)
-        self.assertNotIn(42, self.mgr.active_connections[ws])
+        await self.mgr.connect(ws, _user(role="viewer", allowed_chat_refs={"refGranted0000000100AA"}))
+        self.mgr.subscribe(ws, "refGranted0000000100AA")
+
+        await self.mgr.broadcast_to_chat(_chat_row(100, "refGranted0000000100AA"), {"type": "test"})
+        ws.send_json.assert_awaited_once_with({"type": "test"})
+
+    async def test_unrestricted_user_receives_any_subscribed_ref(self):
+        """A None grant (unrestricted) delivers frames for any subscribed chat."""
+        ws = AsyncMock()
+        await self.mgr.connect(ws, _user(allowed_chat_refs=None))
+        self.mgr.subscribe(ws, "refAnyChatAtAll0000999A")
+
+        await self.mgr.broadcast_to_chat(_chat_row(999, "refAnyChatAtAll0000999A"), {"type": "test"})
+        ws.send_json.assert_awaited_once_with({"type": "test"})
+
+    async def test_unsubscribe_removes_chat_ref(self):
+        """unsubscribe() removes the chat ref from subscriptions."""
+        ws = AsyncMock()
+        await self.mgr.connect(ws, _user())
+        self.mgr.subscribe(ws, "refUnsubscribe00000042")
+        self.mgr.unsubscribe(ws, "refUnsubscribe00000042")
+        self.assertNotIn("refUnsubscribe00000042", self.mgr.active_connections[ws])
 
     async def test_unsubscribe_nonexistent_chat_is_noop(self):
         """unsubscribe() does not raise when chat was never subscribed."""
         ws = AsyncMock()
-        await self.mgr.connect(ws)
-        self.mgr.unsubscribe(ws, 999)  # should not raise
+        await self.mgr.connect(ws, _user())
+        self.mgr.unsubscribe(ws, "refNeverSubscribed999A")  # should not raise
 
 
 @_skip_unless_web_main
@@ -130,47 +155,54 @@ class TestConnectionManagerBroadcast(unittest.IsolatedAsyncioTestCase):
 
     def setUp(self):
         self.mgr = web_main.ConnectionManager()
+        self._saved_display = web_main.config.display_chat_ids
+        web_main.config.display_chat_ids = set()
+
+    def tearDown(self):
+        web_main.config.display_chat_ids = self._saved_display
 
     async def test_broadcast_to_chat_sends_to_subscribed(self):
-        """broadcast_to_chat sends message to connections subscribed to that chat."""
+        """broadcast_to_chat sends message to connections subscribed to that chat's ref."""
         ws1 = AsyncMock()
         ws2 = AsyncMock()
-        await self.mgr.connect(ws1)
-        await self.mgr.connect(ws2)
-        self.mgr.subscribe(ws1, 42)
-        # ws2 is not subscribed to 42
+        await self.mgr.connect(ws1, _user())
+        await self.mgr.connect(ws2, _user())
+        self.mgr.subscribe(ws1, "refBroadcast0000000042")
+        # ws2 is not subscribed to the ref
 
-        await self.mgr.broadcast_to_chat(42, {"type": "test"})
+        await self.mgr.broadcast_to_chat(_chat_row(42, "refBroadcast0000000042"), {"type": "test"})
 
         ws1.send_json.assert_awaited_once_with({"type": "test"})
         # Empty subscriptions no longer receive chat-specific events.
         ws2.send_json.assert_not_awaited()
 
     async def test_broadcast_to_chat_respects_acl(self):
-        """broadcast_to_chat skips connections whose ACL excludes the chat."""
+        """broadcast_to_chat re-checks each socket's grant against the chat at delivery."""
         ws = AsyncMock()
-        await self.mgr.connect(ws, allowed_chat_ids={100})
-        self.mgr.subscribe(ws, 100)
+        await self.mgr.connect(ws, _user(role="viewer", allowed_chat_refs={"refGranted0000000100AA"}))
+        # Force a subscription the grant does not cover: the delivery re-check
+        # is the guard, not the subscription set.
+        self.mgr.subscribe(ws, "refForbidden000000999A")
 
-        await self.mgr.broadcast_to_chat(999, {"type": "test"})
+        await self.mgr.broadcast_to_chat(_chat_row(999, "refForbidden000000999A"), {"type": "test"})
         ws.send_json.assert_not_awaited()
 
     async def test_broadcast_to_chat_disconnects_failed_ws(self):
         """broadcast_to_chat removes websockets that fail to send."""
         ws = AsyncMock()
         ws.send_json.side_effect = Exception("broken pipe")
-        await self.mgr.connect(ws)
-        self.mgr.subscribe(ws, 1)
+        await self.mgr.connect(ws, _user())
+        self.mgr.subscribe(ws, "refBrokenPipe000000001")
 
-        await self.mgr.broadcast_to_chat(1, {"type": "test"})
+        await self.mgr.broadcast_to_chat(_chat_row(1, "refBrokenPipe000000001"), {"type": "test"})
         self.assertNotIn(ws, self.mgr.active_connections)
 
     async def test_broadcast_to_all_sends_to_every_connection(self):
         """broadcast_to_all sends to all connected websockets."""
         ws1 = AsyncMock()
         ws2 = AsyncMock()
-        await self.mgr.connect(ws1)
-        await self.mgr.connect(ws2)
+        await self.mgr.connect(ws1, _user())
+        await self.mgr.connect(ws2, _user())
 
         await self.mgr.broadcast_to_all({"type": "ping"})
         ws1.send_json.assert_awaited_once()
@@ -180,7 +212,7 @@ class TestConnectionManagerBroadcast(unittest.IsolatedAsyncioTestCase):
         """broadcast_to_all removes broken websockets."""
         ws = AsyncMock()
         ws.send_json.side_effect = RuntimeError("closed")
-        await self.mgr.connect(ws)
+        await self.mgr.connect(ws, _user())
 
         await self.mgr.broadcast_to_all({"type": "ping"})
         self.assertNotIn(ws, self.mgr.active_connections)
@@ -404,53 +436,77 @@ class TestGetSecureCookies(unittest.TestCase):
 
 
 # ============================================================================
-# get_user_chat_ids (access control logic)
+# _visible_chat_id_set (access control logic; replaced get_user_chat_ids in v8.0)
 # ============================================================================
 
 
 @_skip_unless_web_main
-class TestGetUserChatIds(unittest.TestCase):
-    """Test get_user_chat_ids access control merging."""
+class TestVisibleChatIdSet(unittest.IsolatedAsyncioTestCase):
+    """Test _visible_chat_id_set: ref-based grants merged with DISPLAY_CHAT_IDS.
+
+    Entitlements are ref-keyed since v8.0, so the id set is computed by
+    filtering the chat list through _chat_visible rather than intersecting
+    id sets directly.
+    """
 
     def setUp(self):
         self._saved_display = web_main.config.display_chat_ids
+        self._saved_db = web_main.db
         web_main.config.display_chat_ids = set()
+        web_main.db = AsyncMock()
+        web_main.db.get_all_chats = AsyncMock(
+            return_value=[
+                _chat_row(5, "refChat0000000000005A"),
+                _chat_row(10, "refChat0000000000010A"),
+                _chat_row(20, "refChat0000000000020A"),
+                _chat_row(40, "refChat0000000000040A"),
+            ]
+        )
 
     def tearDown(self):
         web_main.config.display_chat_ids = self._saved_display
+        web_main.db = self._saved_db
 
-    def test_master_no_filter_returns_none(self):
+    async def test_master_no_filter_returns_none(self):
         """Master with no display_chat_ids returns None (all chats)."""
         user = web_main.UserContext(username="admin", role="master")
-        self.assertIsNone(web_main.get_user_chat_ids(user))
+        self.assertIsNone(await web_main._visible_chat_id_set(user))
 
-    def test_master_with_filter_returns_filter(self):
-        """Master with display_chat_ids returns the filter set."""
-        web_main.config.display_chat_ids = {1, 2, 3}
-        user = web_main.UserContext(username="admin", role="master")
-        self.assertEqual(web_main.get_user_chat_ids(user), {1, 2, 3})
-
-    def test_viewer_no_restrictions_no_filter_returns_none(self):
-        """Viewer with allowed_chat_ids=None and no display filter returns None."""
-        user = web_main.UserContext(username="viewer1", role="viewer", allowed_chat_ids=None)
-        self.assertIsNone(web_main.get_user_chat_ids(user))
-
-    def test_viewer_with_allowed_no_filter_returns_allowed(self):
-        """Viewer with allowed_chat_ids returns those IDs when no master filter."""
-        user = web_main.UserContext(username="viewer1", role="viewer", allowed_chat_ids={10, 20})
-        self.assertEqual(web_main.get_user_chat_ids(user), {10, 20})
-
-    def test_viewer_with_allowed_and_filter_returns_intersection(self):
-        """Viewer's allowed_chat_ids intersected with master display filter."""
-        web_main.config.display_chat_ids = {10, 20, 30}
-        user = web_main.UserContext(username="viewer1", role="viewer", allowed_chat_ids={20, 40})
-        self.assertEqual(web_main.get_user_chat_ids(user), {20})
-
-    def test_viewer_allowed_none_with_filter_returns_filter(self):
-        """Viewer with no restriction but master filter returns the filter."""
+    async def test_master_with_filter_returns_filter(self):
+        """Master with display_chat_ids sees only the filtered chats."""
         web_main.config.display_chat_ids = {5, 10}
-        user = web_main.UserContext(username="viewer1", role="viewer", allowed_chat_ids=None)
-        self.assertEqual(web_main.get_user_chat_ids(user), {5, 10})
+        user = web_main.UserContext(username="admin", role="master")
+        self.assertEqual(await web_main._visible_chat_id_set(user), {5, 10})
+
+    async def test_viewer_no_restrictions_no_filter_returns_none(self):
+        """Viewer with allowed_chat_refs=None and no display filter returns None."""
+        user = web_main.UserContext(username="viewer1", role="viewer", allowed_chat_refs=None)
+        self.assertIsNone(await web_main._visible_chat_id_set(user))
+
+    async def test_viewer_with_allowed_no_filter_returns_allowed(self):
+        """Viewer with a ref grant sees exactly those chats' ids."""
+        user = web_main.UserContext(
+            username="viewer1",
+            role="viewer",
+            allowed_chat_refs={"refChat0000000000010A", "refChat0000000000020A"},
+        )
+        self.assertEqual(await web_main._visible_chat_id_set(user), {10, 20})
+
+    async def test_viewer_with_allowed_and_filter_returns_intersection(self):
+        """A ref grant and the master display filter both bind (intersection)."""
+        web_main.config.display_chat_ids = {10, 20, 30}
+        user = web_main.UserContext(
+            username="viewer1",
+            role="viewer",
+            allowed_chat_refs={"refChat0000000000020A", "refChat0000000000040A"},
+        )
+        self.assertEqual(await web_main._visible_chat_id_set(user), {20})
+
+    async def test_viewer_allowed_none_with_filter_returns_filter(self):
+        """Viewer with no restriction but master filter sees the filtered chats."""
+        web_main.config.display_chat_ids = {5, 10}
+        user = web_main.UserContext(username="viewer1", role="viewer", allowed_chat_refs=None)
+        self.assertEqual(await web_main._visible_chat_id_set(user), {5, 10})
 
 
 # ============================================================================
@@ -611,10 +667,11 @@ class TestSessionData(unittest.TestCase):
         self.assertLessEqual(session.created_at, after)
         self.assertGreaterEqual(session.last_accessed, before)
 
-    def test_allowed_chat_ids_default_none(self):
-        """SessionData defaults allowed_chat_ids to None."""
+    def test_grant_fields_default_none(self):
+        """SessionData defaults both v8.0 grant fields to None (unrestricted)."""
         session = web_main.SessionData(username="u", role="master")
-        self.assertIsNone(session.allowed_chat_ids)
+        self.assertIsNone(session.allowed_accounts)
+        self.assertIsNone(session.allowed_chat_refs)
 
     def test_no_download_default_false(self):
         """SessionData defaults no_download to False."""
@@ -631,10 +688,11 @@ class TestUserContext(unittest.TestCase):
         user = web_main.UserContext(username="u", role="master")
         self.assertFalse(user.no_download)
 
-    def test_allowed_chat_ids_default_none(self):
-        """UserContext defaults allowed_chat_ids to None."""
+    def test_grant_fields_default_none(self):
+        """UserContext defaults both v8.0 grant fields to None (unrestricted)."""
         user = web_main.UserContext(username="u", role="viewer")
-        self.assertIsNone(user.allowed_chat_ids)
+        self.assertIsNone(user.allowed_accounts)
+        self.assertIsNone(user.allowed_chat_refs)
 
 
 # ============================================================================
@@ -684,10 +742,18 @@ class TestCreateSession(unittest.IsolatedAsyncioTestCase):
         count_after = len([s for s in web_main._sessions.values() if s.username == "user1"])
         self.assertEqual(count_after, web_main._MAX_SESSIONS_PER_USER)
 
-    async def test_preserves_allowed_chat_ids(self):
-        """_create_session stores allowed_chat_ids in session."""
-        token = await web_main._create_session("v1", "viewer", allowed_chat_ids={1, 2, 3})
-        self.assertEqual(web_main._sessions[token].allowed_chat_ids, {1, 2, 3})
+    async def test_preserves_grants(self):
+        """_create_session stores both v8.0 grant fields in the session."""
+        token = await web_main._create_session(
+            "v1",
+            "viewer",
+            allowed_accounts={1, 2},
+            allowed_chat_refs={"refGrantA0000000000001", "refGrantB0000000000002"},
+        )
+        self.assertEqual(web_main._sessions[token].allowed_accounts, {1, 2})
+        self.assertEqual(
+            web_main._sessions[token].allowed_chat_refs, {"refGrantA0000000000001", "refGrantB0000000000002"}
+        )
 
 
 @_skip_unless_web_main
@@ -751,17 +817,29 @@ class TestInvalidateTokenSessions(unittest.IsolatedAsyncioTestCase):
 
 @_skip_unless_web_main
 class TestHandleRealtimeNotification(unittest.IsolatedAsyncioTestCase):
-    """Test handle_realtime_notification dispatch logic."""
+    """Test handle_realtime_notification dispatch logic.
+
+    v8.0: the writer-side chat id is resolved to its row once, and every
+    outward frame is ref-addressed — no chat_id may appear in a frame.
+    """
 
     def setUp(self):
         self._saved_display = web_main.config.display_chat_ids
         self._saved_push = web_main.push_manager
+        self._saved_db = web_main.db
         web_main.config.display_chat_ids = set()
         web_main.push_manager = None
+        web_main.db = AsyncMock()
+        web_main.db.get_chat_by_id = AsyncMock(
+            side_effect=lambda chat_id, **kwargs: _chat_row(chat_id, f"refRealtime{chat_id:011d}")
+        )
+        web_main._broadcast_chat_cache.clear()
 
     def tearDown(self):
         web_main.config.display_chat_ids = self._saved_display
         web_main.push_manager = self._saved_push
+        web_main.db = self._saved_db
+        web_main._broadcast_chat_cache.clear()
 
     async def test_ignores_notification_for_restricted_chat(self):
         """handle_realtime_notification ignores chats not in display_chat_ids."""
@@ -771,7 +849,7 @@ class TestHandleRealtimeNotification(unittest.IsolatedAsyncioTestCase):
         mock_bc.assert_not_awaited()
 
     async def test_broadcasts_new_message(self):
-        """handle_realtime_notification broadcasts new_message events."""
+        """handle_realtime_notification broadcasts ref-addressed new_message frames."""
         with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock) as mock_bc:
             await web_main.handle_realtime_notification(
                 {
@@ -782,8 +860,10 @@ class TestHandleRealtimeNotification(unittest.IsolatedAsyncioTestCase):
             )
         mock_bc.assert_awaited_once()
         call_args = mock_bc.call_args
-        self.assertEqual(call_args[0][0], 42)
+        self.assertEqual(call_args[0][0]["id"], 42)
         self.assertEqual(call_args[0][1]["type"], "new_message")
+        self.assertEqual(call_args[0][1]["chat_ref"], "refRealtime00000000042")
+        self.assertNotIn("chat_id", call_args[0][1])
 
     async def test_broadcasts_edit_event(self):
         """handle_realtime_notification broadcasts edit events."""
@@ -797,6 +877,7 @@ class TestHandleRealtimeNotification(unittest.IsolatedAsyncioTestCase):
             )
         mock_bc.assert_awaited_once()
         self.assertEqual(mock_bc.call_args[0][1]["type"], "edit")
+        self.assertEqual(mock_bc.call_args[0][1]["chat_ref"], "refRealtime00000000010")
 
     async def test_broadcasts_delete_event(self):
         """handle_realtime_notification broadcasts delete events."""
@@ -810,6 +891,7 @@ class TestHandleRealtimeNotification(unittest.IsolatedAsyncioTestCase):
             )
         mock_bc.assert_awaited_once()
         self.assertEqual(mock_bc.call_args[0][1]["type"], "delete")
+        self.assertNotIn("chat_id", mock_bc.call_args[0][1])
 
     async def test_broadcasts_pin_event(self):
         """handle_realtime_notification broadcasts pin events."""
@@ -878,28 +960,31 @@ class TestSecurityHelpers(unittest.TestCase):
         with patch.dict(os.environ, {"CORS_ORIGINS": "https://other.example"}):
             self.assertFalse(web_main._websocket_origin_allowed(websocket))
 
-    def test_enforce_media_acl_allows_unrestricted_user(self):
-        """Master/unrestricted users can access any normalized media path."""
-        user = web_main.UserContext(username="master", role="master", allowed_chat_ids=None)
-        web_main._enforce_media_acl("123/file.jpg", user)
+    def test_parse_media_key_splits_on_first_underscore(self):
+        """The URL's {message_id}_{type} key splits on the FIRST underscore only,
+        so multi-underscore types (video_note) survive intact — mirroring how the
+        storage key {chat_id}_{message_id}_{type} is built by the writers."""
+        self.assertEqual(web_main._parse_media_key("12_photo"), (12, "photo"))
+        self.assertEqual(web_main._parse_media_key("9_video_note"), (9, "video_note"))
 
-    def test_enforce_media_acl_avatar_branches(self):
-        """Restricted users only get avatars for allowed chat IDs."""
-        user = web_main.UserContext(username="viewer", role="viewer", allowed_chat_ids={123})
-        web_main._enforce_media_acl("avatars/chats/123_456.jpg", user)
+    def test_parse_media_key_rejects_malformed(self):
+        """Keys without a type or with a non-numeric message id parse to None
+        (the route then answers the same 404 as a missing media row)."""
+        for key in ("noseparator", "12_", "abc_photo", "_photo", "12.5_photo"):
+            with self.subTest(key=key):
+                self.assertIsNone(web_main._parse_media_key(key))
 
-        for path in ("avatars/chats", "avatars/chats/not-a-number.jpg", "avatars/chats/999_456.jpg"):
-            with self.subTest(path=path), self.assertRaises(web_main.HTTPException) as ctx:
-                web_main._enforce_media_acl(path, user)
-            self.assertEqual(ctx.exception.status_code, 403)
+    def test_media_relative_path_normalizes_absolute_under_root(self):
+        """A media row's absolute file_path under the media root normalizes to a
+        root-relative path; anything that cannot be proven inside stays None
+        (rejection branches are pinned in test_viewer_acl_hardening.py)."""
+        from pathlib import Path
 
-    def test_enforce_media_acl_rejects_malformed_or_unallowed_media_path(self):
-        """Restricted users cannot access non-chat folders or unallowed chat IDs."""
-        user = web_main.UserContext(username="viewer", role="viewer", allowed_chat_ids={123})
-        for path in ("one-segment", "_shared/file.jpg", "999/file.jpg"):
-            with self.subTest(path=path), self.assertRaises(web_main.HTTPException) as ctx:
-                web_main._enforce_media_acl(path, user)
-            self.assertEqual(ctx.exception.status_code, 403)
+        with patch.object(web_main, "_media_root", Path("/srv/media")):
+            self.assertEqual(web_main._media_relative_path("/srv/media/123/file.jpg"), "123/file.jpg")
+            self.assertEqual(web_main._media_relative_path("123/file.jpg"), "123/file.jpg")
+            self.assertIsNone(web_main._media_relative_path(None))
+            self.assertIsNone(web_main._media_relative_path(""))
 
     def test_strip_original_media_paths_handles_media_items(self):
         """No-download sessions strip both legacy media and multi-media item paths."""

--- a/tests/test_web_push.py
+++ b/tests/test_web_push.py
@@ -418,7 +418,12 @@ class TestNotifyNewMessage(unittest.IsolatedAsyncioTestCase):
 
         long_text = "x" * 200
         await mgr.notify_new_message(
-            chat_id=1, chat_title="Chat", sender_name="Alice", message_text=long_text, message_id=99
+            chat_id=1,
+            chat_ref="pushRefChat000001ABC",
+            chat_title="Chat",
+            sender_name="Alice",
+            message_text=long_text,
+            message_id=99,
         )
 
         call_kwargs = mgr.send_notification.call_args.kwargs
@@ -431,7 +436,12 @@ class TestNotifyNewMessage(unittest.IsolatedAsyncioTestCase):
         mgr.send_notification = AsyncMock(return_value=1)
 
         await mgr.notify_new_message(
-            chat_id=1, chat_title="Chat", sender_name="Bob", message_text="Hello", message_id=10
+            chat_id=1,
+            chat_ref="pushRefChat000001ABC",
+            chat_title="Chat",
+            sender_name="Bob",
+            message_text="Hello",
+            message_id=10,
         )
 
         call_kwargs = mgr.send_notification.call_args.kwargs
@@ -442,24 +452,40 @@ class TestNotifyNewMessage(unittest.IsolatedAsyncioTestCase):
         mgr = _make_manager()
         mgr.send_notification = AsyncMock(return_value=1)
 
-        await mgr.notify_new_message(chat_id=1, chat_title="Group", sender_name="", message_text="Hi", message_id=5)
+        await mgr.notify_new_message(
+            chat_id=1,
+            chat_ref="pushRefChat000001ABC",
+            chat_title="Group",
+            sender_name="",
+            message_text="Hi",
+            message_id=5,
+        )
 
         call_kwargs = mgr.send_notification.call_args.kwargs
         self.assertEqual(call_kwargs["body"], "Hi")
 
     async def test_data_includes_url_and_message_id(self):
-        """notify_new_message passes correct data with url and type."""
+        """notify_new_message passes ref-addressed data: the chat id never enters
+        the payload, its URL, or the grouping tag."""
         mgr = _make_manager()
         mgr.send_notification = AsyncMock(return_value=1)
 
-        await mgr.notify_new_message(chat_id=42, chat_title="Test", sender_name="X", message_text="msg", message_id=7)
+        await mgr.notify_new_message(
+            chat_id=42,
+            chat_ref="pushRefChat000042ABC",
+            chat_title="Test",
+            sender_name="X",
+            message_text="msg",
+            message_id=7,
+        )
 
         call_kwargs = mgr.send_notification.call_args.kwargs
         self.assertEqual(call_kwargs["data"]["type"], "new_message")
-        self.assertEqual(call_kwargs["data"]["chat_id"], 42)
+        self.assertEqual(call_kwargs["data"]["chat_ref"], "pushRefChat000042ABC")
+        self.assertNotIn("chat_id", call_kwargs["data"])
         self.assertEqual(call_kwargs["data"]["message_id"], 7)
-        self.assertEqual(call_kwargs["data"]["url"], "/?chat=42&msg=7")
-        self.assertEqual(call_kwargs["tag"], "chat-42")
+        self.assertEqual(call_kwargs["data"]["url"], "/?chat=pushRefChat000042ABC&msg=7")
+        self.assertEqual(call_kwargs["tag"], "chat-pushRefChat000042ABC")
 
 
 # ============================================================================

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -35,11 +35,21 @@ def _skip_unless_web(cls_or_fn):
 
 
 def _mock_db():
-    """Create a mock database adapter with common methods."""
+    """Create a mock database adapter with common methods.
+
+    get_chat_by_ref echoes the requested ref back as an existing chat (id=1,
+    account 1) so ref-addressed routes resolve by default; tests that need an
+    unknown ref or a specific chat identity override it.
+    """
     db = AsyncMock()
     db.get_all_chats = AsyncMock(return_value=[])
     db.get_chat_count = AsyncMock(return_value=0)
     db.get_chat_by_id = AsyncMock(return_value=None)
+    db.get_chat_by_ref = AsyncMock(
+        side_effect=lambda ref, **kwargs: {"id": 1, "account_id": 1, "ref": ref, "type": "group"}
+    )
+    db.get_media_by_id = AsyncMock(return_value=None)
+    db.get_message_sender_id = AsyncMock(return_value=None)
     db.get_messages_paginated = AsyncMock(return_value=[])
     db.get_message_versions = AsyncMock(return_value=[])
     db.get_message_versions_by_date_range = AsyncMock(return_value=[])
@@ -112,6 +122,8 @@ class _WebTestBase(unittest.IsolatedAsyncioTestCase):
         web_main._avatar_cache.clear()
         web_main._avatar_cache_time = None
         web_main._chat_stats_cache.clear()
+        web_main._broadcast_chat_cache.clear()
+        web_main._sender_lookup_cache.clear()
 
     def tearDown(self):
         web_main.db = self._saved_db
@@ -126,6 +138,8 @@ class _WebTestBase(unittest.IsolatedAsyncioTestCase):
         web_main._avatar_cache_time = self._saved_avatar_cache_time
         web_main._chat_stats_cache.clear()
         web_main._chat_stats_cache.update(self._saved_chat_stats_cache)
+        web_main._broadcast_chat_cache.clear()
+        web_main._sender_lookup_cache.clear()
 
     def _client(self):
         transport = ASGITransport(app=web_main.app)
@@ -332,15 +346,17 @@ class TestChatsEndpoint(_WebTestBase):
         self.assertEqual(data["total"], 10)
         self.assertTrue(data["has_more"])
 
-    async def test_chats_filtered_by_user_allowed_ids(self):
-        """get_chats filters chats when user has allowed_chat_ids."""
+    async def test_chats_filtered_by_user_allowed_refs(self):
+        """get_chats filters chats when user has an allowed_chat_refs grant."""
         web_main.AUTH_ENABLED = True
         token = "viewer-token"
-        web_main._sessions[token] = web_main.SessionData(username="viewer1", role="viewer", allowed_chat_ids={1, 3})
+        web_main._sessions[token] = web_main.SessionData(
+            username="viewer1", role="viewer", allowed_chat_refs={"chatRefOne0000000001A", "chatRefThree00000003A"}
+        )
         all_chats = [
-            {"id": 1, "title": "Allowed", "type": "private"},
-            {"id": 2, "title": "Denied", "type": "group"},
-            {"id": 3, "title": "Also Allowed", "type": "private"},
+            {"id": 1, "account_id": 1, "ref": "chatRefOne0000000001A", "title": "Allowed", "type": "private"},
+            {"id": 2, "account_id": 1, "ref": "chatRefTwo0000000002A", "title": "Denied", "type": "group"},
+            {"id": 3, "account_id": 1, "ref": "chatRefThree00000003A", "title": "Also Allowed", "type": "private"},
         ]
         self.mock_db.get_all_chats = AsyncMock(return_value=all_chats)
         async with self._client() as client:
@@ -395,13 +411,16 @@ class TestMessagesEndpoint(_WebTestBase):
         self.assertEqual(resp.status_code, 200)
 
     async def test_denies_access_to_restricted_chat(self):
-        """get_messages returns 403 when user cannot access the chat."""
+        """get_messages answers a forbidden ref with the SAME 404 as an unknown one."""
         web_main.AUTH_ENABLED = True
         token = "restricted-viewer"
-        web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={100})
+        web_main._sessions[token] = web_main.SessionData(
+            username="v1", role="viewer", allowed_chat_refs={"grantedRef00000000100"}
+        )
         async with self._client() as client:
-            resp = await client.get("/api/chats/999/messages", cookies={"viewer_auth": token})
-        self.assertEqual(resp.status_code, 403)
+            resp = await client.get("/api/chats/forbiddenRef000000999/messages", cookies={"viewer_auth": token})
+        self.assertEqual(resp.status_code, 404)
+        self.assertEqual(resp.json(), {"detail": "Chat not found"})
 
     async def test_passes_cursor_pagination_params(self):
         """get_messages forwards before_date and before_id to db."""
@@ -460,23 +479,31 @@ class TestMessageVersionsEndpoint(_WebTestBase):
             ]
         )
 
+        self.mock_db.get_chat_by_ref = AsyncMock(
+            return_value={"id": 123, "account_id": 1, "ref": "versionsRef0000123AB", "type": "group"}
+        )
         async with self._client() as client:
-            resp = await client.get("/api/chats/123/messages/42/versions?limit=25")
+            resp = await client.get("/api/chats/versionsRef0000123AB/messages/42/versions?limit=25")
 
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.json()[0]["text"], "old")
-        self.mock_db.get_message_versions.assert_awaited_once_with(chat_id=123, message_id=42, limit=25)
+        self.mock_db.get_message_versions.assert_awaited_once_with(chat_id=123, message_id=42, limit=25, account_id=1)
 
     async def test_denies_access_to_restricted_chat(self):
-        """get_message_versions returns 403 when user cannot access the chat."""
+        """get_message_versions answers a forbidden ref with the uniform 404,
+        without touching the versions table."""
         web_main.AUTH_ENABLED = True
         token = "restricted-message-versions"
-        web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={100})
+        web_main._sessions[token] = web_main.SessionData(
+            username="v1", role="viewer", allowed_chat_refs={"grantedRef00000000100"}
+        )
 
         async with self._client() as client:
-            resp = await client.get("/api/chats/999/messages/42/versions", cookies={"viewer_auth": token})
+            resp = await client.get(
+                "/api/chats/forbiddenRef000000999/messages/42/versions", cookies={"viewer_auth": token}
+            )
 
-        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 404)
         self.mock_db.get_message_versions.assert_not_awaited()
 
     async def test_requires_auth_when_auth_enabled(self):
@@ -527,13 +554,15 @@ class TestPinnedMessagesEndpoint(_WebTestBase):
         self.assertEqual(len(data), 1)
 
     async def test_pinned_denies_restricted_chat(self):
-        """get_pinned_messages returns 403 for restricted chat."""
+        """get_pinned_messages answers a forbidden ref with the uniform 404."""
         web_main.AUTH_ENABLED = True
         token = "rv"
-        web_main._sessions[token] = web_main.SessionData(username="v", role="viewer", allowed_chat_ids={10})
+        web_main._sessions[token] = web_main.SessionData(
+            username="v", role="viewer", allowed_chat_refs={"grantedRef00000000010"}
+        )
         async with self._client() as client:
-            resp = await client.get("/api/chats/999/pinned", cookies={"viewer_auth": token})
-        self.assertEqual(resp.status_code, 403)
+            resp = await client.get("/api/chats/forbiddenRef000000999/pinned", cookies={"viewer_auth": token})
+        self.assertEqual(resp.status_code, 404)
 
 
 # ============================================================================
@@ -592,11 +621,21 @@ class TestArchivedCountEndpoint(_WebTestBase):
         self.assertEqual(resp.json()["count"], 5)
 
     async def test_archived_count_filtered_by_user_chats(self):
-        """get_archived_count filters by user allowed chats."""
+        """get_archived_count filters by the user's ref grant."""
         web_main.AUTH_ENABLED = True
         token = "av"
-        web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={1, 2, 3})
-        self.mock_db.get_all_chats = AsyncMock(return_value=[{"id": 1}, {"id": 2}, {"id": 99}])
+        web_main._sessions[token] = web_main.SessionData(
+            username="v1",
+            role="viewer",
+            allowed_chat_refs={"archRefA000000000001A", "archRefB000000000002A", "archRefC000000000003A"},
+        )
+        self.mock_db.get_all_chats = AsyncMock(
+            return_value=[
+                {"id": 1, "account_id": 1, "ref": "archRefA000000000001A"},
+                {"id": 2, "account_id": 1, "ref": "archRefB000000000002A"},
+                {"id": 99, "account_id": 1, "ref": "archRefZ000000000099A"},
+            ]
+        )
         async with self._client() as client:
             resp = await client.get("/api/archived/count", cookies={"viewer_auth": token})
         self.assertEqual(resp.status_code, 200)
@@ -625,10 +664,18 @@ class TestStatsEndpoint(_WebTestBase):
         self.assertIn("push_enabled", data)
 
     async def test_stats_filters_per_chat_for_restricted_user(self):
-        """get_stats filters per_chat_message_counts by user allowed chats."""
+        """get_stats filters per_chat_message_counts by the user's ref grant."""
         web_main.AUTH_ENABLED = True
         token = "sv"
-        web_main._sessions[token] = web_main.SessionData(username="v1", role="viewer", allowed_chat_ids={1})
+        web_main._sessions[token] = web_main.SessionData(
+            username="v1", role="viewer", allowed_chat_refs={"statsRefOne000000001A"}
+        )
+        self.mock_db.get_all_chats = AsyncMock(
+            return_value=[
+                {"id": 1, "account_id": 1, "ref": "statsRefOne000000001A"},
+                {"id": 2, "account_id": 1, "ref": "statsRefTwo000000002A"},
+            ]
+        )
         self.mock_db.get_cached_statistics = AsyncMock(
             return_value={
                 "per_chat_message_counts": {"1": 100, "2": 200},
@@ -730,13 +777,15 @@ class TestChatStatsEndpoint(_WebTestBase):
         self.assertEqual(resp.status_code, 200)
 
     async def test_chat_stats_denies_restricted_chat(self):
-        """get_chat_stats returns 403 for restricted chat."""
+        """get_chat_stats answers a forbidden ref with the uniform 404."""
         web_main.AUTH_ENABLED = True
         token = "cs"
-        web_main._sessions[token] = web_main.SessionData(username="v", role="viewer", allowed_chat_ids={1})
+        web_main._sessions[token] = web_main.SessionData(
+            username="v", role="viewer", allowed_chat_refs={"grantedRef00000000001"}
+        )
         async with self._client() as client:
-            resp = await client.get("/api/chats/999/stats", cookies={"viewer_auth": token})
-        self.assertEqual(resp.status_code, 403)
+            resp = await client.get("/api/chats/forbiddenRef000000999/stats", cookies={"viewer_auth": token})
+        self.assertEqual(resp.status_code, 404)
 
     async def test_chat_stats_cache_hit_avoids_second_db_call(self):
         """A second request within the TTL is served from cache without hitting the db."""
@@ -750,18 +799,23 @@ class TestChatStatsEndpoint(_WebTestBase):
         self.mock_db.get_chat_stats.assert_awaited_once()
 
     async def test_chat_stats_cache_hit_still_enforces_acl(self):
-        """A cached stats entry must not leak to a viewer without access to that chat."""
+        """A cached stats entry must not leak to a viewer without access to that chat;
+        the denial is the uniform 404 the resolver gives every forbidden ref."""
         self.mock_db.get_chat_stats = AsyncMock(return_value={"messages": 5, "media": 1})
         web_main.AUTH_ENABLED = True
         master_token = "cs-master"
         web_main._sessions[master_token] = web_main.SessionData(username="admin", role="master")
         restricted_token = "cs-restricted"
-        web_main._sessions[restricted_token] = web_main.SessionData(username="v", role="viewer", allowed_chat_ids={1})
+        web_main._sessions[restricted_token] = web_main.SessionData(
+            username="v", role="viewer", allowed_chat_refs={"grantedRef00000000001"}
+        )
         async with self._client() as client:
-            warm = await client.get("/api/chats/42/stats", cookies={"viewer_auth": master_token})
-            blocked = await client.get("/api/chats/42/stats", cookies={"viewer_auth": restricted_token})
+            warm = await client.get("/api/chats/cachedChatRef00042AB/stats", cookies={"viewer_auth": master_token})
+            blocked = await client.get(
+                "/api/chats/cachedChatRef00042AB/stats", cookies={"viewer_auth": restricted_token}
+            )
         self.assertEqual(warm.status_code, 200)
-        self.assertEqual(blocked.status_code, 403)
+        self.assertEqual(blocked.status_code, 404)
 
 
 # ============================================================================
@@ -811,6 +865,7 @@ class TestMessageByDateEndpoint(_WebTestBase):
             1,
             datetime(2025, 6, 14, 22),
             77,
+            account_id=1,
         )
 
     async def test_rejects_explicit_invalid_timezone(self):
@@ -840,8 +895,13 @@ class TestMessageDatesEndpoint(_WebTestBase):
 
     async def test_returns_contract_with_utc_spillover_and_topic(self):
         self.mock_db.get_message_dates = AsyncMock(return_value=["2026-03-01", "2026-03-31"])
+        self.mock_db.get_chat_by_ref = AsyncMock(
+            return_value={"id": 42, "account_id": 1, "ref": "datesChatRef00042ABC", "type": "group"}
+        )
         async with self._client() as client:
-            resp = await client.get("/api/chats/42/messages/dates?month=2026-03&timezone=Asia/Tokyo&topic_id=17")
+            resp = await client.get(
+                "/api/chats/datesChatRef00042ABC/messages/dates?month=2026-03&timezone=Asia/Tokyo&topic_id=17"
+            )
 
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(
@@ -936,14 +996,14 @@ class TestMessageDatesEndpoint(_WebTestBase):
         web_main._sessions[token] = web_main.SessionData(
             username="viewer",
             role="viewer",
-            allowed_chat_ids={100},
+            allowed_chat_refs={"grantedRef00000000100"},
         )
         async with self._client() as client:
             resp = await client.get(
-                "/api/chats/999/messages/dates?month=0001-01&timezone=Invalid/Zone",
+                "/api/chats/forbiddenRef000000999/messages/dates?month=0001-01&timezone=Invalid/Zone",
                 cookies={"viewer_auth": token},
             )
-        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 404)
         self.mock_db.get_message_dates.assert_not_awaited()
 
     async def test_returns_empty_dates(self):
@@ -1247,13 +1307,16 @@ class TestAdminViewersEndpoint(_MasterTestBase):
         self.assertEqual(resp.json()["viewers"], [])
 
     async def test_list_viewers_returns_accounts(self):
-        """list_viewers returns viewer account data."""
+        """list_viewers returns viewer account data with the v8.0 grant columns;
+        the legacy allowed_chat_ids never reaches the response."""
         self.mock_db.get_all_viewer_accounts = AsyncMock(
             return_value=[
                 {
                     "id": 1,
                     "username": "v1",
-                    "allowed_chat_ids": json.dumps([1, 2]),
+                    "allowed_chat_ids": "[]",  # rollback tombstone, not a grant
+                    "allowed_accounts": None,
+                    "allowed_chat_refs": json.dumps(["viewerRefA00000001AB", "viewerRefB00000002AB"]),
                     "is_active": 1,
                     "no_download": 0,
                     "created_by": "admin",
@@ -1266,7 +1329,9 @@ class TestAdminViewersEndpoint(_MasterTestBase):
             resp = await client.get("/api/admin/viewers")
         data = resp.json()
         self.assertEqual(len(data["viewers"]), 1)
-        self.assertEqual(data["viewers"][0]["allowed_chat_ids"], [1, 2])
+        self.assertEqual(data["viewers"][0]["allowed_chat_refs"], ["viewerRefA00000001AB", "viewerRefB00000002AB"])
+        self.assertIsNone(data["viewers"][0]["allowed_accounts"])
+        self.assertNotIn("allowed_chat_ids", data["viewers"][0])
 
     async def test_create_viewer_validates_username(self):
         """create_viewer returns 400 for short username."""
@@ -1370,20 +1435,24 @@ class TestAdminTokensEndpoint(_MasterTestBase):
         data = resp.json()
         self.assertEqual(len(data["tokens"]), 1)
 
-    async def test_create_token_requires_allowed_chat_ids(self):
-        """create_token returns 400 when allowed_chat_ids missing."""
+    async def test_create_token_requires_allowed_chat_refs(self):
+        """create_token returns 400 when allowed_chat_refs missing (tokens are always scoped)."""
         async with self._client() as client:
             resp = await client.post("/api/admin/tokens", json={"label": "test"})
         self.assertEqual(resp.status_code, 400)
 
     async def test_create_token_success(self):
-        """create_token returns token with plaintext."""
+        """create_token returns token with plaintext and echoes the ref grant."""
         async with self._client() as client:
-            resp = await client.post("/api/admin/tokens", json={"allowed_chat_ids": [1, 2, 3], "label": "my-token"})
+            resp = await client.post(
+                "/api/admin/tokens",
+                json={"allowed_chat_refs": ["tokRefA000000000001A", "tokRefB000000000002A"], "label": "my-token"},
+            )
         self.assertEqual(resp.status_code, 200)
         data = resp.json()
         self.assertIn("token", data)
         self.assertIsNotNone(data["token"])
+        self.assertEqual(data["allowed_chat_refs"], ["tokRefA000000000001A", "tokRefB000000000002A"])
 
     async def test_update_token_not_found(self):
         """update_token returns 404 when token not found."""
@@ -1557,16 +1626,28 @@ class TestNotificationSettingsEndpoint(_WebTestBase):
 
 @_skip_unless_web
 class TestBroadcastHelpers(_WebTestBase):
-    """Test broadcast_new_message, broadcast_message_edit, broadcast_message_delete."""
+    """Test broadcast_new_message, broadcast_message_edit, broadcast_message_delete.
+
+    The writer side speaks chat ids; every outward frame is ref-addressed, so
+    the helpers resolve the id to its chat row first and drop unresolvable ids.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.mock_db.get_chat_by_id = AsyncMock(
+            return_value={"id": 42, "account_id": 1, "ref": "broadcastRef000042AB", "title": "Chat"}
+        )
 
     async def test_broadcast_new_message(self):
-        """broadcast_new_message calls ws_manager.broadcast_to_chat."""
+        """broadcast_new_message resolves the chat and broadcasts a ref frame."""
         with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock) as mock_bc:
             await web_main.broadcast_new_message(42, {"id": 1, "text": "hi"})
         mock_bc.assert_awaited_once()
         args = mock_bc.call_args[0]
-        self.assertEqual(args[0], 42)
+        self.assertEqual(args[0]["id"], 42)
         self.assertEqual(args[1]["type"], "new_message")
+        self.assertEqual(args[1]["chat_ref"], "broadcastRef000042AB")
+        self.assertNotIn("chat_id", args[1])
 
     async def test_broadcast_message_edit(self):
         """broadcast_message_edit calls ws_manager.broadcast_to_chat."""
@@ -1576,6 +1657,7 @@ class TestBroadcastHelpers(_WebTestBase):
         msg = mock_bc.call_args[0][1]
         self.assertEqual(msg["type"], "edit")
         self.assertEqual(msg["new_text"], "edited text")
+        self.assertEqual(msg["chat_ref"], "broadcastRef000042AB")
 
     async def test_broadcast_message_delete(self):
         """broadcast_message_delete calls ws_manager.broadcast_to_chat."""
@@ -1585,6 +1667,13 @@ class TestBroadcastHelpers(_WebTestBase):
         msg = mock_bc.call_args[0][1]
         self.assertEqual(msg["type"], "delete")
         self.assertEqual(msg["message_id"], 10)
+
+    async def test_broadcast_drops_unresolvable_chat_id(self):
+        """An id that resolves to no row emits nothing (never an id-addressed frame)."""
+        self.mock_db.get_chat_by_id = AsyncMock(return_value=None)
+        with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock) as mock_bc:
+            await web_main.broadcast_new_message(42, {"id": 1, "text": "hi"})
+        mock_bc.assert_not_awaited()
 
 
 # ============================================================================
@@ -1730,13 +1819,16 @@ class TestResolveSession(_WebTestBase):
         self.assertIsNone(result)
 
     async def test_loads_valid_session_from_db(self):
-        """_resolve_session loads valid session from db and caches it."""
+        """_resolve_session loads valid session from db and caches it; the grant
+        comes from the v8.0 columns, the legacy tombstone is never read."""
         now = time.time()
         self.mock_db.get_session = AsyncMock(
             return_value={
                 "username": "dbuser",
                 "role": "viewer",
-                "allowed_chat_ids": json.dumps([1, 2]),
+                "allowed_chat_ids": "[]",  # rollback tombstone
+                "allowed_accounts": None,
+                "allowed_chat_refs": json.dumps(["sessRefA000000000001", "sessRefB000000000002"]),
                 "no_download": 1,
                 "source_token_id": 5,
                 "created_at": now,
@@ -1746,7 +1838,8 @@ class TestResolveSession(_WebTestBase):
         result = await web_main._resolve_session("db-tok")
         self.assertIsNotNone(result)
         self.assertEqual(result.username, "dbuser")
-        self.assertEqual(result.allowed_chat_ids, {1, 2})
+        self.assertEqual(result.allowed_chat_refs, {"sessRefA000000000001", "sessRefB000000000002"})
+        self.assertIsNone(result.allowed_accounts)
         self.assertTrue(result.no_download)
         # Should be cached now
         self.assertIn("db-tok", web_main._sessions)
@@ -1773,7 +1866,8 @@ class TestRequireAuth(_WebTestBase):
         result = await web_main.require_auth(request=self._mock_request(), auth_cookie=None)
         self.assertEqual(result.username, "anonymous")
         self.assertEqual(result.role, "viewer")
-        self.assertIsNone(result.allowed_chat_ids)
+        self.assertIsNone(result.allowed_accounts)
+        self.assertIsNone(result.allowed_chat_refs)
         self.assertFalse(result.no_download)
 
     async def test_auth_disabled_without_opt_in_fails_closed(self):
@@ -1854,7 +1948,9 @@ class TestRealtimeNotificationWithPush(_WebTestBase):
         mock_pm.is_enabled = True
         mock_pm.notify_new_message = AsyncMock(return_value=1)
         web_main.push_manager = mock_pm
-        self.mock_db.get_chat_by_id = AsyncMock(return_value={"title": "Test Chat"})
+        self.mock_db.get_chat_by_id = AsyncMock(
+            return_value={"id": 42, "account_id": 1, "ref": "pushChatRef0000042AB", "title": "Test Chat"}
+        )
         self.mock_db.get_user_by_id = AsyncMock(return_value={"first_name": "Alice", "username": "alice"})
 
         with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock):
@@ -1869,6 +1965,7 @@ class TestRealtimeNotificationWithPush(_WebTestBase):
         mock_pm.notify_new_message.assert_awaited_once()
         call_kwargs = mock_pm.notify_new_message.call_args.kwargs
         self.assertEqual(call_kwargs["chat_id"], 42)
+        self.assertEqual(call_kwargs["chat_ref"], "pushChatRef0000042AB")
         self.assertEqual(call_kwargs["sender_name"], "Alice")
 
     async def test_push_prefers_archived_sender_snapshot(self) -> None:
@@ -1876,7 +1973,9 @@ class TestRealtimeNotificationWithPush(_WebTestBase):
         mock_pm.is_enabled = True
         mock_pm.notify_new_message = AsyncMock(return_value=1)
         web_main.push_manager = mock_pm
-        self.mock_db.get_chat_by_id = AsyncMock(return_value={"title": "Test Chat"})
+        self.mock_db.get_chat_by_id = AsyncMock(
+            return_value={"id": 42, "account_id": 1, "ref": "pushChatRef0000042AB", "title": "Test Chat"}
+        )
         self.mock_db.get_user_by_id = AsyncMock(return_value={"first_name": "Current Name"})
 
         with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock):

--- a/tests/test_websocket_route.py
+++ b/tests/test_websocket_route.py
@@ -36,6 +36,7 @@ pytestmark = pytest.mark.skipif(not _WS_AVAILABLE, reason="fastapi/starlette Tes
 def _make_mock_db():
     db = AsyncMock()
     db.get_all_chats = AsyncMock(return_value=[])
+    db.get_chat_by_ref = AsyncMock(return_value=None)
     db.get_session = AsyncMock(return_value=None)
     db.delete_session = AsyncMock()
     return db
@@ -119,23 +120,29 @@ class TestWebSocketSubscribeFlow:
         token = "ws-subscribe-session"
         mod._sessions[token] = mod.SessionData(username="admin", role="master", created_at=time.time())
         client.cookies.set("viewer_auth", token)
+        ref = "wsRoundTripRef00000042"
+        mod.db.get_chat_by_ref = AsyncMock(return_value={"id": 42, "account_id": 1, "ref": ref, "type": "group"})
 
         with client.websocket_connect("/ws/updates") as ws:
-            ws.send_json({"action": "subscribe", "chat_id": 42})
-            assert ws.receive_json() == {"type": "subscribed", "chat_id": 42}
+            ws.send_json({"action": "subscribe", "chat_ref": ref})
+            assert ws.receive_json() == {"type": "subscribed", "chat_ref": ref}
 
-            ws.send_json({"action": "unsubscribe", "chat_id": 42})
-            assert ws.receive_json() == {"type": "unsubscribed", "chat_id": 42}
+            ws.send_json({"action": "unsubscribe", "chat_ref": ref})
+            assert ws.receive_json() == {"type": "unsubscribed", "chat_ref": ref}
 
-    def test_subscribe_denied_for_chat_outside_allowed_ids(self, auth_env):
-        """A viewer session restricted to specific chats gets subscribe_denied for others."""
+    def test_subscribe_denied_for_chat_outside_allowed_refs(self, auth_env):
+        """A viewer session restricted to specific chat refs gets subscribe_denied for others."""
         client, mod = _get_client()
         token = "ws-restricted-viewer"
         mod._sessions[token] = mod.SessionData(
-            username="v1", role="viewer", allowed_chat_ids={1, 2}, created_at=time.time()
+            username="v1", role="viewer", allowed_chat_refs={"grantedRefAAAABBBB0001"}, created_at=time.time()
         )
         client.cookies.set("viewer_auth", token)
+        forbidden_ref = "forbiddenRefAAAABB0999"
+        mod.db.get_chat_by_ref = AsyncMock(
+            return_value={"id": 999, "account_id": 1, "ref": forbidden_ref, "type": "group"}
+        )
 
         with client.websocket_connect("/ws/updates") as ws:
-            ws.send_json({"action": "subscribe", "chat_id": 999})
-            assert ws.receive_json() == {"type": "subscribe_denied", "chat_id": 999}
+            ws.send_json({"action": "subscribe", "chat_ref": forbidden_ref})
+            assert ws.receive_json() == {"type": "subscribe_denied", "chat_ref": forbidden_ref}


### PR DESCRIPTION
## The problem

Even after the 8.0 core, the viewer still spoke numeric chat ids: in every URL, in browser history, in access logs, in push payloads — and each of its ten chat-scoped routes carried its own copy of the ACL preamble, which is how the audit's websocket gap happened once already.

## What this does

Every chat-scoped surface — the ten API routes, the websocket protocol, media, thumbnails, and two new avatar routes — now addresses chats by the opaque `chats.ref` (128-bit `secrets.token_urlsafe(16)`). **One** shared dependency resolves ref → chat and enforces the 8.0 entitlement columns fail-closed, replacing all ten preambles: unknown, malformed and forbidden refs answer an identical 404 through the same single indexed query, so nothing distinguishes a chat you may not see from one that does not exist.

Grants come only from `allowed_accounts`/`allowed_chat_refs` — NULL unrestricted, anything unparseable an empty grant that denies everything. The legacy `allowed_chat_ids` column is never read again: 8.0 writers leave it as a deny-only rollback tombstone, and a row still carrying only the legacy restriction denies rather than fails open — mirrored identically in push delivery. Media stays exactly where it is on disk: `/media/{chat_ref}/{message_id}_{type}` resolves through the media row, and the traversal/symlink containment applies unchanged to the resolved path. Sender avatars resolve through the message row, so user ids leave URLs too.

## Verification

- **Adversarial review (fresh-eyes lane): APPROVE, 42/42 attacks repelled** on a real migrated database — numeric ids through every route family, the forbidden-ref oracle across five ref shapes, the legacy fail-open attempt, media traversal (`..`, encoded separators, symlinks), and websocket parity for restricted sessions.
- **Log hygiene proven, not assumed**: a full workload seeded with distinctive ids (900777001…), then every produced surface — request paths, captured logs, audit rows, stored grants — grepped for them: zero hits outside the database, with a positive control proving the grep can see them inside it.
- `tests/test_chat_ref_acl.py`: the fail-closed matrix on both backends, with three positive controls watched going red (legacy-column pin, the oracle, the unparseable-grant deny).
- Full suite after rebasing onto the merged core: **3226 passed, 0 failed, 0 skipped** with a real PostgreSQL leg. ruff check and format clean.

Viewer URLs change shape entirely — that is the point, and it ships inside the same 8.0.0 major. No version bump here: still 7.33.6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chats, media, notifications, WebSocket connections, and deep links now use secure opaque chat references.
  * Viewer accounts, sessions, tokens, and push subscriptions support account- and chat-reference-based access grants.
  * Media and avatar links are generated securely by the server.
* **Bug Fixes**
  * Unauthorized, malformed, legacy, or unavailable access grants now fail safely and consistently.
  * Improved URL encoding, notification navigation, media access controls, and stale-request handling.
* **Tests**
  * Expanded coverage for authorization, media security, notifications, WebSockets, and reference-based navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->