### PR TITLE
fix(migration): heal messages whose chat no longer exists instead of refusing the 8.0 upgrade

### DIFF
--- a/alembic/versions/20260815_022_multi_account_keys.py
+++ b/alembic/versions/20260815_022_multi_account_keys.py
@@ -50,6 +50,18 @@ second rebuild of the same tables:
   (account 123, chat 456) grants access rather than denying it. Every restricted
   row is converted here rather than left NULL, because NULL means "unrestricted".
 
+One repair rides in front of all of it. Archives that lived through Telegram's
+group→supergroup renumbering — or that arrived through a bulk copy which ran
+with enforcement disabled, as data movers and restores routinely do — hold
+messages, sync rows, topics or folder members whose ``chats`` row no longer
+exists, and on PostgreSQL the 7.x constraint's ``convalidated`` flag still
+reads true over them because nothing ever re-checked it. Recreating the
+foreign keys below re-checks every row, so the first orphan used to abort the
+whole upgrade. Every distinct chat id those tables still reference and
+``chats`` no longer holds now gets a neutral placeholder row first — see
+``_create_placeholder_chats`` — after which the formerly orphaned rows are
+first-class and the viewer can serve them under their placeholder-titled chat.
+
 Safety, in the order it matters:
 
 1. **The first statement is DML.** Alembic sets ``transactional_ddl = False`` for
@@ -145,6 +157,16 @@ ACCOUNT_ID_TABLES: tuple[str, ...] = (
     "chat_folders",
     "chat_folder_members",
 )
+
+# Tables whose rows name a parent chat. A row in any of these whose chat id has
+# no chats row is an orphan, and recreating the foreign keys below would refuse
+# the whole upgrade over the first one it meets.
+CHATS_REFERENCING_TABLES: tuple[str, ...] = ("messages", "sync_status", "forum_topics", "chat_folder_members")
+
+# The marked-id convention this project stores (see telegram_backup's marked
+# ids): supergroups and channels are -100 followed by the internal id, so they
+# sit below -10^12; legacy basic groups are small negatives; users are positive.
+SUPERGROUP_ID_CEILING = -(10**12)
 
 # New primary keys, in column order. Leading with account_id makes it the
 # partition key of every seek instead of a filter applied after one.
@@ -529,6 +551,75 @@ def _create_accounts_table(conn: sa.Connection, inspector: sa.Inspector) -> None
                 "SELECT setval(pg_get_serial_sequence('accounts', 'id'), (SELECT COALESCE(MAX(id), 1) FROM accounts))"
             )
         )
