### PR TITLE
feat: many accounts at runtime - indexed env vars, claimed rows, sequential sweeps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,25 @@ TELEGRAM_PHONE=+1234567890
 # TELEGRAM_PROXY_PASSWORD=
 # TELEGRAM_PROXY_RDNS=false
 
+# --- Multiple accounts (v8.0.0+, optional) ---
+# Archive several Telegram accounts into the same database and media store.
+# Indexes start at 1 and must be contiguous; declaring any TG_ACCOUNT_*
+# variable switches to indexed mode and the legacy triple above is ignored.
+# With none set, the single account above is used unchanged.
+# Account 1 keeps the legacy session file (SESSION_NAME, default
+# telegram_backup) unless TG_ACCOUNT_1_SESSION_NAME is set, so an upgraded
+# deployment never re-logins; accounts 2+ default to telegram_backup_account<N>.
+# Each account needs one interactive login: ./init_auth.sh (python -m src auth).
+# TG_ACCOUNT_1_API_ID=your_api_id_here
+# TG_ACCOUNT_1_API_HASH=your_api_hash_here
+# TG_ACCOUNT_1_PHONE_NUMBER=+1234567890
+# TG_ACCOUNT_1_LABEL=personal
+# TG_ACCOUNT_2_API_ID=second_api_id_here
+# TG_ACCOUNT_2_API_HASH=second_api_hash_here
+# TG_ACCOUNT_2_PHONE_NUMBER=+0987654321
+# TG_ACCOUNT_2_LABEL=work
+# TG_ACCOUNT_2_SESSION_NAME=telegram_backup_account2
+
 # ==============================================================================
 # BACKUP SCHEDULE & STORAGE
 # ==============================================================================

