### PR TITLE
fix: revocation now closes the live channels it revokes

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -34,6 +34,7 @@ from .models import (
     Message,
     MessageVersion,
     Metadata,
+    PushSubscription,
     Reaction,
     SyncStatus,
     User,
@@ -3760,6 +3761,20 @@ class DatabaseAdapter:
         """Delete all sessions created from a specific share token."""
         async with self.db_manager.async_session_factory() as session:
             result = await session.execute(delete(ViewerSession).where(ViewerSession.source_token_id == token_id))
+            await session.commit()
+            return result.rowcount
+
+    @retry_on_locked()
+    async def delete_push_subscriptions_for_username(self, *, username: str) -> int:
+        """Delete every push subscription owned by ``username``. Returns count deleted.
+
+        The revocation half of push ownership: a subscription is a delivery
+        channel that survives the session that created it, so every path that
+        invalidates a principal's sessions deletes its push rows through here.
+        Writes push_subscriptions and nothing else.
+        """
+        async with self.db_manager.async_session_factory() as session:
+            result = await session.execute(delete(PushSubscription).where(PushSubscription.username == username))
             await session.commit()
             return result.rowcount
 

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -14,7 +14,7 @@ import os
 import secrets
 import time
 import traceback
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Iterable
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -54,6 +54,22 @@ mimetypes.add_type("video/webm", ".webm")
 mimetypes.add_type("image/webp", ".webp")
 
 
+@dataclass(frozen=True)
+class ConnectionIdentity:
+    """A socket's revocation coordinates: how a revoking path finds it again.
+
+    The UserContext a socket carries is a SNAPSHOT of the grant it was admitted
+    with, so it can never answer "is this principal still allowed in?". These
+    three fields can: the session that admitted the socket, the principal that
+    owns it, and the share token that minted the session (token sessions only).
+    Proxy-header and anonymous sockets carry a username and nothing else.
+    """
+
+    username: str
+    session_key: str | None = None
+    source_token_id: int | None = None
+
+
 # WebSocket Connection Manager for real-time updates
 class ConnectionManager:
     """Manages WebSocket connections for real-time updates.
@@ -63,22 +79,69 @@ class ConnectionManager:
     is enforced by the endpoint through the SAME resolver the HTTP routes use;
     broadcast_to_chat re-checks the chat against the socket's context so a frame
     can never outrun the grant it rode in on.
+
+    A socket also carries its ConnectionIdentity, which is what makes revocation
+    reach it: the grant snapshot cannot notice that its principal was logged
+    out, disabled, deleted, revoked or expired, so close_for() closes the socket
+    from the outside when any of those happen.
     """
 
     def __init__(self):
         self.active_connections: dict[WebSocket, set[str]] = {}
         self._contexts: dict[WebSocket, UserContext] = {}
+        self._identities: dict[WebSocket, ConnectionIdentity] = {}
 
-    async def connect(self, websocket: WebSocket, user: UserContext):
+    async def connect(self, websocket: WebSocket, user: UserContext, identity: ConnectionIdentity | None = None):
         await websocket.accept()
         self.active_connections[websocket] = set()
         self._contexts[websocket] = user
+        self._identities[websocket] = identity or ConnectionIdentity(username=user.username)
         logger.info(f"WebSocket connected. Total connections: {len(self.active_connections)}")
 
     def disconnect(self, websocket: WebSocket):
         self.active_connections.pop(websocket, None)
         self._contexts.pop(websocket, None)
+        self._identities.pop(websocket, None)
         logger.info(f"WebSocket disconnected. Total connections: {len(self.active_connections)}")
+
+    async def close_for(
+        self,
+        *,
+        username: str | None = None,
+        session_keys: Iterable[str] | None = None,
+        source_token_id: int | None = None,
+    ) -> int:
+        """Close every socket held by a revoked principal. Returns how many.
+
+        A socket matches when ANY supplied coordinate matches its identity —
+        each caller passes exactly the coordinate it is revoking (one session
+        key on logout and on expiry, a username on viewer disable/delete, a
+        token id on share-token revoke). 4001 is the same code the upgrade
+        path already closes with when a socket cannot be tied to a live
+        principal, so a client sees one "you are no longer authenticated"
+        signal however the grant ended.
+        """
+        keys = set(session_keys) if session_keys is not None else set()
+        revoked = [
+            websocket
+            for websocket, identity in self._identities.items()
+            if (username is not None and identity.username == username)
+            or (identity.session_key is not None and identity.session_key in keys)
+            or (source_token_id is not None and identity.source_token_id == source_token_id)
+        ]
+        for websocket in revoked:
+            # Drop the socket's state BEFORE awaiting the close: a broadcast
+            # landing in another task while the close frame is in flight must
+            # not find a revoked socket still subscribed.
+            self.disconnect(websocket)
+            try:
+                await websocket.close(code=4001, reason="Session revoked")
+            except Exception as e:
+                # Already-closing sockets raise here; the state is gone either way.
+                logger.debug(f"Closing a revoked websocket raised {type(e).__name__}")
+        if revoked:
+            logger.info(f"Closed {len(revoked)} websocket(s) for a revoked principal")
+        return len(revoked)
 
     def subscribe(self, websocket: WebSocket, chat_ref: str) -> bool:
         """Record a subscription for an already-authorized chat ref."""
@@ -349,6 +412,14 @@ async def session_cleanup_task():
                 _sessions.pop(k, None)
             if expired:
                 logger.info(f"Cleaned up {len(expired)} expired sessions from cache")
+                # An expired session must lose its socket too, or the principal
+                # keeps receiving frames from the grant it was admitted with.
+                # Closing them HERE rather than re-checking the session on the
+                # broadcast path is the choice that cannot regress delivery
+                # latency: this runs once per sweep over a list the sweep has
+                # already built, while a per-frame check would add a session
+                # lookup to every message for every subscribed socket.
+                await ws_manager.close_for(session_keys=expired)
             # Also clean DB
             if db:
                 try:
@@ -473,7 +544,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     if config.push_notifications == "full":
         from .push import PushNotificationManager
 
-        push_manager = PushNotificationManager(db, config)
+        push_manager = PushNotificationManager(db, config, configured_principals=_configured_principals())
         push_enabled = await push_manager.initialize()
         if push_enabled:
             logger.info("Web Push notifications enabled (PUSH_NOTIFICATIONS=full)")
@@ -793,13 +864,17 @@ async def _create_session(
     user_sessions = [(k, v) for k, v in _sessions.items() if v.username == username]
     if len(user_sessions) >= _MAX_SESSIONS_PER_USER:
         user_sessions.sort(key=lambda x: x[1].created_at)
-        for token, _ in user_sessions[: len(user_sessions) - _MAX_SESSIONS_PER_USER + 1]:
+        evicted = [token for token, _ in user_sessions[: len(user_sessions) - _MAX_SESSIONS_PER_USER + 1]]
+        for token in evicted:
             _sessions.pop(token, None)
             if db:
                 try:
                     await db.delete_session(token)
                 except Exception:
                     pass
+        # Eviction deletes a session like any other revocation, so it closes
+        # that session's sockets too.
+        await ws_manager.close_for(session_keys=evicted)
 
     now = time.time()
     token = secrets.token_urlsafe(32)
@@ -841,8 +916,40 @@ async def _create_session(
     return token
 
 
+async def _purge_push_subscriptions(username: str) -> None:
+    """Delete every stored push channel owned by ``username``.
+
+    A push subscription outlives every session: the push service delivers to
+    the browser with no cookie and no socket involved, so revoking sessions
+    alone leaves a revoked principal still being notified. Best-effort by
+    design — a failure here must not abort the rest of a revocation, and
+    PushNotificationManager.get_subscriptions re-checks owner liveness at send
+    time as the backstop for exactly that case.
+
+    Deletion is per USERNAME, not per browser: the server cannot tell which
+    endpoint belongs to which session, so logging out of one browser drops the
+    user's other browsers' subscriptions too. They re-subscribe on their next
+    load; the reverse (leaving a revoked channel armed) is the unsafe half.
+    """
+    if not db:
+        return
+    try:
+        deleted = await db.delete_push_subscriptions_for_username(username=username)
+    except Exception as e:
+        logger.warning(f"Failed to delete push subscriptions ({type(e).__name__})")
+        return
+    if deleted:
+        logger.info(f"Deleted {deleted} push subscription(s) for a revoked principal")
+
+
 async def _invalidate_user_sessions(username: str) -> None:
-    """Remove all sessions for a given username."""
+    """Revoke everything a username holds: sessions, open sockets, push channels.
+
+    The single choke point for viewer update/disable/delete. Sessions are only
+    the credential; the socket and the push subscription are live delivery
+    channels that keep working after the session row is gone, so all three end
+    here.
+    """
     to_remove = [k for k, v in _sessions.items() if v.username == username]
     for k in to_remove:
         _sessions.pop(k, None)
@@ -851,18 +958,43 @@ async def _invalidate_user_sessions(username: str) -> None:
             await db.delete_user_sessions(username)
         except Exception as e:
             logger.warning(f"Failed to delete DB sessions for {username}: {e}")
+    await ws_manager.close_for(username=username)
+    await _purge_push_subscriptions(username)
 
 
 async def _invalidate_token_sessions(token_id: int) -> None:
-    """Remove all sessions created from a specific share token (on revoke/delete/update)."""
-    to_remove = [k for k, v in _sessions.items() if v.source_token_id == token_id]
-    for k in to_remove:
+    """Revoke everything a share token holds (on revoke/delete/update).
+
+    The token's push channels are stored under the session username the token
+    minted, so they are purged for each username the revoked sessions carried.
+    A token whose sessions are all already gone leaves no username to purge
+    here — get_subscriptions' owner-liveness check is what silences that row.
+    """
+    to_remove = [(k, v.username) for k, v in _sessions.items() if v.source_token_id == token_id]
+    for k, _ in to_remove:
         _sessions.pop(k, None)
     if db:
         try:
             await db.delete_sessions_by_source_token_id(token_id)
         except Exception as e:
             logger.warning(f"Failed to delete token sessions for token_id={token_id}: {e}")
+    await ws_manager.close_for(source_token_id=token_id)
+    for username in {username for _, username in to_remove}:
+        await _purge_push_subscriptions(username)
+
+
+def _configured_principals() -> set[str]:
+    """Usernames that exist by CONFIGURATION rather than by a viewer_accounts row.
+
+    The env master, the trusted-proxy admins and the anonymous viewer never
+    have an account row, so a liveness check against viewer_accounts would read
+    them as deleted and silence their push notifications. The database cannot
+    prove a configured principal dead; only the operator's config can.
+    """
+    names = {VIEWER_USERNAME, *AUTH_PROXY_ADMIN_USERS}
+    if ALLOW_ANONYMOUS_VIEWER:
+        names.add("anonymous")
+    return {name for name in names if name}
 
 
 def _get_secure_cookies(request: Request) -> bool:
@@ -994,7 +1126,11 @@ async def _resolve_user_context(proxy_header_value: str | None, auth_cookie: str
         raise HTTPException(status_code=401, detail="Unauthorized")
 
     if time.time() - session.created_at > AUTH_SESSION_SECONDS:
+        # This request expires the session ahead of the sweep, which then never
+        # sees it — so the socket it admitted has to be closed from here, or it
+        # outlives every path that could have closed it.
         _sessions.pop(auth_cookie, None)
+        await ws_manager.close_for(session_keys=(auth_cookie,))
         raise HTTPException(status_code=401, detail="Session expired")
 
     session.last_accessed = time.time()
@@ -1005,6 +1141,24 @@ async def _resolve_user_context(proxy_header_value: str | None, auth_cookie: str
         allowed_chat_refs=session.allowed_chat_refs,
         no_download=session.no_download,
     )
+
+
+def _socket_identity(user: UserContext, auth_cookie: str | None) -> ConnectionIdentity:
+    """The revocation coordinates to file a new socket under.
+
+    Cookie-authenticated sockets are filed under their session key and, for a
+    share-token session, the token that minted it — the two coordinates the
+    revoking paths know. Proxy-header and anonymous sockets have no session, so
+    the username is all there is; revoking such a principal is a viewer
+    disable/delete, which matches on the username anyway. A cookie that
+    resolved to a DIFFERENT principal than the one admitted (proxy auth won,
+    with a stale cookie still attached) is not this socket's key and is
+    ignored.
+    """
+    session = _sessions.get(auth_cookie) if auth_cookie else None
+    if session is None or session.username != user.username:
+        return ConnectionIdentity(username=user.username)
+    return ConnectionIdentity(username=user.username, session_key=auth_cookie, source_token_id=session.source_token_id)
 
 
 async def require_auth(
@@ -1573,7 +1727,10 @@ async def check_auth(request: Request, auth_cookie: str | None = Cookie(default=
     if not session:
         return {"authenticated": False, "auth_required": True}
     if time.time() - session.created_at > AUTH_SESSION_SECONDS:
+        # Same rule as _resolve_user_context: whoever expires the session owns
+        # closing the sockets it admitted.
         _sessions.pop(auth_cookie, None)
+        await ws_manager.close_for(session_keys=(auth_cookie,))
         return {"authenticated": False, "auth_required": True}
 
     return {
@@ -1715,9 +1872,15 @@ async def logout(
     request: Request,
     auth_cookie: str | None = Cookie(default=None, alias=AUTH_COOKIE_NAME),
 ):
-    """Invalidate current session and clear cookie."""
+    """Invalidate current session and clear cookie.
+
+    Logout revokes the BROWSER's channels, not the account's: this session's
+    sockets are closed and this user's push subscriptions are deleted, while
+    the user's other sessions stay live.
+    """
     if auth_cookie:
         session = _sessions.pop(auth_cookie, None)
+        await ws_manager.close_for(session_keys=(auth_cookie,))
         if db:
             # Always attempt DB delete (session may exist in DB but not in memory cache)
             try:
@@ -1736,6 +1899,8 @@ async def logout(
                     endpoint="/api/logout",
                     ip_address=request.client.host if request.client else None,
                 )
+        if session:
+            await _purge_push_subscriptions(session.username)
 
     response = JSONResponse({"success": True})
     response.delete_cookie(AUTH_COOKIE_NAME)
@@ -3265,16 +3430,17 @@ async def websocket_endpoint(websocket: WebSocket):
     # use: proxy header first, then the session cookie, then the anonymous
     # fallback. A socket that resolves to no principal is closed rather than
     # connected, and the ACL it carries is that principal's ACL.
+    auth_cookie = websocket.cookies.get(AUTH_COOKIE_NAME)
     try:
         user_ctx = await _resolve_user_context(
             websocket.headers.get(AUTH_PROXY_HEADER) if _PROXY_AUTH_ENABLED else None,
-            websocket.cookies.get(AUTH_COOKIE_NAME),
+            auth_cookie,
         )
     except HTTPException as exc:
         await websocket.close(code=4001, reason=exc.detail)
         return
 
-    await ws_manager.connect(websocket, user_ctx)
+    await ws_manager.connect(websocket, user_ctx, _socket_identity(user_ctx, auth_cookie))
 
     try:
         while True:

--- a/src/web/push.py
+++ b/src/web/push.py
@@ -12,6 +12,7 @@ import ipaddress
 import json
 import logging
 import socket
+from collections.abc import Iterable
 from typing import Any
 from urllib.parse import urlparse
 
@@ -26,6 +27,9 @@ from ..message_utils import utcnow_naive
 logger = logging.getLogger(__name__)
 
 _LOCAL_HOSTNAME_SUFFIXES = (".local", ".internal")
+
+# Share-token sessions (and so their push rows) are stored under this prefix.
+_TOKEN_USERNAME_PREFIX = "token:"
 
 # webpush() is pywebpush's synchronous requests.post, and it always forwards its
 # own timeout argument -- so leaving it out means requests.post(timeout=None),
@@ -110,9 +114,13 @@ def validate_push_endpoint(endpoint: str) -> bool:
 class PushNotificationManager:
     """Manages Web Push notifications for the viewer."""
 
-    def __init__(self, db_adapter, config):
+    def __init__(self, db_adapter, config, *, configured_principals: Iterable[str] = ()):
         self.db = db_adapter
         self.config = config
+        # Usernames that exist by configuration rather than by a viewer_accounts
+        # row (the env master, proxy admins, the anonymous viewer). The owner
+        # liveness check below can never prove those dead, so it leaves them be.
+        self.configured_principals = frozenset(configured_principals)
         self._vapid: Vapid | None = None
         self._public_key: str | None = None
         self._private_key: str | None = None
@@ -311,6 +319,11 @@ class PushNotificationManager:
         exists only there (or cannot be parsed) receives nothing, exactly like
         the viewer's own resolver. Without a chat context only unrestricted
         subscriptions qualify.
+
+        The grant is a SNAPSHOT taken at subscribe time, so it cannot notice
+        that its owner was disabled, deleted or revoked since; owner liveness
+        is therefore checked here as well, as the backstop for a revocation
+        whose push purge never ran.
         """
         try:
             from sqlalchemy import or_, select
@@ -326,7 +339,7 @@ class PushNotificationManager:
                 result = await session.execute(query)
                 subs = result.scalars().all()
 
-                filtered = []
+                entitled = []
                 for sub in subs:
                     accounts = parse_entitlement_column(sub.allowed_accounts, int)
                     refs = parse_entitlement_column(sub.allowed_chat_refs, str)
@@ -339,13 +352,78 @@ class PushNotificationManager:
                         continue
                     if refs is not None and chat_ref not in refs:
                         continue
-                    filtered.append({"endpoint": sub.endpoint, "keys": {"p256dh": sub.p256dh, "auth": sub.auth}})
+                    entitled.append(sub)
 
-                return filtered
+                live = await self._live_owners(session, {sub.username for sub in entitled if sub.username})
+
+                return [
+                    {"endpoint": sub.endpoint, "keys": {"p256dh": sub.p256dh, "auth": sub.auth}}
+                    for sub in entitled
+                    if not sub.username or sub.username in live
+                ]
 
         except Exception as e:
             logger.error(f"Failed to get push subscriptions: {e}")
             return []
+
+    async def _live_owners(self, session, usernames: set[str]) -> set[str]:
+        """Which of ``usernames`` still resolve to a principal allowed to receive.
+
+        Two queries at most, never one per row: ``token:`` owners are checked
+        against the share tokens, everyone else against the viewer accounts.
+        A name is live when
+
+        - it is a configured principal (see ``configured_principals``), or
+        - it is an ACTIVE viewer account, or
+        - it is the session username of a share token that is neither revoked
+          nor expired.
+
+        Everything else — a deleted account, a disabled one, a revoked or
+        expired token — is dropped. A row with no owner recorded predates
+        ownership and is left to the grant columns, which still gate it.
+
+        Share-token labels are not unique, so two tokens sharing a label also
+        share one session username, and revoking just one of them leaves that
+        name live. The purge on the revoking path is the precise instrument;
+        this is the backstop behind it.
+        """
+        if not usernames:
+            return set()
+
+        from sqlalchemy import or_, select
+
+        from src.db.models import ViewerAccount, ViewerToken
+
+        live = {name for name in usernames if name in self.configured_principals}
+        remaining = usernames - live
+        token_names = {name for name in remaining if name.startswith(_TOKEN_USERNAME_PREFIX)}
+        account_names = remaining - token_names
+
+        if account_names:
+            result = await session.execute(
+                select(ViewerAccount.username).where(
+                    ViewerAccount.username.in_(account_names), ViewerAccount.is_active == 1
+                )
+            )
+            live.update(result.scalars().all())
+
+        if token_names:
+            now = utcnow_naive()
+            result = await session.execute(
+                select(ViewerToken.id, ViewerToken.label).where(
+                    ViewerToken.is_revoked == 0,
+                    or_(ViewerToken.expires_at.is_(None), ViewerToken.expires_at > now),
+                )
+            )
+            for token_id, label in result.all():
+                # Mirrors the username auth_via_token mints in main.py:
+                # f"token:{label or f'token:{id}'}". A label-less token really
+                # does end up doubled, and reversing it must match exactly.
+                minted = f"{_TOKEN_USERNAME_PREFIX}{label or f'{_TOKEN_USERNAME_PREFIX}{token_id}'}"
+                if minted in token_names:
+                    live.add(minted)
+
+        return live
 
     async def send_notification(
         self,

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -3842,6 +3842,15 @@
                 }
 
                 const performLogout = async () => {
+                    // Drop this browser's push channel first: /api/push/unsubscribe
+                    // is session-authenticated, so it has to run while the cookie is
+                    // still valid, and push_enabled must go or the next load
+                    // re-subscribes automatically. Best-effort only — the server
+                    // purge in /api/logout is the guarantee.
+                    try {
+                        await unsubscribeFromPush()
+                    } catch (e) { /* ignore */ }
+                    localStorage.removeItem('push_enabled')
                     try {
                         await fetch('/api/logout', { method: 'POST', credentials: 'include' })
                     } catch (e) { /* ignore */ }

--- a/tests/test_frontend_audit_fixes.py
+++ b/tests/test_frontend_audit_fixes.py
@@ -1336,3 +1336,67 @@ def test_every_chat_scoped_url_interpolation_is_encoded() -> None:
         for m in re.finditer(r"/api/chats/\$\{(?!encodeURIComponent\()", html)
     ]
     assert violations == [], f"unencoded chat-scoped interpolations: {violations}"
+
+
+# --------------------------------------------------------------------------------------
+# Logging out left this browser's push channel armed and re-arming
+# --------------------------------------------------------------------------------------
+
+
+def test_logout_drops_this_browsers_push_channel_before_the_session_dies() -> None:
+    """Logout must revoke the browser's half of the push channel, in that order.
+
+    ``unsubscribeFromPush`` POSTs to ``/api/push/unsubscribe``, which is
+    session-authenticated -- so it has to run BEFORE the logout request kills
+    the cookie, or it silently 401s. Clearing ``push_enabled`` is the other
+    half: the service-worker bootstrap re-subscribes on the next load whenever
+    that key is still ``'true'`` and permission is granted, so leaving it
+    behind re-arms the channel for whoever logs in next on this browser.
+
+    The server purge in ``/api/logout`` is the guarantee; this is hygiene.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    script = "\n".join(
+        [
+            '"use strict";',
+            "const assert = require('node:assert/strict');",
+            """
+const ref = value => ({ value });
+const isAuthenticated = ref(true);
+const userRole = ref('viewer');
+const currentUsername = ref('someone');
+const showAdminPanel = ref(true);
+const calls = [];
+const store = { push_enabled: 'true' };
+const localStorage = {
+    getItem: key => (key in store ? store[key] : null),
+    setItem: (key, value) => { store[key] = String(value); },
+    removeItem: key => { delete store[key]; },
+};
+const unsubscribeFromPush = async () => { calls.push('unsubscribeFromPush'); };
+const fetch = async (url) => { calls.push(`fetch:${url}`); return { ok: true }; };
+""",
+            _extract_const_arrow_function(html, "performLogout", asynchronous=True),
+            """
+(async () => {
+    await performLogout();
+
+    const unsubscribedAt = calls.indexOf('unsubscribeFromPush');
+    const loggedOutAt = calls.indexOf('fetch:/api/logout');
+    assert.ok(unsubscribedAt >= 0, 'logout never unsubscribed this browser from push');
+    assert.ok(loggedOutAt >= 0, 'logout no longer posts /api/logout');
+    assert.ok(unsubscribedAt < loggedOutAt,
+        'the push unsubscribe ran after the cookie was gone, so it could only 401');
+    assert.equal(store.push_enabled, undefined,
+        'push_enabled survived logout, so the next load re-subscribes this browser');
+    assert.equal(isAuthenticated.value, false, 'logout no longer clears the session state');
+})().catch(error => {
+    process.stderr.write(`${error.stack}\\n`);
+    process.exitCode = 1;
+});
+""",
+        ]
+    )
+
+    _run_node(script)

--- a/tests/test_revocation_closes_channels.py
+++ b/tests/test_revocation_closes_channels.py
@@ -1,0 +1,607 @@
+"""Revoking a principal must close its LIVE channels, not just its session row.
+
+A principal reaches the archive through three things, not one: the session
+cookie, any open WebSocket, and any stored Web Push subscription. Only the
+first was ever revoked -- logout, viewer update/deactivate/delete, share-token
+revoke/update/delete and session expiry each edited ``_sessions`` and the
+``viewer_sessions`` table and stopped there. The socket kept delivering frames
+from the ``UserContext`` frozen into it at upgrade time, and the push row kept
+delivering notifications with no session involved at all.
+
+Every test here drives the real routes against a database built by ``alembic
+upgrade head`` on both supported backends, and proves a channel is gone by
+trying to USE it: a socket is proven closed by broadcasting into the very chat
+it subscribed to and watching the close frame arrive instead of the message.
+
+The last defence is in ``PushNotificationManager.get_subscriptions``: even if
+the purge on a revoking path never ran, a subscription whose owner no longer
+resolves to a live principal must receive nothing.
+"""
+
+import asyncio
+import contextlib
+import json
+import os
+import secrets
+import tempfile
+import time
+from datetime import datetime
+from functools import partial
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+import sqlalchemy as sa
+from alembic.config import Config as AlembicConfig
+from conftest import NO_POSTGRES_REASON
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import Session
+from sqlalchemy.pool import NullPool
+from starlette.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from alembic import command
+
+os.environ.setdefault("BACKUP_PATH", tempfile.mkdtemp(prefix="ta_test_revocation_"))
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Chat, PushSubscription
+from src.web import main as web_main
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+CHAT_ID = 900888001
+
+MASTER_USERNAME = "revoc-master"
+MASTER_PASSWORD = "master-pass@test/value"  # obvious fake
+VIEWER_PASSWORD = "revoc-pass@test/value"  # obvious fake
+
+
+def _upgrade_to_head(url: str) -> None:
+    """Run this tree's real Alembic environment against ``url``."""
+    config = AlembicConfig()
+    config.set_main_option("script_location", str(REPO_ROOT / "alembic"))
+    config.set_main_option("sqlalchemy.url", url)
+    previous = os.environ.get("DATABASE_URL")
+    os.environ["DATABASE_URL"] = url
+    try:
+        command.upgrade(config, "head")
+    finally:
+        if previous is None:
+            os.environ.pop("DATABASE_URL", None)
+        else:
+            os.environ["DATABASE_URL"] = previous
+
+
+def _seed(sync_url: str) -> str:
+    """One chat under account 1. Returns the ref the ORM minted on INSERT."""
+    engine = sa.create_engine(sync_url)
+    try:
+        with Session(engine) as session:
+            session.add(Chat(account_id=1, id=CHAT_ID, type="private", first_name="Revoc", username="revoc_chat"))
+            session.commit()
+        with engine.connect() as conn:
+            ref = conn.execute(sa.text("SELECT ref FROM chats WHERE id = :id"), {"id": CHAT_ID}).scalar_one()
+    finally:
+        engine.dispose()
+    return ref
+
+
+@pytest.fixture(scope="module", params=("sqlite", "postgresql"))
+def revocation_archive(request, tmp_path_factory, postgres_server_url, make_postgres_database):
+    """A migration-built, seeded 8.0 database per backend."""
+    if request.param == "postgresql":
+        if not postgres_server_url:
+            pytest.skip(NO_POSTGRES_REASON)
+        async_url, sync_url = make_postgres_database("telegram_archive_pytest_revocation")
+    else:
+        db_path = tmp_path_factory.mktemp("revocation-db") / "archive.db"
+        sync_url = f"sqlite:///{db_path}"
+        async_url = f"sqlite+aiosqlite:///{db_path}"
+    _upgrade_to_head(async_url)
+    ref = _seed(sync_url)
+    return SimpleNamespace(backend=request.param, async_url=async_url, ref=ref)
+
+
+def _null_pool_manager(async_url: str) -> DatabaseManager:
+    """A DatabaseManager whose engine never pools connections.
+
+    TestClient runs the app on its own portal loop, a different one from
+    pytest's; a pooled asyncpg connection binds to the loop that created it, so
+    only NullPool lets the same test touch the database from both.
+    """
+    manager = DatabaseManager(async_url)
+    manager.engine = create_async_engine(manager.database_url, poolclass=NullPool, hide_parameters=True)
+    manager.async_session_factory = async_sessionmaker(manager.engine, class_=AsyncSession, expire_on_commit=False)
+    return manager
+
+
+@pytest.fixture
+async def viewer_app(revocation_archive):
+    """The real app wired to the migrated database, auth on, state restored after."""
+    manager = _null_pool_manager(revocation_archive.async_url)
+    adapter = DatabaseAdapter(manager)
+
+    saved = {
+        "db": web_main.db,
+        "auth_enabled": web_main.AUTH_ENABLED,
+        "allow_anonymous": web_main.ALLOW_ANONYMOUS_VIEWER,
+        "viewer_username": web_main.VIEWER_USERNAME,
+        "viewer_password": web_main.VIEWER_PASSWORD,
+        "sessions": dict(web_main._sessions),
+        "login_attempts": dict(web_main._login_attempts),
+        "display_chat_ids": web_main.config.display_chat_ids,
+        "broadcast_chat_cache": dict(web_main._broadcast_chat_cache),
+    }
+    web_main.db = adapter
+    web_main.AUTH_ENABLED = True
+    web_main.ALLOW_ANONYMOUS_VIEWER = False
+    web_main.VIEWER_USERNAME = MASTER_USERNAME
+    web_main.VIEWER_PASSWORD = MASTER_PASSWORD
+    web_main._sessions.clear()
+    web_main._login_attempts.clear()
+    web_main.config.display_chat_ids = set()
+    web_main._broadcast_chat_cache.clear()
+
+    try:
+        yield SimpleNamespace(adapter=adapter, archive=revocation_archive, ref=revocation_archive.ref)
+    finally:
+        await _delete_all_push_subscriptions(adapter)
+        web_main.db = saved["db"]
+        web_main.AUTH_ENABLED = saved["auth_enabled"]
+        web_main.ALLOW_ANONYMOUS_VIEWER = saved["allow_anonymous"]
+        web_main.VIEWER_USERNAME = saved["viewer_username"]
+        web_main.VIEWER_PASSWORD = saved["viewer_password"]
+        web_main._sessions.clear()
+        web_main._sessions.update(saved["sessions"])
+        web_main._login_attempts.clear()
+        web_main._login_attempts.update(saved["login_attempts"])
+        web_main.config.display_chat_ids = saved["display_chat_ids"]
+        web_main._broadcast_chat_cache.clear()
+        web_main._broadcast_chat_cache.update(saved["broadcast_chat_cache"])
+        await manager.close()
+
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+
+async def _request(method: str, url: str, *, cookie: str | None = None, body: dict | None = None):
+    """One request through the real ASGI app, on whatever loop is current."""
+    cookies = {web_main.AUTH_COOKIE_NAME: cookie} if cookie else None
+    async with AsyncClient(
+        transport=ASGITransport(app=web_main.app), base_url="http://test", cookies=cookies
+    ) as client:
+        return await client.request(method, url, json=body)
+
+
+async def _viewer_with_session(adapter: DatabaseAdapter, *, username: str | None = None) -> tuple[str, str]:
+    """A real viewer account plus a live session cookie minted the real way."""
+    username = username or f"revoc-viewer-{secrets.token_hex(4)}"
+    salt = secrets.token_hex(8)
+    await adapter.create_viewer_account(
+        username=username,
+        password_hash=web_main._hash_password(VIEWER_PASSWORD, salt),
+        salt=salt,
+        created_by="test",
+        is_active=1,
+    )
+    return username, await web_main._create_session(username, "viewer")
+
+
+async def _master_cookie() -> str:
+    return await web_main._create_session(MASTER_USERNAME, "master")
+
+
+async def _viewer_id(adapter: DatabaseAdapter, username: str) -> int:
+    account = await adapter.get_viewer_by_username(username)
+    assert account is not None
+    return account["id"]
+
+
+async def _add_push_subscription(
+    adapter: DatabaseAdapter,
+    *,
+    endpoint: str,
+    username: str | None,
+    chat_id: int | None = None,
+) -> None:
+    """Insert a push subscription row exactly as PushNotificationManager.subscribe does."""
+    async with adapter.db_manager.async_session_factory() as session:
+        session.add(
+            PushSubscription(
+                endpoint=endpoint,
+                p256dh="p256dh-not-a-real-key",
+                auth="auth-not-a-real-secret",
+                chat_id=chat_id,
+                username=username,
+                created_at=datetime(2026, 4, 1, 9, 0, 0),
+            )
+        )
+        await session.commit()
+
+
+async def _push_endpoints(adapter: DatabaseAdapter) -> set[str]:
+    async with adapter.db_manager.async_session_factory() as session:
+        result = await session.execute(sa.select(PushSubscription.endpoint))
+        return set(result.scalars().all())
+
+
+async def _delete_all_push_subscriptions(adapter: DatabaseAdapter) -> None:
+    async with adapter.db_manager.async_session_factory() as session:
+        await session.execute(sa.delete(PushSubscription))
+        await session.commit()
+
+
+@contextlib.contextmanager
+def _revocable_socket(cookie: str):
+    """A live socket whose SERVER may close it under us.
+
+    Teardown sends a client-side close, which errors once the server has
+    already torn the connection down -- that is the outcome under test, not a
+    failure, so only the teardown is suppressed (the body's own exceptions
+    still propagate).
+    """
+    client = TestClient(web_main.app, raise_server_exceptions=False)
+    client.cookies.set(web_main.AUTH_COOKIE_NAME, cookie)
+    session = client.websocket_connect("/ws/updates")
+    socket = session.__enter__()
+    try:
+        yield socket
+    finally:
+        with contextlib.suppress(Exception):
+            session.__exit__(None, None, None)
+
+
+def _subscribe(socket, ref: str) -> None:
+    socket.send_json({"action": "subscribe", "chat_ref": ref})
+    assert socket.receive_json() == {"type": "subscribed", "chat_ref": ref}
+
+
+def _assert_socket_revoked(socket, ref: str) -> None:
+    """Broadcast into the socket's own subscription; a revoked socket is closed, not fed.
+
+    Sending the frame is what makes the assertion falsifiable: a socket that
+    outlived its revocation answers with the message, so the failure is a
+    delivered frame rather than a hang.
+    """
+    socket.portal.call(web_main.broadcast_new_message, CHAT_ID, {"id": 9, "text": "after-revocation"})
+    with pytest.raises(WebSocketDisconnect) as disconnect:
+        socket.receive_json()
+    assert disconnect.value.code == 4001
+
+
+# ============================================================================
+# (1) Logout closes THAT browser's socket, and only that one
+# ============================================================================
+
+
+async def test_logout_closes_that_sessions_socket_and_leaves_other_sessions_alone(viewer_app):
+    ref = viewer_app.ref
+    username, cookie_a = await _viewer_with_session(viewer_app.adapter)
+    cookie_b = await web_main._create_session(username, "viewer")
+
+    with _revocable_socket(cookie_a) as socket_a:
+        _subscribe(socket_a, ref)
+
+        with _revocable_socket(cookie_b) as socket_b:
+            _subscribe(socket_b, ref)
+
+            response = socket_a.portal.call(partial(_request, "POST", "/api/logout", cookie=cookie_a))
+            assert response.status_code == 200, response.text
+
+            # The other browser is a different session: it must survive intact.
+            socket_b.send_json({"action": "ping"})
+            assert socket_b.receive_json() == {"type": "pong"}
+            assert cookie_b in web_main._sessions
+
+        _assert_socket_revoked(socket_a, ref)
+
+
+# ============================================================================
+# (2) Viewer deactivate / delete, and share-token revoke, close their sockets
+# ============================================================================
+
+
+async def test_deactivating_a_viewer_closes_its_socket(viewer_app):
+    ref = viewer_app.ref
+    username, cookie = await _viewer_with_session(viewer_app.adapter)
+    viewer_id = await _viewer_id(viewer_app.adapter, username)
+    master = await _master_cookie()
+
+    with _revocable_socket(cookie) as socket:
+        _subscribe(socket, ref)
+        response = socket.portal.call(
+            partial(_request, "PUT", f"/api/admin/viewers/{viewer_id}", cookie=master, body={"is_active": False})
+        )
+        assert response.status_code == 200, response.text
+        _assert_socket_revoked(socket, ref)
+
+
+async def test_deleting_a_viewer_closes_its_socket(viewer_app):
+    ref = viewer_app.ref
+    username, cookie = await _viewer_with_session(viewer_app.adapter)
+    viewer_id = await _viewer_id(viewer_app.adapter, username)
+    master = await _master_cookie()
+
+    with _revocable_socket(cookie) as socket:
+        _subscribe(socket, ref)
+        response = socket.portal.call(partial(_request, "DELETE", f"/api/admin/viewers/{viewer_id}", cookie=master))
+        assert response.status_code == 200, response.text
+        _assert_socket_revoked(socket, ref)
+
+
+async def test_revoking_a_share_token_closes_its_socket(viewer_app):
+    ref = viewer_app.ref
+    master = await _master_cookie()
+
+    created = await _request(
+        "POST", "/api/admin/tokens", cookie=master, body={"label": "revoc-share", "allowed_chat_refs": [ref]}
+    )
+    assert created.status_code == 200, created.text
+    token_id = created.json()["id"]
+
+    authenticated = await _request("POST", "/auth/token", body={"token": created.json()["token"]})
+    assert authenticated.status_code == 200, authenticated.text
+    cookie = authenticated.cookies[web_main.AUTH_COOKIE_NAME]
+
+    with _revocable_socket(cookie) as socket:
+        _subscribe(socket, ref)
+        response = socket.portal.call(
+            partial(_request, "PUT", f"/api/admin/tokens/{token_id}", cookie=master, body={"is_revoked": True})
+        )
+        assert response.status_code == 200, response.text
+        _assert_socket_revoked(socket, ref)
+
+
+# ============================================================================
+# (3) An expired session loses its socket too
+# ============================================================================
+
+
+async def _sweep_expired_sessions() -> None:
+    """Run the real background sweep once, then stop it."""
+    saved_interval = web_main._SESSION_CLEANUP_INTERVAL
+    web_main._SESSION_CLEANUP_INTERVAL = 0.01
+    task = asyncio.create_task(web_main.session_cleanup_task())
+    try:
+        await asyncio.sleep(0.3)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+        web_main._SESSION_CLEANUP_INTERVAL = saved_interval
+
+
+async def test_expired_session_loses_its_socket_on_the_cleanup_sweep(viewer_app):
+    ref = viewer_app.ref
+    _username, cookie = await _viewer_with_session(viewer_app.adapter)
+
+    with _revocable_socket(cookie) as socket:
+        _subscribe(socket, ref)
+
+        # The socket was admitted by a live session; the session then ages out
+        # underneath it, which is exactly the case a sweep of _sessions alone
+        # cannot reach.
+        web_main._sessions[cookie].created_at = time.time() - web_main.AUTH_SESSION_SECONDS - 60
+        socket.portal.call(_sweep_expired_sessions)
+        assert cookie not in web_main._sessions
+
+        _assert_socket_revoked(socket, ref)
+
+
+async def test_a_request_that_expires_a_session_closes_its_socket_too(viewer_app):
+    """The sweep is not the only path that expires a session.
+
+    A request carrying an aged cookie expires it on the spot, which takes it
+    out of the sweep's reach: whoever expires a session owns closing the
+    sockets it admitted, or this one outlives every path that could close it.
+    """
+    ref = viewer_app.ref
+    _username, cookie = await _viewer_with_session(viewer_app.adapter)
+
+    with _revocable_socket(cookie) as socket:
+        _subscribe(socket, ref)
+
+        web_main._sessions[cookie].created_at = time.time() - web_main.AUTH_SESSION_SECONDS - 60
+        response = socket.portal.call(partial(_request, "GET", "/api/chats", cookie=cookie))
+        assert response.status_code == 401, response.text
+        assert cookie not in web_main._sessions
+
+        _assert_socket_revoked(socket, ref)
+
+
+# ============================================================================
+# (4) Every revocation trigger deletes the principal's push subscriptions
+# ============================================================================
+
+
+async def test_logout_purges_that_users_push_subscriptions(viewer_app):
+    adapter = viewer_app.adapter
+    username, cookie = await _viewer_with_session(adapter)
+    bystander, _ = await _viewer_with_session(adapter)
+    await _add_push_subscription(adapter, endpoint="https://push.example.com/logout-owner", username=username)
+    await _add_push_subscription(adapter, endpoint="https://push.example.com/bystander", username=bystander)
+
+    response = await _request("POST", "/api/logout", cookie=cookie)
+    assert response.status_code == 200, response.text
+
+    assert await _push_endpoints(adapter) == {"https://push.example.com/bystander"}
+
+
+async def test_deactivating_and_deleting_a_viewer_purge_its_push_subscriptions(viewer_app):
+    adapter = viewer_app.adapter
+    master = await _master_cookie()
+
+    deactivated, _ = await _viewer_with_session(adapter)
+    deleted, _ = await _viewer_with_session(adapter)
+    bystander, _ = await _viewer_with_session(adapter)
+    await _add_push_subscription(adapter, endpoint="https://push.example.com/deactivated", username=deactivated)
+    await _add_push_subscription(adapter, endpoint="https://push.example.com/deleted", username=deleted)
+    await _add_push_subscription(adapter, endpoint="https://push.example.com/bystander", username=bystander)
+
+    disabled = await _request(
+        "PUT",
+        f"/api/admin/viewers/{await _viewer_id(adapter, deactivated)}",
+        cookie=master,
+        body={"is_active": False},
+    )
+    assert disabled.status_code == 200, disabled.text
+    removed = await _request("DELETE", f"/api/admin/viewers/{await _viewer_id(adapter, deleted)}", cookie=master)
+    assert removed.status_code == 200, removed.text
+
+    assert await _push_endpoints(adapter) == {"https://push.example.com/bystander"}
+
+
+async def test_revoking_a_share_token_purges_its_push_subscriptions(viewer_app):
+    adapter = viewer_app.adapter
+    master = await _master_cookie()
+
+    created = await _request(
+        "POST",
+        "/api/admin/tokens",
+        cookie=master,
+        body={"label": "revoc-push-share", "allowed_chat_refs": [viewer_app.ref]},
+    )
+    assert created.status_code == 200, created.text
+    token_id = created.json()["id"]
+
+    authenticated = await _request("POST", "/auth/token", body={"token": created.json()["token"]})
+    assert authenticated.status_code == 200, authenticated.text
+    # The username the token principal really subscribes under, read from the
+    # mint site itself rather than reconstructed here.
+    principal = authenticated.json()["username"]
+    assert principal.startswith("token:")
+    await _add_push_subscription(adapter, endpoint="https://push.example.com/token-owner", username=principal)
+
+    response = await _request("PUT", f"/api/admin/tokens/{token_id}", cookie=master, body={"is_revoked": True})
+    assert response.status_code == 200, response.text
+
+    assert await _push_endpoints(adapter) == set()
+
+
+# ============================================================================
+# (5) The backstop: a subscription whose owner is gone receives nothing
+# ============================================================================
+
+
+async def test_get_subscriptions_drops_rows_whose_owner_no_longer_lives(viewer_app):
+    """Even with every purge missed, a dead owner's channel must go quiet.
+
+    The rows here are written straight to the table, which is what a missed
+    purge leaves behind: the revoking path already ran and deleted nothing.
+    """
+    pytest.importorskip("pywebpush")
+    from src.web.push import PushNotificationManager
+
+    adapter = viewer_app.adapter
+    master = await _master_cookie()
+
+    live_viewer, _ = await _viewer_with_session(adapter)
+    inactive_viewer, _ = await _viewer_with_session(adapter)
+    await adapter.update_viewer_account(await _viewer_id(adapter, inactive_viewer), is_active=0)
+
+    live_token = await _request(
+        "POST",
+        "/api/admin/tokens",
+        cookie=master,
+        body={"label": "backstop-live", "allowed_chat_refs": [viewer_app.ref]},
+    )
+    revoked_token = await _request(
+        "POST",
+        "/api/admin/tokens",
+        cookie=master,
+        body={"label": "backstop-revoked", "allowed_chat_refs": [viewer_app.ref]},
+    )
+    live_principal = (await _request("POST", "/auth/token", body={"token": live_token.json()["token"]})).json()[
+        "username"
+    ]
+    revoked_principal = (await _request("POST", "/auth/token", body={"token": revoked_token.json()["token"]})).json()[
+        "username"
+    ]
+    revoke = await _request(
+        "PUT", f"/api/admin/tokens/{revoked_token.json()['id']}", cookie=master, body={"is_revoked": True}
+    )
+    assert revoke.status_code == 200, revoke.text
+
+    rows = {
+        "https://push.example.com/live-viewer": live_viewer,
+        "https://push.example.com/inactive-viewer": inactive_viewer,
+        "https://push.example.com/deleted-viewer": "revoc-viewer-never-existed",
+        "https://push.example.com/live-token": live_principal,
+        "https://push.example.com/revoked-token": revoked_principal,
+        "https://push.example.com/master": MASTER_USERNAME,
+        "https://push.example.com/legacy-row": None,
+    }
+    for endpoint, username in rows.items():
+        await _add_push_subscription(adapter, endpoint=endpoint, username=username)
+
+    manager = PushNotificationManager(adapter, web_main.config, configured_principals=web_main._configured_principals())
+    delivered = await manager.get_subscriptions(CHAT_ID, account_id=1, chat_ref=viewer_app.ref)
+
+    assert {sub["endpoint"] for sub in delivered} == {
+        "https://push.example.com/live-viewer",
+        "https://push.example.com/live-token",
+        "https://push.example.com/master",
+        "https://push.example.com/legacy-row",
+    }
+
+
+async def test_a_live_owner_still_receives_after_an_unrelated_revocation(viewer_app):
+    """The backstop must not become a silent global mute.
+
+    Deleting one viewer account leaves everyone else's channel working -- the
+    check that proves the filter can go red also has to prove it can stay green.
+    """
+    pytest.importorskip("pywebpush")
+    from src.web.push import PushNotificationManager
+
+    adapter = viewer_app.adapter
+    master = await _master_cookie()
+    keeper, _ = await _viewer_with_session(adapter)
+    doomed, _ = await _viewer_with_session(adapter)
+
+    await _add_push_subscription(adapter, endpoint="https://push.example.com/keeper", username=keeper)
+    removed = await _request("DELETE", f"/api/admin/viewers/{await _viewer_id(adapter, doomed)}", cookie=master)
+    assert removed.status_code == 200, removed.text
+
+    manager = PushNotificationManager(adapter, web_main.config, configured_principals=web_main._configured_principals())
+    delivered = await manager.get_subscriptions(CHAT_ID, account_id=1, chat_ref=viewer_app.ref)
+    assert [sub["endpoint"] for sub in delivered] == ["https://push.example.com/keeper"]
+
+
+# ============================================================================
+# The entitlement snapshot a subscription carries is still enforced
+# ============================================================================
+
+
+async def test_a_live_owners_grant_still_bounds_delivery(viewer_app):
+    """Liveness is an ADDITIONAL gate, never a replacement for the ref grant."""
+    pytest.importorskip("pywebpush")
+    from src.web.push import PushNotificationManager
+
+    adapter = viewer_app.adapter
+    username, _ = await _viewer_with_session(adapter)
+    async with adapter.db_manager.async_session_factory() as session:
+        session.add(
+            PushSubscription(
+                endpoint="https://push.example.com/other-chat-only",
+                p256dh="p256dh-not-a-real-key",
+                auth="auth-not-a-real-secret",
+                username=username,
+                allowed_chat_ids="[]",
+                allowed_chat_refs=json.dumps(["someOtherRefAAAABB0001"]),
+                created_at=datetime(2026, 4, 1, 9, 0, 0),
+            )
+        )
+        await session.commit()
+
+    manager = PushNotificationManager(adapter, web_main.config, configured_principals=web_main._configured_principals())
+    assert await manager.get_subscriptions(CHAT_ID, account_id=1, chat_ref=viewer_app.ref) == []

--- a/tests/test_web_coverage.py
+++ b/tests/test_web_coverage.py
@@ -1932,6 +1932,11 @@ class TestPushGetSubscriptions(unittest.IsolatedAsyncioTestCase):
         mock_sub.allowed_chat_ids = None  # Master user, no restriction
         mock_sub.allowed_accounts = None
         mock_sub.allowed_chat_refs = None
+        # No owner recorded: these tests pin the ENTITLEMENT filter, and a row
+        # from before ownership existed is left to the grant columns. The
+        # owner-liveness backstop has its own coverage against a real database
+        # in tests/test_revocation_closes_channels.py.
+        mock_sub.username = None
 
         mock_session = AsyncMock()
         mock_result = MagicMock()
@@ -1960,6 +1965,7 @@ class TestPushGetSubscriptions(unittest.IsolatedAsyncioTestCase):
         mock_sub1.allowed_chat_ids = "[]"  # rollback tombstone, never read as a grant
         mock_sub1.allowed_accounts = None
         mock_sub1.allowed_chat_refs = json.dumps(["pushRefAllowed000042A", "pushRefAllowed000043A"])
+        mock_sub1.username = None  # entitlement filter only; see the note above
 
         mock_sub2 = MagicMock()
         mock_sub2.endpoint = "https://push.example.com/denied"
@@ -1968,6 +1974,7 @@ class TestPushGetSubscriptions(unittest.IsolatedAsyncioTestCase):
         mock_sub2.allowed_chat_ids = "[]"
         mock_sub2.allowed_accounts = None
         mock_sub2.allowed_chat_refs = json.dumps(["pushRefOther000000100"])
+        mock_sub2.username = None  # entitlement filter only; see the note above
 
         mock_session = AsyncMock()
         mock_result = MagicMock()
@@ -1996,6 +2003,7 @@ class TestPushGetSubscriptions(unittest.IsolatedAsyncioTestCase):
         mock_sub.allowed_chat_ids = None
         mock_sub.allowed_accounts = None
         mock_sub.allowed_chat_refs = None
+        mock_sub.username = None  # entitlement filter only; see the note above
 
         mock_session = AsyncMock()
         mock_result = MagicMock()


### PR DESCRIPTION
## The problem

8.0.0's headline is entitlements that fail closed — but revocation didn't reach the live channels. An open websocket outlived logout, viewer deactivation or deletion, token revocation and session expiry, because the delivery re-check reads the connect-time frozen context, never the session store. And push subscriptions had no revocation path at all: nothing deleted the rows on any trigger, delivery trusted the subscribe-time grant snapshot, and logout never unsubscribed the browser — so a revoked share token kept receiving notifications carrying sender names and 100 characters of message text. (Beads 9t6.4.6, 9t6.4.7, 9t6.4.10, 9t6.4.11, re-verified at file:line against current main before this fix.)

## The fix

- **Sockets carry revocation coordinates** (username, session key, token id, frozen at upgrade time from the same resolver that admitted them). `ConnectionManager.close_for(...)` closes matching sockets with the existing 4001 code, dropping their state before the close so a concurrent broadcast cannot deliver to a revoked socket.
- **Two choke points revoke everything.** `_invalidate_user_sessions` / `_invalidate_token_sessions` now kill sessions, close sockets, and purge the principal's push rows — covering viewer update/deactivate/delete and token revoke/update/delete. Logout does the same for its own session; the expiry sweep closes the sockets of sessions it expires, and the request-path expiry pops (which remove sessions the sweep would never see) close their own — the reverse-hole of the sweep-only design, found and tested.
- **Owner-liveness backstop in push delivery**: after the unchanged entitlement filter, rows whose owner no longer resolves (inactive/deleted viewer, revoked/expired token) are dropped — at most two queries total, never one per row; env-configured principals pass through since the database cannot prove them dead.
- **Browser hygiene**: `performLogout` unsubscribes from push and clears the auto-resubscribe flag before the cookie dies; the server purge remains the guarantee.

## Verification

- New `tests/test_revocation_closes_channels.py`: 12 scenarios × both backends on a real migrated database, socket revocation proven by watching the close frame arrive instead of the broadcast. Plus a node-harness test running the real extracted `performLogout`.
- **13 behavioural tests watched red against pre-fix code** — the six socket tests failed with the frame still delivered, and the backstop's red was strengthened by stubbing the new symbols as no-ops so it failed on behaviour, not a missing attribute. Two deliberate non-regression controls prove the filter is neither a global mute nor a replacement for the grant check.
- Full suite both backends: **3256 passed, 0 failed** with a real PostgreSQL leg (run twice: implementer and orchestrator independently). ruff check and format clean.

## Stated residuals

A fully idle expired socket persists up to one cleanup sweep (15 min) — the deliberate price of keeping session checks off the delivery hot path. The socket registry is per-process; the viewer image runs a single uvicorn worker, which preserves this by construction (adding `--workers` would silently make socket revocation per-worker — documented in code). The notification preview text itself (bead 9t6.4.10's lock-screen angle) is a product decision left untouched.

No version bump: still 7.33.6.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time connections now close automatically when sessions expire, users are logged out or deactivated, or shared access is revoked.
  * Push notifications are delivered only to active, authorized accounts and valid shared sessions.
* **Bug Fixes**
  * Logging out now unsubscribes the current browser from push notifications and clears its local push settings.
  * Push subscriptions are removed when associated access is revoked or an account is deactivated or deleted.
* **Tests**
  * Added coverage for connection closure, subscription cleanup, and notification eligibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->