+
+
+def _create_placeholder_chats(conn: sa.Connection, inspector: sa.Inspector) -> None:
+    """Give every orphaned row a parent chat before anything writes to its table.
+
+    Archives that lived through Telegram's group→supergroup renumbering — or a
+    bulk copy that ran with enforcement disabled, which is how the SQLite→
+    PostgreSQL path moves data — hold messages, sync rows, topics and folder
+    members whose ``chats`` row is long gone. PostgreSQL's ``convalidated``
+    flag still reads true for the 7.x constraint over such rows, because a
+    trigger-bypassing copy never re-checks it; recreating ``fk_messages_chat``
+    below re-checks every row and used to abort the whole upgrade on the first
+    orphan. Refusing was the wrong answer: the rows are the user's history, and
+    a rollback keeps them hostage on 7.x forever.
+
+    So, before ref minting and before any statement writes to a table that
+    references ``chats``, every distinct chat id that ``messages``,
+    ``sync_status``, ``forum_topics`` or ``chat_folder_members`` still points
+    at and ``chats`` no longer holds gets a placeholder row. Type comes from
+    the id pattern alone (supergroup below -10^12, group for other negatives,
+    private otherwise), the title is empty, the cursors are zero and the
+    timestamps are the database's now — never a value derived from message
+    content. Running right after ``_create_accounts_table`` is what lets the
+    stubs ride the same machinery as every real chat: ``_add_account_id_columns``
+    backfills them to account 1, ``_mint_chat_refs`` mints their ref, and the
+    recreated foreign keys cover them — after which the formerly orphaned rows
+    are first-class and the viewer serves them under a placeholder-titled chat.
+
+    One INSERT..SELECT, identical on both backends, idempotent by its
+    NOT EXISTS. Only columns the live pre-rebuild table actually has are named,
+    with values every 020-era NOT NULL column accepts; everything else keeps
+    its default or NULL.
+    """
+    present = _tables(inspector)
+    if "chats" not in present:
+        return
+    sources = [table for table in CHATS_REFERENCING_TABLES if table in present]
+    if not sources:
+        return
+
+    placeholder = {
+        "id": "missing.chat_id",
+        "type": (
+            f"CASE WHEN missing.chat_id < {SUPERGROUP_ID_CEILING} THEN 'supergroup' "
+            "WHEN missing.chat_id < 0 THEN 'group' ELSE 'private' END"
+        ),
+        "title": "''",
+        "is_forum": "0",
+        "is_archived": "0",
+        "last_synced_message_id": "0",
+        "created_at": "CURRENT_TIMESTAMP",
+        "updated_at": "CURRENT_TIMESTAMP",
+    }
+    live = _column_names(inspector, "chats")
+    columns = [column for column in placeholder if column in live]
+    referenced = " UNION ".join(f'SELECT chat_id FROM "{table}"' for table in sources)
+    names = ", ".join(f'"{column}"' for column in columns)
+    values = ", ".join(placeholder[column] for column in columns)
+    created = conn.execute(
+        sa.text(
+            f"INSERT INTO chats ({names}) "
+            f"SELECT {values} FROM ({referenced}) AS missing "
+            "WHERE missing.chat_id IS NOT NULL "
+            "AND NOT EXISTS (SELECT 1 FROM chats WHERE chats.id = missing.chat_id)"
+        )
+    ).rowcount
+    if created:
+        # Count only - a chat id is PII in this project's logs.
+        logger.info("022: created %d placeholder chat row(s) for rows whose chat no longer exists", created)
 
 
 def _add_account_id_columns(conn: sa.Connection, inspector: sa.Inspector) -> None:
@@ -950,6 +1041,7 @@ def upgrade() -> None:
         try:
             _open_write_transaction(conn, inspector)
             _create_accounts_table(conn, sa.inspect(conn))
+            _create_placeholder_chats(conn, sa.inspect(conn))
             _add_account_id_columns(conn, sa.inspect(conn))
             _mint_chat_refs(conn, sa.inspect(conn))
             _add_entitlement_columns(conn, sa.inspect(conn))

--- a/tests/test_migration_022.py
+++ b/tests/test_migration_022.py
@@ -22,10 +22,17 @@ covers is removed.
   important, must NOT refuse when they are alone. The first version of the
   exclusive-access check used a second connection, which in WAL mode sees
   Alembic's own connection and would have refused every real upgrade there is.