--- a/README.md
+++ b/README.md
@@ -240,6 +240,11 @@ The **Scope** column shows whether each variable applies to the backup scheduler
 | `TELEGRAM_API_ID` | *required* | B | API ID from [my.telegram.org](https://my.telegram.org/apps) |
 | `TELEGRAM_API_HASH` | *required* | B | API Hash from [my.telegram.org](https://my.telegram.org/apps) |
 | `TELEGRAM_PHONE` | *required* | B | Phone number with country code (e.g., `+1234567890`) |
+| `TG_ACCOUNT_<N>_API_ID` | - | B | [Multiple accounts](#multiple-accounts): API ID of account `N`. `N` starts at 1 and must be contiguous. Declaring any `TG_ACCOUNT_*` variable switches to indexed mode and the three legacy variables above are ignored |
+| `TG_ACCOUNT_<N>_API_HASH` | - | B | API Hash of account `N` |
+| `TG_ACCOUNT_<N>_PHONE_NUMBER` | - | B | Phone number of account `N` with country code. Must be distinct across accounts |
+| `TG_ACCOUNT_<N>_LABEL` | `default` (N=1), `account<N>` (N≥2) | B | Optional display label for account `N` |
+| `TG_ACCOUNT_<N>_SESSION_NAME` | see description | B | Optional session file name for account `N`. Account 1 defaults to the legacy `SESSION_NAME` chain (so an upgraded deployment keeps its session file and never re-logins); accounts 2+ default to `telegram_backup_account<N>` |
 | `TELEGRAM_PROXY_TYPE` | - | B | Optional proxy type for all Telegram clients. Currently supports `socks5` |
 | `TELEGRAM_PROXY_ADDR` | - | B | SOCKS5 proxy host or IP address |
 | `TELEGRAM_PROXY_PORT` | - | B | SOCKS5 proxy port |
@@ -354,6 +359,34 @@ The **Scope** column shows whether each variable applies to the backup scheduler
 | `VAPID_CONTACT` | `mailto:admin@example.com` | V | Contact email included in Web Push requests |
 
 > ⚠️ **`AUTH_PROXY_HEADER` requires a trusted reverse proxy.** Your proxy MUST strip or overwrite this header on **every** inbound request before it reaches the viewer. If it merely passes the header through, any client can set it themselves and impersonate any user — including an admin — with a single request header. This is a full authentication bypass, not a hardening nicety. Only enable this if you've verified your proxy config strips client-supplied values for the header you choose.
+
+### Multiple Accounts
+
+Since v8.0.0 one deployment can archive several Telegram accounts into the same database and media store. Accounts are declared with indexed variables — `<N>` starts at 1 and must be contiguous:
+
+```bash
+TG_ACCOUNT_1_API_ID=11111
+TG_ACCOUNT_1_API_HASH=first_account_api_hash
+TG_ACCOUNT_1_PHONE_NUMBER=+1234567890
+TG_ACCOUNT_1_LABEL=personal
+
+TG_ACCOUNT_2_API_ID=22222
+TG_ACCOUNT_2_API_HASH=second_account_api_hash
+TG_ACCOUNT_2_PHONE_NUMBER=+0987654321
+TG_ACCOUNT_2_LABEL=work
+```
+
+How it behaves:
+
+- **No `TG_ACCOUNT_*` variables → nothing changes.** Exactly one account is used, taken from `TELEGRAM_API_ID` / `TELEGRAM_API_HASH` / `TELEGRAM_PHONE` with the same session file as before. Existing deployments upgrade with zero env changes and no re-login.
+- **Indexed wins.** When both styles are set, the `TG_ACCOUNT_*` declarations are used and the legacy triple is ignored; startup logs `Multi-account: using N configured account(s)`.
+- **Account 1 keeps your existing archive.** On its first login under v8.0.0, the account at index 1 adopts the account row all pre-8.0 data was migrated under. From then on accounts are recognized by their Telegram user id, so re-ordering the indexes later never moves or splits an account's data.
+- **Sequential sweeps.** Scheduled backups run account 1 to completion, then account 2, and so on — one Telethon client per account, each with its own session file and its own rate-limit budget.
+- **One interactive login per account.** Run the same auth flow as always (`./init_auth.sh`, i.e. `python -m src auth`); it walks every configured account that does not yet have an authorized session. Account 1 reuses the legacy session file; accounts 2+ default to `telegram_backup_account<N>.session`.
+- **Filters are global.** `CHAT_IDS`, `CHAT_TYPES`, the include/exclude lists, and all media/listener settings apply to every account alike. In whitelist mode each account backs up whichever whitelisted chats it can see.
+- **Loud config errors.** A gap in the numbering, an incomplete account (an ID without its hash), a duplicate phone number, or an unrecognized `TG_ACCOUNT_*` variable stops startup with an error naming the variable.
+
+When configuring through `docker-compose.yml`'s `environment:` block, remember Compose only forwards variables declared there — uncomment the `TG_ACCOUNT_*` lines in the backup service (or switch to `env_file:`) so your `.env` entries reach the container.
 
 ### Chat Filtering
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,20 @@ services:
       TELEGRAM_PROXY_PASSWORD: ${TELEGRAM_PROXY_PASSWORD:-}
       TELEGRAM_PROXY_RDNS: ${TELEGRAM_PROXY_RDNS:-}
 
+      # Multiple accounts (v8.0.0+): archive several Telegram accounts into the
+      # same database and media store. Indexes start at 1 and are contiguous;
+      # declaring any TG_ACCOUNT_* variable makes the indexed set win over the
+      # legacy credentials above. See README → Multiple Accounts.
+      # TG_ACCOUNT_1_API_ID: ${TG_ACCOUNT_1_API_ID:-}
+      # TG_ACCOUNT_1_API_HASH: ${TG_ACCOUNT_1_API_HASH:-}
+      # TG_ACCOUNT_1_PHONE_NUMBER: ${TG_ACCOUNT_1_PHONE_NUMBER:-}
+      # TG_ACCOUNT_1_LABEL: ${TG_ACCOUNT_1_LABEL:-}
+      # TG_ACCOUNT_2_API_ID: ${TG_ACCOUNT_2_API_ID:-}
+      # TG_ACCOUNT_2_API_HASH: ${TG_ACCOUNT_2_API_HASH:-}
+      # TG_ACCOUNT_2_PHONE_NUMBER: ${TG_ACCOUNT_2_PHONE_NUMBER:-}
+      # TG_ACCOUNT_2_LABEL: ${TG_ACCOUNT_2_LABEL:-}
+      # TG_ACCOUNT_2_SESSION_NAME: ${TG_ACCOUNT_2_SESSION_NAME:-telegram_backup_account2}
+
       # Schedule (cron format)
       SCHEDULE: ${SCHEDULE:-0 */6 * * *}
 

--- a/src/config.py
+++ b/src/config.py
@@ -5,6 +5,8 @@ Loads and validates settings from environment variables.
 
 import logging
 import os
+import re
+from dataclasses import dataclass, field
 
 from dotenv import load_dotenv
 
@@ -107,6 +109,43 @@ def build_telegram_client_kwargs() -> dict:
     if proxy is not None:
         kwargs["proxy"] = dict(proxy)
     return kwargs
+
+
+# The full shape of one indexed account variable (v8.0.0 multi-account).
+# Parsing scans the environment for the TG_ACCOUNT_ prefix and then requires
+# this exact shape, so a typo'd suffix or index (TG_ACCOUNT_2_APIHASH,
+# TG_ACCOUNT_02_API_ID) is a loud startup error instead of a credential
+# silently not applying.
+_TG_ACCOUNT_ENV_RE = re.compile(r"^TG_ACCOUNT_([1-9]\d*)_(API_ID|API_HASH|PHONE_NUMBER|LABEL|SESSION_NAME)$")
+
+# The suffixes every account must declare; LABEL and SESSION_NAME are optional.
+_TG_ACCOUNT_REQUIRED_SUFFIXES = ("API_ID", "API_HASH", "PHONE_NUMBER")
+
+
+@dataclass(frozen=True)
+class AccountConfig:
+    """One Telegram account the archiver captures with (v8.0.0 multi-account).
+
+    ``index`` is the 1-based TG_ACCOUNT_<N>_* position — an env-file coordinate
+    only. The database row an account's data lives under is resolved from the
+    Telegram user id after login, never from this number, so re-ordering the
+    indexes never moves data between accounts.
+
+    ``api_id``/``api_hash``/``phone``/``label`` are kept out of the dataclass
+    repr: reprs travel into logs and exception text, the phone number is PII
+    and the hash is a credential — accounts appear in logs by index or database
+    row id only. The credential fields are Optional solely for the synthesized
+    zero-config account, which the viewer constructs without credentials;
+    indexed accounts always carry a complete, validated triple.
+    """
+
+    index: int
+    api_id: int | None = field(repr=False)
+    api_hash: str | None = field(repr=False)
+    phone: str | None = field(repr=False)
+    label: str = field(repr=False)
+    session_name: str
+    session_path: str
 
 
 class Config:
@@ -272,6 +311,14 @@ class Config:
         backup_parent = os.path.dirname(self.backup_path.rstrip("/\\"))
         self.session_dir = os.path.abspath(os.getenv("SESSION_DIR", os.path.join(backup_parent, "session")))
         self.session_path = os.path.join(self.session_dir, self.session_name)
+
+        # Multi-account declaration (v8.0.0). Parsed after the legacy session
+        # settings because account 1 inherits their resolution: with no
+        # TG_ACCOUNT_* variable set, exactly one account is synthesized from
+        # the legacy TELEGRAM_* variables with the same session file, so a 7.x
+        # deployment upgrades with zero env changes and zero re-login. When
+        # TG_ACCOUNT_* variables are present, they win over the legacy triple.
+        self.accounts, self._indexed_accounts = self._parse_accounts()
 
         # Database path configuration
         # Default: inside backup_path
@@ -458,6 +505,12 @@ class Config:
         logger.debug(f"Backup path: {self.backup_path}")
         logger.debug(f"Download media: {self.download_media}")
 
+        # Indexed mode announces itself by count only; identifying values
+        # (labels, phone numbers) stay out of the log. Zero-config deployments
+        # deliberately log nothing new here — their output stays 7.x-identical.
+        if self._indexed_accounts:
+            logger.info(f"Multi-account: using {len(self.accounts)} configured account(s)")
+
         # Log filtering mode
         if self.whitelist_mode:
             logger.info(f"Filter mode: WHITELIST - backing up ONLY {len(self.chat_ids)} specific chats")
@@ -580,6 +633,113 @@ class Config:
                 ) from e
             result.setdefault(chat_id, set()).add(topic_id)
         return result
+
+    def _parse_accounts(self) -> tuple[list[AccountConfig], bool]:
+        """Parse TG_ACCOUNT_<N>_* into an ordered account list.
+
+        Returns ``(accounts, indexed)`` where ``indexed`` is True when any
+        TG_ACCOUNT_* variable declared an account and False when the single
+        account was synthesized from the legacy TELEGRAM_* variables.
+
+        Session-name resolution: TG_ACCOUNT_<N>_SESSION_NAME wins when set;
+        account 1 then falls back to the legacy chain (SESSION_NAME env →
+        'telegram_backup') so an existing deployment keeps its session file,
+        and accounts 2+ fall back to 'telegram_backup_account<N>'.
+
+        Error messages name the offending VARIABLE, never its value: the
+        values are credentials and phone numbers (PII).
+        """
+        declared: dict[int, dict[str, str]] = {}
+        for key, value in os.environ.items():
+            if not key.startswith("TG_ACCOUNT_"):
+                continue
+            match = _TG_ACCOUNT_ENV_RE.match(key)
+            if match is None:
+                raise ValueError(
+                    f"Unrecognized account variable '{key}'. Expected TG_ACCOUNT_<N>_API_ID / _API_HASH / "
+                    "_PHONE_NUMBER / _LABEL / _SESSION_NAME with N starting at 1 (no leading zeros)."
+                )
+            # docker-compose's ${VAR:-} idiom injects empty strings for unset
+            # host variables; treat them exactly like absent variables.
+            if not value.strip():
+                continue
+            declared.setdefault(int(match.group(1)), {})[match.group(2)] = value.strip()
+
+        if not declared:
+            # Zero-config upgrade: byte-identical single-account behavior,
+            # including the credentials-optional viewer case (the Nones).
+            # 'default' matches the label migration 022 seeds on row 1, so the
+            # runtime's claim of that row rewrites nothing.
+            return [
+                AccountConfig(
+                    index=1,
+                    api_id=self.api_id,
+                    api_hash=self.api_hash,
+                    phone=self.phone,
+                    label="default",
+                    session_name=self.session_name,
+                    session_path=self.session_path,
+                )
+            ], False
+
+        indexes = sorted(declared)
+        if indexes != list(range(1, len(indexes) + 1)):
+            missing = next(i for i in range(1, max(indexes) + 1) if i not in declared)
+            raise ValueError(
+                f"TG_ACCOUNT_* indexes must be contiguous starting at 1: "
+                f"account {max(indexes)} is declared but TG_ACCOUNT_{missing}_API_ID is missing"
+            )
+
+        accounts: list[AccountConfig] = []
+        phone_owner: dict[str, int] = {}
+        session_owner: dict[str, int] = {}
+        for index in indexes:
+            variables = declared[index]
+            missing_suffixes = [s for s in _TG_ACCOUNT_REQUIRED_SUFFIXES if s not in variables]
+            if missing_suffixes:
+                names = ", ".join(f"TG_ACCOUNT_{index}_{suffix}" for suffix in missing_suffixes)
+                raise ValueError(f"Account {index} is incomplete: {names} missing")
+            try:
+                api_id = int(variables["API_ID"])
+            except ValueError:
+                # ``from None`` on purpose: the chained int() error would echo
+                # the raw value, and these messages never carry values.
+                raise ValueError(f"TG_ACCOUNT_{index}_API_ID must be an integer") from None
+
+            phone = variables["PHONE_NUMBER"]
+            if phone in phone_owner:
+                raise ValueError(
+                    f"TG_ACCOUNT_{index}_PHONE_NUMBER duplicates TG_ACCOUNT_{phone_owner[phone]}_PHONE_NUMBER: "
+                    "each account must be a distinct Telegram identity"
+                )
+            phone_owner[phone] = index
+
+            if index == 1:
+                # Account 1 keeps the legacy resolution so no existing
+                # deployment ever re-logins after declaring indexed accounts.
+                session_name = variables.get("SESSION_NAME") or self.session_name
+            else:
+                session_name = variables.get("SESSION_NAME") or f"telegram_backup_account{index}"
+            if session_name in session_owner:
+                raise ValueError(
+                    f"Accounts {session_owner[session_name]} and {index} resolve to the same session file: "
+                    f"set a distinct TG_ACCOUNT_{index}_SESSION_NAME (two clients sharing one Telethon "
+                    "session corrupt it)"
+                )
+            session_owner[session_name] = index
+
+            accounts.append(
+                AccountConfig(
+                    index=index,
+                    api_id=api_id,
+                    api_hash=variables["API_HASH"],
+                    phone=phone,
+                    label=variables.get("LABEL") or ("default" if index == 1 else f"account{index}"),
+                    session_name=session_name,
+                    session_path=os.path.join(self.session_dir, session_name),
+                )
+            )
+        return accounts, True
 
     def should_skip_topic(self, chat_id: int, topic_id: int | None) -> bool:
         """Check if a specific topic in a chat should be skipped.
@@ -764,7 +924,12 @@ class Config:
         return True
 
     def validate_credentials(self):
-        """Ensure Telegram credentials are present."""
+        """Ensure Telegram credentials are present for every configured account."""
+        if self._indexed_accounts:
+            # Indexed TG_ACCOUNT_<N>_* accounts were validated for complete
+            # triples (and an integer API_ID) when they were parsed, so being
+            # here means every declared account is whole.
+            return
         if not all([self.api_id, self.api_hash, self.phone]):
             raise ValueError(
                 "Missing required Telegram credentials (TELEGRAM_API_ID, TELEGRAM_API_HASH, TELEGRAM_PHONE). "

--- a/src/connection.py
+++ b/src/connection.py
@@ -1,11 +1,13 @@
 """
 Shared Telegram client connection manager.
 
-This module provides a single TelegramClient instance that can be shared between
-the backup and listener components, avoiding session file lock conflicts.
+This module provides one TelegramClient instance per account that is shared
+between the backup and listener components, avoiding session file lock
+conflicts (v8.0.0: the scheduler owns one TelegramConnection per configured
+account; a single-account deployment still has exactly one).
 
 Architecture:
-- TelegramConnection owns the single client
+- TelegramConnection owns the single client for its account's session file
 - Listener uses it for real-time events
 - Backup uses it for fetching message history
 - Both work on the same connection without conflicts
@@ -21,7 +23,7 @@ import sqlite3
 from telethon import TelegramClient
 from telethon.errors import FloodWaitError
 
-from .config import Config
+from .config import AccountConfig, Config
 
 logger = logging.getLogger(__name__)
 
@@ -101,27 +103,33 @@ class TelegramConnection:
     This solves the session lock conflict between listener and backup by
     ensuring only one TelegramClient instance exists and is shared.
 
-    Usage:
-        connection = TelegramConnection(config)
+    Usage (one connection per configured account):
+        connection = TelegramConnection(config, account=config.accounts[0])
         await connection.connect()
 
-        # Pass to backup and listener (single-account stage: account_id=1)
-        backup = TelegramBackup(config, db, client=connection.client, account_id=1)
-        listener = TelegramListener(config, db, client=connection.client, account_id=1)
+        # Pass to backup and listener with that account's resolved row id
+        backup = TelegramBackup(config, db, client=connection.client, account_id=row_id)
+        listener = TelegramListener(config, db, client=connection.client, account_id=row_id)
 
         # Both use the same connection
         await backup.backup_all()  # Uses shared client
         await listener.run()       # Uses shared client
     """
 
-    def __init__(self, config: Config):
+    def __init__(self, config: Config, account: AccountConfig | None = None):
         """
         Initialize the connection manager.
 
         Args:
-            config: Configuration object with Telegram credentials
+            config: Configuration object
+            account: The account this connection belongs to (session file and
+                API credentials). Defaults to ``config.accounts[0]``, which in a
+                zero-config deployment is the account synthesized from the
+                legacy TELEGRAM_* variables — same values this class read from
+                ``config`` directly before v8.0.0.
         """
         self.config = config
+        self.account = account if account is not None else config.accounts[0]
         config.validate_credentials()
 
         self._client: TelegramClient | None = None
@@ -218,11 +226,11 @@ class TelegramConnection:
             return self._client
 
         logger.info("Connecting to Telegram...")
-        logger.info(f"Using Telethon session database: {self.config.session_path}.session")
+        logger.info(f"Using Telethon session database: {self.account.session_path}.session")
 
-        session_file = self.config.session_path + ".session"
-        snapshot_file = self.config.session_path + ".session.bak"
-        golden_file = self.config.session_path + ".session.authenticated"
+        session_file = self.account.session_path + ".session"
+        snapshot_file = self.account.session_path + ".session.bak"
+        golden_file = self.account.session_path + ".session.authenticated"
 
         # Tier 1: if the golden backup exists and the live session lost its auth,
         # restore BEFORE TelegramClient even touches the file.
@@ -251,9 +259,9 @@ class TelegramConnection:
         # and that only a fresh connect() call can revive.
         if self._client is None:
             self._client = TelegramClient(
-                self.config.session_path,
-                self.config.api_id,
-                self.config.api_hash,
+                self.account.session_path,
+                self.account.api_id,
+                self.account.api_hash,
                 **self.config.get_telegram_client_kwargs(),
             )
         else:

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -25,6 +25,8 @@ from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from ..message_utils import compute_directory_size, resolve_sender_display_name, utcnow_naive
 from .base import DatabaseManager
 from .models import (
+    DEFAULT_ACCOUNT_ID,
+    Account,
     AppSettings,
     Chat,
     ChatFolder,
@@ -656,6 +658,71 @@ class DatabaseAdapter:
                 if isinstance(new_id, int):
                     markers.append((chat_id, new_id))
         return markers
+
+    # ========== Account Operations (v8.0.0) ==========
+
+    @retry_on_locked()
+    async def ensure_account(self, *, telegram_user_id: int, env_index: int, label: str) -> int:
+        """Resolve the ``accounts`` row a logged-in account writes under.
+
+        Called once per configured account per process start, after its client
+        authenticates and ``get_me()`` yields the Telegram user id. Returns the
+        ``accounts.id`` every capture-side call then passes as ``account_id``.
+
+        Resolution order — the user id owns the row, the env index owns nothing:
+
+        1. A row already carrying ``telegram_user_id`` wins outright (re-runs and
+           re-ordered ``TG_ACCOUNT_<N>_*`` indexes always land here). The label is
+           rewritten when it differs: the env is the display-name source of truth
+           on every start.
+        2. Only the account at env index 1 may claim the migrated row — pre-8.0
+           rows carry no user id, and index 1 is defined as their continuation.
+           The ``telegram_user_id IS NULL`` guard inside the UPDATE's WHERE makes
+           the claim atomic and once-only; a row 1 already owned by a different
+           user makes the guard miss, so reshuffled indexes never steal data.
+        3. Anything else is a new identity: INSERT and return the generated id
+           (migration 022 re-synced PostgreSQL's sequence past the seeded row).
+
+        PII: the Telegram user id and the label never reach the log — the debug
+        line names the env index and the resolved row id only (#272).
+        """
+        async with self.db_manager.async_session_factory() as session:
+            # No unique constraint backs telegram_user_id, so read defensively:
+            # if a corrupted archive ever held duplicates, the oldest row wins
+            # deterministically instead of MultipleResultsFound killing every
+            # backup run forever.
+            row = (
+                (
+                    await session.execute(
+                        select(Account).where(Account.telegram_user_id == telegram_user_id).order_by(Account.id)
+                    )
+                )
+                .scalars()
+                .first()
+            )
+            if row is not None:
+                if row.label != label:
+                    row.label = label
+                    await session.commit()
+                logger.debug(f"account {env_index} -> row {row.id}")
+                return row.id
+
+            if env_index == 1:
+                result = await session.execute(
+                    update(Account)
+                    .where(and_(Account.id == DEFAULT_ACCOUNT_ID, Account.telegram_user_id.is_(None)))
+                    .values(telegram_user_id=telegram_user_id, label=label)
+                )
+                if result.rowcount == 1:
+                    await session.commit()
+                    logger.debug(f"account {env_index} -> row {DEFAULT_ACCOUNT_ID} (claimed migrated row)")
+                    return DEFAULT_ACCOUNT_ID
+
+            account = Account(label=label, telegram_user_id=telegram_user_id)
+            session.add(account)
+            await session.commit()
+            logger.debug(f"account {env_index} -> row {account.id} (new)")
+            return account.id
 
     # ========== Chat Operations ==========
 

--- a/src/listener.py
+++ b/src/listener.py
@@ -35,9 +35,8 @@ from telethon.tl.types import (
 from telethon.utils import get_peer_id
 
 from .avatar_utils import get_avatar_paths
-from .config import Config
+from .config import AccountConfig, Config
 from .db import DatabaseAdapter, create_adapter
-from .db.models import DEFAULT_ACCOUNT_ID
 from .message_utils import (
     build_media_filename,
     compute_file_hash,
@@ -243,7 +242,16 @@ class TelegramListener:
     - For zero deletions from backup, set LISTEN_DELETIONS=false
     """
 
-    def __init__(self, config: Config, db: DatabaseAdapter, client: TelegramClient | None = None, *, account_id: int):
+    def __init__(
+        self,
+        config: Config,
+        db: DatabaseAdapter,
+        client: TelegramClient | None = None,
+        *,
+        account_id: int | None = None,
+        account: AccountConfig | None = None,
+        account_resolver=None,
+    ):
         """
         Initialize the listener.
 
@@ -253,11 +261,25 @@ class TelegramListener:
             client: Optional existing TelegramClient to use (for shared connection).
                    If not provided, will create a new client in connect().
             account_id: accounts.id every row written by this listener belongs to.
+                May be None only when ``account_resolver`` is given.
+            account: The configured account this listener captures for (session
+                file and API credentials for the own-client path). Defaults to
+                ``config.accounts[0]`` — the synthesized legacy account in a
+                zero-config deployment.
+            account_resolver: Optional ``async (client, db) -> int`` awaited by
+                connect() once the client is proven authorized — and before any
+                event handler is registered — yielding the accounts.id. Needed
+                by the own-client path, where no client exists before connect()
+                and the row is keyed on the Telegram user id.
         """
+        if account_id is None and account_resolver is None:
+            raise ValueError("account_id or account_resolver is required")
         self.config = config
         self.config.validate_credentials()
         self.db = db
         self.account_id = account_id
+        self.account = account if account is not None else config.accounts[0]
+        self._account_resolver = account_resolver
         self.client: TelegramClient | None = client
         self._owns_client = client is None  # Track if we created the client
         self._running = False
@@ -344,7 +366,15 @@ class TelegramListener:
         logger.info("=" * 70)
 
     @classmethod
-    async def create(cls, config: Config, client: TelegramClient | None = None, *, account_id: int) -> TelegramListener:
+    async def create(
+        cls,
+        config: Config,
+        client: TelegramClient | None = None,
+        *,
+        account_id: int | None = None,
+        account: AccountConfig | None = None,
+        account_resolver=None,
+    ) -> TelegramListener:
         """
         Factory method to create TelegramListener with initialized database.
 
@@ -352,12 +382,15 @@ class TelegramListener:
             config: Configuration object
             client: Optional existing TelegramClient to use (for shared connection)
             account_id: accounts.id every row written by this listener belongs to
+                (omit only when ``account_resolver`` is given)
+            account: The configured account to listen for (see ``__init__``)
+            account_resolver: Deferred accounts.id resolution (see ``__init__``)
 
         Returns:
             Initialized TelegramListener instance
         """
         db = await create_adapter()
-        return cls(config, db, client=client, account_id=account_id)
+        return cls(config, db, client=client, account_id=account_id, account=account, account_resolver=account_resolver)
 
     async def connect(self) -> None:
         """
@@ -382,11 +415,11 @@ class TelegramListener:
             logger.info("Connected")
         else:
             # Create new client
-            logger.info(f"Using Telethon session database: {self.config.session_path}.session")
+            logger.info(f"Using Telethon session database: {self.account.session_path}.session")
             self.client = TelegramClient(
-                self.config.session_path,
-                self.config.api_id,
-                self.config.api_hash,
+                self.account.session_path,
+                self.account.api_id,
+                self.account.api_hash,
                 **self.config.get_telegram_client_kwargs(),
             )
             self._owns_client = True
@@ -401,6 +434,14 @@ class TelegramListener:
 
             # Authorization already proven by the check above; no get_me() needed.
             logger.info("Connected")
+
+        # Resolve which accounts row this login writes under, now that the
+        # client is proven authorized. This MUST happen before handlers are
+        # registered below: a handler firing with an unresolved account_id
+        # would file its rows under the wrong account. Logs nothing at INFO,
+        # so the single-account startup output is unchanged.
+        if self._account_resolver is not None and self.account_id is None:
+            self.account_id = await self._account_resolver(self.client, self.db)
 
         # Load tracked chat IDs from database
         await self._load_tracked_chats()
@@ -1646,22 +1687,57 @@ class TelegramListener:
 
 async def run_listener(config: Config) -> None:
     """
-    Run the real-time listener as a standalone process.
+    Run the real-time listener as a standalone process — one listener per
+    configured account, each registered on its own client.
 
     Args:
         config: Configuration object
     """
-    # Single-account stage: every row belongs to the migration-seeded account.
-    # Phase 5 replaces the constant with real per-account resolution here.
-    listener = await TelegramListener.create(config, account_id=DEFAULT_ACCOUNT_ID)
 
+    def account_row_resolver(account: AccountConfig):
+        # Same contract as telegram_backup's resolver: the accounts row is
+        # keyed on the Telegram user id, so it can only be resolved once this
+        # account's own client is authorized; connect() awaits this before any
+        # event handler is registered.
+        async def resolve(client: TelegramClient, db: DatabaseAdapter) -> int:
+            me = await client.get_me()
+            return await db.ensure_account(telegram_user_id=me.id, env_index=account.index, label=account.label)
+
+        return resolve
+
+    listeners: list[TelegramListener] = []
+    connected: list[TelegramListener] = []
+    failed = 0
     try:
-        await listener.connect()
-        await listener.run()
+        for account in config.accounts:
+            try:
+                listener = await TelegramListener.create(
+                    config, account=account, account_resolver=account_row_resolver(account)
+                )
+                listeners.append(listener)
+                await listener.connect()
+                connected.append(listener)
+            except Exception as e:
+                # One broken account must not silence the other accounts'
+                # listeners — but with a single account there is nothing to
+                # shield, so keep the pre-8.0 behavior of letting the failure
+                # propagate to main().
+                if len(config.accounts) == 1:
+                    raise
+                # Type name only: exception text can carry the phone (#272).
+                failed += 1
+                logger.error(f"account {account.index} failed: {type(e).__name__}")
+        if failed and not connected:
+            raise RuntimeError(f"all {failed} configured accounts failed to start a listener")
+        if len(connected) == 1:
+            await connected[0].run()
+        elif connected:
+            await asyncio.gather(*(listener.run() for listener in connected))
     except KeyboardInterrupt:
         logger.info("Keyboard interrupt received")
     finally:
-        await listener.close()
+        for listener in listeners:
+            await listener.close()
 
 
 async def main() -> None:

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -6,31 +6,59 @@ Optionally runs a real-time listener that catches message edits and deletions
 between scheduled backup runs (when ENABLE_LISTENER=true).
 
 SHARED CONNECTION ARCHITECTURE:
-A single TelegramClient is shared between the backup and listener components.
-This avoids session file lock conflicts and allows both to run simultaneously.
+Each configured account has a single TelegramClient shared between its backup
+and listener components. This avoids session file lock conflicts and allows
+both to run simultaneously. Accounts are swept SEQUENTIALLY: account 1's full
+backup completes before account 2's starts — Telegram tolerates N sessions,
+not N concurrent full sweeps from one box.
 """
 
 import asyncio
 import logging
 import signal
 import sys
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.triggers.cron import CronTrigger
 
-from .config import Config
+from .config import AccountConfig, Config
 from .connection import TelegramConnection
 from .telegram_backup import run_backup
 
+if TYPE_CHECKING:
+    from .listener import TelegramListener
+
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _AccountRuntime:
+    """Per-account runtime state: one shared connection, one listener, one row id.
+
+    ``row_id`` is the ``accounts.id`` resolved from the Telegram user id after
+    login (see ``DatabaseAdapter.ensure_account``); None until the account has
+    connected once. ``log_prefix`` is "" in a single-account deployment — log
+    lines stay byte-identical to pre-8.0 — and ``"[account <index>] "``
+    otherwise, so multi-account output is attributable by env index, never by
+    label or phone (#272).
+    """
+
+    account: AccountConfig
+    connection: TelegramConnection
+    log_prefix: str = ""
+    row_id: int | None = None
+    listener: TelegramListener | None = None
+    listener_task: asyncio.Task | None = None
 
 
 class BackupScheduler:
     """
     Scheduler for automated backups with optional real-time listener.
 
-    Uses a shared TelegramClient connection for both backup and listener,
-    eliminating session file lock conflicts.
+    Uses a shared TelegramClient connection per account for both backup and
+    listener, eliminating session file lock conflicts.
     """
 
     def __init__(self, config: Config):
@@ -45,16 +73,14 @@ class BackupScheduler:
         self.running = False
         self._backup_lock = asyncio.Lock()
 
-        # Shared Telegram connection (used by both backup and listener)
-        self._connection: TelegramConnection | None = None
+        # Per-account runtime state (one shared connection + listener each),
+        # populated by _connect() in config order. Sweeps iterate it in order.
+        self._accounts: list[_AccountRuntime] = []
 
-        # Real-time listener (optional)
-        self._listener = None
-        self._listener_task: asyncio.Task | None = None
-        # Set once (in run_forever) when the listener is supposed to be running for
-        # the life of the process. Unlike checking config directly, this lets the
-        # watchdog keep retrying after a failed start -- _start_listener resets
-        # _listener_task to None on failure, but the listener is still "enabled".
+        # Set once (in run_forever) when the listeners are supposed to be running
+        # for the life of the process. Unlike checking config directly, this lets
+        # the watchdog keep retrying after a failed start -- _start_account_listener
+        # resets listener_task to None on failure, but the listener is still "enabled".
         self._listener_enabled = False
 
         # Setup signal handlers for graceful shutdown
@@ -66,12 +92,84 @@ class BackupScheduler:
         logger.info(f"Received signal {signum}, shutting down gracefully...")
         self.stop()
 
+    async def _resolve_account_rows(self) -> None:
+        """Resolve each connected account's ``accounts`` row id, once.
+
+        The row is keyed on the Telegram user id from the account's own login
+        (``DatabaseAdapter.ensure_account`` — including the claim of the
+        migrated pre-8.0 row by the account at env index 1). Entries whose
+        connection has not come up yet are left unresolved and retried by the
+        next sweep or listener start. Uses one short-lived adapter, the same
+        engine lifecycle run_backup itself uses per run.
+        """
+        pending = [e for e in self._accounts if e.row_id is None and e.connection.me is not None]
+        if not pending:
+            return
+        from .db import create_adapter
+
+        db = await create_adapter()
+        try:
+            for entry in pending:
+                entry.row_id = await db.ensure_account(
+                    telegram_user_id=entry.connection.me.id,
+                    env_index=entry.account.index,
+                    label=entry.account.label,
+                )
+        finally:
+            await db.close()
+
+    async def _sweep_account(self, entry: _AccountRuntime) -> bool:
+        """One account's full scheduled sweep: backup, then optional gap-fill.
+
+        Returns False when gap-fill reported errors. Raises on hard failure
+        (connection, row resolution, backup) — the caller decides whether that
+        kills the run (single account) or moves on to the next account.
+        """
+        # Ensure connection is still alive
+        client = await entry.connection.ensure_connected()
+
+        # Normally resolved at startup; retried here for an account whose
+        # connection (or the database) was down back then.
+        if entry.row_id is None:
+            await self._resolve_account_rows()
+        if entry.row_id is None:
+            raise RuntimeError(f"account {entry.account.index} row not resolved")
+
+        # Run backup using this account's shared client
+        await run_backup(self.config, client=client, account_id=entry.row_id)
+
+        # Run gap-fill if enabled
+        gap_fill_ok = True
+        if self.config.fill_gaps:
+            try:
+                from .telegram_backup import run_fill_gaps
+
+                logger.info(f"{entry.log_prefix}Running post-backup gap-fill...")
+                result = await run_fill_gaps(self.config, client=client, account_id=entry.row_id)
+                if result.get("errors", 0) > 0:
+                    gap_fill_ok = False
+                    logger.warning(
+                        f"{entry.log_prefix}Gap-fill completed with {result['errors']} error(s) "
+                        f"({result['total_recovered']} messages recovered)"
+                    )
+            except Exception as e:
+                gap_fill_ok = False
+                logger.error(f"{entry.log_prefix}Gap-fill failed: {e}", exc_info=True)
+
+        # Reload tracked chats in this account's listener after its backup
+        # (new chats may have been added)
+        if entry.listener:
+            await entry.listener._load_tracked_chats()
+
+        return gap_fill_ok
+
     async def _run_backup_job(self):
         """
         Wrapper for backup job that handles errors.
 
-        Uses the shared connection - no need to pause the listener since both
-        use the same TelegramClient.
+        Uses the shared connections - no need to pause the listeners since each
+        account's backup and listener use the same TelegramClient. Accounts are
+        swept sequentially, in config order.
         """
         if self._backup_lock.locked():
             logger.warning("Skipping scheduled backup because another backup is already running")
@@ -81,36 +179,24 @@ class BackupScheduler:
             try:
                 logger.info("Scheduled backup starting...")
 
-                # Ensure connection is still alive
-                client = await self._connection.ensure_connected()
-
-                # Run backup using shared client
-                await run_backup(self.config, client=client)
-
-                # Run gap-fill if enabled
                 gap_fill_ok = True
-                if self.config.fill_gaps:
+                failed = 0
+                for entry in self._accounts:
                     try:
-                        from .telegram_backup import run_fill_gaps
-
-                        logger.info("Running post-backup gap-fill...")
-                        result = await run_fill_gaps(self.config, client=client)
-                        if result.get("errors", 0) > 0:
-                            gap_fill_ok = False
-                            logger.warning(
-                                f"Gap-fill completed with {result['errors']} error(s) "
-                                f"({result['total_recovered']} messages recovered)"
-                            )
+                        gap_fill_ok = await self._sweep_account(entry) and gap_fill_ok
                     except Exception as e:
-                        gap_fill_ok = False
-                        logger.error(f"Gap-fill failed: {e}", exc_info=True)
+                        # One broken account must not consume the other accounts'
+                        # sweeps; a single-account deployment keeps the pre-8.0
+                        # error path below instead.
+                        if len(self._accounts) == 1:
+                            raise
+                        # Type name only: exception text can carry the phone (#272).
+                        failed += 1
+                        logger.error(f"account {entry.account.index} failed: {type(e).__name__}")
 
-                # Reload tracked chats in listener after backup
-                # (new chats may have been added)
-                if self._listener:
-                    await self._listener._load_tracked_chats()
-
-                if gap_fill_ok:
+                if failed:
+                    logger.warning(f"Scheduled backup completed, but {failed} account(s) failed")
+                elif gap_fill_ok:
                     logger.info("Scheduled backup completed successfully")
                 else:
                     logger.warning("Scheduled backup completed, but gap-fill had errors")
@@ -165,27 +251,68 @@ class BackupScheduler:
             logger.info("Scheduler stopped")
 
     async def _connect(self) -> None:
-        """Establish shared Telegram connection."""
-        logger.info("Establishing shared Telegram connection...")
-        self._connection = TelegramConnection(self.config)
-        await self._connection.connect()
-        logger.info("Shared connection established")
+        """Establish one shared Telegram connection per configured account."""
+        multi = len(self.config.accounts) > 1
+        for account in self.config.accounts:
+            prefix = f"[account {account.index}] " if multi else ""
+            logger.info(f"{prefix}Establishing shared Telegram connection...")
+            entry = _AccountRuntime(
+                account=account,
+                connection=TelegramConnection(self.config, account=account),
+                log_prefix=prefix,
+            )
+            try:
+                await entry.connection.connect()
+                logger.info(f"{prefix}Shared connection established")
+            except Exception as e:
+                # One unreachable account must not keep the others from coming
+                # up; its connection heals through ensure_connected() on later
+                # sweeps and listener starts. A single-account deployment keeps
+                # the pre-8.0 fail-fast startup.
+                if not multi:
+                    raise
+                # Type name only: exception text can carry the phone (#272).
+                logger.error(f"account {account.index} failed: {type(e).__name__}")
+            self._accounts.append(entry)
+
+        try:
+            await self._resolve_account_rows()
+        except Exception as e:
+            # The database being down at startup must not kill the process:
+            # pre-8.0 the first DB touch happened inside the initial backup,
+            # which is retried every cycle — keep that resilience. Resolution
+            # is retried by every sweep and listener start. Type name only
+            # (the text can carry a connection DSN).
+            logger.warning(f"Could not resolve account rows yet: {type(e).__name__}")
 
     async def _disconnect(self) -> None:
-        """Close shared Telegram connection."""
-        if self._connection:
-            await self._connection.disconnect()
-            self._connection = None
+        """Close all shared Telegram connections."""
+        for entry in self._accounts:
+            await entry.connection.disconnect()
+        self._accounts = []
 
     async def _start_listener(self) -> None:
-        """Start the real-time listener if enabled."""
+        """Start the real-time listener for every account, if enabled.
+
+        Idempotent per account: an entry whose listener task is alive is left
+        untouched, so the watchdog can call this to revive only what died —
+        healthy accounts' handlers are never re-registered (the duplicate-
+        handler trap _remove_handlers exists for).
+        """
         if not self.config.enable_listener:
             return
 
-        if not self._connection:
+        if not self._accounts:
             logger.error("Cannot start listener: not connected to Telegram")
             return
 
+        for entry in self._accounts:
+            if entry.listener_task is not None and not entry.listener_task.done():
+                continue
+            await self._start_account_listener(entry)
+
+    async def _start_account_listener(self, entry: _AccountRuntime) -> None:
+        """Start one account's real-time listener on its shared connection."""
         # ``TelegramConnection.is_connected`` is an app-level flag: it stays True
         # after Telethon's sender exhausts its own reconnect budget (~55s) and
         # marks itself disconnected, so it cannot tell us the socket is dead.
@@ -203,43 +330,60 @@ class BackupScheduler:
         # a backup can run for hours, and the listener would stay dead for all
         # of it, which is the outage #265 is about.
         try:
-            await self._connection.ensure_connected()
+            await entry.connection.ensure_connected()
         except Exception as e:
-            logger.warning(f"Could not re-establish the shared connection before starting the listener: {e}")
+            logger.warning(
+                f"{entry.log_prefix}Could not re-establish the shared connection before starting the listener: {e}"
+            )
 
-        if not self._connection.is_connected:
-            logger.error("Cannot start listener: not connected to Telegram")
+        if not entry.connection.is_connected:
+            logger.error(f"{entry.log_prefix}Cannot start listener: not connected to Telegram")
             return
 
         try:
-            from .db.models import DEFAULT_ACCOUNT_ID
             from .listener import TelegramListener
 
-            logger.info("Starting real-time listener...")
+            logger.info(f"{entry.log_prefix}Starting real-time listener...")
 
-            # Create listener with shared client.
-            # Single-account stage: phase 5 resolves per-account ids here.
-            self._listener = await TelegramListener.create(
-                self.config, client=self._connection.client, account_id=DEFAULT_ACCOUNT_ID
+            # Normally resolved at startup; retried here for an account whose
+            # connection (or the database) was down back then.
+            if entry.row_id is None:
+                await self._resolve_account_rows()
+            if entry.row_id is None:
+                raise RuntimeError(f"account {entry.account.index} row not resolved")
+
+            # Create listener with this account's shared client.
+            entry.listener = await TelegramListener.create(
+                self.config, client=entry.connection.client, account_id=entry.row_id
             )
-            await self._listener.connect()
+            await entry.listener.connect()
 
             # Run listener in background task
-            self._listener_task = asyncio.create_task(self._listener.run(), name="telegram_listener")
-            logger.info("Real-time listener started successfully")
+            task_name = (
+                "telegram_listener" if len(self._accounts) == 1 else f"telegram_listener_account{entry.account.index}"
+            )
+            entry.listener_task = asyncio.create_task(entry.listener.run(), name=task_name)
+            logger.info(f"{entry.log_prefix}Real-time listener started successfully")
 
         except Exception as e:
-            logger.error(f"Failed to start listener: {e}", exc_info=True)
-            self._listener = None
-            self._listener_task = None
+            logger.error(f"{entry.log_prefix}Failed to start listener: {e}", exc_info=True)
+            entry.listener = None
+            entry.listener_task = None
 
-    async def _stop_listener(self) -> None:
-        """Stop the real-time listener if running."""
-        if self._listener_task:
-            logger.info("Stopping real-time listener...")
-            self._listener_task.cancel()
+    async def _stop_listener(self, only_dead: bool = False) -> None:
+        """Stop listeners — all of them (shutdown), or only dead ones (watchdog)."""
+        for entry in self._accounts:
+            if only_dead and entry.listener_task is not None and not entry.listener_task.done():
+                continue
+            await self._stop_account_listener(entry)
+
+    async def _stop_account_listener(self, entry: _AccountRuntime) -> None:
+        """Stop one account's real-time listener if running."""
+        if entry.listener_task:
+            logger.info(f"{entry.log_prefix}Stopping real-time listener...")
+            entry.listener_task.cancel()
             try:
-                await self._listener_task
+                await entry.listener_task
             except asyncio.CancelledError:
                 pass
             except Exception:
@@ -248,57 +392,86 @@ class BackupScheduler:
                 # task re-raises it, so swallow here to let teardown/restart
                 # proceed instead of crashing the process.
                 pass
-            self._listener_task = None
+            entry.listener_task = None
 
-        if self._listener:
-            await self._listener.close()
-            self._listener = None
-            logger.info("Real-time listener stopped")
+        if entry.listener:
+            await entry.listener.close()
+            entry.listener = None
+            logger.info(f"{entry.log_prefix}Real-time listener stopped")
+
+    async def _initial_backup_account(self, entry: _AccountRuntime) -> None:
+        """The startup backup for one account, mirroring the scheduled sweep.
+
+        Kept separate from _sweep_account because the startup sequence logs
+        'Initial backup completed' between the backup and the gap-fill — the
+        pre-8.0 order, which single-account deployments keep byte-for-byte.
+        """
+        # The connection was just established by _connect(); the ensure below
+        # only matters for an account whose startup connect failed (multi-
+        # account mode) — it raises into the caller's per-account handler.
+        client = entry.connection.client
+        if client is None or not entry.connection.is_connected:
+            client = await entry.connection.ensure_connected()
+
+        if entry.row_id is None:
+            await self._resolve_account_rows()
+        if entry.row_id is None:
+            raise RuntimeError(f"account {entry.account.index} row not resolved")
+
+        await run_backup(self.config, client=client, account_id=entry.row_id)
+        logger.info(f"{entry.log_prefix}Initial backup completed")
+
+        # Run gap-fill if enabled
+        if self.config.fill_gaps:
+            try:
+                from .telegram_backup import run_fill_gaps
+
+                logger.info(f"{entry.log_prefix}Running initial gap-fill...")
+                result = await run_fill_gaps(self.config, client=client, account_id=entry.row_id)
+                if result.get("errors", 0) > 0:
+                    logger.warning(f"{entry.log_prefix}Initial gap-fill completed with {result['errors']} error(s)")
+            except Exception as e:
+                logger.error(f"{entry.log_prefix}Initial gap-fill failed: {e}", exc_info=True)
+
+        # Reload tracked chats in this account's listener after initial backup
+        if entry.listener:
+            await entry.listener._load_tracked_chats()
 
     async def run_forever(self):
         """
-        Keep the scheduler running with optional listener.
+        Keep the scheduler running with optional listeners.
 
         Flow:
-        1. Connect to Telegram (shared connection)
+        1. Connect to Telegram (one shared connection per account)
         2. Start scheduler
-        3. Start listener if enabled (uses shared connection)
-        4. Run initial backup (uses shared connection)
+        3. Start listeners if enabled (each on its account's shared connection)
+        4. Run initial backup, account by account (shared connections)
         5. Keep running until stopped
         """
-        # Establish shared connection
+        # Establish shared connections
         await self._connect()
 
         # Start scheduler
         self.start()
 
-        # Start real-time listener if enabled (uses shared connection).
+        # Start real-time listeners if enabled (each uses its shared connection).
         self._listener_enabled = self.config.enable_listener
         await self._start_listener()
 
-        # Run initial backup immediately on startup (uses shared connection)
+        # Run initial backup immediately on startup (uses shared connections)
         logger.info("Running initial backup on startup...")
         async with self._backup_lock:
             try:
-                await run_backup(self.config, client=self._connection.client)
-                logger.info("Initial backup completed")
-
-                # Run gap-fill if enabled
-                if self.config.fill_gaps:
+                for entry in self._accounts:
                     try:
-                        from .telegram_backup import run_fill_gaps
-
-                        logger.info("Running initial gap-fill...")
-                        result = await run_fill_gaps(self.config, client=self._connection.client)
-                        if result.get("errors", 0) > 0:
-                            logger.warning(f"Initial gap-fill completed with {result['errors']} error(s)")
+                        await self._initial_backup_account(entry)
                     except Exception as e:
-                        logger.error(f"Initial gap-fill failed: {e}", exc_info=True)
-
-                # Reload tracked chats in listener after initial backup
-                if self._listener:
-                    await self._listener._load_tracked_chats()
-
+                        # Same continuation rule as the scheduled sweep: only a
+                        # single-account deployment lets the failure reach the
+                        # pre-8.0 catch below.
+                        if len(self._accounts) == 1:
+                            raise
+                        logger.error(f"account {entry.account.index} failed: {type(e).__name__}")
             except Exception as e:
                 logger.error(f"Initial backup failed: {e}", exc_info=True)
 
@@ -307,23 +480,27 @@ class BackupScheduler:
             while self.running:
                 await asyncio.sleep(1)
 
-                # Check if the listener task died, or never came up at all (a failed
-                # restart leaves _listener_task as None -- see _start_listener), and
-                # restart it either way. Retrying on None (not just "died") is what
+                # Check if any listener task died, or never came up at all (a failed
+                # restart leaves listener_task as None -- see _start_account_listener),
+                # and restart it either way. Retrying on None (not just "died") is what
                 # keeps a flapping listener from being permanently disabled after a
-                # single failed restart attempt.
-                if self._listener_enabled and (self._listener_task is None or self._listener_task.done()):
-                    if self._listener_task is not None and self._listener_task.done():
-                        # Check if there was an exception
-                        try:
-                            exc = self._listener_task.exception()
-                            if exc:
-                                logger.error(f"Listener task died with error: {exc}")
-                        except asyncio.CancelledError:
-                            pass
+                # single failed restart attempt. Only dead entries are restarted --
+                # healthy accounts' listeners keep running untouched.
+                if self._listener_enabled and any(
+                    entry.listener_task is None or entry.listener_task.done() for entry in self._accounts
+                ):
+                    for entry in self._accounts:
+                        if entry.listener_task is not None and entry.listener_task.done():
+                            # Check if there was an exception
+                            try:
+                                exc = entry.listener_task.exception()
+                                if exc:
+                                    logger.error(f"{entry.log_prefix}Listener task died with error: {exc}")
+                            except asyncio.CancelledError:
+                                pass
 
                     logger.warning("Listener task not running, attempting restart...")
-                    await self._stop_listener()
+                    await self._stop_listener(only_dead=True)
                     await asyncio.sleep(5)  # Brief pause before restart
                     await self._start_listener()
 

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -72,6 +72,11 @@ class BackupScheduler:
         self.scheduler = AsyncIOScheduler()
         self.running = False
         self._backup_lock = asyncio.Lock()
+        # Serializes account-row resolution: the sweep, a listener start and the
+        # initial backup can all call it concurrently, and accounts has no
+        # DB-level unique on telegram_user_id, so two interleaved misses would
+        # both INSERT a row for the same account.
+        self._resolve_rows_lock = asyncio.Lock()
 
         # Per-account runtime state (one shared connection + listener each),
         # populated by _connect() in config order. Sweeps iterate it in order.
@@ -102,21 +107,24 @@ class BackupScheduler:
         next sweep or listener start. Uses one short-lived adapter, the same
         engine lifecycle run_backup itself uses per run.
         """
-        pending = [e for e in self._accounts if e.row_id is None and e.connection.me is not None]
-        if not pending:
-            return
-        from .db import create_adapter
+        async with self._resolve_rows_lock:
+            # Recomputed under the lock: a caller that queued behind a completed
+            # resolution finds nothing pending and does no database work.
+            pending = [e for e in self._accounts if e.row_id is None and e.connection.me is not None]
+            if not pending:
+                return
+            from .db import create_adapter
 
-        db = await create_adapter()
-        try:
-            for entry in pending:
-                entry.row_id = await db.ensure_account(
-                    telegram_user_id=entry.connection.me.id,
-                    env_index=entry.account.index,
-                    label=entry.account.label,
-                )
-        finally:
-            await db.close()
+            db = await create_adapter()
+            try:
+                for entry in pending:
+                    entry.row_id = await db.ensure_account(
+                        telegram_user_id=entry.connection.me.id,
+                        env_index=entry.account.index,
+                        label=entry.account.label,
+                    )
+            finally:
+                await db.close()
 
     async def _sweep_account(self, entry: _AccountRuntime) -> bool:
         """One account's full scheduled sweep: backup, then optional gap-fill.
@@ -333,7 +341,10 @@ class BackupScheduler:
             await entry.connection.ensure_connected()
         except Exception as e:
             logger.warning(
-                f"{entry.log_prefix}Could not re-establish the shared connection before starting the listener: {e}"
+                # Exception text can embed the DSN or host; type name only, like
+                # the sibling handlers in this file.
+                f"{entry.log_prefix}Could not re-establish the shared connection before starting the listener: "
+                f"{type(e).__name__}"
             )
 
         if not entry.connection.is_connected:

--- a/src/setup_auth.py
+++ b/src/setup_auth.py
@@ -63,8 +63,119 @@ def _same_phone_number(left: str | None, right: str | None) -> bool:
     return _normalised_phone_digits(left) == _normalised_phone_digits(right)
 
 
+async def _authorize_account(config, account, phone_var: str) -> bool:
+    """Interactively authorize one configured account; True once verified.
+
+    The flow self-skips the interactive part when the account's session file is
+    already authorized, so re-running the setup only prompts for accounts that
+    still need a login. ``phone_var`` is the NAME of the variable the expected
+    number came from (``TELEGRAM_PHONE`` or ``TG_ACCOUNT_<N>_PHONE_NUMBER``) —
+    messages name the variable, never its value.
+    """
+    # The phone number is deliberately not echoed. This flow looks
+    # interactive, but it emits through setup_logging -> basicConfig ->
+    # stderr, and where that stream ends up is the OPERATOR's choice, not
+    # ours: docker-compose.yml declares no logging driver, so under
+    # journald, syslog, gelf, fluentd or a Loki plugin every line is shipped
+    # off-box the moment it is written and outlives the --rm container that
+    # produced it. That is the argument; "docker logs captures it" is not,
+    # since `docker compose exec` output never reaches docker logs at all
+    # and --rm deletes the json-file log on exit.
+    logger.info(f"Session will be saved to: {account.session_path}")
+    logger.info("=" * 60)
+
+    # Create Telegram client
+    client = TelegramClient(
+        account.session_path,
+        account.api_id,
+        account.api_hash,
+        **config.get_telegram_client_kwargs(),
+    )
+
+    # Connect and authenticate
+    logger.info("Connecting to Telegram...")
+    await client.connect()
+
+    if not await client.is_user_authorized():
+        logger.info("Not authorized yet. Starting authentication process...")
+
+        # Send code request
+        await client.send_code_request(account.phone)
+        print("\n" + "=" * 60)
+        print("A verification code has been sent to your Telegram app.")
+        print("Please check your Telegram and enter the code below.")
+        print("=" * 60)
+
+        # Get code from user
+        code = input("Enter verification code: ").strip()
+
+        try:
+            # Sign in with code
+            await client.sign_in(account.phone, code)
+            logger.info("Authentication successful!")
+
+        except Exception as e:
+            # If code is wrong or 2FA is enabled
+            if "Two-steps verification" in str(e) or "password" in str(e).lower():
+                print("\n" + "=" * 60)
+                print("Two-factor authentication is enabled on your account.")
+                print("=" * 60)
+                password = input("Enter your 2FA password: ").strip()
+                await client.sign_in(password=password)
+                logger.info("Authentication successful with 2FA!")
+            else:
+                raise
+    else:
+        logger.info("Already authorized!")
+
+    # Confirm WHICH account answered, without naming it. The session path
+    # below cannot do this: SESSION_NAME defaults to "telegram_backup" in
+    # config.py, docker-compose.yml and .env.example alike, so it is the
+    # same string for every user — and even when it is customised it names
+    # the destination slot the operator chose, not the identity Telegram
+    # returned. Comparing the two is what actually answers "did I
+    # authenticate the account I meant to?", and it answers it for the
+    # `Already authorized!` branch above, where a stale session file from a
+    # different account would otherwise pass in silence. The result is a
+    # boolean, so nothing identifying reaches the log.
+    me = await client.get_me()
+    # get_me() returns None on an unauthorized session rather than raising,
+    # so read through it defensively: a session that died between the check
+    # above and here must not crash with an AttributeError.
+    account_matches_configured_phone = _same_phone_number(getattr(me, "phone", None), account.phone)
+    logger.info("=" * 60)
+    logger.info("Authentication verified!")
+    logger.info(f"Authenticated account matches {phone_var}: {account_matches_configured_phone}")
+    if not account_matches_configured_phone:
+        # Fail closed. Reporting the mismatch and returning success anyway
+        # would let main() announce a completed setup while the session
+        # belongs to another account — the daemons check authorization but
+        # never identity, so nothing downstream would catch it either.
+        logger.error(
+            f"The authorized session does not belong to {phone_var}. "
+            "Delete the session file and re-run this setup, or correct "
+            f"{phone_var} if the number is written in a different form."
+        )
+        await client.disconnect()
+        return False
+    logger.info("=" * 60)
+    logger.info(f"Session saved to: {account.session_path}")
+    logger.info("You can now use this session with Docker or the scheduler.")
+    logger.info("=" * 60)
+
+    await client.disconnect()
+
+    return True
+
+
 async def setup_authentication():
-    """Interactive authentication setup."""
+    """Interactive authentication setup, walking every configured account.
+
+    A single (zero-config) account keeps the exact pre-8.0 flow. With indexed
+    accounts each is authorized in turn — already-authorized sessions need no
+    interaction — and a failure stops the walk so the operator can fix that
+    account and re-run (finished accounts then skip straight through).
+    """
     try:
         # Load configuration
         from .config import Config, setup_logging
@@ -76,98 +187,22 @@ async def setup_authentication():
         logger.info("=" * 60)
         logger.info("Telegram Authentication Setup")
         logger.info("=" * 60)
-        # The phone number is deliberately not echoed. This flow looks
-        # interactive, but it emits through setup_logging -> basicConfig ->
-        # stderr, and where that stream ends up is the OPERATOR's choice, not
-        # ours: docker-compose.yml declares no logging driver, so under
-        # journald, syslog, gelf, fluentd or a Loki plugin every line is shipped
-        # off-box the moment it is written and outlives the --rm container that
-        # produced it. That is the argument; "docker logs captures it" is not,
-        # since `docker compose exec` output never reaches docker logs at all
-        # and --rm deletes the json-file log on exit.
-        logger.info(f"Session will be saved to: {config.session_path}")
-        logger.info("=" * 60)
 
-        # Create Telegram client
-        client = TelegramClient(
-            config.session_path,
-            config.api_id,
-            config.api_hash,
-            **config.get_telegram_client_kwargs(),
-        )
-
-        # Connect and authenticate
-        logger.info("Connecting to Telegram...")
-        await client.connect()
-
-        if not await client.is_user_authorized():
-            logger.info("Not authorized yet. Starting authentication process...")
-
-            # Send code request
-            await client.send_code_request(config.phone)
-            print("\n" + "=" * 60)
-            print("A verification code has been sent to your Telegram app.")
-            print("Please check your Telegram and enter the code below.")
-            print("=" * 60)
-
-            # Get code from user
-            code = input("Enter verification code: ").strip()
-
-            try:
-                # Sign in with code
-                await client.sign_in(config.phone, code)
-                logger.info("Authentication successful!")
-
-            except Exception as e:
-                # If code is wrong or 2FA is enabled
-                if "Two-steps verification" in str(e) or "password" in str(e).lower():
-                    print("\n" + "=" * 60)
-                    print("Two-factor authentication is enabled on your account.")
-                    print("=" * 60)
-                    password = input("Enter your 2FA password: ").strip()
-                    await client.sign_in(password=password)
-                    logger.info("Authentication successful with 2FA!")
-                else:
-                    raise
-        else:
-            logger.info("Already authorized!")
-
-        # Confirm WHICH account answered, without naming it. The session path
-        # below cannot do this: SESSION_NAME defaults to "telegram_backup" in
-        # config.py, docker-compose.yml and .env.example alike, so it is the
-        # same string for every user — and even when it is customised it names
-        # the destination slot the operator chose, not the identity Telegram
-        # returned. Comparing the two is what actually answers "did I
-        # authenticate the account I meant to?", and it answers it for the
-        # `Already authorized!` branch above, where a stale session file from a
-        # different account would otherwise pass in silence. The result is a
-        # boolean, so nothing identifying reaches the log.
-        me = await client.get_me()
-        # get_me() returns None on an unauthorized session rather than raising,
-        # so read through it defensively: a session that died between the check
-        # above and here must not crash with an AttributeError.
-        account_matches_configured_phone = _same_phone_number(getattr(me, "phone", None), config.phone)
-        logger.info("=" * 60)
-        logger.info("Authentication verified!")
-        logger.info(f"Authenticated account matches TELEGRAM_PHONE: {account_matches_configured_phone}")
-        if not account_matches_configured_phone:
-            # Fail closed. Reporting the mismatch and returning success anyway
-            # would let main() announce a completed setup while the session
-            # belongs to another account — the daemons check authorization but
-            # never identity, so nothing downstream would catch it either.
-            logger.error(
-                "The authorized session does not belong to TELEGRAM_PHONE. "
-                "Delete the session file and re-run this setup, or correct "
-                "TELEGRAM_PHONE if the number is written in a different form."
-            )
-            await client.disconnect()
-            return False
-        logger.info("=" * 60)
-        logger.info(f"Session saved to: {config.session_path}")
-        logger.info("You can now use this session with Docker or the scheduler.")
-        logger.info("=" * 60)
-
-        await client.disconnect()
+        multi = len(config.accounts) > 1
+        for account in config.accounts:
+            if multi:
+                # Index only: the label and phone stay out of the log (#272).
+                logger.info(f"--- Account {account.index} ---")
+            # Name the variable the expected phone number came from.
+            # ``_indexed_accounts`` is Config's own flag for "TG_ACCOUNT_* is
+            # in effect"; it is read here only to pick the right NAME — the
+            # credentials themselves always come from the account entry.
+            if config._indexed_accounts:
+                phone_var = f"TG_ACCOUNT_{account.index}_PHONE_NUMBER"
+            else:
+                phone_var = "TELEGRAM_PHONE"
+            if not await _authorize_account(config, account, phone_var):
+                return False
 
         return True
 

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -49,9 +49,8 @@ from telethon.tl.types import (
 from telethon.utils import get_peer_id
 
 from .avatar_utils import get_avatar_paths
-from .config import Config
+from .config import AccountConfig, Config
 from .db import DatabaseAdapter, create_adapter
-from .db.models import DEFAULT_ACCOUNT_ID
 from .folder_utils import FolderChat, FolderRules, resolve_folder_member_ids
 from .media_errors import is_media_location_error
 from .message_utils import (
@@ -595,7 +594,16 @@ async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
 class TelegramBackup:
     """Main class for managing Telegram backups."""
 
-    def __init__(self, config: Config, db: DatabaseAdapter, client: TelegramClient | None = None, *, account_id: int):
+    def __init__(
+        self,
+        config: Config,
+        db: DatabaseAdapter,
+        client: TelegramClient | None = None,
+        *,
+        account_id: int | None = None,
+        account: AccountConfig | None = None,
+        account_resolver=None,
+    ):
         """
         Initialize Telegram backup manager.
 
@@ -605,11 +613,25 @@ class TelegramBackup:
             client: Optional existing TelegramClient to use (for shared connection).
                    If not provided, will create a new client in connect().
             account_id: accounts.id every row written by this backup belongs to.
+                May be None only when ``account_resolver`` is given.
+            account: The configured account this backup captures with (session
+                file and API credentials for the own-client path). Defaults to
+                ``config.accounts[0]`` — the synthesized legacy account in a
+                zero-config deployment.
+            account_resolver: Optional ``async (client, db) -> int`` awaited by
+                connect() once the client is proven authorized, yielding the
+                accounts.id. This exists because the own-client path cannot know
+                the row id before a client exists: the row is keyed on the
+                Telegram user id, which only a logged-in client can produce.
         """
+        if account_id is None and account_resolver is None:
+            raise ValueError("account_id or account_resolver is required")
         self.config = config
         self.config.validate_credentials()
         self.db = db
         self.account_id = account_id
+        self.account = account if account is not None else config.accounts[0]
+        self._account_resolver = account_resolver
         self.client: TelegramClient | None = client
         self._owns_client = client is None  # Track if we created the client
         self._cleaned_media_chats: set[int] = set()  # Track chats already cleaned this session
@@ -843,7 +865,15 @@ class TelegramBackup:
         return True
 
     @classmethod
-    async def create(cls, config: Config, client: TelegramClient | None = None, *, account_id: int) -> TelegramBackup:
+    async def create(
+        cls,
+        config: Config,
+        client: TelegramClient | None = None,
+        *,
+        account_id: int | None = None,
+        account: AccountConfig | None = None,
+        account_resolver=None,
+    ) -> TelegramBackup:
         """
         Factory method to create TelegramBackup with initialized database.
 
@@ -851,12 +881,15 @@ class TelegramBackup:
             config: Configuration object
             client: Optional existing TelegramClient to use (for shared connection)
             account_id: accounts.id every row written by this backup belongs to
+                (omit only when ``account_resolver`` is given)
+            account: The configured account to capture with (see ``__init__``)
+            account_resolver: Deferred accounts.id resolution (see ``__init__``)
 
         Returns:
             Initialized TelegramBackup instance
         """
         db = await create_adapter()
-        return cls(config, db, client=client, account_id=account_id)
+        return cls(config, db, client=client, account_id=account_id, account=account, account_resolver=account_resolver)
 
     async def connect(self):
         """
@@ -876,50 +909,55 @@ class TelegramBackup:
             if not await self.client.is_user_authorized():
                 raise RuntimeError("Shared client session is not authorized")
             logger.debug("Using shared Telegram client")
-            return
+        else:
+            # Create new client
+            logger.info(f"Using Telethon session database: {self.account.session_path}.session")
+            self.client = TelegramClient(
+                self.account.session_path,
+                self.account.api_id,
+                self.account.api_hash,
+                **self.config.get_telegram_client_kwargs(),
+            )
+            self._owns_client = True
 
-        # Create new client
-        logger.info(f"Using Telethon session database: {self.config.session_path}.session")
-        self.client = TelegramClient(
-            self.config.session_path,
-            self.config.api_id,
-            self.config.api_hash,
-            **self.config.get_telegram_client_kwargs(),
-        )
-        self._owns_client = True
+            # Fix for database locked errors: Enable WAL mode for session DB
+            # This is critical for concurrency when the viewer is also running
+            try:
+                if hasattr(self.client.session, "_conn"):
+                    # Ensure connection is open
+                    if self.client.session._conn is None:
+                        # Trigger connection if lazy loaded (though usually it's open)
+                        pass
 
-        # Fix for database locked errors: Enable WAL mode for session DB
-        # This is critical for concurrency when the viewer is also running
-        try:
-            if hasattr(self.client.session, "_conn"):
-                # Ensure connection is open
-                if self.client.session._conn is None:
-                    # Trigger connection if lazy loaded (though usually it's open)
-                    pass
+                    if self.client.session._conn:
+                        self.client.session._conn.execute("PRAGMA journal_mode=WAL")
+                        self.client.session._conn.execute("PRAGMA busy_timeout=30000")
+                        logger.info("Enabled WAL mode for Telethon session database")
+            except Exception as e:
+                logger.warning(f"Could not enable WAL mode for session DB: {e}")
 
-                if self.client.session._conn:
-                    self.client.session._conn.execute("PRAGMA journal_mode=WAL")
-                    self.client.session._conn.execute("PRAGMA busy_timeout=30000")
-                    logger.info("Enabled WAL mode for Telethon session database")
-        except Exception as e:
-            logger.warning(f"Could not enable WAL mode for session DB: {e}")
+            # Connect without starting interactive flow
+            await self.client.connect()
 
-        # Connect without starting interactive flow
-        await self.client.connect()
+            # Check authorization status
+            if not await self.client.is_user_authorized():
+                logger.error("❌ Session not authorized!")
+                logger.error("Please run the authentication setup first:")
+                logger.error("  Docker: ./init_auth.bat (Windows) or ./init_auth.sh (Linux/Mac)")
+                logger.error("  Local:  python -m src.setup_auth")
+                raise RuntimeError("Session not authorized. Please run authentication setup.")
 
-        # Check authorization status
-        if not await self.client.is_user_authorized():
-            logger.error("❌ Session not authorized!")
-            logger.error("Please run the authentication setup first:")
-            logger.error("  Docker: ./init_auth.bat (Windows) or ./init_auth.sh (Linux/Mac)")
-            logger.error("  Local:  python -m src.setup_auth")
-            raise RuntimeError("Session not authorized. Please run authentication setup.")
+            # No get_me() here: authorization is already proven by the check above,
+            # and the account's name and phone must not be logged (#272). Telethon's
+            # get_me() would not add a guarantee anyway — it returns None on an
+            # unauthorized session rather than raising.
+            logger.info("Connected")
 
-        # No get_me() here: authorization is already proven by the check above,
-        # and the account's name and phone must not be logged (#272). Telethon's
-        # get_me() would not add a guarantee anyway — it returns None on an
-        # unauthorized session rather than raising.
-        logger.info("Connected")
+        # Resolve which accounts row this login writes under, now that the
+        # client is proven authorized. Runs before any capture write and logs
+        # nothing at INFO, so the single-account startup output is unchanged.
+        if self._account_resolver is not None and self.account_id is None:
+            self.account_id = await self._account_resolver(self.client, self.db)
 
     async def disconnect(self):
         """
@@ -3908,18 +3946,24 @@ class TelegramBackup:
             return 0
 
 
-async def run_backup(config: Config, client: TelegramClient | None = None):
-    """
-    Run a single backup operation.
+def _account_row_resolver(account: AccountConfig):
+    """Deferred accounts-row resolution for one configured account.
 
-    Args:
-        config: Configuration object
-        client: Optional existing TelegramClient to use (for shared connection).
-               If provided, the backup will use this client instead of creating
-               its own, avoiding session file lock conflicts.
+    The row an account writes under is keyed on the Telegram user id, which
+    only a logged-in client can produce — so resolution has to run after
+    connect(), not at construction. TelegramBackup/TelegramListener await this
+    right after their client is proven authorized and before any capture write.
     """
-    # Single-account stage: phase 5 resolves per-account ids from indexed env vars.
-    backup = await TelegramBackup.create(config, client=client, account_id=DEFAULT_ACCOUNT_ID)
+
+    async def resolve(client: TelegramClient, db: DatabaseAdapter) -> int:
+        me = await client.get_me()
+        return await db.ensure_account(telegram_user_id=me.id, env_index=account.index, label=account.label)
+
+    return resolve
+
+
+async def _execute_backup(backup: TelegramBackup, config: Config) -> None:
+    """connect → repair → backup_all → teardown, for one account's backup."""
     try:
         await backup.connect()
         # One-time repair of media files corrupted by the pre-7.11.3 finalize bug (#175).
@@ -3932,22 +3976,48 @@ async def run_backup(config: Config, client: TelegramClient | None = None):
         await backup.db.close()
 
 
-async def run_fill_gaps(config: Config, client: TelegramClient | None = None, chat_id: int | None = None) -> dict:
+async def run_backup(config: Config, client: TelegramClient | None = None, *, account_id: int | None = None):
     """
-    Run gap-fill to recover missing messages in backed-up chats.
+    Run a single backup operation for every configured account, sequentially.
 
     Args:
         config: Configuration object
         client: Optional existing TelegramClient to use (for shared connection).
-               If provided, the operation will use this client instead of creating
-               its own, avoiding session file lock conflicts.
-        chat_id: If provided, scan only this chat. Otherwise scan all chats.
-
-    Returns:
-        Summary dict with gap-fill statistics.
+               If provided, the backup sweeps ONLY the account that client is
+               logged in as — the scheduler calls this once per account with
+               each account's own shared client.
+        account_id: That client's resolved accounts.id (scheduler path). When
+               omitted with a client, the row is resolved from the client's own
+               login on connect.
     """
-    # Single-account stage: phase 5 resolves per-account ids from indexed env vars.
-    backup = await TelegramBackup.create(config, client=client, account_id=DEFAULT_ACCOUNT_ID)
+    if client is not None:
+        resolver = _account_row_resolver(config.accounts[0]) if account_id is None else None
+        backup = await TelegramBackup.create(config, client=client, account_id=account_id, account_resolver=resolver)
+        await _execute_backup(backup, config)
+        return
+
+    failed = 0
+    for account in config.accounts:
+        try:
+            backup = await TelegramBackup.create(
+                config, account=account, account_resolver=_account_row_resolver(account)
+            )
+            await _execute_backup(backup, config)
+        except Exception as e:
+            # One broken account must not consume the other accounts' sweeps —
+            # but with a single account there is nothing to shield, so keep the
+            # pre-8.0 behavior of letting the failure propagate to the caller.
+            if len(config.accounts) == 1:
+                raise
+            # Type name only: Telethon exception text can carry the phone (#272).
+            failed += 1
+            logger.error(f"account {account.index} failed: {type(e).__name__}")
+    if failed and failed == len(config.accounts):
+        raise RuntimeError(f"all {failed} configured accounts failed to back up")
+
+
+async def _execute_fill_gaps(backup: TelegramBackup, config: Config, chat_id: int | None) -> dict:
+    """connect → _fill_gaps → stats refresh → teardown, for one account."""
     try:
         await backup.connect()
         summary = await backup._fill_gaps(chat_id=chat_id)
@@ -3965,6 +4035,67 @@ async def run_fill_gaps(config: Config, client: TelegramClient | None = None, ch
     finally:
         await backup.disconnect()
         await backup.db.close()
+
+
+async def run_fill_gaps(
+    config: Config,
+    client: TelegramClient | None = None,
+    chat_id: int | None = None,
+    *,
+    account_id: int | None = None,
+) -> dict:
+    """
+    Run gap-fill to recover missing messages, for every configured account.
+
+    Args:
+        config: Configuration object
+        client: Optional existing TelegramClient to use (for shared connection).
+               If provided, only that client's account is scanned — the
+               scheduler calls this once per account.
+        chat_id: If provided, scan only this chat. Otherwise scan all chats.
+        account_id: That client's resolved accounts.id (scheduler path). When
+               omitted with a client, resolved from the client's login.
+
+    Returns:
+        Summary dict with gap-fill statistics (summed across accounts when
+        more than one is configured; a failed account counts into ``errors``).
+    """
+    if client is not None:
+        resolver = _account_row_resolver(config.accounts[0]) if account_id is None else None
+        backup = await TelegramBackup.create(config, client=client, account_id=account_id, account_resolver=resolver)
+        return await _execute_fill_gaps(backup, config, chat_id)
+
+    summaries: list[dict] = []
+    failed = 0
+    for account in config.accounts:
+        try:
+            backup = await TelegramBackup.create(
+                config, account=account, account_resolver=_account_row_resolver(account)
+            )
+            summaries.append(await _execute_fill_gaps(backup, config, chat_id))
+        except Exception as e:
+            # Same continuation rule as run_backup, same type-name-only logging.
+            if len(config.accounts) == 1:
+                raise
+            failed += 1
+            logger.error(f"account {account.index} failed: {type(e).__name__}")
+    if failed and failed == len(config.accounts):
+        raise RuntimeError(f"all {failed} configured accounts failed to fill gaps")
+    if len(config.accounts) == 1:
+        return summaries[0]
+    total = {
+        "chats_scanned": 0,
+        "chats_with_gaps": 0,
+        "total_gaps": 0,
+        "total_recovered": 0,
+        "errors": failed,
+        "details": [],
+    }
+    for summary in summaries:
+        for key in ("chats_scanned", "chats_with_gaps", "total_gaps", "total_recovered", "errors"):
+            total[key] += summary.get(key, 0)
+        total["details"].extend(summary.get("details", []))
+    return total
 
 
 def main():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1518,3 +1518,297 @@ class TestWhitelistResolveDialogLimit(unittest.TestCase):
         with patch.dict(os.environ, env, clear=True):
             config = Config()
         self.assertEqual(config.whitelist_resolve_dialog_limit, 0)
+
+
+def _account_triple(index: int) -> dict:
+    """A complete TG_ACCOUNT_<index>_* credential triple with obviously-fake values."""
+    return {
+        f"TG_ACCOUNT_{index}_API_ID": str(10000 + index),
+        f"TG_ACCOUNT_{index}_API_HASH": f"test-hash-account-{index}",
+        f"TG_ACCOUNT_{index}_PHONE_NUMBER": f"+3460000000{index}",
+    }
+
+
+class TestMultiAccountConfig(unittest.TestCase):
+    """TG_ACCOUNT_<N>_* parsing (v8.0.0 multi-account) and the zero-config upgrade.
+
+    Two rules run through every test here:
+    - Zero-config (no TG_ACCOUNT_* set) must be byte-identical to 7.x: one
+      synthesized account with the legacy session resolution, no new log lines.
+    - Error messages and reprs name VARIABLES, never values — phone numbers are
+      PII and the hash is a credential (#272), so each error test also asserts
+      the offending VALUE is absent from the exception text.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        # SESSION_DIR keeps Config._ensure_directories inside the temp dir and
+        # makes session_path assertions independent of BACKUP_PATH's parent.
+        self.session_dir = os.path.join(self.temp_dir, "session")
+        self.base_env = {
+            "CHAT_TYPES": "private",
+            "BACKUP_PATH": self.temp_dir,
+            "SESSION_DIR": self.session_dir,
+        }
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    # ------------------------------------------------------------------
+    # Zero-config synthesis (the 7.x upgrade path)
+    # ------------------------------------------------------------------
+
+    def test_legacy_only_env_synthesizes_one_account_with_legacy_session(self):
+        """No TG_ACCOUNT_*: exactly one account from TELEGRAM_*, same session file."""
+        env = self.base_env | {
+            "TELEGRAM_API_ID": "12345",
+            "TELEGRAM_API_HASH": "abcdef",
+            "TELEGRAM_PHONE": "+1234567890",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = Config()
+        self.assertEqual(len(config.accounts), 1)
+        account = config.accounts[0]
+        self.assertEqual(account.index, 1)
+        self.assertEqual(account.api_id, 12345)
+        self.assertEqual(account.api_hash, "abcdef")
+        self.assertEqual(account.phone, "+1234567890")
+        self.assertEqual(account.label, "default")
+        self.assertEqual(account.session_name, "telegram_backup")
+        self.assertEqual(account.session_name, config.session_name)
+        # String-identical to config.session_path: same session file, no re-login.
+        self.assertEqual(account.session_path, config.session_path)
+        self.assertFalse(config._indexed_accounts)
+
+    def test_legacy_only_env_honors_session_name_env(self):
+        env = self.base_env | {
+            "TELEGRAM_API_ID": "12345",
+            "TELEGRAM_API_HASH": "abcdef",
+            "TELEGRAM_PHONE": "+1234567890",
+            "SESSION_NAME": "my_session",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = Config()
+        self.assertEqual(config.accounts[0].session_name, "my_session")
+        self.assertEqual(config.accounts[0].session_path, config.session_path)
+
+    def test_viewer_without_credentials_still_gets_one_account(self):
+        """The viewer builds Config with no credentials at all; the synthesized
+        account carries Nones rather than the parse raising."""
+        with patch.dict(os.environ, dict(self.base_env), clear=True):
+            config = Config()
+        self.assertEqual(len(config.accounts), 1)
+        account = config.accounts[0]
+        self.assertIsNone(account.api_id)
+        self.assertIsNone(account.api_hash)
+        self.assertIsNone(account.phone)
+        self.assertEqual(account.session_name, "telegram_backup")
+
+    # ------------------------------------------------------------------
+    # Indexed accounts: session-name and label chains
+    # ------------------------------------------------------------------
+
+    def test_two_indexed_accounts_default_sessions_and_labels(self):
+        env = self.base_env | _account_triple(1) | _account_triple(2)
+        with patch.dict(os.environ, env, clear=True):
+            config = Config()
+        self.assertTrue(config._indexed_accounts)
+        self.assertEqual([a.index for a in config.accounts], [1, 2])
+        one, two = config.accounts
+        # Account 1 keeps the legacy default so no existing deployment re-logins.
+        self.assertEqual(one.session_name, "telegram_backup")
+        self.assertEqual(two.session_name, "telegram_backup_account2")
+        self.assertEqual(one.label, "default")
+        self.assertEqual(two.label, "account2")
+        self.assertEqual(one.api_id, 10001)
+        self.assertEqual(two.api_id, 10002)
+        for account in config.accounts:
+            self.assertEqual(account.session_path, os.path.join(config.session_dir, account.session_name))
+
+    def test_account_one_explicit_session_name_wins(self):
+        env = self.base_env | _account_triple(1) | _account_triple(2) | {"TG_ACCOUNT_1_SESSION_NAME": "primary"}
+        with patch.dict(os.environ, env, clear=True):
+            config = Config()
+        self.assertEqual(config.accounts[0].session_name, "primary")
+
+    def test_account_one_falls_back_to_session_name_env(self):
+        """Full legacy chain for account 1: TG_ACCOUNT_1_SESSION_NAME →
+        SESSION_NAME env → 'telegram_backup'. Accounts 2+ never read SESSION_NAME."""
+        env = self.base_env | _account_triple(1) | _account_triple(2) | {"SESSION_NAME": "legacy_sess"}
+        with patch.dict(os.environ, env, clear=True):
+            config = Config()
+        self.assertEqual(config.accounts[0].session_name, "legacy_sess")
+        self.assertEqual(config.accounts[1].session_name, "telegram_backup_account2")
+
+    def test_labels_come_from_env_when_set(self):
+        env = (
+            self.base_env
+            | _account_triple(1)
+            | _account_triple(2)
+            | {"TG_ACCOUNT_1_LABEL": "personal", "TG_ACCOUNT_2_LABEL": "work"}
+        )
+        with patch.dict(os.environ, env, clear=True):
+            config = Config()
+        self.assertEqual([a.label for a in config.accounts], ["personal", "work"])
+
+    # ------------------------------------------------------------------
+    # Error matrix — every message names variables, never values
+    # ------------------------------------------------------------------
+
+    def _assert_no_credential_values(self, message: str, *envs: dict):
+        """#272: no phone number or hash VALUE may appear in exception text."""
+        for env in envs:
+            for key, value in env.items():
+                if value and ("PHONE_NUMBER" in key or "API_HASH" in key or key.startswith("TELEGRAM_")):
+                    self.assertNotIn(value, message, f"value of {key} leaked into the error text")
+
+    def test_index_gap_is_a_loud_error_naming_the_missing_variable(self):
+        env = self.base_env | _account_triple(1) | _account_triple(3)
+        with patch.dict(os.environ, env, clear=True), self.assertRaises(ValueError) as ctx:
+            Config()
+        message = str(ctx.exception)
+        self.assertIn("contiguous", message)
+        self.assertIn("TG_ACCOUNT_2_API_ID", message)
+        self._assert_no_credential_values(message, env)
+
+    def test_indexes_must_start_at_one(self):
+        env = self.base_env | _account_triple(2)
+        with patch.dict(os.environ, env, clear=True), self.assertRaises(ValueError) as ctx:
+            Config()
+        message = str(ctx.exception)
+        self.assertIn("contiguous", message)
+        self.assertIn("TG_ACCOUNT_1_API_ID", message)
+
+    def test_partial_triple_is_a_loud_error_naming_the_variables(self):
+        env = self.base_env | _account_triple(1) | {"TG_ACCOUNT_2_API_ID": "10002"}
+        with patch.dict(os.environ, env, clear=True), self.assertRaises(ValueError) as ctx:
+            Config()
+        message = str(ctx.exception)
+        self.assertIn("Account 2 is incomplete", message)
+        self.assertIn("TG_ACCOUNT_2_API_HASH", message)
+        self.assertIn("TG_ACCOUNT_2_PHONE_NUMBER", message)
+        self._assert_no_credential_values(message, env)
+
+    def test_duplicate_phone_is_a_loud_error_without_the_number(self):
+        env = self.base_env | _account_triple(1) | _account_triple(2)
+        env["TG_ACCOUNT_2_PHONE_NUMBER"] = env["TG_ACCOUNT_1_PHONE_NUMBER"]
+        with patch.dict(os.environ, env, clear=True), self.assertRaises(ValueError) as ctx:
+            Config()
+        message = str(ctx.exception)
+        self.assertIn("TG_ACCOUNT_2_PHONE_NUMBER", message)
+        self.assertIn("TG_ACCOUNT_1_PHONE_NUMBER", message)
+        self._assert_no_credential_values(message, env)
+
+    def test_non_integer_api_id_error_never_echoes_the_value(self):
+        env = self.base_env | _account_triple(1)
+        env["TG_ACCOUNT_1_API_ID"] = "not-an-int-credential"
+        with patch.dict(os.environ, env, clear=True), self.assertRaises(ValueError) as ctx:
+            Config()
+        message = str(ctx.exception)
+        self.assertIn("TG_ACCOUNT_1_API_ID must be an integer", message)
+        self.assertNotIn("not-an-int-credential", message)
+        # ``raise ... from None``: the chained int() text (which echoes the
+        # value) must not ride along as __cause__/__context__.
+        self.assertIsNone(ctx.exception.__cause__)
+        self.assertTrue(ctx.exception.__suppress_context__)
+
+    def test_unrecognized_variable_shapes_raise(self):
+        for bad_key in ("TG_ACCOUNT_2_APIHASH", "TG_ACCOUNT_0_API_ID", "TG_ACCOUNT_01_API_ID"):
+            with self.subTest(bad_key=bad_key):
+                env = self.base_env | _account_triple(1) | {bad_key: "anything"}
+                with patch.dict(os.environ, env, clear=True), self.assertRaises(ValueError) as ctx:
+                    Config()
+                message = str(ctx.exception)
+                self.assertIn("Unrecognized account variable", message)
+                self.assertIn(bad_key, message)
+
+    def test_session_collision_is_a_loud_error(self):
+        """Account 2 explicitly naming account 1's resolved default ('telegram_backup')
+        would put two clients on one Telethon SQLite session."""
+        env = self.base_env | _account_triple(1) | _account_triple(2)
+        env["TG_ACCOUNT_2_SESSION_NAME"] = "telegram_backup"
+        with patch.dict(os.environ, env, clear=True), self.assertRaises(ValueError) as ctx:
+            Config()
+        self.assertIn("same session file", str(ctx.exception))
+        self.assertIn("TG_ACCOUNT_2_SESSION_NAME", str(ctx.exception))
+
+    def test_empty_values_are_treated_as_absent(self):
+        """docker-compose's ${VAR:-} idiom injects empty strings; an index whose
+        variables are all empty is undeclared, and an empty LABEL falls back."""
+        env = self.base_env | _account_triple(1) | _account_triple(2)
+        env |= {
+            "TG_ACCOUNT_3_API_ID": "",
+            "TG_ACCOUNT_3_API_HASH": "",
+            "TG_ACCOUNT_3_PHONE_NUMBER": "",
+            "TG_ACCOUNT_2_LABEL": "",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            config = Config()
+        self.assertEqual(len(config.accounts), 2)
+        self.assertEqual(config.accounts[1].label, "account2")
+
+    # ------------------------------------------------------------------
+    # Precedence, validate_credentials, logging, repr
+    # ------------------------------------------------------------------
+
+    def test_indexed_wins_over_legacy_but_config_triple_reflects_legacy(self):
+        """Both set: accounts come from TG_ACCOUNT_*; config.api_id/api_hash/phone
+        still reflect TELEGRAM_* (and must not be read for capture)."""
+        env = (
+            self.base_env
+            | {
+                "TELEGRAM_API_ID": "12345",
+                "TELEGRAM_API_HASH": "abcdef",
+                "TELEGRAM_PHONE": "+1234567890",
+            }
+            | _account_triple(1)
+            | _account_triple(2)
+        )
+        with patch.dict(os.environ, env, clear=True):
+            config = Config()
+        self.assertTrue(config._indexed_accounts)
+        self.assertEqual([a.api_id for a in config.accounts], [10001, 10002])
+        self.assertEqual(config.api_id, 12345)
+        self.assertEqual(config.api_hash, "abcdef")
+        self.assertEqual(config.phone, "+1234567890")
+
+    def test_validate_credentials_returns_immediately_in_indexed_mode(self):
+        """Indexed triples were proven whole at parse time, so the legacy
+        TELEGRAM_* check must not fire even with those variables absent."""
+        env = self.base_env | _account_triple(1) | _account_triple(2)
+        with patch.dict(os.environ, env, clear=True):
+            config = Config()
+            config.validate_credentials()  # must not raise
+
+    def test_indexed_mode_logs_count_only(self):
+        env = self.base_env | _account_triple(1) | _account_triple(2)
+        with patch.dict(os.environ, env, clear=True), self.assertLogs("src.config", level="INFO") as captured:
+            Config()
+        multi = [m for m in captured.output if "Multi-account" in m]
+        self.assertEqual(len(multi), 1)
+        self.assertIn("Multi-account: using 2 configured account(s)", multi[0])
+        self._assert_no_credential_values("\n".join(captured.output), env)
+
+    def test_zero_config_logs_nothing_new(self):
+        """The 7.x-byte-identical claim: no 'Multi-account' line without TG_ACCOUNT_*."""
+        env = self.base_env | {
+            "TELEGRAM_API_ID": "12345",
+            "TELEGRAM_API_HASH": "abcdef",
+            "TELEGRAM_PHONE": "+1234567890",
+        }
+        with patch.dict(os.environ, env, clear=True), self.assertLogs("src.config", level="DEBUG") as captured:
+            Config()
+        self.assertFalse([m for m in captured.output if "Multi-account" in m])
+
+    def test_account_config_repr_hides_credentials_phone_and_label(self):
+        """Reprs travel into logs and exception text: the credential fields and
+        the label must be excluded, so logging the dataclass is safe."""
+        env = self.base_env | _account_triple(1) | {"TG_ACCOUNT_1_LABEL": "very-private-label"}
+        with patch.dict(os.environ, env, clear=True):
+            config = Config()
+        text = repr(config.accounts[0])
+        self.assertNotIn("test-hash-account-1", text)
+        self.assertNotIn("+34600000001", text)
+        self.assertNotIn("very-private-label", text)
+        self.assertNotIn("10001", text)
+        self.assertIn("index=1", text)

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -14,6 +14,24 @@ from src import connection
 from src.connection import TelegramConnection
 
 
+def _wire_default_account(config):
+    """Mirror Config on a MagicMock: ``accounts[0]`` carries the credentials.
+
+    v8.0.0: TelegramConnection reads the session path and API credentials from
+    its AccountConfig (defaulting to ``config.accounts[0]``), never from the
+    legacy config attributes — a real Config always provides that list.
+    """
+    account = MagicMock()
+    account.index = 1
+    account.label = "default"
+    account.session_path = config.session_path
+    account.api_id = config.api_id
+    account.api_hash = config.api_hash
+    account.phone = config.phone
+    config.accounts = [account]
+    return config
+
+
 def test_get_int_env_falls_back_for_invalid_value():
     """Malformed flood-wait env values fall back instead of crashing imports."""
     with patch.dict(os.environ, {"MAX_FLOOD_RETRIES": "not-an-int"}):
@@ -263,6 +281,7 @@ async def test_connect_creates_client_and_authenticates():
         config.api_id = 12345
         config.api_hash = "abcdef"
         config.get_telegram_client_kwargs.return_value = {}
+        _wire_default_account(config)
         conn = TelegramConnection(config)
 
         mock_client = AsyncMock()
@@ -312,6 +331,7 @@ async def test_connect_restores_golden_backup_when_session_has_no_auth():
         config.api_id = 12345
         config.api_hash = "abcdef"
         config.get_telegram_client_kwargs.return_value = {}
+        _wire_default_account(config)
         conn = TelegramConnection(config)
 
         mock_client = AsyncMock()
@@ -355,6 +375,7 @@ async def test_connect_creates_snapshot_before_connecting():
         config.api_id = 12345
         config.api_hash = "abcdef"
         config.get_telegram_client_kwargs.return_value = {}
+        _wire_default_account(config)
         conn = TelegramConnection(config)
 
         mock_client = AsyncMock()
@@ -383,6 +404,7 @@ async def test_connect_raises_when_not_authorized():
         config.api_id = 12345
         config.api_hash = "abcdef"
         config.get_telegram_client_kwargs.return_value = {}
+        _wire_default_account(config)
         conn = TelegramConnection(config)
 
         mock_client = AsyncMock()
@@ -426,6 +448,7 @@ async def test_connect_restores_from_backup_on_auth_failure():
         config.api_id = 12345
         config.api_hash = "abcdef"
         config.get_telegram_client_kwargs.return_value = {}
+        _wire_default_account(config)
         conn = TelegramConnection(config)
 
         mock_client = AsyncMock()
@@ -463,6 +486,7 @@ async def test_connect_flushes_wal_on_success():
         config.api_id = 12345
         config.api_hash = "abcdef"
         config.get_telegram_client_kwargs.return_value = {}
+        _wire_default_account(config)
         conn = TelegramConnection(config)
 
         mock_session_conn = MagicMock()
@@ -496,6 +520,7 @@ async def test_connect_wal_flush_exception_is_suppressed():
         config.api_id = 12345
         config.api_hash = "abcdef"
         config.get_telegram_client_kwargs.return_value = {}
+        _wire_default_account(config)
         conn = TelegramConnection(config)
 
         mock_session_conn = MagicMock()

--- a/tests/test_connection_heal_race.py
+++ b/tests/test_connection_heal_race.py
@@ -35,6 +35,23 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from src.connection import TelegramConnection
 
 
+def _wire_default_account(config):
+    """Mirror Config on a MagicMock: ``accounts[0]`` carries the credentials.
+
+    v8.0.0: TelegramConnection reads the session path and API credentials from
+    its AccountConfig (defaulting to ``config.accounts[0]``), never from the
+    legacy config attributes — a real Config always provides that list.
+    """
+    account = MagicMock()
+    account.index = 1
+    account.label = "default"
+    account.session_path = config.session_path
+    account.api_id = config.api_id
+    account.api_hash = config.api_hash
+    config.accounts = [account]
+    return config
+
+
 def _shared_client():
     """A Telethon-shaped shared client that can die and be revived in place."""
     state = {"alive": True, "connects": 0, "disconnects": 0, "fail_next_connect": False, "slow_connect": False}
@@ -81,6 +98,7 @@ def _connection(tmp_path, client):
     config.api_id = 12345
     config.api_hash = "test-api-hash"
     config.get_telegram_client_kwargs.return_value = {}
+    _wire_default_account(config)
 
     conn = TelegramConnection(config)
     conn._client = client
@@ -161,13 +179,16 @@ class TestWatchdogHealsWhileABackupIsSuspended:
 
     def _scheduler(self, connection):
         with patch("src.scheduler.signal.signal"):
-            from src.scheduler import BackupScheduler
+            from src.scheduler import BackupScheduler, _AccountRuntime
 
             config = MagicMock()
             config.enable_listener = True
             config.fill_gaps = False
             scheduler = BackupScheduler(config)
-        scheduler._connection = connection
+        account = MagicMock()
+        account.index = 1
+        account.label = "default"
+        scheduler._accounts = [_AccountRuntime(account=account, connection=connection, row_id=1)]
         scheduler._listener_enabled = True
         return scheduler
 
@@ -205,7 +226,7 @@ class TestWatchdogHealsWhileABackupIsSuspended:
         watchdog_done = asyncio.Event()
         seen = {}
 
-        async def fake_run_backup(config, client=None):
+        async def fake_run_backup(config, client=None, account_id=None):
             seen["at_start"] = client
             backup_started.set()
             # Suspended mid-run: every await inside a real backup is a point
@@ -234,8 +255,9 @@ class TestWatchdogHealsWhileABackupIsSuspended:
             watchdog_done.set()
             await backup_task
 
-        assert scheduler._listener is not None
-        scheduler._listener_task.cancel()
+        entry = scheduler._accounts[0]
+        assert entry.listener is not None
+        entry.listener_task.cancel()
 
         assert builder.call_count == 0, "healing built a new client instead of reviving the shared one"
         assert seen["at_start"] is client
@@ -243,7 +265,7 @@ class TestWatchdogHealsWhileABackupIsSuspended:
         assert seen["still_the_connections_client"] is True, "the watchdog replaced the client under the backup"
         assert seen["usable_at_resume"] is True, "the backup resumed on a disconnected client"
         # The listener was started on the very same client the backup is using.
-        assert scheduler._listener.client is client
+        assert entry.listener.client is client
 
     async def test_the_backup_never_overlaps_the_watchdogs_connect(self, tmp_path):
         """Both reach ensure_connected(); the lock keeps them out of each other."""
@@ -266,7 +288,7 @@ class TestWatchdogHealsWhileABackupIsSuspended:
 
         client.connect = AsyncMock(side_effect=counting_connect)
 
-        async def fake_run_backup(config, client=None):
+        async def fake_run_backup(config, client=None, account_id=None):
             return None
 
         with (
@@ -276,8 +298,8 @@ class TestWatchdogHealsWhileABackupIsSuspended:
         ):
             await asyncio.gather(scheduler._run_backup_job(), scheduler._start_listener())
 
-        if scheduler._listener_task:
-            scheduler._listener_task.cancel()
+        if scheduler._accounts[0].listener_task:
+            scheduler._accounts[0].listener_task.cancel()
 
         assert inside["max"] == 1, "a backup and the watchdog were inside connect() at the same time"
         # The loser of the race finds a healthy client and does not connect again.
@@ -342,6 +364,7 @@ class TestRebuildingIsReservedForARestoredSession:
         config.api_id = 12345
         config.api_hash = "test-api-hash"
         config.get_telegram_client_kwargs.return_value = {}
+        _wire_default_account(config)
         conn = TelegramConnection(config)
         conn._client = old_client
         conn._connected = False
@@ -386,13 +409,16 @@ class TestTheOriginalFailureStillHeals:
         assert not client.is_connected()  # real state
 
         with patch("src.scheduler.signal.signal"):
-            from src.scheduler import BackupScheduler
+            from src.scheduler import BackupScheduler, _AccountRuntime
 
             config = MagicMock()
             config.enable_listener = True
             config.fill_gaps = False
             scheduler = BackupScheduler(config)
-        scheduler._connection = conn
+        account = MagicMock()
+        account.index = 1
+        account.label = "default"
+        scheduler._accounts = [_AccountRuntime(account=account, connection=conn, row_id=1)]
 
         seen = {}
 
@@ -416,9 +442,10 @@ class TestTheOriginalFailureStillHeals:
 
         assert revived["n"] == 1
         assert seen["connected_at_connect"] is True
-        assert scheduler._listener.client is client, "the listener must share the connection's own client"
+        entry = scheduler._accounts[0]
+        assert entry.listener.client is client, "the listener must share the connection's own client"
         assert conn.client is client
-        scheduler._listener_task.cancel()
+        entry.listener_task.cancel()
 
 
 @pytest.mark.asyncio

--- a/tests/test_flood_wait_visibility.py
+++ b/tests/test_flood_wait_visibility.py
@@ -52,6 +52,11 @@ def fake_db(monkeypatch):
     """Opt-in fixture for tests that import src.telegram_backup."""
     _patch_db_module(monkeypatch)
     yield
+    # Restore the REAL src.db before reloading: fixture teardown runs before
+    # monkeypatch's own undo, so without this the reload re-imports the modules
+    # against the fake again and leaves every later test file a stale
+    # create_adapter — an order-dependent poisoning, not a cleanup.
+    monkeypatch.undo()
     if "src.db" in sys.modules:
         import src.connection
         import src.telegram_backup

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -28,6 +28,11 @@ class TestSessionPathLogging:
         backup.config.api_id = 12345
         backup.config.api_hash = "testhash"
         backup.config.get_telegram_client_kwargs = MagicMock(return_value={"flood_sleep_threshold": 0})
+        # v8.0.0: the own-client path reads the account's credential fields,
+        # which for a zero-config deployment mirror the legacy config ones —
+        # reuse the config mock so the assignments above cover both.
+        backup.account = backup.config
+        backup._account_resolver = None
         backup.db = AsyncMock()
         backup.client = None
         backup._owns_client = True
@@ -113,6 +118,16 @@ class TestListenerSessionPathLogging:
         config.mass_operation_window_seconds = 30
         config.mass_operation_buffer_delay = 2.0
         config.get_telegram_client_kwargs = MagicMock(return_value={"flood_sleep_threshold": 0})
+        # v8.0.0: client construction reads accounts[0]; mirror the legacy
+        # attributes above so the real __init__ resolves the same values.
+        account = MagicMock()
+        account.index = 1
+        account.label = "default"
+        account.session_path = config.session_path
+        account.api_id = config.api_id
+        account.api_hash = config.api_hash
+        account.phone = config.phone
+        config.accounts = [account]
 
         db = AsyncMock()
         db.get_all_chats = AsyncMock(return_value=[])

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -67,6 +67,16 @@ def _make_config(**overrides):
     config.should_download_media_for_chat = MagicMock(return_value=True)
     config.get_max_media_size_bytes = MagicMock(return_value=50 * 1024 * 1024)
     config.deduplicate_media = True
+    # v8.0.0: the runtime reads credentials from config.accounts, never the
+    # legacy attributes; mirror a real (zero-config) Config's single account.
+    account = MagicMock()
+    account.index = 1
+    account.label = "default"
+    account.session_path = config.session_path
+    account.api_id = config.api_id
+    account.api_hash = config.api_hash
+    account.phone = config.phone
+    config.accounts = [account]
     for key, value in overrides.items():
         setattr(config, key, value)
     return config
@@ -2253,10 +2263,10 @@ class TestRunFinallyMetadataClear:
 
 
 class TestRunListenerStandalone:
-    """Tests for run_listener standalone function (lines 1258-1266)."""
+    """Tests for run_listener standalone function (the phase-5 account seam)."""
 
     async def test_run_listener_connects_runs_and_closes(self):
-        """run_listener creates listener, connects, runs, and closes."""
+        """run_listener creates one listener per account, connects, runs, closes."""
         from src.listener import run_listener
 
         mock_listener = AsyncMock()
@@ -2271,8 +2281,19 @@ class TestRunListenerStandalone:
         ) as mock_create:
             await run_listener(config)
 
-        # The standalone entry point is a phase-5 seam: it must name the account.
-        mock_create.assert_awaited_once_with(config, account_id=1)
+        # The standalone entry is a phase-5 seam: each listener is built for ONE
+        # account, carrying the deferred resolver that maps that account's login
+        # to its accounts row (connect() awaits it before handlers register).
+        mock_create.assert_awaited_once()
+        kwargs = mock_create.await_args.kwargs
+        assert kwargs["account"] is config.accounts[0]
+        resolver = kwargs["account_resolver"]
+        client = AsyncMock()
+        client.get_me = AsyncMock(return_value=MagicMock(id=900001111))
+        db = AsyncMock()
+        db.ensure_account = AsyncMock(return_value=1)
+        assert await resolver(client, db) == 1
+        db.ensure_account.assert_awaited_once_with(telegram_user_id=900001111, env_index=1, label="default")
         mock_listener.connect.assert_awaited_once()
         mock_listener.run.assert_awaited_once()
         mock_listener.close.assert_awaited_once()
@@ -2293,14 +2314,15 @@ class TestRunListenerStandalone:
 
         mock_listener.close.assert_awaited_once()
 
-    async def test_run_listener_builds_real_listener_for_the_default_account(self):
+    async def test_run_listener_builds_real_listener_for_the_resolved_account(self):
         """The standalone entry runs the REAL TelegramListener.create/__init__ chain.
 
         The tests above patch create() away, so they cannot catch the entry
-        dropping the required account_id kwarg. Here only leaf dependencies are
-        mocked; a missing kwarg raises TypeError out of run_listener itself.
+        dropping the account wiring. Here only leaf dependencies are mocked; the
+        real construction must carry the account and the deferred resolver —
+        and NO hardwired row id (resolution belongs to connect(), patched here,
+        so account_id must still be None at this seam).
         """
-        from src.db.models import DEFAULT_ACCOUNT_ID
         from src.listener import run_listener
 
         config = _make_config()
@@ -2315,7 +2337,49 @@ class TestRunListenerStandalone:
 
         listener = mock_connect.await_args.args[0]
         assert isinstance(listener, TelegramListener)
-        assert listener.account_id == DEFAULT_ACCOUNT_ID
+        assert listener.account is config.accounts[0]
+        assert listener.account_id is None, "the row id is resolved by connect(), never hardwired"
+        assert listener._account_resolver is not None
+
+    async def test_connect_resolves_the_account_row_before_any_handler_registers(self):
+        """The resolver runs after authorization and BEFORE handler registration.
+
+        The ordering is load-bearing, not cosmetic: a handler firing ahead of
+        resolution would file its rows under the wrong account. The tracked-chat
+        load must also already see the resolved id.
+        """
+        config = _make_config()
+        db = _make_db()
+        events = []
+
+        mock_client = AsyncMock()
+        mock_client.is_connected = MagicMock(return_value=True)
+        mock_client.is_user_authorized = AsyncMock(return_value=True)
+
+        def fake_on(event_type):
+            def register(handler):
+                events.append("handler")
+                return handler
+
+            return register
+
+        mock_client.on = fake_on
+
+        async def resolver(client, adapter):
+            events.append("resolve")
+            return 7
+
+        listener = TelegramListener(config, db, client=mock_client, account_resolver=resolver)
+
+        mock_db_manager = MagicMock()
+        mock_db_manager._is_sqlite = True
+        with patch("src.db.get_db_manager", new_callable=AsyncMock, return_value=mock_db_manager):
+            await listener.connect()
+
+        assert listener.account_id == 7
+        assert "resolve" in events and "handler" in events
+        assert events.index("resolve") < events.index("handler")
+        db.get_all_chats.assert_awaited_once_with(account_id=7)
 
 
 # ===========================================================================

--- a/tests/test_multi_account_runtime.py
+++ b/tests/test_multi_account_runtime.py
@@ -394,3 +394,49 @@ class TestSequentialSweeps:
         assert "RuntimeError" in log_text, "the failure is reported by exception type"
         for pii in (PHONE_ONE, PHONE_TWO, str(UID_ONE), str(UID_TWO)):
             assert pii not in log_text
+
+
+class TestResolutionIsSerialized:
+    """The sweep, a listener start and the initial backup can all ask for row
+    resolution concurrently; without serialization two interleaved misses would
+    both INSERT a row for the same Telegram account (accounts has no DB-level
+    unique on telegram_user_id)."""
+
+    async def test_concurrent_resolvers_call_ensure_account_once_per_account(self):
+        from types import SimpleNamespace
+        from unittest.mock import AsyncMock, MagicMock
+        from unittest.mock import patch as mock_patch
+
+        from src.scheduler import BackupScheduler, _AccountRuntime
+
+        with mock_patch("src.scheduler.signal.signal"):
+            config = MagicMock()
+            scheduler = BackupScheduler.__new__(BackupScheduler)
+            scheduler.config = config
+            scheduler._resolve_rows_lock = asyncio.Lock()
+            scheduler._accounts = [
+                _AccountRuntime(
+                    account=SimpleNamespace(index=n, label=f"account{n}"),
+                    connection=SimpleNamespace(me=SimpleNamespace(id=900_000 + n)),
+                )
+                for n in (1, 2)
+            ]
+
+        calls: list[int] = []
+
+        async def slow_ensure_account(*, telegram_user_id, env_index, label):
+            calls.append(telegram_user_id)
+            # Long enough that an unserialized second resolver re-reads
+            # row_id=None and duplicates every call.
+            await asyncio.sleep(0.05)
+            return env_index
+
+        adapter = SimpleNamespace(ensure_account=slow_ensure_account, close=AsyncMock())
+        with mock_patch("src.db.create_adapter", AsyncMock(return_value=adapter)):
+            await asyncio.gather(
+                scheduler._resolve_account_rows(),
+                scheduler._resolve_account_rows(),
+            )
+
+        assert sorted(calls) == [900_001, 900_002], calls
+        assert [e.row_id for e in scheduler._accounts] == [1, 2]

--- a/tests/test_multi_account_runtime.py
+++ b/tests/test_multi_account_runtime.py
@@ -1,0 +1,396 @@
+"""Multi-account RUNTIME (v8.0.0 phase 5), proved on real engines and real flows.
+
+``tests/test_multiaccount_schema.py`` proves the keys admit N accounts and
+``tests/test_account_isolation.py`` proves the adapter keeps their rows apart.
+This file proves the piece that connects a CONFIGURED account (an env index) to
+a DATABASE account (an ``accounts`` row): ``DatabaseAdapter.ensure_account``,
+and the sequential per-account sweep built on top of it.
+
+The resolution rule under test, in one line: the Telegram user id owns the row,
+the env index owns nothing — except that index 1 is defined as the continuation
+of a pre-8.0 archive, whose migrated row 1 carries ``telegram_user_id NULL``.
+Get this wrong in either direction and data is silently orphaned (a migrated
+archive's rows left under a row nobody resolves to) or silently merged (a
+reshuffled index stealing another identity's rows), so the resolution tests all
+run against real engines on both backends via ``real_db``/``real_adapter``.
+
+The sweep tests pin the other phase-5 promise: accounts are processed
+SEQUENTIALLY (account 1's ``backup_all`` completes before account 2's client is
+even built — Telegram tolerates N sessions, not N concurrent full sweeps from
+one box), one account's failure does not consume the others' turns, and log
+output identifies accounts by index or row id only — never by phone, label or
+Telegram user id (#272).
+"""
+
+import asyncio
+import logging
+import os
+import sqlite3
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from sqlalchemy import func, select, text
+
+from src.config import Config
+from src.db.models import DEFAULT_ACCOUNT_ID, Account, Chat, Message
+
+# NOTE: src.telegram_backup members are imported inside the sweep tests, not
+# here. Other test files (test_flood_wait_visibility, test_telegram_proxy)
+# reload that module around a stubbed src.db; a from-import at collection time
+# would freeze the pre-reload objects and make these tests order-dependent —
+# patch targets and the code under test would come from different module
+# generations.
+
+# Obviously-fake Telegram user ids (synthetic archives only). Real user ids are
+# PII; these exist to prove they never reach logs.
+UID_ONE = 900001111
+UID_TWO = 900002222
+
+CHAT_ID = -100901
+MESSAGE_ID = 601
+BASE_DATE = datetime(2026, 8, 16, 12, 0, 0)
+
+
+def _message_data(message_text: str) -> dict:
+    return {
+        "id": MESSAGE_ID,
+        "chat_id": CHAT_ID,
+        "sender_id": 4242,
+        "date": BASE_DATE,
+        "text": message_text,
+        "raw_data": {},
+    }
+
+
+async def _seed_migrated_accounts_table(db) -> None:
+    """Shape ``accounts`` exactly as migration 022 leaves a 7.x archive.
+
+    Row 1 is ``('default', NULL)`` — the label 022 seeds, and no Telegram user
+    id because pre-8.0 rows never stored one. On PostgreSQL the seed writes the
+    id explicitly, which does not advance the SERIAL sequence, so mirror 022's
+    ``setval`` — without it the next DEFAULT insert would collide with the
+    seeded row, a failure mode production cannot have.
+    """
+    async with db.async_session_factory() as session:
+        await session.merge(Account(id=DEFAULT_ACCOUNT_ID, label="default", telegram_user_id=None))
+        await session.commit()
+    if db.engine.dialect.name == "postgresql":
+        async with db.engine.begin() as conn:
+            await conn.execute(
+                text("SELECT setval(pg_get_serial_sequence('accounts', 'id'), (SELECT MAX(id) FROM accounts))")
+            )
+
+
+async def _seed_archive_owned_by_row_one(adapter) -> None:
+    """A migrated archive's data: one chat and one message under account 1."""
+    await adapter.upsert_chat(
+        {"id": CHAT_ID, "type": "supergroup", "title": "pre-8.0 archive"}, account_id=DEFAULT_ACCOUNT_ID
+    )
+    await adapter.insert_message(
+        _message_data("kept since 7.x"),
+        account_id=DEFAULT_ACCOUNT_ID,
+    )
+
+
+async def _account_rows(db) -> list[Account]:
+    async with db.async_session_factory() as session:
+        return list((await session.execute(select(Account).order_by(Account.id))).scalars())
+
+
+async def _message_owned_by(db, account_id: int) -> Message | None:
+    async with db.async_session_factory() as session:
+        return await session.get(Message, (account_id, CHAT_ID, MESSAGE_ID))
+
+
+class TestEnsureAccountResolution:
+    """``ensure_account`` on real engines: idempotent, claim-once, steal-never."""
+
+    async def test_two_startups_same_user_id_resolve_to_one_row(self, real_adapter, caplog):
+        """(a) Re-running never duplicates: same user id -> same row, once.
+
+        Also the PII gate: resolution happens right after login, exactly where
+        the user id is in hand, so assert it never reaches a log record (#272).
+        """
+        await _seed_migrated_accounts_table(real_adapter.db_manager)
+
+        with caplog.at_level(logging.DEBUG):
+            first = await real_adapter.ensure_account(telegram_user_id=UID_ONE, env_index=1, label="default")
+            second = await real_adapter.ensure_account(telegram_user_id=UID_ONE, env_index=1, label="default")
+
+        assert first == second == DEFAULT_ACCOUNT_ID
+        rows = await _account_rows(real_adapter.db_manager)
+        assert len(rows) == 1
+        assert rows[0].telegram_user_id == UID_ONE
+        # Scope: the app's own loggers. Third-party driver channels (aiosqlite)
+        # echo every bound parameter at DEBUG by design; the app-side defence
+        # there is ``hide_parameters=True`` on the engine, and #272 is about
+        # what OUR log lines say — at most 'account <env_index> -> row <id>'.
+        for record in caplog.records:
+            if record.name.startswith("src"):
+                assert str(UID_ONE) not in record.getMessage()
+
+    async def test_fresh_database_insert_path_is_idempotent_too(self, real_adapter):
+        """(a) No seeded row at all (create_all fallback): insert, then reuse.
+
+        The claim guard's WHERE must MISS an absent row 1, not explode on it.
+        """
+        first = await real_adapter.ensure_account(telegram_user_id=UID_ONE, env_index=1, label="default")
+        second = await real_adapter.ensure_account(telegram_user_id=UID_ONE, env_index=1, label="default")
+        assert first == second
+        assert len(await _account_rows(real_adapter.db_manager)) == 1
+
+    async def test_account_one_claims_the_migrated_row_and_its_archive(self, real_adapter):
+        """(b) The zero-config upgrade: row 1 (NULL) is claimed, data stays owned.
+
+        A migrated archive's rows all carry ``account_id=1`` and row 1 carries
+        no user id. The account at env index 1 must resolve to THAT row — the
+        message written under 7.x must be reachable under the id returned —
+        or the whole pre-8.0 archive is orphaned under a row nobody maps to.
+        """
+        await _seed_migrated_accounts_table(real_adapter.db_manager)
+        await _seed_archive_owned_by_row_one(real_adapter)
+
+        row_id = await real_adapter.ensure_account(telegram_user_id=UID_ONE, env_index=1, label="default")
+
+        assert row_id == DEFAULT_ACCOUNT_ID
+        rows = await _account_rows(real_adapter.db_manager)
+        assert len(rows) == 1, "claiming must rewrite row 1, never add a row"
+        assert rows[0].telegram_user_id == UID_ONE
+        surviving = await _message_owned_by(real_adapter.db_manager, row_id)
+        assert surviving is not None, "the 7.x archive must be owned by the resolved row"
+        assert surviving.text == "kept since 7.x"
+
+    async def test_second_account_gets_its_own_row_and_writes_do_not_cross(self, real_adapter):
+        """(c) Account 2 lands under a NEW row; account 1's rows stay untouched."""
+        await _seed_migrated_accounts_table(real_adapter.db_manager)
+        await _seed_archive_owned_by_row_one(real_adapter)
+        row_one = await real_adapter.ensure_account(telegram_user_id=UID_ONE, env_index=1, label="default")
+
+        row_two = await real_adapter.ensure_account(telegram_user_id=UID_TWO, env_index=2, label="account2")
+
+        assert row_two == 2, "the sequence must be past the seeded row (migration 022's setval)"
+        assert row_two != row_one
+
+        # Account 2 archives the very same coordinates; both copies must exist.
+        await real_adapter.upsert_chat(
+            {"id": CHAT_ID, "type": "supergroup", "title": "copy of two"}, account_id=row_two
+        )
+        await real_adapter.insert_message(_message_data("written by two"), account_id=row_two)
+
+        one_copy = await _message_owned_by(real_adapter.db_manager, row_one)
+        two_copy = await _message_owned_by(real_adapter.db_manager, row_two)
+        assert one_copy.text == "kept since 7.x"
+        assert two_copy.text == "written by two"
+        async with real_adapter.db_manager.async_session_factory() as session:
+            chats_of_one = (
+                await session.execute(select(func.count()).select_from(Chat).where(Chat.account_id == row_one))
+            ).scalar()
+        assert chats_of_one == 1
+
+    async def test_reshuffled_index_finds_the_same_row_and_steals_nothing(self, real_adapter):
+        """(d) The user id owns the row: index 2 -> index 1 is a no-op.
+
+        The second start also puts UID_TWO at env index 1, so a broken
+        resolution keyed on the index would claim the migrated row — assert
+        row 1 keeps ``telegram_user_id NULL``, exactly as it started.
+        """
+        await _seed_migrated_accounts_table(real_adapter.db_manager)
+        original = await real_adapter.ensure_account(telegram_user_id=UID_TWO, env_index=2, label="account2")
+
+        moved = await real_adapter.ensure_account(telegram_user_id=UID_TWO, env_index=1, label="account2")
+
+        assert moved == original
+        rows = await _account_rows(real_adapter.db_manager)
+        assert len(rows) == 2
+        assert rows[0].id == DEFAULT_ACCOUNT_ID
+        assert rows[0].telegram_user_id is None, "reshuffling must never claim the migrated row"
+        assert rows[1].telegram_user_id == UID_TWO
+
+    async def test_an_already_claimed_row_one_is_never_stolen(self, real_adapter):
+        """(d) A DIFFERENT identity at index 1 falls through to a new row.
+
+        Once row 1 belongs to UID_ONE, the guarded claim (``WHERE id=1 AND
+        telegram_user_id IS NULL``) must miss for UID_TWO even at env index 1;
+        anything else would merge two identities' archives under one row.
+        """
+        await _seed_migrated_accounts_table(real_adapter.db_manager)
+        row_one = await real_adapter.ensure_account(telegram_user_id=UID_ONE, env_index=1, label="default")
+
+        row_two = await real_adapter.ensure_account(telegram_user_id=UID_TWO, env_index=1, label="intruder")
+
+        assert row_one == DEFAULT_ACCOUNT_ID
+        assert row_two != row_one
+        rows = await _account_rows(real_adapter.db_manager)
+        assert rows[0].telegram_user_id == UID_ONE, "the claimed row keeps its owner"
+
+    async def test_label_follows_the_env_on_every_start(self, real_adapter):
+        """The env is the display-name source of truth: a changed label lands."""
+        await _seed_migrated_accounts_table(real_adapter.db_manager)
+        row_id = await real_adapter.ensure_account(telegram_user_id=UID_ONE, env_index=1, label="default")
+
+        again = await real_adapter.ensure_account(telegram_user_id=UID_ONE, env_index=1, label="personal")
+
+        assert again == row_id
+        rows = await _account_rows(real_adapter.db_manager)
+        assert rows[0].label == "personal"
+
+
+# ---------------------------------------------------------------------------
+# The sequential sweep (run_backup over config.accounts)
+# ---------------------------------------------------------------------------
+
+PHONE_ONE = "+34600000001"  # obviously-fake; exist to prove they never reach logs
+PHONE_TWO = "+34600000002"
+
+# Session-file basename -> the user id Telegram "answers" with for that session.
+# Keyed on the session file because that is the one per-account value the client
+# constructor receives that the fake can read back out.
+UID_BY_SESSION = {"telegram_backup": UID_ONE, "telegram_backup_account2": UID_TWO}
+
+
+def _two_account_env(tmp_path) -> dict:
+    return {
+        "CHAT_TYPES": "private",
+        "BACKUP_PATH": str(tmp_path / "backups"),
+        "SESSION_DIR": str(tmp_path / "session"),
+        "DATABASE_PATH": str(tmp_path / "runtime.db"),
+        "TG_ACCOUNT_1_API_ID": "10001",
+        "TG_ACCOUNT_1_API_HASH": "test-hash-account-1",
+        "TG_ACCOUNT_1_PHONE_NUMBER": PHONE_ONE,
+        "TG_ACCOUNT_2_API_ID": "10002",
+        "TG_ACCOUNT_2_API_HASH": "test-hash-account-2",
+        "TG_ACCOUNT_2_PHONE_NUMBER": PHONE_TWO,
+    }
+
+
+class _SweepHarness:
+    """Everything below ``backup_all`` faked; everything ABOVE it real.
+
+    The Telethon client class is a mock factory (no network, no real session)
+    and ``backup_all`` is a recorder — but ``TelegramBackup.create``,
+    ``connect()`` and the account resolver all run for real, against the real
+    adapter on a real SQLite file (DATABASE_PATH above). So the sweep tests
+    prove the shipped composition path: per-account client construction, the
+    deferred ``ensure_account`` resolution keyed on that client's ``get_me()``,
+    and only then the sweep.
+    """
+
+    def __init__(self, fail_indexes: set[int] = frozenset()):
+        self.fail_indexes = fail_indexes  # AccountConfig.index values whose sweep raises
+        self.events: list[tuple[str, int]] = []  # (event, resolved accounts.id)
+        self.constructed_clients: list[tuple[str, int, str]] = []  # (session_path, api_id, api_hash)
+        self.clients_by_session: dict[str, MagicMock] = {}
+
+    def fake_client(self, session_path, api_id, api_hash, **kwargs):
+        # The contract pins **config.get_telegram_client_kwargs() for every
+        # account — same kwargs, no per-account overrides in 8.0.0. The
+        # flood threshold staying 0 is what keeps FloodWaits visible (#124).
+        assert kwargs.get("flood_sleep_threshold") == 0
+        self.constructed_clients.append((str(session_path), api_id, api_hash))
+        uid = UID_BY_SESSION[os.path.basename(str(session_path))]
+        client = MagicMock(name=f"client[{os.path.basename(str(session_path))}]")
+        client.connect = AsyncMock()
+        client.is_connected = MagicMock(return_value=True)
+        client.is_user_authorized = AsyncMock(return_value=True)
+        client.get_me = AsyncMock(return_value=SimpleNamespace(id=uid))
+        client.disconnect = AsyncMock()
+        self.clients_by_session[os.path.basename(str(session_path))] = client
+        return client
+
+    def patches(self):
+        from src.telegram_backup import TelegramBackup
+
+        harness = self
+
+        async def recording_backup_all(backup_self):
+            # account_id here is what connect()'s resolver produced — the test
+            # reads the REAL resolution, not a mock of it.
+            harness.events.append(("sweep-start", backup_self.account_id))
+            # A parallel implementation (gather/TaskGroup) interleaves at this
+            # checkpoint, so the strict-ordering assertion genuinely can fail.
+            await asyncio.sleep(0)
+            if backup_self.account.index in harness.fail_indexes:
+                raise RuntimeError("sweep exploded mid-dialog")
+            harness.events.append(("sweep-end", backup_self.account_id))
+
+        return (
+            patch("src.telegram_backup.TelegramClient", side_effect=self.fake_client),
+            patch.object(TelegramBackup, "backup_all", new=recording_backup_all),
+            patch("src.repair_media_extensions.repair_media_extensions", new=AsyncMock(return_value=None)),
+        )
+
+
+def _accounts_in_sqlite(db_path: str) -> list[tuple[int, int | None]]:
+    with sqlite3.connect(db_path) as conn:
+        return conn.execute("SELECT id, telegram_user_id FROM accounts ORDER BY id").fetchall()
+
+
+class TestSequentialSweeps:
+    """(e)/(f): the run_backup loop — order, resolved ids, failure isolation."""
+
+    async def test_account_one_completes_before_account_two_begins(self, tmp_path):
+        """(e) Strictly sequential, and each backup got its RESOLVED row id.
+
+        Fresh database: ensure_account inserts row 1 for the account at index 1
+        and row 2 for index 2, so the ids handed to ``TelegramBackup.create``
+        must be exactly [1, 2] — read back from the real SQLite file, not from
+        a mock — and account 1's sweep must END before account 2's STARTS.
+        """
+        from src.telegram_backup import run_backup
+
+        env = _two_account_env(tmp_path)
+        harness = _SweepHarness()
+        with patch.dict(os.environ, env, clear=True):
+            config = Config()
+            client_patch, backup_all_patch, repair_patch = harness.patches()
+            with client_patch, backup_all_patch, repair_patch:
+                await run_backup(config)
+
+        # The ids in the events are the ones connect()'s resolver handed each
+        # backup: [1, 2] proves both the strict ordering AND that every backup
+        # swept under its own resolved row id.
+        assert harness.events == [
+            ("sweep-start", 1),
+            ("sweep-end", 1),
+            ("sweep-start", 2),
+            ("sweep-end", 2),
+        ]
+        # The exact per-account client construction the contract pins.
+        assert harness.constructed_clients == [
+            (config.accounts[0].session_path, 10001, "test-hash-account-1"),
+            (config.accounts[1].session_path, 10002, "test-hash-account-2"),
+        ]
+        # The ids were minted by the real ensure_account, keyed on get_me()'s id.
+        assert _accounts_in_sqlite(env["DATABASE_PATH"]) == [(1, UID_ONE), (2, UID_TWO)]
+
+    async def test_a_failing_sweep_does_not_consume_the_next_accounts_turn(self, tmp_path, caplog):
+        """(f) Account 1 raising leaves account 2's sweep intact.
+
+        The failure must be LOGGED by exception type name and the log must not
+        carry the phone number, the Telegram user id or the label — an
+        account's crash report identifies it by index/row id only (#272).
+        """
+        from src.telegram_backup import run_backup
+
+        env = _two_account_env(tmp_path)
+        harness = _SweepHarness(fail_indexes={1})
+        with patch.dict(os.environ, env, clear=True):
+            config = Config()
+            client_patch, backup_all_patch, repair_patch = harness.patches()
+            with client_patch, backup_all_patch, repair_patch, caplog.at_level(logging.DEBUG):
+                await run_backup(config)
+
+        assert ("sweep-start", 1) in harness.events, "account 1's sweep did start"
+        assert ("sweep-end", 1) not in harness.events, "account 1's sweep did fail"
+        assert ("sweep-end", 2) in harness.events, "account 2 still got its full turn"
+        # The failed account's teardown still ran: its client was disconnected.
+        harness.clients_by_session["telegram_backup"].disconnect.assert_awaited()
+        harness.clients_by_session["telegram_backup_account2"].disconnect.assert_awaited()
+
+        # Same scope rule as the resolution tests: the app's own loggers. The
+        # aiosqlite driver channel echoes bound parameters at DEBUG by design.
+        log_text = "\n".join(record.getMessage() for record in caplog.records if record.name.startswith("src"))
+        assert "RuntimeError" in log_text, "the failure is reported by exception type"
+        for pii in (PHONE_ONE, PHONE_TWO, str(UID_ONE), str(UID_TWO)):
+            assert pii not in log_text

--- a/tests/test_reconnect_before_retry.py
+++ b/tests/test_reconnect_before_retry.py
@@ -548,12 +548,15 @@ class TestListenerRestartAfterAGiveUp:
 
     def _scheduler(self, connection):
         with patch("src.scheduler.signal.signal"):
-            from src.scheduler import BackupScheduler
+            from src.scheduler import BackupScheduler, _AccountRuntime
 
             config = MagicMock()
             config.enable_listener = True
             scheduler = BackupScheduler(config)
-        scheduler._connection = connection
+        account = MagicMock()
+        account.index = 1
+        account.label = "default"
+        scheduler._accounts = [_AccountRuntime(account=account, connection=connection, row_id=1)]
         return scheduler
 
     def _connection(self, client, *, ensure_raises=None):
@@ -627,9 +630,10 @@ class TestListenerRestartAfterAGiveUp:
 
         assert state["ensure"] == 1
         assert seen["connected_at_connect"] is True
-        assert scheduler._listener is not None
-        assert scheduler._listener_task is not None
-        scheduler._listener_task.cancel()
+        entry = scheduler._accounts[0]
+        assert entry.listener is not None
+        assert entry.listener_task is not None
+        entry.listener_task.cancel()
 
     async def test_start_listener_gives_up_cleanly_when_the_network_is_still_down(self, caplog):
         client = _dead_client()
@@ -640,6 +644,7 @@ class TestListenerRestartAfterAGiveUp:
             await scheduler._start_listener()
 
         assert state["ensure"] == 1
-        assert scheduler._listener is None
-        assert scheduler._listener_task is None
+        entry = scheduler._accounts[0]
+        assert entry.listener is None
+        assert entry.listener_task is None
         assert any("Cannot start listener" in r.getMessage() for r in caplog.records)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -9,6 +9,31 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 
+def _make_entry(connection=None, row_id=1, index=1, listener=None, listener_task=None):
+    """One _AccountRuntime as _connect() would build it, with a mock connection.
+
+    v8.0.0: the scheduler keeps per-account runtime state in ``_accounts``
+    instead of the old singular ``_connection``/``_listener`` attributes; tests
+    inject their mocks through entries like this one.
+    """
+    from src.scheduler import _AccountRuntime
+
+    account = MagicMock()
+    account.index = index
+    account.label = "default"
+    if connection is None:
+        connection = AsyncMock()
+        connection.is_connected = True
+        connection.client = MagicMock()
+    return _AccountRuntime(
+        account=account,
+        connection=connection,
+        row_id=row_id,
+        listener=listener,
+        listener_task=listener_task,
+    )
+
+
 class TestBackupSchedulerInit:
     """Tests for BackupScheduler.__init__."""
 
@@ -32,26 +57,25 @@ class TestBackupSchedulerInit:
 
             assert scheduler.running is False
 
-    def test_init_sets_connection_none(self):
-        """BackupScheduler starts with no connection."""
+    def test_init_starts_with_no_account_runtimes(self):
+        """BackupScheduler starts with no per-account connections."""
         with patch("src.scheduler.signal.signal"):
             from src.scheduler import BackupScheduler
 
             config = MagicMock()
             scheduler = BackupScheduler(config)
 
-            assert scheduler._connection is None
+            assert scheduler._accounts == []
 
-    def test_init_sets_listener_none(self):
-        """BackupScheduler starts with no listener."""
+    def test_init_sets_listener_disabled(self):
+        """BackupScheduler starts with listeners not yet enabled."""
         with patch("src.scheduler.signal.signal"):
             from src.scheduler import BackupScheduler
 
             config = MagicMock()
             scheduler = BackupScheduler(config)
 
-            assert scheduler._listener is None
-            assert scheduler._listener_task is None
+            assert scheduler._listener_enabled is False
 
     def test_init_creates_backup_lock(self):
         """BackupScheduler creates a lock to prevent overlapping backup runs."""
@@ -180,28 +204,72 @@ class TestBackupSchedulerRunBackupJob:
 
     @pytest.fixture
     def scheduler_with_connection(self):
-        """Create a scheduler with mocked connection."""
+        """Create a scheduler with one mocked account runtime."""
         with patch("src.scheduler.signal.signal"):
             from src.scheduler import BackupScheduler
 
             config = MagicMock()
             config.fill_gaps = False
             scheduler = BackupScheduler(config)
-            scheduler._connection = AsyncMock()
-            scheduler._connection.ensure_connected = AsyncMock(return_value=MagicMock())
-            scheduler._listener = None
+            scheduler._accounts = [_make_entry()]
             return scheduler
 
     async def test_run_backup_job_calls_run_backup(self, scheduler_with_connection):
-        """Backup job calls run_backup with config and shared client."""
+        """Backup job calls run_backup with config, shared client and row id."""
         scheduler = scheduler_with_connection
         mock_client = MagicMock()
-        scheduler._connection.ensure_connected = AsyncMock(return_value=mock_client)
+        entry = scheduler._accounts[0]
+        entry.connection.ensure_connected = AsyncMock(return_value=mock_client)
 
         with patch("src.scheduler.run_backup", new_callable=AsyncMock) as mock_backup:
             await scheduler._run_backup_job()
 
-            mock_backup.assert_called_once_with(scheduler.config, client=mock_client)
+            mock_backup.assert_called_once_with(scheduler.config, client=mock_client, account_id=entry.row_id)
+
+    async def test_run_backup_job_sweeps_accounts_sequentially(self):
+        """Two accounts are swept in config order, each under its own row id."""
+        with patch("src.scheduler.signal.signal"):
+            from src.scheduler import BackupScheduler
+
+            config = MagicMock()
+            config.fill_gaps = False
+            scheduler = BackupScheduler(config)
+            scheduler._accounts = [_make_entry(row_id=1, index=1), _make_entry(row_id=5, index=2)]
+
+            with patch("src.scheduler.run_backup", new_callable=AsyncMock) as mock_backup:
+                await scheduler._run_backup_job()
+
+            assert [c.kwargs["account_id"] for c in mock_backup.await_args_list] == [1, 5]
+
+    async def test_run_backup_job_one_broken_account_does_not_consume_the_others(self, caplog):
+        """Account 1 failing to connect still leaves account 2 its full sweep.
+
+        The failure is logged by env index and exception TYPE only — the text
+        of a Telethon error can carry the phone number (#272).
+        """
+        import logging
+
+        with patch("src.scheduler.signal.signal"):
+            from src.scheduler import BackupScheduler
+
+            config = MagicMock()
+            config.fill_gaps = False
+            scheduler = BackupScheduler(config)
+            broken = _make_entry(row_id=1, index=1)
+            broken.connection.ensure_connected = AsyncMock(side_effect=ConnectionError("+34600000001 unreachable"))
+            healthy = _make_entry(row_id=2, index=2)
+            scheduler._accounts = [broken, healthy]
+
+            with (
+                patch("src.scheduler.run_backup", new_callable=AsyncMock) as mock_backup,
+                caplog.at_level(logging.ERROR, logger="src.scheduler"),
+            ):
+                await scheduler._run_backup_job()
+
+            assert [c.kwargs["account_id"] for c in mock_backup.await_args_list] == [2]
+            messages = [r.getMessage() for r in caplog.records]
+            assert "account 1 failed: ConnectionError" in messages
+            assert all("+34600000001" not in m for m in messages)
 
     async def test_run_backup_job_with_gap_fill_enabled(self, scheduler_with_connection):
         """Backup job runs gap-fill when fill_gaps is enabled."""
@@ -212,31 +280,28 @@ class TestBackupSchedulerRunBackupJob:
 
         with (
             patch("src.scheduler.run_backup", new_callable=AsyncMock),
-            patch.dict("sys.modules", {}),
             patch("src.telegram_backup.run_fill_gaps", mock_run_fill_gaps, create=True),
-            patch("src.scheduler.BackupScheduler._run_backup_job", wraps=scheduler._run_backup_job),
         ):
-            pass
-
-        # Simpler approach: just verify the backup runs without error
-        with patch("src.scheduler.run_backup", new_callable=AsyncMock):
             await scheduler._run_backup_job()
+
+        mock_run_fill_gaps.assert_awaited_once()
 
     async def test_run_backup_job_reloads_listener_tracked_chats(self, scheduler_with_connection):
-        """Backup job reloads listener tracked chats after completing."""
+        """Backup job reloads the account's listener tracked chats after completing."""
         scheduler = scheduler_with_connection
-        scheduler._listener = AsyncMock()
-        scheduler._listener._load_tracked_chats = AsyncMock()
+        entry = scheduler._accounts[0]
+        entry.listener = AsyncMock()
+        entry.listener._load_tracked_chats = AsyncMock()
 
         with patch("src.scheduler.run_backup", new_callable=AsyncMock):
             await scheduler._run_backup_job()
 
-            scheduler._listener._load_tracked_chats.assert_called_once()
+            entry.listener._load_tracked_chats.assert_called_once()
 
     async def test_run_backup_job_handles_exception_gracefully(self, scheduler_with_connection):
         """Backup job catches and logs exceptions without crashing."""
         scheduler = scheduler_with_connection
-        scheduler._connection.ensure_connected = AsyncMock(side_effect=Exception("connection lost"))
+        scheduler._accounts[0].connection.ensure_connected = AsyncMock(side_effect=Exception("connection lost"))
 
         # Should NOT raise
         await scheduler._run_backup_job()
@@ -260,9 +325,7 @@ class TestBackupSchedulerRunBackupJob:
             config = MagicMock()
             config.fill_gaps = True
             scheduler = BackupScheduler(config)
-            scheduler._connection = AsyncMock()
-            scheduler._connection.ensure_connected = AsyncMock(return_value=MagicMock())
-            scheduler._listener = None
+            scheduler._accounts = [_make_entry()]
 
             mock_fill_gaps = AsyncMock(return_value={"errors": 2, "total_recovered": 3})
 
@@ -272,6 +335,8 @@ class TestBackupSchedulerRunBackupJob:
             ):
                 await scheduler._run_backup_job()
 
+            mock_fill_gaps.assert_awaited_once()
+
     async def test_run_backup_job_gap_fill_exception(self):
         """Backup job catches gap-fill exceptions without crashing."""
         with patch("src.scheduler.signal.signal"):
@@ -280,20 +345,22 @@ class TestBackupSchedulerRunBackupJob:
             config = MagicMock()
             config.fill_gaps = True
             scheduler = BackupScheduler(config)
-            scheduler._connection = AsyncMock()
-            scheduler._connection.ensure_connected = AsyncMock(return_value=MagicMock())
-            scheduler._listener = None
+            scheduler._accounts = [_make_entry()]
 
-            with patch("src.scheduler.run_backup", new_callable=AsyncMock):
-                # gap-fill import will fail since we don't mock it, triggering the except branch
+            with (
+                patch("src.scheduler.run_backup", new_callable=AsyncMock),
+                patch(
+                    "src.telegram_backup.run_fill_gaps", new_callable=AsyncMock, side_effect=Exception("gap fill boom")
+                ),
+            ):
                 await scheduler._run_backup_job()
 
 
 class TestBackupSchedulerConnect:
     """Tests for BackupScheduler._connect and _disconnect."""
 
-    async def test_connect_creates_telegram_connection(self):
-        """_connect creates and connects a TelegramConnection."""
+    async def test_connect_creates_telegram_connection_per_account_and_resolves_rows(self):
+        """_connect builds one TelegramConnection per account and resolves row ids."""
         with (
             patch("src.scheduler.signal.signal"),
             patch("src.scheduler.TelegramConnection") as MockConn,
@@ -301,31 +368,45 @@ class TestBackupSchedulerConnect:
             from src.scheduler import BackupScheduler
 
             config = MagicMock()
+            account = MagicMock()
+            account.index = 1
+            account.label = "default"
+            config.accounts = [account]
             scheduler = BackupScheduler(config)
 
             mock_conn_instance = AsyncMock()
+            mock_conn_instance.me = MagicMock(id=900001111)
             MockConn.return_value = mock_conn_instance
 
-            await scheduler._connect()
+            mock_db = AsyncMock()
+            mock_db.ensure_account = AsyncMock(return_value=1)
 
-            MockConn.assert_called_once_with(config)
+            with patch("src.db.create_adapter", new_callable=AsyncMock, return_value=mock_db):
+                await scheduler._connect()
+
+            MockConn.assert_called_once_with(config, account=account)
             mock_conn_instance.connect.assert_called_once()
-            assert scheduler._connection is mock_conn_instance
+            assert len(scheduler._accounts) == 1
+            assert scheduler._accounts[0].connection is mock_conn_instance
+            # The row id came from ensure_account, keyed on the login's user id.
+            mock_db.ensure_account.assert_awaited_once_with(telegram_user_id=900001111, env_index=1, label="default")
+            assert scheduler._accounts[0].row_id == 1
+            mock_db.close.assert_awaited_once()
 
     async def test_disconnect_closes_connection(self):
-        """_disconnect calls disconnect on the connection."""
+        """_disconnect calls disconnect on every account's connection."""
         with patch("src.scheduler.signal.signal"):
             from src.scheduler import BackupScheduler
 
             config = MagicMock()
             scheduler = BackupScheduler(config)
             mock_conn = AsyncMock()
-            scheduler._connection = mock_conn
+            scheduler._accounts = [_make_entry(connection=mock_conn)]
 
             await scheduler._disconnect()
 
             mock_conn.disconnect.assert_called_once()
-            assert scheduler._connection is None
+            assert scheduler._accounts == []
 
     async def test_disconnect_when_no_connection_is_noop(self):
         """_disconnect is safe when no connection exists."""
@@ -334,7 +415,7 @@ class TestBackupSchedulerConnect:
 
             config = MagicMock()
             scheduler = BackupScheduler(config)
-            scheduler._connection = None
+            scheduler._accounts = []
 
             # Should not raise
             await scheduler._disconnect()
@@ -351,40 +432,43 @@ class TestBackupSchedulerListener:
             config = MagicMock()
             config.enable_listener = False
             scheduler = BackupScheduler(config)
+            entry = _make_entry()
+            scheduler._accounts = [entry]
 
             await scheduler._start_listener()
 
-            assert scheduler._listener is None
-            assert scheduler._listener_task is None
+            assert entry.listener is None
+            assert entry.listener_task is None
 
     async def test_start_listener_when_not_connected_logs_error(self):
-        """_start_listener fails gracefully when not connected."""
+        """_start_listener fails gracefully when no account ever connected."""
         with patch("src.scheduler.signal.signal"):
             from src.scheduler import BackupScheduler
 
             config = MagicMock()
             config.enable_listener = True
             scheduler = BackupScheduler(config)
-            scheduler._connection = None
+            scheduler._accounts = []
 
+            # Should not raise; nothing to start.
             await scheduler._start_listener()
-
-            assert scheduler._listener is None
 
     async def test_start_listener_when_connection_not_connected_logs_error(self):
-        """_start_listener fails gracefully when connection exists but is not connected."""
+        """_start_listener fails gracefully when a connection is down."""
         with patch("src.scheduler.signal.signal"):
             from src.scheduler import BackupScheduler
 
             config = MagicMock()
             config.enable_listener = True
             scheduler = BackupScheduler(config)
-            scheduler._connection = MagicMock()
-            scheduler._connection.is_connected = False
+            connection = AsyncMock()
+            connection.is_connected = False
+            entry = _make_entry(connection=connection)
+            scheduler._accounts = [entry]
 
             await scheduler._start_listener()
 
-            assert scheduler._listener is None
+            assert entry.listener is None
 
     async def test_start_listener_creates_and_starts_listener(self):
         """_start_listener creates a TelegramListener and starts it."""
@@ -394,9 +478,8 @@ class TestBackupSchedulerListener:
             config = MagicMock()
             config.enable_listener = True
             scheduler = BackupScheduler(config)
-            scheduler._connection = MagicMock()
-            scheduler._connection.is_connected = True
-            scheduler._connection.client = MagicMock()
+            entry = _make_entry()
+            scheduler._accounts = [entry]
 
             mock_listener = AsyncMock()
             mock_listener.run = AsyncMock()
@@ -407,17 +490,21 @@ class TestBackupSchedulerListener:
                     mock_task.return_value = MagicMock()
                     await scheduler._start_listener()
 
-    async def test_start_listener_builds_real_listener_for_the_default_account(self):
+            assert entry.listener is mock_listener
+            MockListener.create.assert_awaited_once_with(
+                scheduler.config, client=entry.connection.client, account_id=entry.row_id
+            )
+
+    async def test_start_listener_builds_real_listener_for_the_resolved_account(self):
         """The scheduler path runs the REAL TelegramListener.create/__init__ chain.
 
         Only leaf dependencies are mocked (DB adapter, network methods): if the
-        create() call at the scheduler's composition seam ever drops the required
-        account_id kwarg, the TypeError is swallowed by _start_listener's except
-        and _listener stays None — which these assertions turn red. The patched
-        class in the test above cannot catch that.
+        create() call at the scheduler's composition seam ever drops the
+        account_id kwarg, the entry's listener would be built without a row id —
+        which these assertions turn red. The patched class in the test above
+        cannot catch that.
         """
         with patch("src.scheduler.signal.signal"):
-            from src.db.models import DEFAULT_ACCOUNT_ID
             from src.listener import TelegramListener
             from src.scheduler import BackupScheduler
 
@@ -429,10 +516,8 @@ class TestBackupSchedulerListener:
             config.mass_operation_window_seconds = 30
             config.mass_operation_buffer_delay = 2.0
             scheduler = BackupScheduler(config)
-            scheduler._connection = MagicMock()
-            scheduler._connection.ensure_connected = AsyncMock()
-            scheduler._connection.is_connected = True
-            scheduler._connection.client = MagicMock()
+            entry = _make_entry(row_id=7)
+            scheduler._accounts = [entry]
 
             with (
                 patch("src.listener.create_adapter", new_callable=AsyncMock, return_value=AsyncMock()),
@@ -441,10 +526,10 @@ class TestBackupSchedulerListener:
             ):
                 await scheduler._start_listener()
 
-                assert isinstance(scheduler._listener, TelegramListener)
-                assert scheduler._listener.account_id == DEFAULT_ACCOUNT_ID
-                assert scheduler._listener_task is not None
-                await scheduler._listener_task
+                assert isinstance(entry.listener, TelegramListener)
+                assert entry.listener.account_id == 7
+                assert entry.listener_task is not None
+                await entry.listener_task
 
     async def test_start_listener_handles_exception_gracefully(self):
         """_start_listener catches exceptions during listener creation."""
@@ -454,9 +539,8 @@ class TestBackupSchedulerListener:
             config = MagicMock()
             config.enable_listener = True
             scheduler = BackupScheduler(config)
-            scheduler._connection = MagicMock()
-            scheduler._connection.is_connected = True
-            scheduler._connection.client = MagicMock()
+            entry = _make_entry()
+            scheduler._accounts = [entry]
 
             # Force the import/create to fail
             with patch.dict(
@@ -469,8 +553,8 @@ class TestBackupSchedulerListener:
             ):
                 await scheduler._start_listener()
 
-            assert scheduler._listener is None
-            assert scheduler._listener_task is None
+            assert entry.listener is None
+            assert entry.listener_task is None
 
     async def test_stop_listener_cancels_task_and_closes_listener(self):
         """_stop_listener cancels the task and closes the listener."""
@@ -488,14 +572,14 @@ class TestBackupSchedulerListener:
             mock_listener = AsyncMock()
             mock_listener.close = AsyncMock()
 
-            scheduler._listener_task = mock_task
-            scheduler._listener = mock_listener
+            entry = _make_entry(listener=mock_listener, listener_task=mock_task)
+            scheduler._accounts = [entry]
 
             await scheduler._stop_listener()
 
             mock_listener.close.assert_called_once()
-            assert scheduler._listener is None
-            assert scheduler._listener_task is None
+            assert entry.listener is None
+            assert entry.listener_task is None
 
     async def test_stop_listener_swallows_dead_task_exception(self):
         """_stop_listener does not re-raise a dead task's stored exception.
@@ -521,15 +605,48 @@ class TestBackupSchedulerListener:
             mock_listener = AsyncMock()
             mock_listener.close = AsyncMock()
 
-            scheduler._listener_task = dead_task
-            scheduler._listener = mock_listener
+            entry = _make_entry(listener=mock_listener, listener_task=dead_task)
+            scheduler._accounts = [entry]
 
             # Must not raise — teardown should proceed cleanly.
             await scheduler._stop_listener()
 
             mock_listener.close.assert_called_once()
-            assert scheduler._listener is None
-            assert scheduler._listener_task is None
+            assert entry.listener is None
+            assert entry.listener_task is None
+
+    async def test_stop_listener_only_dead_leaves_live_listeners_running(self):
+        """The watchdog's only_dead stop never touches a healthy account.
+
+        Restarting a healthy listener would detach and re-register its handlers
+        for no reason; the watchdog restarts exactly what died.
+        """
+        with patch("src.scheduler.signal.signal"):
+            from src.scheduler import BackupScheduler
+
+            config = MagicMock()
+            scheduler = BackupScheduler(config)
+
+            loop = asyncio.get_event_loop()
+            dead_task = loop.create_future()
+            dead_task.cancel()
+            dead_listener = AsyncMock()
+
+            live_task = MagicMock()
+            live_task.done = MagicMock(return_value=False)
+            live_listener = AsyncMock()
+
+            dead = _make_entry(index=1, listener=dead_listener, listener_task=dead_task)
+            live = _make_entry(index=2, listener=live_listener, listener_task=live_task)
+            scheduler._accounts = [dead, live]
+
+            await scheduler._stop_listener(only_dead=True)
+
+            dead_listener.close.assert_called_once()
+            assert dead.listener is None and dead.listener_task is None
+            live_listener.close.assert_not_called()
+            live_task.cancel.assert_not_called()
+            assert live.listener is live_listener
 
     async def test_stop_listener_when_no_listener_is_noop(self):
         """_stop_listener is safe when no listener is running."""
@@ -538,8 +655,7 @@ class TestBackupSchedulerListener:
 
             config = MagicMock()
             scheduler = BackupScheduler(config)
-            scheduler._listener = None
-            scheduler._listener_task = None
+            scheduler._accounts = [_make_entry()]
 
             # Should not raise
             await scheduler._stop_listener()
@@ -558,11 +674,9 @@ class TestBackupSchedulerRunForever:
             config.enable_listener = False
             scheduler = BackupScheduler(config)
 
-            mock_connection = AsyncMock()
-            mock_connection.client = MagicMock()
+            entry = _make_entry()
 
-            scheduler._connect = AsyncMock()
-            scheduler._connection = mock_connection
+            scheduler._connect = AsyncMock(side_effect=lambda: scheduler._accounts.append(entry))
             scheduler.start = MagicMock()
             scheduler._start_listener = AsyncMock()
             scheduler._stop_listener = AsyncMock()
@@ -585,7 +699,7 @@ class TestBackupSchedulerRunForever:
 
             scheduler._connect.assert_called_once()
             scheduler.start.assert_called_once()
-            mock_backup.assert_called_once()
+            mock_backup.assert_called_once_with(config, client=entry.connection.client, account_id=entry.row_id)
 
     async def test_run_forever_handles_initial_backup_failure(self):
         """run_forever catches exceptions from initial backup."""
@@ -597,11 +711,9 @@ class TestBackupSchedulerRunForever:
             config.enable_listener = False
             scheduler = BackupScheduler(config)
 
-            mock_connection = AsyncMock()
-            mock_connection.client = MagicMock()
+            entry = _make_entry()
 
-            scheduler._connect = AsyncMock()
-            scheduler._connection = mock_connection
+            scheduler._connect = AsyncMock(side_effect=lambda: scheduler._accounts.append(entry))
             scheduler.start = MagicMock()
             scheduler._start_listener = AsyncMock()
             scheduler._stop_listener = AsyncMock()
@@ -633,11 +745,9 @@ class TestBackupSchedulerRunForever:
             config.enable_listener = False
             scheduler = BackupScheduler(config)
 
-            mock_connection = AsyncMock()
-            mock_connection.client = MagicMock()
+            entry = _make_entry()
 
-            scheduler._connect = AsyncMock()
-            scheduler._connection = mock_connection
+            scheduler._connect = AsyncMock(side_effect=lambda: scheduler._accounts.append(entry))
             scheduler.start = MagicMock()
             scheduler._start_listener = AsyncMock()
             scheduler._stop_listener = AsyncMock()
@@ -728,9 +838,7 @@ class TestRunBackupJobGapFillException:
             config = MagicMock()
             config.fill_gaps = True
             scheduler = BackupScheduler(config)
-            scheduler._connection = AsyncMock()
-            scheduler._connection.ensure_connected = AsyncMock(return_value=MagicMock())
-            scheduler._listener = None
+            scheduler._accounts = [_make_entry()]
 
             with (
                 patch("src.scheduler.run_backup", new_callable=AsyncMock),
@@ -760,11 +868,9 @@ class TestRunForeverInitialGapFill:
             config.enable_listener = False
             scheduler = BackupScheduler(config)
 
-            mock_connection = AsyncMock()
-            mock_connection.client = MagicMock()
+            entry = _make_entry()
 
-            scheduler._connect = AsyncMock()
-            scheduler._connection = mock_connection
+            scheduler._connect = AsyncMock(side_effect=lambda: scheduler._accounts.append(entry))
             scheduler.start = MagicMock()
             scheduler._start_listener = AsyncMock()
             scheduler._stop_listener = AsyncMock()
@@ -801,11 +907,9 @@ class TestRunForeverInitialGapFill:
             config.enable_listener = False
             scheduler = BackupScheduler(config)
 
-            mock_connection = AsyncMock()
-            mock_connection.client = MagicMock()
+            entry = _make_entry()
 
-            scheduler._connect = AsyncMock()
-            scheduler._connection = mock_connection
+            scheduler._connect = AsyncMock(side_effect=lambda: scheduler._accounts.append(entry))
             scheduler.start = MagicMock()
             scheduler._start_listener = AsyncMock()
             scheduler._stop_listener = AsyncMock()
@@ -840,11 +944,9 @@ class TestRunForeverInitialGapFill:
             config.enable_listener = False
             scheduler = BackupScheduler(config)
 
-            mock_connection = AsyncMock()
-            mock_connection.client = MagicMock()
+            entry = _make_entry()
 
-            scheduler._connect = AsyncMock()
-            scheduler._connection = mock_connection
+            scheduler._connect = AsyncMock(side_effect=lambda: scheduler._accounts.append(entry))
             scheduler.start = MagicMock()
             scheduler._start_listener = AsyncMock()
             scheduler._stop_listener = AsyncMock()
@@ -886,19 +988,16 @@ class TestRunForeverListenerReload:
             config.enable_listener = True
             scheduler = BackupScheduler(config)
 
-            mock_connection = AsyncMock()
-            mock_connection.client = MagicMock()
-
             mock_listener = AsyncMock()
             mock_listener._load_tracked_chats = AsyncMock()
 
-            scheduler._connect = AsyncMock()
-            scheduler._connection = mock_connection
+            entry = _make_entry(listener=mock_listener)
+
+            scheduler._connect = AsyncMock(side_effect=lambda: scheduler._accounts.append(entry))
             scheduler.start = MagicMock()
             scheduler._start_listener = AsyncMock()
             scheduler._stop_listener = AsyncMock()
             scheduler._disconnect = AsyncMock()
-            scheduler._listener = mock_listener
 
             call_count = 0
 
@@ -935,11 +1034,9 @@ class TestRunForeverListenerRestart:
             config.enable_listener = True
             scheduler = BackupScheduler(config)
 
-            mock_connection = AsyncMock()
-            mock_connection.client = MagicMock()
+            entry = _make_entry()
 
-            scheduler._connect = AsyncMock()
-            scheduler._connection = mock_connection
+            scheduler._connect = AsyncMock(side_effect=lambda: scheduler._accounts.append(entry))
             scheduler.start = MagicMock()
             scheduler._start_listener = AsyncMock()
             scheduler._stop_listener = AsyncMock()
@@ -949,8 +1046,8 @@ class TestRunForeverListenerRestart:
             loop = asyncio.get_event_loop()
             done_task = loop.create_future()
             done_task.set_exception(Exception("listener crashed"))
-            scheduler._listener_task = done_task
-            scheduler._listener = AsyncMock()
+            entry.listener_task = done_task
+            entry.listener = AsyncMock()
 
             call_count = 0
 
@@ -987,11 +1084,9 @@ class TestRunForeverListenerRestart:
             config.enable_listener = True
             scheduler = BackupScheduler(config)
 
-            mock_connection = AsyncMock()
-            mock_connection.client = MagicMock()
+            entry = _make_entry()
 
-            scheduler._connect = AsyncMock()
-            scheduler._connection = mock_connection
+            scheduler._connect = AsyncMock(side_effect=lambda: scheduler._accounts.append(entry))
             # scheduler.start() is mocked out, so it never sets self.running -- set it
             # directly to actually enter the `while self.running:` watchdog loop below.
             scheduler.start = MagicMock(side_effect=lambda: setattr(scheduler, "running", True))
@@ -1003,12 +1098,13 @@ class TestRunForeverListenerRestart:
             async def flaky_start_listener():
                 attempt[0] += 1
                 if attempt[0] < 3:
-                    # Mirrors the real _start_listener failure path: task/listener stay None.
-                    scheduler._listener_task = None
-                    scheduler._listener = None
+                    # Mirrors the real _start_account_listener failure path:
+                    # the entry's task/listener stay None.
+                    entry.listener_task = None
+                    entry.listener = None
                 else:
-                    scheduler._listener_task = MagicMock(done=MagicMock(return_value=False))
-                    scheduler._listener = AsyncMock()
+                    entry.listener_task = MagicMock(done=MagicMock(return_value=False))
+                    entry.listener = AsyncMock()
 
             scheduler._start_listener = AsyncMock(side_effect=flaky_start_listener)
 
@@ -1029,7 +1125,7 @@ class TestRunForeverListenerRestart:
             # Initial start (attempt 1) plus at least one watchdog-triggered retry
             # while the task stayed None -- proves the watchdog didn't give up after one try.
             assert attempt[0] >= 2
-            assert scheduler._listener_task is not None
+            assert entry.listener_task is not None
 
     async def test_listener_task_cancelled_restart(self):
         """Cancelled listener task is restarted during the main loop."""
@@ -1041,11 +1137,9 @@ class TestRunForeverListenerRestart:
             config.enable_listener = True
             scheduler = BackupScheduler(config)
 
-            mock_connection = AsyncMock()
-            mock_connection.client = MagicMock()
+            entry = _make_entry()
 
-            scheduler._connect = AsyncMock()
-            scheduler._connection = mock_connection
+            scheduler._connect = AsyncMock(side_effect=lambda: scheduler._accounts.append(entry))
             scheduler.start = MagicMock()
             scheduler._start_listener = AsyncMock()
             scheduler._stop_listener = AsyncMock()
@@ -1055,8 +1149,8 @@ class TestRunForeverListenerRestart:
             loop = asyncio.get_event_loop()
             done_task = loop.create_future()
             done_task.cancel()
-            scheduler._listener_task = done_task
-            scheduler._listener = AsyncMock()
+            entry.listener_task = done_task
+            entry.listener = AsyncMock()
 
             call_count = 0
 

--- a/tests/test_setup_auth.py
+++ b/tests/test_setup_auth.py
@@ -61,6 +61,11 @@ async def test_setup_fails_closed_when_the_session_belongs_to_another_account():
     config.api_hash = "hash"
     config.phone = "+34687016994"
     config.get_telegram_client_kwargs.return_value = {}
+    config._indexed_accounts = False
+    config.accounts = [
+        MagicMock(index=1, session_path=config.session_path, api_id=config.api_id, api_hash=config.api_hash)
+    ]
+    config.accounts[0].phone = config.phone
 
     client = AsyncMock()
     client.is_user_authorized.return_value = True
@@ -88,6 +93,11 @@ async def test_setup_succeeds_when_the_session_matches_the_configured_number():
     config.api_hash = "hash"
     config.phone = "+34687016994"
     config.get_telegram_client_kwargs.return_value = {}
+    config._indexed_accounts = False
+    config.accounts = [
+        MagicMock(index=1, session_path=config.session_path, api_id=config.api_id, api_hash=config.api_hash)
+    ]
+    config.accounts[0].phone = config.phone
 
     client = AsyncMock()
     client.is_user_authorized.return_value = True

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -66,6 +66,11 @@ def _make_backup(**overrides):
     backup.client = overrides.get("client", AsyncMock())
     backup._owns_client = overrides.get("_owns_client", True)
     backup._cleaned_media_chats = set()
+    # v8.0.0: the own-client path reads the account's credential fields, which
+    # for a zero-config deployment mirror the legacy config ones — reuse the
+    # config mock so per-test `backup.config.session_path = ...` covers both.
+    backup.account = backup.config
+    backup._account_resolver = None
     return backup
 
 
@@ -2525,6 +2530,7 @@ class TestRunBackup(unittest.TestCase):
         mock_create.return_value = mock_backup
 
         config = MagicMock()
+        config.accounts = [MagicMock()]
         _run(run_backup(config))
 
         mock_backup.connect.assert_awaited_once()
@@ -2539,6 +2545,7 @@ class TestRunBackup(unittest.TestCase):
         mock_create.return_value = mock_backup
 
         config = MagicMock()
+        config.accounts = [MagicMock()]
         config.media_path = "/tmp/media-path"
 
         order = []
@@ -2558,6 +2565,7 @@ class TestRunBackup(unittest.TestCase):
         mock_create.return_value = mock_backup
 
         config = MagicMock()
+        config.accounts = [MagicMock()]
         with self.assertRaises(RuntimeError):
             _run(run_backup(config))
 
@@ -2575,6 +2583,7 @@ class TestRunFillGaps(unittest.TestCase):
         mock_create.return_value = mock_backup
 
         config = MagicMock()
+        config.accounts = [MagicMock()]
         summary = _run(run_fill_gaps(config, chat_id=100))
 
         self.assertEqual(summary["total_recovered"], 10)
@@ -2588,6 +2597,7 @@ class TestRunFillGaps(unittest.TestCase):
         mock_create.return_value = mock_backup
 
         config = MagicMock()
+        config.accounts = [MagicMock()]
         summary = _run(run_fill_gaps(config))
 
         self.assertEqual(summary["total_recovered"], 0)
@@ -2602,6 +2612,7 @@ class TestRunFillGaps(unittest.TestCase):
         mock_create.return_value = mock_backup
 
         config = MagicMock()
+        config.accounts = [MagicMock()]
         summary = _run(run_fill_gaps(config))
 
         self.assertEqual(summary["total_recovered"], 5)
@@ -2614,6 +2625,7 @@ class TestRunFillGaps(unittest.TestCase):
         mock_create.return_value = mock_backup
 
         config = MagicMock()
+        config.accounts = [MagicMock()]
         with self.assertRaises(RuntimeError):
             _run(run_fill_gaps(config))
 

--- a/tests/test_telegram_proxy.py
+++ b/tests/test_telegram_proxy.py
@@ -32,11 +32,34 @@ def _fake_db(monkeypatch):
 
     yield
 
+    # Restore the REAL src.db before reloading: this teardown runs before
+    # monkeypatch's own undo, so without this the reload re-imports the modules
+    # against the fake again and leaves later test files a stale create_adapter.
+    monkeypatch.undo()
     # Reload again to restore real module state for other test files
     if "src.db" in sys.modules:
         importlib.reload(src.connection)
         importlib.reload(src.listener)
         importlib.reload(src.telegram_backup)
+
+
+def _wire_default_account(config):
+    """Mirror Config on a MagicMock: ``accounts[0]`` carries the credentials.
+
+    v8.0.0: client construction reads the session path and API credentials
+    from the AccountConfig (defaulting to ``config.accounts[0]``), never from
+    the legacy config attributes — a real Config always provides that list.
+    """
+    account = MagicMock()
+    account.index = 1
+    account.label = "default"
+    account.session_path = config.session_path
+    account.api_id = config.api_id
+    account.api_hash = config.api_hash
+    account.phone = config.phone
+    config.accounts = [account]
+    config._indexed_accounts = False
+    return config
 
 
 def _get_telegram_classes():
@@ -58,6 +81,7 @@ async def test_connection_passes_proxy_kwargs():
     config.get_telegram_client_kwargs.return_value = {
         "proxy": {"proxy_type": "socks5", "addr": "127.0.0.1", "port": 1080}
     }
+    _wire_default_account(config)
 
     client = AsyncMock()
     client.session = SimpleNamespace(_conn=None)
@@ -90,6 +114,7 @@ async def test_connection_omits_proxy_when_not_configured():
     config.api_id = 12345
     config.api_hash = "hash"
     config.get_telegram_client_kwargs.return_value = {}
+    _wire_default_account(config)
 
     client = AsyncMock()
     client.session = SimpleNamespace(_conn=None)
@@ -121,6 +146,7 @@ async def test_backup_connect_passes_proxy_kwargs():
         "proxy": {"proxy_type": "socks5", "addr": "127.0.0.1", "port": 1080}
     }
 
+    _wire_default_account(config)
     _, _, TelegramBackup = _get_telegram_classes()
 
     db = AsyncMock()
@@ -168,6 +194,7 @@ async def test_listener_connect_passes_proxy_kwargs():
         "proxy": {"proxy_type": "socks5", "addr": "127.0.0.1", "port": 1080}
     }
 
+    _wire_default_account(config)
     _, TelegramListener, _ = _get_telegram_classes()
 
     db = AsyncMock()
@@ -206,6 +233,8 @@ async def test_setup_authentication_passes_proxy_kwargs():
     config.get_telegram_client_kwargs.return_value = {
         "proxy": {"proxy_type": "socks5", "addr": "127.0.0.1", "port": 1080}
     }
+
+    _wire_default_account(config)
 
     client = AsyncMock()
     client.is_user_authorized.return_value = True


### PR DESCRIPTION
## The problem

The 8.0 schema, migration and viewer all speak accounts — but the runtime still ran exactly one, hardcoded as account 1. This is the last piece: one container, one database, one media volume, N Telegram accounts.

## What this does

- **Indexed environment accounts.** `TG_ACCOUNT_<N>_API_ID/_API_HASH/_PHONE_NUMBER` (optional `_LABEL`, `_SESSION_NAME`), contiguous from 1 — a gap, a partial triple, a duplicate phone or a session-file collision is a loud startup error that names the variable and never its value.
- **Zero-config upgrade.** With no `TG_ACCOUNT_*` set, one account is synthesized from the legacy variables with the byte-identical legacy session path — an existing deployment upgrades with no configuration change and no re-login. Account 1 keeps the legacy session default even in indexed mode.
- **Rows are owned by the Telegram user id, not the env position.** After each client authenticates, `ensure_account` resolves by user id; index 1 claims the migrated row through an atomic guarded UPDATE while it is still unclaimed, which is how a pre-8.0 archive stays under account 1. Reshuffling indexes can never steal or split an account's data; re-running never duplicates a row.
- **Sequential sweeps, isolated failures.** Account N's full sweep completes before N+1 starts (one client per account, own session file, own listener registration — flood thresholds are per-client so the absorb machinery is untouched). One account failing logs its exception type only and the next account still runs; a sole account failing keeps today's exact behavior.

## Verification

- Fresh-eyes review lane: **APPROVE, zero blockers.** The upgrade path was proven with its own runs — legacy-env-only start yields a session path string-identical to the pre-change config across four env scenarios, and writes land on the claimed row 1 of a migrated database.
- Positive controls watched red: breaking the claim rule orphans the archive (caught), breaking the session fallback forces a re-login (caught).
- Grep-audited composition: every construction site passes a resolved row id; zero `DEFAULT_ACCOUNT_ID` literals left in runtime paths.
- Full suite after rebasing onto main (core + trigram + ref viewer): **3271 passed, 0 failed** with a real PostgreSQL leg, run independently by the integrator, the reviewer, and once more post-rebase. ruff clean.

No version bump: still 7.33.6 — the single 8.0.0 bump rides the release PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring and running Telegram backups across multiple accounts.
  * Added per-account labels, credentials, session names, authentication, listeners, and backup processing.
  * Preserved compatibility with existing single-account configurations.
  * Added account validation, startup status, failure isolation, reconnection, and sequential backup handling.

* **Documentation**
  * Documented multi-account environment variables, migration behavior, authentication, session handling, and Docker configuration.

* **Tests**
  * Expanded coverage for configuration validation, account isolation, authentication, scheduling, reconnection, and multi-account runtime behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->