### PR TITLE
release: 8.0.1 - archives with vanished chats now upgrade

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [8.0.1] - 2026-08-16
+
+### Fixed
+
+- **An archive holding messages whose chat no longer exists can now upgrade.** The first real production archive to attempt the 8.0 upgrade was refused by it: years of Telegram's group→supergroup renumbering had left messages and sync rows whose `chats` row was long gone, and recreating the composite foreign keys re-checks every row, so migration `022` aborted on the first orphan it met — on PostgreSQL these rows hide behind a `convalidated` flag that still reads true, because the bulk copies that let them in (the SQLite→PostgreSQL mover among them) run with enforcement disabled and nothing ever re-checks. The transaction rolled back cleanly, exactly as designed, but a refusal keeps that history hostage on 7.x forever — and an archive old enough to carry renumbering scars is precisely the archive 8.0 exists for. Migration `022` now creates a neutral placeholder chat for every distinct chat id that `messages`, `sync_status`, `forum_topics` or `chat_folder_members` still references and `chats` no longer holds — typed by the id pattern alone, empty title, never anything derived from message content — before it touches those tables. The placeholders ride the same machinery as every real chat (account 1, minted ref, recreated keys), so the formerly orphaned history becomes first-class and the viewer serves it under its placeholder chat: after this upgrade you may find chats with no title in your sidebar, and they are exactly that recovered history. SQLite archives carried the same orphans *through* `022` silently instead of failing on them; the same step now heals them too, so both backends land on the same end state. The one case this cannot reach is a SQLite archive that already completed the 8.0.0 upgrade with orphans aboard — `022` never runs twice, so that history stays as unreachable as it was on 7.x. ([#308](https://github.com/GeiserX/Telegram-Archive/pull/308))
+
 ## [8.0.0] - 2026-08-16
 
 ### Breaking

--- a/docs/UPGRADING-8.0.md
+++ b/docs/UPGRADING-8.0.md
@@ -85,10 +85,15 @@ ships, `git pull` brings the new pins. If you keep your own, edit both:
 ```yaml
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:8.0.0
+    image: drumsergio/telegram-archive:8.0.1
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:8.0.0
+    image: drumsergio/telegram-archive-viewer:8.0.1
 ```
+
+Use 8.0.1 or later, not 8.0.0: the first production archive to attempt this
+upgrade was refused by 8.0.0 over messages whose chat no longer existed —
+history that Telegram's group→supergroup renumbering leaves behind in any
+sufficiently old archive — and 8.0.1 upgrades those archives instead.
 
 **2. Start the backup container on its own**, and let it migrate:
 
@@ -122,6 +127,13 @@ of the rewrite, so nobody has to be set up again.
 The one thing that will look wrong is a bookmark. Every chat URL changed, so an
 old one no longer resolves. Open the chat from the sidebar and bookmark it again.
 
+You may also find chats with no title in the sidebar that you have never seen
+before. Those are recovered history: messages whose chat vanished from Telegram
+years ago — group→supergroup migrations leave exactly this behind — were
+unreachable in 7.x, and the upgrade gives each such orphaned chat id a
+placeholder chat so its messages can be served again. The migration reports
+how many it created, as a count.
+
 ## If it fails
 
 **An interrupted upgrade leaves your 7.x database intact.** The migration is a
@@ -139,6 +151,14 @@ so explicitly and end with "Nothing has been changed":
   anything else pointed at the same file, then start the backup container again.
 - **Not enough free disk space.** The message gives you both numbers — what it
   needs and what is free. Free some space and start the container again.
+
+If 8.0.0 refused your archive with a foreign-key violation on
+`fk_messages_chat`, that is the one failure that was the migration's fault
+rather than your machine's: your archive holds messages whose chat no longer
+exists, and 8.0.0 refused them where it should have recovered them. Your
+database is intact — the transaction rolled back — and the fix is to upgrade
+with 8.0.1 or later instead, which turns exactly that refusal into recovered
+history.
 
 **A completed upgrade cannot be migrated back below `022`.** Reversing the
 search-index migration (`023`) works; `alembic downgrade` past `022` refuses,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "8.0.0"
+version = "8.0.1"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "8.0.0"
+__version__ = "8.0.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1192,7 +1192,7 @@ wheels = [
 
 [[package]]
 name = "telegram-archive"
-version = "8.0.0"
+version = "8.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
8.0.0's migration refused the first real production archive that attempted it: messages whose chat vanished years ago (group-to-supergroup renumbering) tripped the recreated foreign keys and aborted the upgrade. #308 turned that refusal into recovery - placeholder chats give the orphaned history a home, on both backends.

This releases it as 8.0.1: version bumps, changelog entry, and the upgrade guide now points at 8.0.1 pins, explains the no-title placeholder chats users will find in their sidebar, and turns the `fk_messages_chat` failure story from "pin back to 7.x" into "upgrade with 8.0.1".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed archive upgrades failing when messages or related records reference missing chats.
  * Missing chats are now recovered as neutral placeholder chats during upgrades.
  * Archives that failed during the 8.0.0 upgrade can be retried with 8.0.1 or later.

* **Documentation**
  * Updated upgrade instructions with the new recovery behavior and version requirements.
  * Added release notes for version 8.0.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->