+* **The 8.0.0 field failure** is reproduced the way production had it: orphaned
+  messages and sync rows planted through a trigger-bypassing path, so on
+  PostgreSQL the 7.x constraint's ``convalidated`` flag reads true over rows
+  that violate it. Recreating ``fk_messages_chat`` then aborted the whole
+  upgrade. The upgrade must now heal the archive with neutral placeholder
+  chats instead of refusing — creating nothing on an archive that needs none.
 """
 
 import importlib.util
 import json
+import logging
 import os
 import shutil
 import sqlite3
@@ -831,6 +838,418 @@ class TestResult:
         finally:
             engine.dispose()
         assert after == before
+
+
+# ---------------------------------------------------------------------------
+# The 8.0.0 field failure: rows whose chat no longer exists
+# ---------------------------------------------------------------------------
+
+# Synthetic vanished chats in all three id shapes: plain-negative legacy
+# groups and -100-prefixed supergroups (what the group→supergroup renumbering
+# leaves behind), plus a positive-id private chat (a deleted account), with a
+# lopsided, roughly binomial spread of messages over six of them, the way a
+# real archive has it. Every id is synthetic.
+VANISHED_GROUPS = (-990001, -990002)
+VANISHED_SUPERGROUPS = (-1009900000001, -1009900000002, -1009900000003)
+VANISHED_PRIVATE = (990003,)
+ORPHAN_MESSAGES: dict[int, int] = {
+    VANISHED_GROUPS[0]: 1,
+    VANISHED_GROUPS[1]: 4,
+    VANISHED_SUPERGROUPS[0]: 6,
+    VANISHED_SUPERGROUPS[1]: 4,
+    VANISHED_SUPERGROUPS[2]: 1,
+    VANISHED_PRIVATE[0]: 2,
+}
+ORPHAN_MESSAGE_TOTAL = sum(ORPHAN_MESSAGES.values())
+EXPECTED_PLACEHOLDER_TYPES = {
+    **{chat_id: "group" for chat_id in VANISHED_GROUPS},
+    **{chat_id: "supergroup" for chat_id in VANISHED_SUPERGROUPS},
+    **{chat_id: "private" for chat_id in VANISHED_PRIVATE},
+}
+PLACEHOLDER_LOG_LINE = (
+    f"022: created {len(EXPECTED_PLACEHOLDER_TYPES)} placeholder chat row(s) for rows whose chat no longer exists"
+)
+
+# Tables whose pre-upgrade rows must come through the healed upgrade
+# byte-for-byte (projected onto their pre-upgrade columns; the placeholder
+# chats are the only permitted additions).
+STABLE_TABLES = (
+    "chats",
+    "users",
+    "messages",
+    "media",
+    "reactions",
+    "message_versions",
+    "sync_status",
+    "forum_topics",
+    "chat_folders",
+    "chat_folder_members",
+    "viewer_accounts",
+    "viewer_tokens",
+    "viewer_sessions",
+    "push_subscriptions",
+)
+
+
+def plant_orphans(sync_url: str) -> None:
+    """Insert messages and sync_status rows whose chats row does not exist.
+
+    On PostgreSQL this goes through ``session_replication_role = replica`` so
+    the 7.x foreign key's triggers never fire — the exact state a bulk
+    trigger-bypassing copy leaves behind, where ``convalidated`` still reads
+    true over rows that violate the constraint. On SQLite plain inserts do it:
+    nothing in this project ever turns ``PRAGMA foreign_keys`` on.
+    """
+    engine = sa.create_engine(sync_url)
+    try:
+        with engine.begin() as conn:
+            if conn.dialect.name == "postgresql":
+                conn.execute(sa.text("SET session_replication_role = replica"))
+            message_id = 9000
+            for chat_id, count in ORPHAN_MESSAGES.items():
+                for _ in range(count):
+                    message_id += 1
+                    conn.execute(
+                        sa.text(
+                            "INSERT INTO messages (id, chat_id, sender_id, sender_name, date, text, raw_data, "
+                            "created_at, is_outgoing, is_pinned, is_deleted) "
+                            "VALUES (:id, :chat_id, 7001, 'S', :when, :text, :raw, :when, 0, 0, 0)"
+                        ),
+                        {
+                            "id": message_id,
+                            "chat_id": chat_id,
+                            "when": WHEN,
+                            "text": f"orphan {message_id}",
+                            "raw": json.dumps({"n": message_id}),
+                        },
+                    )
+                conn.execute(
+                    sa.text(
+                        "INSERT INTO sync_status (chat_id, last_message_id, last_sync_date, message_count) "
+                        "VALUES (:chat_id, :last, :when, :count)"
+                    ),
+                    {"chat_id": chat_id, "last": message_id, "when": WHEN, "count": count},
+                )
+    finally:
+        engine.dispose()
+
+
+def orphan_counts(sync_url: str) -> dict[str, int]:
+    """Rows per chats-referencing table whose chat id has no chats row."""
+    engine = sa.create_engine(sync_url)
+    try:
+        with engine.connect() as conn:
+            return {
+                table: conn.execute(
+                    sa.text(
+                        f'SELECT COUNT(*) FROM "{table}" t LEFT JOIN chats c ON c.id = t.chat_id WHERE c.id IS NULL'
+                    )
+                ).scalar()
+                for table in ("messages", "sync_status", "forum_topics", "chat_folder_members")
+            }
+    finally:
+        engine.dispose()
+
+
+def count_rows(sync_url: str, table: str) -> int:
+    engine = sa.create_engine(sync_url)
+    try:
+        with engine.connect() as conn:
+            return conn.execute(sa.text(f'SELECT COUNT(*) FROM "{table}"')).scalar()
+    finally:
+        engine.dispose()
+
+
+def pre_upgrade_columns(sync_url: str, tables: tuple[str, ...]) -> dict[str, tuple[str, ...]]:
+    engine = sa.create_engine(sync_url)
+    try:
+        inspector = sa.inspect(engine)
+        return {table: tuple(column["name"] for column in inspector.get_columns(table)) for table in tables}
+    finally:
+        engine.dispose()
+
+
+def stable_digest(sync_url: str, columns_by_table: dict[str, tuple[str, ...]]) -> dict[str, set[frozenset]]:
+    """Every row of every listed table, projected onto the given columns.
+
+    Values are stringified so the same data reads identically before and after
+    the migration on either backend; rows are frozensets of (column, value) so
+    the comparison survives column reordering by a rebuild.
+    """
+    out: dict[str, set[frozenset]] = {}
+    engine = sa.create_engine(sync_url)
+    try:
+        with engine.connect() as conn:
+            for table, columns in columns_by_table.items():
+                select = ", ".join(f'"{column}"' for column in columns)
+                out[table] = {
+                    frozenset(
+                        (column, None if value is None else str(value))
+                        for column, value in zip(columns, row, strict=True)
+                    )
+                    for row in conn.execute(sa.text(f'SELECT {select} FROM "{table}"'))
+                }
+    finally:
+        engine.dispose()
+    return out
+
+
+def placeholder_rows(sync_url: str) -> dict[int, dict]:
+    engine = sa.create_engine(sync_url)
+    try:
+        with engine.connect() as conn:
+            rows = (
+                conn.execute(
+                    sa.text(
+                        "SELECT id, account_id, type, title, is_archived, last_synced_message_id, ref, "
+                        "created_at, updated_at FROM chats WHERE id IN :ids"
+                    ).bindparams(sa.bindparam("ids", expanding=True)),
+                    {"ids": list(EXPECTED_PLACEHOLDER_TYPES)},
+                )
+                .mappings()
+                .all()
+            )
+            return {row["id"]: dict(row) for row in rows}
+    finally:
+        engine.dispose()
+
+
+def pg_constraint(sync_url: str, table: str, name: str) -> tuple[bool, str] | None:
+    """(convalidated, definition) of the named constraint, or None."""
+    engine = sa.create_engine(sync_url)
+    try:
+        with engine.connect() as conn:
+            row = conn.execute(
+                sa.text(
+                    "SELECT convalidated, pg_get_constraintdef(oid) FROM pg_constraint "
+                    "WHERE conname = :name AND conrelid = CAST(:table AS regclass)"
+                ),
+                {"name": name, "table": table},
+            ).first()
+        return None if row is None else (bool(row[0]), str(row[1]))
+    finally:
+        engine.dispose()
+
+
+def revalidate_for_real(sync_url: str, table: str, name: str) -> None:
+    """Drop and re-add the constraint verbatim, forcing a fresh full scan.
+
+    ``VALIDATE CONSTRAINT`` skips a constraint already flagged valid, and the
+    flag is exactly what the field incident taught us not to trust — an
+    archive can arrive with ``convalidated = true`` over rows that violate the
+    constraint. Re-adding validates unconditionally, so an orphan left behind
+    raises here instead of hiding behind the flag.
+    """
+    state = pg_constraint(sync_url, table, name)
+    assert state is not None, f"{name} does not exist on {table}"
+    _validated, definition = state
+    engine = sa.create_engine(sync_url)
+    try:
+        with engine.begin() as conn:
+            conn.execute(sa.text(f'ALTER TABLE "{table}" DROP CONSTRAINT "{name}"'))
+            conn.execute(sa.text(f'ALTER TABLE "{table}" ADD CONSTRAINT "{name}" {definition}'))
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture(scope="module")
+def orphaned_020(tmp_path_factory) -> Path:
+    """A seeded SQLite archive at revision 020 carrying the field failure.
+
+    Revision 020 because that is where the production archive stood when 8.0.0
+    refused it, so the run under test crosses 021 over the orphans as well.
+    """
+    path = tmp_path_factory.mktemp("orphaned") / "archive.db"
+    upgrade_to(f"sqlite+aiosqlite:///{path}", "020")
+    seed(f"sqlite:///{path}")
+    plant_orphans(f"sqlite:///{path}")
+    conn = sqlite3.connect(str(path))
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.commit()
+    conn.close()
+    return path
+
+
+@pytest.fixture
+def orphaned_archive(orphaned_020, tmp_path) -> Path:
+    path = tmp_path / "archive.db"
+    shutil.copy(orphaned_020, path)
+    return path
+
+
+class TestOrphanedChats:
+    """An archive whose messages outlived their chats must upgrade, healed."""
+
+    def _assert_healed(self, sync_url: str, before: dict, columns: dict) -> None:
+        # Exactly the vanished chats came back, as neutral placeholders typed
+        # by their id pattern — never anything read from message content.
+        stubs = placeholder_rows(sync_url)
+        assert set(stubs) == set(EXPECTED_PLACEHOLDER_TYPES)
+        for chat_id, row in stubs.items():
+            assert row["type"] == EXPECTED_PLACEHOLDER_TYPES[chat_id], f"type wrong for a {row['type']} stub"
+            assert row["title"] == ""
+            assert int(row["account_id"]) == 1
+            assert int(row["is_archived"]) == 0
+            assert int(row["last_synced_message_id"]) == 0
+            assert row["ref"] and len(row["ref"]) == 22
+            # Database-now timestamps, not the messages' dates.
+            assert row["created_at"] is not None and str(row["created_at"]) != str(WHEN)
+            assert row["updated_at"] is not None and str(row["updated_at"]) != str(WHEN)
+
+        # The stubs' refs are real minted refs: present and globally unique.
+        assert count_rows(sync_url, "chats") == len(CHAT_IDS) + len(EXPECTED_PLACEHOLDER_TYPES)
+        engine = sa.create_engine(sync_url)
+        try:
+            with engine.connect() as conn:
+                total, distinct = conn.execute(sa.text("SELECT COUNT(*), COUNT(DISTINCT ref) FROM chats")).first()
+            assert (total, distinct) == (len(CHAT_IDS) + len(EXPECTED_PLACEHOLDER_TYPES),) * 2
+        finally:
+            engine.dispose()
+
+        # Every orphan is still there and none of them is an orphan any more.
+        assert count_rows(sync_url, "messages") == len(CHAT_IDS) * 3 + ORPHAN_MESSAGE_TOTAL
+        assert count_rows(sync_url, "sync_status") == len(CHAT_IDS) + len(EXPECTED_PLACEHOLDER_TYPES)
+        assert orphan_counts(sync_url) == {
+            "messages": 0,
+            "sync_status": 0,
+            "forum_topics": 0,
+            "chat_folder_members": 0,
+        }
+
+        # And not because anything was rewritten: every pre-existing row of
+        # every table survived byte-for-byte on its pre-upgrade columns.
+        after = stable_digest(sync_url, columns)
+        stub_ids = {str(chat_id) for chat_id in EXPECTED_PLACEHOLDER_TYPES}
+        for table, rows in before.items():
+            survivors = after[table]
+            if table == "chats":
+                survivors = {row for row in survivors if not any(("id", stub) in row for stub in stub_ids)}
+            assert survivors == rows, f"{table}: pre-existing rows changed"
+
+    def _assert_log_discipline(self, caplog) -> None:
+        lines = [record.getMessage() for record in caplog.records if "placeholder chat row" in record.getMessage()]
+        assert lines == [PLACEHOLDER_LOG_LINE]
+        # Counts only, never ids: no vanished chat id may appear in any log.
+        for chat_id in EXPECTED_PLACEHOLDER_TYPES:
+            assert str(abs(chat_id)) not in caplog.text
+
+    def test_the_field_signature_upgrades_on_sqlite(self, orphaned_archive, caplog):
+        caplog.set_level(logging.INFO, logger="alembic.runtime.migration")
+        sync_url = f"sqlite:///{orphaned_archive}"
+        assert alembic_version(orphaned_archive) == "020"
+        assert orphan_counts(sync_url) == {
+            "messages": ORPHAN_MESSAGE_TOTAL,
+            "sync_status": len(EXPECTED_PLACEHOLDER_TYPES),
+            "forum_topics": 0,
+            "chat_folder_members": 0,
+        }
+        columns = pre_upgrade_columns(sync_url, STABLE_TABLES)
+        before = stable_digest(sync_url, columns)
+
+        upgrade_to(f"sqlite+aiosqlite:///{orphaned_archive}")
+
+        assert alembic_version(orphaned_archive) == chain_head()
+        self._assert_healed(sync_url, before, columns)
+        conn = sqlite3.connect(str(orphaned_archive))
+        try:
+            # SQLite's own referee agrees: nothing dangles after the rebuild.
+            assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+        finally:
+            conn.close()
+        self._assert_log_discipline(caplog)
+
+    def test_the_field_signature_upgrades_on_postgresql(self, require_postgres, make_postgres_database, caplog):
+        """The production failure, in miniature: ``convalidated`` lies.
+
+        Orphans are planted through ``session_replication_role = replica``, the
+        same trigger-bypassing path a bulk copy uses, so the 7.x constraint's
+        flag keeps saying the constraint holds while the planted rows violate it.
+        8.0.0 died recreating ``fk_messages_chat`` here; the upgrade must now
+        succeed, heal, and withstand a genuinely fresh validation.
+        """
+        caplog.set_level(logging.INFO, logger="alembic.runtime.migration")
+        async_url, sync_url = make_postgres_database("telegram_archive_migration_022_orphans")
+        upgrade_to(async_url, "020")
+        seed(sync_url)
+        plant_orphans(sync_url)
+
+        # The field archive's lie, reproduced exactly: the flag says validated,
+        # the rows say violated.
+        for table, name in (("messages", "messages_chat_id_fkey"), ("sync_status", "sync_status_chat_id_fkey")):
+            state = pg_constraint(sync_url, table, name)
+            assert state is not None and state[0] is True, f"{name} should read convalidated"
+        assert orphan_counts(sync_url) == {
+            "messages": ORPHAN_MESSAGE_TOTAL,
+            "sync_status": len(EXPECTED_PLACEHOLDER_TYPES),
+            "forum_topics": 0,
+            "chat_folder_members": 0,
+        }
+        columns = pre_upgrade_columns(sync_url, STABLE_TABLES)
+        before = stable_digest(sync_url, columns)
+
+        upgrade_to(async_url)
+
+        self._assert_healed(sync_url, before, columns)
+        # Validated for real: drop and re-add each recreated chats constraint
+        # verbatim, forcing PostgreSQL to rescan every row.
+        revalidate_for_real(sync_url, "messages", "fk_messages_chat")
+        revalidate_for_real(sync_url, "sync_status", "fk_sync_status_chat")
+        self._assert_log_discipline(caplog)
+
+    def test_every_chats_referencing_table_earns_stubs(self, archive, caplog):
+        """forum_topics and chat_folder_members orphans get parents too.
+
+        The field archive had orphans only in messages and sync_status, but
+        ``fk_forum_topics_chat`` and ``fk_folder_members_chat`` would abort on
+        these just the same, so the repair covers the whole family.
+        """
+        caplog.set_level(logging.INFO, logger="alembic.runtime.migration")
+        vanished_topic_chat, vanished_member_chat = -1009900000777, -990777
+        conn = sqlite3.connect(str(archive))
+        try:
+            conn.execute(
+                "INSERT INTO forum_topics (id, chat_id, title, is_closed, is_pinned, is_hidden, date, "
+                "created_at, updated_at) VALUES (7, ?, 'T', 0, 0, 0, ?, ?, ?)",
+                (vanished_topic_chat, str(WHEN), str(WHEN), str(WHEN)),
+            )
+            conn.execute(
+                "INSERT INTO chat_folder_members (folder_id, chat_id) VALUES (2, ?)",
+                (vanished_member_chat,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        upgrade_to(f"sqlite+aiosqlite:///{archive}")
+
+        conn = sqlite3.connect(str(archive))
+        try:
+            created = dict(
+                conn.execute(
+                    "SELECT id, type FROM chats WHERE id IN (?, ?)",
+                    (vanished_topic_chat, vanished_member_chat),
+                ).fetchall()
+            )
+            assert created == {vanished_topic_chat: "supergroup", vanished_member_chat: "group"}
+            assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+        finally:
+            conn.close()
+        assert "022: created 2 placeholder chat row(s) for rows whose chat no longer exists" in caplog.text
+
+    def test_a_clean_archive_creates_no_placeholders_and_stays_quiet(self, archive, caplog):
+        caplog.set_level(logging.INFO, logger="alembic.runtime.migration")
+        upgrade_to(f"sqlite+aiosqlite:///{archive}")
+        assert count_rows(f"sqlite:///{archive}", "chats") == len(CHAT_IDS)
+        assert "placeholder" not in caplog.text
+
+    def test_rerunning_over_a_healed_archive_creates_nothing_more(self, orphaned_archive, caplog):
+        upgrade_to(f"sqlite+aiosqlite:///{orphaned_archive}")
+        once = sqlite_digest(orphaned_archive)
+        caplog.set_level(logging.INFO, logger="alembic.runtime.migration")
+        caplog.clear()
+        upgrade_to(f"sqlite+aiosqlite:///{orphaned_archive}")
+        assert sqlite_digest(orphaned_archive) == once
+        assert "placeholder" not in caplog.text
 
 
 class TestEntrypointLadder(unittest.TestCase):


### PR DESCRIPTION
## The problem

The first real production archive to attempt the 8.0 upgrade was refused. Migration 022 ran to ref minting and grant conversion, then died recreating `fk_messages_chat`: the archive held messages whose parent chat vanished years ago - Telegram's group-to-supergroup renumbering leaves exactly this behind, and the SQLite-to-PostgreSQL mover's bulk copy let the rows in with enforcement disabled, so PostgreSQL's `convalidated` flag read true over rows that violate the constraint. The one-transaction design rolled back cleanly (that part worked as built), but the refusal keeps the user's history hostage on 7.x forever. An archive old enough to have lived through renumbering is precisely the archive 8.0 exists for.

## The fix

Before ref minting and before any statement writes to a chats-referencing table, 022 now creates a neutral placeholder `chats` row for every distinct chat id that `messages`, `sync_status`, `forum_topics` or `chat_folder_members` still references and `chats` no longer holds:

- type from the id pattern alone (supergroup below -10^12, group for other negatives, private otherwise), empty title, zeroed cursors, database-now timestamps - never a value derived from message content
- one `INSERT..SELECT`, identical on both backends, idempotent by its `NOT EXISTS`, column list intersected with the live pre-rebuild schema
- the stubs ride the existing machinery: account-1 backfill, ref minting, recreated foreign keys - the formerly orphaned rows become first-class and the viewer serves them under their placeholder chat
- logs the created count only, and only when nonzero
- SQLite archives that silently carried the same orphans through 022 are healed by the same step, converging both backends on the same end state

## Evidence

- New `TestOrphanedChats` reproduces the field signature from revision 020 on both backends: on PostgreSQL the orphans are planted through `session_replication_role = replica` so `convalidated` stays true while violated - the exact lie the field archive told. Watched red first against unpatched 022: PostgreSQL dies with the verbatim production `ForeignKeyViolationError`; SQLite completes but leaves every orphan orphaned.
- Healing is lossless: every pre-existing row of 14 tables byte-stable on its pre-upgrade columns, all orphan messages present and FK-satisfied after, placeholder count exact, refs minted and globally unique, `PRAGMA foreign_key_check` empty, and on PostgreSQL both recreated constraints re-validated by verbatim drop-and-re-add full rescans (`VALIDATE CONSTRAINT` would trust the flag this incident taught us not to trust).
- Crash matrix over the enlarged statement set (225 -> 228): every interruption point survivable and every replay convergent, over an orphaned archive, on both backends.
- Fixtures cover all three id shapes (legacy group, supergroup, positive-id private), the whole referencing family (topics and folder members earn stubs too), the clean-archive no-op (zero stubs, zero log lines) and the rerun no-op (byte-stable).
- Full `tests/test_migration_022.py`: 28 passed, 0 skipped, both backends; migration-adjacent suites (021 hardening, schema parity, account isolation) all green; ruff check and format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added comprehensive coverage for orphaned-chat migration scenarios across SQLite and PostgreSQL.
  - Verified placeholder chat creation, preserved records, removed dangling references, correct timestamps, and logging behavior.
  - Added checks for clean archives, constraint handling, and safe repeated migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->