### PR TITLE
docs: merging two existing archives into one multi-account install

### DIFF
--- a/docs/MERGING-ARCHIVES.md
+++ b/docs/MERGING-ARCHIVES.md
@@ -111,8 +111,9 @@ cleanly stopped in step 2, so the file is complete without sidecar files; if
 `-wal`/`-shm` files exist anyway, copy them alongside).
 
 Run the script **interactively** — it deliberately does not commit. You need
-the `sqlite3` command-line shell, version 3.16 or newer (`apt install sqlite3`
-on Debian/Ubuntu; macOS ships one):
+the `sqlite3` command-line shell, version 3.33.0 or newer — the script uses
+`.mode box` for its report (`apt install sqlite3` on Debian/Ubuntu; macOS
+ships one):
 
 ```bash
 cd telegram-archive          # the checkout containing scripts/merge/
@@ -170,11 +171,18 @@ Then run the merge (`SRC_PASSWORD` is the source *server's* password — for the
 scratch-database route above, that is the target server's own one):
 
 ```bash
+read -rs SRC_PW    # type the source password; it stays out of shell history
 docker exec -i telegram-postgres psql -U telegram -d telegram_backup \
   -v SRC_HOST=127.0.0.1 -v SRC_PORT=5432 -v SRC_DB=ta_merge_source \
-  -v SRC_USER=telegram -v SRC_PASSWORD='your-postgres-password' \
+  -v SRC_USER=telegram -v SRC_PASSWORD="$SRC_PW" \
   -f - < scripts/merge/merge_postgres.sql
 ```
+
+`read -rs` keeps the password out of your shell history; it still appears
+briefly in the container's process arguments while psql runs, which on a
+single-admin machine is usually acceptable. On a shared machine, prefer the
+scratch-database route above — restoring the dump into the target's own
+cluster means the only password involved is the target's own.
 
 Unlike the SQLite script, this one commits itself — but only if it gets to the
 end. The whole run is a single transaction; every precondition and every

--- a/docs/MERGING-ARCHIVES.md
+++ b/docs/MERGING-ARCHIVES.md
@@ -1,0 +1,376 @@
+# Merging two archives into one
+
+This page is for one specific situation: **two people each ran their own
+single-account install for years, and now want one multi-account 8.0 archive
+that holds both histories.** One install keeps running and absorbs the other;
+this page calls them the **target** and the **source** throughout.
+
+If instead you have one archive and want to *add* a second Telegram account
+that starts capturing from today, you do not need any of this — declare the
+account and let it log in, as the
+[multi-account quickstart](UPGRADING-8.0.md#multi-account-quickstart) shows.
+The reason to merge is everything a fresh account cannot bring with it:
+
+- **Deleted-message history.** Messages the source captured that have since
+  been deleted on Telegram exist nowhere else. A fresh account can never
+  recapture them; a merge carries them over, deletion markers and all.
+- **Edit history.** Every stored version of every edited message comes along.
+- **Downloaded media.** Files Telegram has since expired or that would take
+  days to re-download are copied, not re-fetched.
+- **Sync cursors.** The source's per-chat progress markers are imported, so
+  the merged account's **first sweep is incremental** — it resumes each chat
+  where the source install left off instead of re-capturing years of history
+  from message 1.
+
+The merge itself is two shell commands around one SQL script that you can read
+line by line before running it — `scripts/merge/merge_sqlite.sql` or
+`scripts/merge/merge_postgres.sql`. That is deliberate. This procedure runs
+against the only copy of two people's Telegram history, so it is plain SQL you
+can audit, not a tool you have to trust: every guard, every insert and every
+verification is on the page, heavily commented, and the whole thing runs in a
+single transaction that either completes every check or leaves the target
+byte-for-byte untouched.
+
+## What this page does not cover
+
+- **Two archives of the same Telegram account.** That is message-level
+  deduplication, a different problem, and the scripts refuse it outright when
+  they see the same Telegram user id on both sides.
+- **A multi-account source.** The source must hold exactly one account (the
+  scripts check). To fold a third archive in, run this whole procedure again
+  with the next source.
+- **A PostgreSQL source into a SQLite target.** There is no
+  PostgreSQL-to-SQLite mover in this project. Make the PostgreSQL install the
+  target instead — see [Mixed backends](#mixed-backends).
+
+## How the merge works
+
+Since 8.0, every table holding Telegram data is keyed by the account that
+captured it, and the `accounts` table maps each row of history to a Telegram
+user id filled in at login. The merge script copies the source's account row
+and all of its data into the target under a fresh account id. The next time
+the target starts with the second account declared, `ensure_account` (in
+`src/db/adapter.py`) matches the login's Telegram user id against the imported
+row and **adopts it** — the second account picks up its entire imported
+history, cursors included, as its own. Nothing about the matching depends on
+env variable order or on which install the data came from.
+
+Chats keep the opaque `ref` values minted for them in the source. Refs are
+128-bit random tokens, so two independent archives cannot collide in practice
+— and the script checks anyway and refuses on a collision rather than relying
+on "cannot". Re-minting would buy nothing: the source viewer's share links die
+with the source install either way.
+
+## Before you start
+
+**1. Upgrade both installs to the same 8.0.x release and start each one once,
+then stop them.** The scripts refuse to run otherwise, for two concrete
+reasons: the merge is written against the 8.0 schema (revision `023`) on both
+sides, and the one-time start is what makes each install claim its account row
+and record its Telegram user id — the value the whole adoption mechanism above
+keys on. A source that never started under 8.0 would import as history no
+login can ever claim.
+
+**2. Stop all four containers — backup and viewer, on both installs.**
+
+```bash
+docker compose stop telegram-backup telegram-viewer   # on each machine
+```
+
+The scripts enforce what they can see (on PostgreSQL, any other connection to
+either database aborts the merge; on SQLite, a concurrent writer makes the
+transaction refuse to open), but a running viewer merely *reading* a SQLite
+file is invisible to them — stopping everything is on you.
+
+**3. Back up both databases.** The merge is guarded and roll-back-safe, but a
+merge you later regret — wrong target, wrong direction — is only undone by
+restoring a backup. Same commands as the
+[8.0 upgrade](UPGRADING-8.0.md#before-you-upgrade):
+
+```bash
+# SQLite (after a clean stop; if -wal or -shm files sit beside the db, copy them too)
+cp /path/to/data/backups/telegram_backup.db* /somewhere/safe/
+
+# PostgreSQL
+docker exec telegram-postgres pg_dump -U telegram telegram_backup > pre-merge.sql
+```
+
+**4. Pick the target.** The target keeps its container names, viewer URL,
+viewer accounts and settings; the source install is retired afterwards. If one
+install is PostgreSQL and the other SQLite, the PostgreSQL one is the target —
+see [Mixed backends](#mixed-backends).
+
+Expect the target database to grow by roughly the size of the source database,
+and the media directory by the size of the source's media (minus whatever both
+already had from shared chats).
+
+## The merge: SQLite target, SQLite source
+
+Copy the source's database file to the target machine first (its install was
+cleanly stopped in step 2, so the file is complete without sidecar files; if
+`-wal`/`-shm` files exist anyway, copy them alongside).
+
+Run the script **interactively** — it deliberately does not commit. You need
+the `sqlite3` command-line shell, version 3.16 or newer (`apt install sqlite3`
+on Debian/Ubuntu; macOS ships one):
+
+```bash
+cd telegram-archive          # the checkout containing scripts/merge/
+sqlite3 /path/to/data/backups/telegram_backup.db
+```
+
+```
+sqlite> .bail on
+sqlite> ATTACH DATABASE '/path/to/copied/source/telegram_backup.db' AS source;
+sqlite> .read scripts/merge/merge_sqlite.sql
+```
+
+The script checks every precondition, imports, re-counts everything it
+imported, and ends with a one-line verdict. **Nothing is saved yet.** The last
+word is yours, and it is one of exactly two:
+
+```
+sqlite> COMMIT;      -- only if the verdict line says OK
+sqlite> ROLLBACK;    -- in every other case, or whenever in doubt
+```
+
+Quitting sqlite3 without typing `COMMIT;` also rolls everything back — there
+is no state in between. If any check fails, the script stops at that check
+with a `MERGE ABORTED:` message naming exactly what is wrong and what to do
+about it; type `ROLLBACK;` (or just quit) and the target is untouched.
+
+What a good run prints: a per-table list of expected vs actual imported row
+counts (all `ok`), a summary with the imported account's row id and a
+`media roots match` indicator, and then:
+
+```
+VERDICT: OK — every check passed. Type COMMIT; now to keep the merge.
+```
+
+## The merge: PostgreSQL target, PostgreSQL source
+
+The script reads the source through `postgres_fdw`, which the stock postgres
+image ships. The simplest way to give it a source is to restore the source's
+dump as a scratch database on the target's own PostgreSQL server:
+
+```bash
+# On the source machine (containers stopped; the postgres server can stay up):
+docker exec telegram-postgres pg_dump -U telegram telegram_backup > source-archive.sql
+# copy source-archive.sql to the target machine, then on the target:
+docker exec telegram-postgres psql -U telegram -d postgres -c 'CREATE DATABASE ta_merge_source'
+docker exec -i telegram-postgres psql -U telegram -d ta_merge_source -f - < source-archive.sql
+```
+
+(If both installs can reach each other on the network you can skip the dump
+and point `SRC_HOST`/`SRC_PORT` at the source's live PostgreSQL server instead
+— with its containers stopped. The script verifies nobody else is connected on
+either side.)
+
+Then run the merge (`SRC_PASSWORD` is the source *server's* password — for the
+scratch-database route above, that is the target server's own one):
+
+```bash
+docker exec -i telegram-postgres psql -U telegram -d telegram_backup \
+  -v SRC_HOST=127.0.0.1 -v SRC_PORT=5432 -v SRC_DB=ta_merge_source \
+  -v SRC_USER=telegram -v SRC_PASSWORD='your-postgres-password' \
+  -f - < scripts/merge/merge_postgres.sql
+```
+
+Unlike the SQLite script, this one commits itself — but only if it gets to the
+end. The whole run is a single transaction; every precondition and every
+verification raises an error on failure, and any error rolls the entire
+transaction back, so the only two outcomes are `MERGE COMMITTED` with a clean
+per-table count report, or an explicit `MERGE ABORTED:`/`MERGE FAILED
+VERIFICATION:` message with the target untouched. There is no partial state.
+
+Afterwards, drop the scratch database:
+
+```bash
+docker exec telegram-postgres psql -U telegram -d postgres -c 'DROP DATABASE ta_merge_source'
+```
+
+## What the scripts refuse, on purpose
+
+Each of these stops the merge before it writes anything, with a message naming
+the condition:
+
+- Source or target not at schema revision `023` (the revision these scripts
+  were written for — use the scripts from the release you are running).
+- A target or source account row that never completed a first start under 8.0
+  (no Telegram user id recorded).
+- A source holding more than one account, or rows outside its one account.
+- **The same Telegram user id on both sides** — two archives of one account
+  are a deduplication problem, not a merge, and are refused with no override.
+- A chat ref present on both sides.
+- (PostgreSQL) any other client connected to either database.
+
+## Media files
+
+The database rows are merged by the script; the files they point at are copied
+by you. Media lives under `<BACKUP_PATH>/media/` — with the stock compose
+file, `./data/backups/media/` on the host — as one directory per chat plus a
+`_shared/` store of deduplicated blobs that the chat directories symlink into
+(relatively, so the links survive copying).
+
+Copy the source's tree into the target's, **never overwriting what the target
+already has**:
+
+```bash
+rsync -a --ignore-existing /path/to/source/data/backups/media/ /path/to/target/data/backups/media/
+# or, without rsync:  cp -an /path/to/source/data/backups/media/. /path/to/target/data/backups/media/
+# (BSD/macOS cp exits 1 when it skips already-existing files — the skips are
+#  the point here, so judge the copy by its output, not its exit code)
+```
+
+`--ignore-existing` matters for chats both accounts were in: those directories
+already exist in the target, and filenames collide precisely where both
+installs downloaded the same Telegram file — identical content, so keeping the
+target's copy is always right. Everything only the source had (its own chats'
+directories, its `_shared` blobs) copies over normally.
+
+The database stores media paths as absolute container paths. If both installs
+used the default `BACKUP_PATH=/data/backups`, imported rows point at the right
+places as soon as the files are copied — the script's `media roots match: yes`
+line confirms it. If it says `NO`, the installs used different `BACKUP_PATH`s,
+and the imported rows need their prefix rewritten once (adjust the two
+literals; the imported account's row id is in the merge summary):
+
+```sql
+-- Same statement on both backends (replace() exists in SQLite and PostgreSQL)
+UPDATE media SET file_path = replace(file_path, '/old/backups/media/', '/data/backups/media/')
+WHERE account_id = 2 AND file_path LIKE '/old/backups/media/%';
+```
+
+## The session file: move it, never copy it
+
+The source person's Telegram login lives in a Telethon session file. It must
+be **moved** — if two processes ever run on the same session, Telegram
+invalidates the key (`AuthKeyDuplicatedError`) and kills the login for both
+copies. Moving it, and never starting the retired source install again, makes
+that impossible; the reward is that the second account joins the target
+without a new login.
+
+Sessions live in `SESSION_DIR` (default: the `session/` directory next to
+`backups/` — `./data/session/` on the host with the stock compose file). Move
+the source's file to the target under the second account's default session
+name:
+
+```bash
+mv /path/to/source/data/session/telegram_backup.session \
+   /path/to/target/data/session/telegram_backup_account2.session
+```
+
+(A `.session-journal` sitting beside it after an unclean stop moves along
+under the same rename. If the source used a custom `SESSION_NAME`, that is the
+file to move.)
+
+## Declare the second account
+
+In the target's environment, name both accounts by index — account 1 is the
+target's own credentials, account 2 the source person's API credentials (from
+[my.telegram.org](https://my.telegram.org), the same values the source install
+used):
+
+```yaml
+environment:
+  TG_ACCOUNT_1_API_ID: "1234567"            # the target's existing values
+  TG_ACCOUNT_1_API_HASH: "target_api_hash_here"
+  TG_ACCOUNT_1_PHONE_NUMBER: "+1234567890"
+
+  TG_ACCOUNT_2_API_ID: "7654321"            # the source install's values
+  TG_ACCOUNT_2_API_HASH: "source_api_hash_here"
+  TG_ACCOUNT_2_PHONE_NUMBER: "+1987654321"
+  TG_ACCOUNT_2_LABEL: "their-name"          # optional display name
+```
+
+Index 2's session file defaults to `telegram_backup_account2` — the name the
+move above used, so no `TG_ACCOUNT_2_SESSION_NAME` is needed. The index is
+only an env coordinate: accounts are matched to their history by Telegram user
+id at login, so even swapping the indexes later would not misfile a single row.
+
+## First start, and what to check
+
+Start the backup container alone and watch the logs:
+
+```bash
+docker compose up -d telegram-backup
+docker compose logs -f telegram-backup
+```
+
+A good first start looks like: migrations report nothing to do, both accounts
+connect **without a login prompt** (account 2 is riding the moved session),
+and the sweep runs the accounts one after the other. Account 2's first sweep
+is the point of the whole exercise: it should be roughly as quick as the
+source install's regular nightly run was — the imported cursors mean it picks
+up each chat where the source left off, plus the gap between the source's last
+run and now. A full-length re-capture of everything means the cursors did not
+come across, which the merge's count checks make effectively impossible — but
+it is the symptom worth knowing.
+
+Then start the viewer. The imported account's chats appear alongside the
+target's own, with their media, edit histories and deleted messages intact. As
+always, the logs report counts only, never chat ids or titles.
+
+## Viewer access after the merge
+
+The source install's viewer accounts, sessions and share tokens are **not
+imported**, deliberately. They are the retiring install's identities and
+grants — password hashes, live session tokens and share links whose trust was
+rooted in that install and whose URLs are dead now anyway. Silently carrying
+them into an archive that now holds two people's history would move access
+nobody re-decided. The target's own viewers keep working unchanged (their
+grants say nothing about the new account, and permissions fail closed); to
+give anyone access to the imported chats, grant it on the target explicitly —
+create the viewer or mint the share token there, scoped to the new account's
+chats.
+
+## Mixed backends
+
+**SQLite source into a PostgreSQL target** works, with one conversion first.
+`scripts/migrate-sqlite-to-postgres.py` is 8.0-schema-aware — it copies
+through the current models, `accounts` first, so `account_id` keys and the
+recorded Telegram user id survive — but it is a whole-archive *mover*, not a
+merge: pointed at a non-empty database it would overwrite rows, so it must
+only ever target an **empty scratch database**, never your archive. The order:
+
+```bash
+# 1. A scratch database on the target's PostgreSQL server:
+docker exec telegram-postgres psql -U telegram -d postgres -c 'CREATE DATABASE ta_merge_source'
+
+# 2. Move the source SQLite archive into it (run wherever this repo's Python
+#    runs and the postgres port is reachable — the script's own header shows a
+#    docker run variant if you have no local Python environment):
+python scripts/migrate-sqlite-to-postgres.py \
+  --sqlite /path/to/copied/source/telegram_backup.db \
+  --postgres postgresql+asyncpg://telegram:your-postgres-password@127.0.0.1:5432/ta_merge_source
+
+# 3. Stamp the schema revision. The mover provisions the full 8.0 schema but
+#    records no Alembic revision (the app's entrypoint normally does that);
+#    the scratch database genuinely is at the 8.0 shape, so say so:
+docker exec telegram-postgres psql -U telegram -d ta_merge_source -c \
+  "CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL, CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)); INSERT INTO alembic_version VALUES ('023')"
+
+# 4. Run the PostgreSQL merge exactly as above, with SRC_DB=ta_merge_source,
+#    then drop the scratch database.
+```
+
+The mover verifies its own copy (per-table source-vs-target counts) before you
+ever reach the merge, and the merge's guards then run against the scratch copy
+like against any other source.
+
+**PostgreSQL source into a SQLite target** is not supported: no
+PostgreSQL-to-SQLite mover exists in this project, and pretending otherwise
+here would help nobody. Make the PostgreSQL install the target and merge the
+SQLite archive into it as just described — if the "wrong" person's hardware
+hosts PostgreSQL, moving a docker volume to the preferred machine is a far
+smaller job than a merge in an unsupported direction.
+
+## If it fails, and the way back
+
+A failed or aborted run changes nothing — that is the design, not a promise:
+one transaction per backend, and every guard fires before `COMMIT` is
+reachable. On SQLite you additionally hold the commit yourself; when in doubt,
+`ROLLBACK;`. A *committed* merge is undone only by restoring the backups from
+step 3 — which is why step 3 is not optional. The one asymmetric caution:
+never start the retired source install again once its session file has moved
+— two processes on one session kill the login for both.

--- a/docs/UPGRADING-8.0.md
+++ b/docs/UPGRADING-8.0.md
@@ -178,6 +178,14 @@ change at all: with no indexed account declared, account 1 is built from the
 and it adopts the session you already logged in with. Your archive and your login
 both carry over — there is no re-authentication.
 
+One case deserves its own page before you declare anything: if the second
+account already has its own archive — two single-account installs becoming one
+— do not add it as a fresh account. [Merging two archives into
+one](MERGING-ARCHIVES.md) carries its deleted-message history, edit versions,
+downloaded media and sync cursors across, so its first sweep here is
+incremental instead of a years-long re-capture that can never recover what
+Telegram has since deleted.
+
 To add a second account, declare them by index instead:
 
 ```yaml

--- a/scripts/merge/merge_postgres.sql
+++ b/scripts/merge/merge_postgres.sql
@@ -1,0 +1,510 @@
+-- merge_postgres.sql — import a second single-account PostgreSQL archive into
+-- this one.
+--
+-- Companion to docs/MERGING-ARCHIVES.md. Read that page first: it explains the
+-- preconditions (both installs upgraded to the same 8.0.x release and started
+-- once, both containers stopped, both databases backed up) and every step that
+-- comes before and after this script (media files, the session file, the env).
+--
+-- How to run it — against a BACKED-UP target database:
+--
+--     psql "host=127.0.0.1 port=5432 dbname=telegram_backup user=telegram" \
+--       -v SRC_HOST=127.0.0.1 -v SRC_PORT=5432 -v SRC_DB=ta_merge_source \
+--       -v SRC_USER=telegram -v SRC_PASSWORD='...' \
+--       -f scripts/merge/merge_postgres.sql
+--
+-- SRC_* names the SOURCE database — either the other install's live (but
+-- stopped-container) PostgreSQL server reachable over the network, or, usually
+-- simpler, a dump of it restored as an extra database on the target's own
+-- PostgreSQL server (the guide shows both). The source is only ever read.
+--
+-- Failure model: the whole script is ONE transaction. Every precondition and
+-- every verification is a DO block that RAISEs EXCEPTION on failure; psql
+-- stops there (ON_ERROR_STOP is set below) and the transaction rolls back, so
+-- a failed run leaves the target byte-for-byte untouched. Only a run in which
+-- every check passed reaches the COMMIT on the last line. (Even without
+-- ON_ERROR_STOP a failed transaction cannot commit — PostgreSQL turns the
+-- final COMMIT of an aborted transaction into a rollback.)
+--
+-- Requirements: run as a superuser of the target cluster (the stock
+-- docker-compose POSTGRES_USER is one) — CREATE EXTENSION postgres_fdw and
+-- reading other sessions in pg_stat_activity need it.
+--
+-- Privacy: output is table names, row counts and yes/no indicators only —
+-- never chat ids, titles, phone numbers or message content, same as the rest
+-- of the project.
+
+\set ON_ERROR_STOP on
+
+-- Refuse to start without the five source parameters, before anything runs.
+\if :{?SRC_HOST}
+\else
+\echo 'MERGE ABORTED: missing -v SRC_HOST=... (see the header of this script). Nothing has been changed.'
+DO $$ BEGIN RAISE EXCEPTION 'MERGE ABORTED: a required -v parameter is missing — see the line above. Nothing has been changed.'; END $$;
+\endif
+\if :{?SRC_PORT}
+\else
+\echo 'MERGE ABORTED: missing -v SRC_PORT=... (see the header of this script). Nothing has been changed.'
+DO $$ BEGIN RAISE EXCEPTION 'MERGE ABORTED: a required -v parameter is missing — see the line above. Nothing has been changed.'; END $$;
+\endif
+\if :{?SRC_DB}
+\else
+\echo 'MERGE ABORTED: missing -v SRC_DB=... (see the header of this script). Nothing has been changed.'
+DO $$ BEGIN RAISE EXCEPTION 'MERGE ABORTED: a required -v parameter is missing — see the line above. Nothing has been changed.'; END $$;
+\endif
+\if :{?SRC_USER}
+\else
+\echo 'MERGE ABORTED: missing -v SRC_USER=... (see the header of this script). Nothing has been changed.'
+DO $$ BEGIN RAISE EXCEPTION 'MERGE ABORTED: a required -v parameter is missing — see the line above. Nothing has been changed.'; END $$;
+\endif
+\if :{?SRC_PASSWORD}
+\else
+\echo 'MERGE ABORTED: missing -v SRC_PASSWORD=... (see the header of this script). Nothing has been changed.'
+DO $$ BEGIN RAISE EXCEPTION 'MERGE ABORTED: a required -v parameter is missing — see the line above. Nothing has been changed.'; END $$;
+\endif
+
+\echo ''
+\echo '=== Telegram-Archive merge (PostgreSQL): preflight ==='
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- Attach the source, read-only, through postgres_fdw. Everything created here
+-- is dropped again at the end of this script (and rolls back with everything
+-- else on failure). application_name 'ta_merge' marks our own connection on
+-- the source server so the nobody-else-connected check below can exclude it.
+-- ---------------------------------------------------------------------------
+CREATE EXTENSION IF NOT EXISTS postgres_fdw;
+
+DROP SERVER IF EXISTS ta_merge_source_srv CASCADE;
+CREATE SERVER ta_merge_source_srv
+  FOREIGN DATA WRAPPER postgres_fdw
+  OPTIONS (host :'SRC_HOST', port :'SRC_PORT', dbname :'SRC_DB', application_name 'ta_merge');
+
+CREATE USER MAPPING FOR CURRENT_USER
+  SERVER ta_merge_source_srv
+  OPTIONS (user :'SRC_USER', password :'SRC_PASSWORD');
+
+DROP SCHEMA IF EXISTS merge_source CASCADE;
+CREATE SCHEMA merge_source;
+
+IMPORT FOREIGN SCHEMA public
+  LIMIT TO (alembic_version, accounts, users, chats, messages, message_versions,
+            media, reactions, sync_status, forum_topics, chat_folders,
+            chat_folder_members)
+  FROM SERVER ta_merge_source_srv INTO merge_source;
+
+-- A window onto the source server's own session list, for the guard that
+-- nothing else is connected to the source while we read it.
+CREATE FOREIGN TABLE merge_source.remote_activity
+  (datname name, application_name text, backend_type text)
+  SERVER ta_merge_source_srv
+  OPTIONS (schema_name 'pg_catalog', table_name 'pg_stat_activity');
+
+-- DO blocks cannot see psql variables, so the one value they need is parked in
+-- a temp table. ON COMMIT DROP: gone whether this run commits or rolls back.
+CREATE TEMP TABLE _merge_params ON COMMIT DROP AS
+SELECT :'SRC_DB'::text AS src_db;
+
+-- ---------------------------------------------------------------------------
+-- Preflight guards. Every one RAISEs a specific, actionable message rather
+-- than importing into a wrong state; any RAISE rolls the whole run back.
+-- ---------------------------------------------------------------------------
+
+-- All twelve tables must have come across, or SRC_DB is not a
+-- Telegram-Archive database (or not one that finished its upgrade).
+DO $$
+DECLARE n bigint;
+BEGIN
+  SELECT count(*) INTO n FROM information_schema.tables
+   WHERE table_schema = 'merge_source'
+     AND table_name IN ('alembic_version', 'accounts', 'users', 'chats',
+                        'messages', 'message_versions', 'media', 'reactions',
+                        'sync_status', 'forum_topics', 'chat_folders',
+                        'chat_folder_members');
+  IF n <> 12 THEN
+    RAISE EXCEPTION 'MERGE ABORTED: only % of the 12 expected tables exist in the source database — is SRC_DB really a Telegram-Archive database at 8.0? Nothing has been changed.', n;
+  END IF;
+END $$;
+
+-- Both databases must be at the schema revision this script was written for.
+-- Equal is not enough: equal-but-older would mean the multi-account keys this
+-- import depends on do not exist yet.
+DO $$
+BEGIN
+  IF (SELECT count(*) FROM alembic_version) <> 1
+     OR (SELECT version_num FROM alembic_version) <> '023' THEN
+    RAISE EXCEPTION 'MERGE ABORTED: the TARGET database is not at schema revision 023, the revision this script was written for. Upgrade the target install to the release this script shipped with, start it once, stop it, and re-run. Nothing has been changed.';
+  END IF;
+  IF (SELECT count(*) FROM merge_source.alembic_version) <> 1
+     OR (SELECT version_num FROM merge_source.alembic_version) <> '023' THEN
+    RAISE EXCEPTION 'MERGE ABORTED: the SOURCE database is not at schema revision 023, the revision this script was written for. Upgrade the source install to the same release as the target, start it once, stop it, and re-run (a source restored from a dump must be dumped AFTER that upgrade). Nothing has been changed.';
+  END IF;
+END $$;
+
+-- The target must have started at least once under 8.0: every account row
+-- claimed (telegram_user_id filled in on first login). An unclaimed row would
+-- later be claimed by env index 1 and could swallow the imported history.
+DO $$
+BEGIN
+  IF (SELECT count(*) FROM accounts) < 1
+     OR EXISTS (SELECT 1 FROM accounts WHERE telegram_user_id IS NULL) THEN
+    RAISE EXCEPTION 'MERGE ABORTED: the TARGET has an account row with no Telegram user id, which means an account has never completed a start under 8.0. Start the target backup container once (it claims its row on login), stop it, and re-run. Nothing has been changed.';
+  END IF;
+END $$;
+
+-- The source must be exactly one account, and that account must have logged in
+-- at least once under 8.0 — its telegram_user_id is what the target's first
+-- start will match on to ADOPT the imported rows (src/db/adapter.py,
+-- ensure_account: a row already carrying the user id wins outright).
+DO $$
+BEGIN
+  IF (SELECT count(*) FROM merge_source.accounts) <> 1 THEN
+    RAISE EXCEPTION 'MERGE ABORTED: the SOURCE archive holds more than one account (or none). This script merges a single-account archive; a multi-account source is out of scope — see docs/MERGING-ARCHIVES.md. Nothing has been changed.';
+  END IF;
+  IF (SELECT telegram_user_id FROM merge_source.accounts) IS NULL THEN
+    RAISE EXCEPTION 'MERGE ABORTED: the SOURCE account row has no Telegram user id, so the merged rows could never be matched to a login. Start the source backup container once under 8.0 (it claims its row on login), stop it, and re-run. Nothing has been changed.';
+  END IF;
+END $$;
+
+-- Every data row in the source must belong to that single account.
+DO $$
+DECLARE
+  t text;
+  n bigint;
+  src_id integer := (SELECT id FROM merge_source.accounts);
+BEGIN
+  FOREACH t IN ARRAY ARRAY['chats', 'messages', 'message_versions', 'media',
+                           'reactions', 'sync_status', 'forum_topics',
+                           'chat_folders', 'chat_folder_members'] LOOP
+    EXECUTE format('SELECT count(*) FROM merge_source.%I WHERE account_id <> $1', t)
+      INTO n USING src_id;
+    IF n > 0 THEN
+      RAISE EXCEPTION 'MERGE ABORTED: the SOURCE archive has % row(s) in % under an account_id that is not its single account row — it is not the clean single-account archive this script expects. Nothing has been changed.', n, t;
+    END IF;
+  END LOOP;
+END $$;
+
+-- Two archives of the same Telegram account are not a merge — refuse.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM accounts t
+             JOIN merge_source.accounts s
+               ON t.telegram_user_id = s.telegram_user_id) THEN
+    RAISE EXCEPTION 'MERGE ABORTED: the source account''s Telegram user id already exists in the target. These are two archives of the SAME Telegram account; merging them is message-level deduplication, a different problem this script refuses to guess at. Nothing has been changed.';
+  END IF;
+END $$;
+
+-- Imported chats KEEP their refs (they are 128-bit random, and the source
+-- install's share links die with that install either way), so a collision must
+-- be impossible rather than improbable: checked here, and enforced again by
+-- uq_chats_ref during the insert.
+DO $$
+DECLARE n bigint;
+BEGIN
+  SELECT count(*) INTO n FROM merge_source.chats s JOIN chats t ON t.ref = s.ref;
+  IF n > 0 THEN
+    RAISE EXCEPTION 'MERGE ABORTED: % chat ref(s) in the source already exist in the target. Refs are 128-bit random values, so this does not happen to honestly generated archives — one of these databases has hand-copied rows. Nothing has been changed.', n;
+  END IF;
+END $$;
+
+-- Nobody else may be connected to the TARGET database: a still-running backup
+-- or viewer container would be writing and reading around this import.
+DO $$
+DECLARE n bigint;
+BEGIN
+  SELECT count(*) INTO n FROM pg_stat_activity
+   WHERE datname = current_database()
+     AND pid <> pg_backend_pid()
+     AND backend_type = 'client backend';
+  IF n > 0 THEN
+    RAISE EXCEPTION 'MERGE ABORTED: % other session(s) are connected to the target database. Stop the backup and viewer containers, close any psql/pgAdmin sessions, and re-run. Nothing has been changed.', n;
+  END IF;
+END $$;
+
+-- Nobody else may be connected to the SOURCE database either (our own fdw
+-- connection announces itself as application_name 'ta_merge' and is excluded).
+-- For a source restored as a scratch database this is trivially true; for a
+-- live source server it is the "containers stopped" precondition, enforced.
+DO $$
+DECLARE n bigint;
+BEGIN
+  SELECT count(*) INTO n
+    FROM merge_source.remote_activity a, _merge_params p
+   WHERE a.datname = p.src_db
+     AND a.backend_type = 'client backend'
+     AND a.application_name IS DISTINCT FROM 'ta_merge';
+  IF n > 0 THEN
+    RAISE EXCEPTION 'MERGE ABORTED: % other session(s) are connected to the source database. Stop the source install''s backup and viewer containers, then re-run. Nothing has been changed.', n;
+  END IF;
+END $$;
+
+\echo 'preflight OK — importing'
+
+-- ---------------------------------------------------------------------------
+-- Expected row counts, captured BEFORE anything is written so the final
+-- comparison is against a snapshot the import cannot have influenced.
+-- For users (a global table — a Telegram user is the same person in both
+-- archives) the expectation is "every source sender exists in the target
+-- afterwards"; rows the target already had are kept as they are.
+-- ---------------------------------------------------------------------------
+CREATE TEMP TABLE _merge_counts (table_name text NOT NULL, expected bigint NOT NULL, actual bigint)
+  ON COMMIT DROP;
+
+INSERT INTO _merge_counts (table_name, expected)
+SELECT 'users (new senders)', count(*) FROM merge_source.users s
+WHERE NOT EXISTS (SELECT 1 FROM users t WHERE t.id = s.id);
+
+INSERT INTO _merge_counts (table_name, expected) SELECT 'chats',               count(*) FROM merge_source.chats;
+INSERT INTO _merge_counts (table_name, expected) SELECT 'messages',            count(*) FROM merge_source.messages;
+INSERT INTO _merge_counts (table_name, expected) SELECT 'message_versions',    count(*) FROM merge_source.message_versions;
+INSERT INTO _merge_counts (table_name, expected) SELECT 'media',               count(*) FROM merge_source.media;
+INSERT INTO _merge_counts (table_name, expected) SELECT 'reactions',           count(*) FROM merge_source.reactions;
+INSERT INTO _merge_counts (table_name, expected) SELECT 'sync_status',         count(*) FROM merge_source.sync_status;
+INSERT INTO _merge_counts (table_name, expected) SELECT 'forum_topics',        count(*) FROM merge_source.forum_topics;
+INSERT INTO _merge_counts (table_name, expected) SELECT 'chat_folders',        count(*) FROM merge_source.chat_folders;
+INSERT INTO _merge_counts (table_name, expected) SELECT 'chat_folder_members', count(*) FROM merge_source.chat_folder_members;
+
+-- ---------------------------------------------------------------------------
+-- The imported account row. id is deliberately omitted: the sequence assigns
+-- the next free id — the id the source used (1) already belongs to the
+-- target's own first account. The label rides along as-is; it is cosmetic,
+-- and the first start rewrites it from the env's TG_ACCOUNT_<N>_LABEL anyway.
+-- _merge_new_account captures the assigned id; every INSERT below stamps it
+-- over the source's account_id.
+-- ---------------------------------------------------------------------------
+CREATE TEMP TABLE _merge_new_account ON COMMIT DROP AS
+WITH ins AS (
+  INSERT INTO accounts (label, telegram_user_id)
+  SELECT label, telegram_user_id FROM merge_source.accounts
+  RETURNING id
+)
+SELECT id FROM ins;
+
+-- ---------------------------------------------------------------------------
+-- The import. Parents before children (users/chats/folders before messages
+-- before media/reactions/versions) — PostgreSQL enforces every foreign key as
+-- the rows land, so a wrong order or a wrong remap fails here, loudly, instead
+-- of being committed. Every column is named explicitly: a migrated schema and
+-- a freshly created one can order columns differently, and this script must
+-- work identically on both.
+--
+-- users: target rows always win. The users table is global by design (see
+-- src/db/models.py) with last-writer-wins display names; a merge keeps the
+-- target's version of anyone both archives know.
+-- ---------------------------------------------------------------------------
+INSERT INTO users (id, username, first_name, last_name, phone, is_bot, created_at, updated_at)
+SELECT s.id, s.username, s.first_name, s.last_name, s.phone, s.is_bot, s.created_at, s.updated_at
+FROM merge_source.users s
+WHERE NOT EXISTS (SELECT 1 FROM users t WHERE t.id = s.id);
+
+INSERT INTO chats (account_id, id, ref, type, title, username, first_name, last_name, phone,
+                   description, participants_count, is_forum, is_archived,
+                   last_synced_message_id, created_at, updated_at)
+SELECT (SELECT id FROM _merge_new_account), s.id, s.ref, s.type, s.title, s.username,
+       s.first_name, s.last_name, s.phone, s.description, s.participants_count, s.is_forum,
+       s.is_archived, s.last_synced_message_id, s.created_at, s.updated_at
+FROM merge_source.chats s;
+
+INSERT INTO chat_folders (account_id, id, title, emoticon, sort_order, created_at, updated_at)
+SELECT (SELECT id FROM _merge_new_account), s.id, s.title, s.emoticon, s.sort_order,
+       s.created_at, s.updated_at
+FROM merge_source.chat_folders s;
+
+INSERT INTO messages (account_id, id, chat_id, sender_id, sender_name, date, text,
+                      reply_to_msg_id, reply_to_top_id, reply_to_text, forward_from_id,
+                      edit_date, raw_data, created_at, is_outgoing, is_pinned,
+                      is_deleted, deleted_at)
+SELECT (SELECT id FROM _merge_new_account), s.id, s.chat_id, s.sender_id, s.sender_name,
+       s.date, s.text, s.reply_to_msg_id, s.reply_to_top_id, s.reply_to_text,
+       s.forward_from_id, s.edit_date, s.raw_data, s.created_at, s.is_outgoing,
+       s.is_pinned, s.is_deleted, s.deleted_at
+FROM merge_source.messages s;
+
+INSERT INTO forum_topics (account_id, id, chat_id, title, icon_color, icon_emoji_id,
+                          icon_emoji, is_closed, is_pinned, is_hidden, date,
+                          created_at, updated_at)
+SELECT (SELECT id FROM _merge_new_account), s.id, s.chat_id, s.title, s.icon_color,
+       s.icon_emoji_id, s.icon_emoji, s.is_closed, s.is_pinned, s.is_hidden, s.date,
+       s.created_at, s.updated_at
+FROM merge_source.forum_topics s;
+
+-- sync_status is what makes the first merged sweep incremental: the imported
+-- last_message_id cursors mean account 2 resumes where the source install
+-- stopped, instead of re-capturing every chat from message 1.
+INSERT INTO sync_status (account_id, chat_id, last_message_id, last_sync_date, message_count)
+SELECT (SELECT id FROM _merge_new_account), s.chat_id, s.last_message_id, s.last_sync_date,
+       s.message_count
+FROM merge_source.sync_status s;
+
+INSERT INTO chat_folder_members (account_id, folder_id, chat_id)
+SELECT (SELECT id FROM _merge_new_account), s.folder_id, s.chat_id
+FROM merge_source.chat_folder_members s;
+
+INSERT INTO media (account_id, id, message_id, chat_id, type, file_path, file_name,
+                   file_size, mime_type, width, height, duration, content_hash,
+                   downloaded, download_attempts, download_date, created_at)
+SELECT (SELECT id FROM _merge_new_account), s.id, s.message_id, s.chat_id, s.type,
+       s.file_path, s.file_name, s.file_size, s.mime_type, s.width, s.height, s.duration,
+       s.content_hash, s.downloaded, s.download_attempts, s.download_date, s.created_at
+FROM merge_source.media s;
+
+-- message_versions and reactions have their own autoincrement ids in each
+-- archive; the source's values would collide with the target's, so the id is
+-- omitted and the target's sequences assign fresh ones. Nothing references
+-- these ids.
+INSERT INTO message_versions (account_id, message_id, chat_id, text, date, change_hash, captured_at)
+SELECT (SELECT id FROM _merge_new_account), s.message_id, s.chat_id, s.text, s.date,
+       s.change_hash, s.captured_at
+FROM merge_source.message_versions s;
+
+INSERT INTO reactions (account_id, message_id, chat_id, emoji, user_id, "count", created_at, removed_at)
+SELECT (SELECT id FROM _merge_new_account), s.message_id, s.chat_id, s.emoji, s.user_id,
+       s."count", s.created_at, s.removed_at
+FROM merge_source.reactions s;
+
+\echo 'import done — verifying'
+
+-- ---------------------------------------------------------------------------
+-- Verification. Actual counts are RE-COUNTED from the target — never assumed
+-- from the statements above — and compared to the pre-import snapshot.
+-- ---------------------------------------------------------------------------
+UPDATE _merge_counts SET actual =
+  expected - (SELECT count(*) FROM merge_source.users s
+              WHERE NOT EXISTS (SELECT 1 FROM users t WHERE t.id = s.id))
+WHERE table_name = 'users (new senders)';
+
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM chats               WHERE account_id = (SELECT id FROM _merge_new_account)) WHERE table_name = 'chats';
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM messages            WHERE account_id = (SELECT id FROM _merge_new_account)) WHERE table_name = 'messages';
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM message_versions    WHERE account_id = (SELECT id FROM _merge_new_account)) WHERE table_name = 'message_versions';
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM media               WHERE account_id = (SELECT id FROM _merge_new_account)) WHERE table_name = 'media';
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM reactions           WHERE account_id = (SELECT id FROM _merge_new_account)) WHERE table_name = 'reactions';
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM sync_status         WHERE account_id = (SELECT id FROM _merge_new_account)) WHERE table_name = 'sync_status';
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM forum_topics        WHERE account_id = (SELECT id FROM _merge_new_account)) WHERE table_name = 'forum_topics';
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM chat_folders        WHERE account_id = (SELECT id FROM _merge_new_account)) WHERE table_name = 'chat_folders';
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM chat_folder_members WHERE account_id = (SELECT id FROM _merge_new_account)) WHERE table_name = 'chat_folder_members';
+
+-- Any mismatch between the snapshot and what actually landed aborts the run.
+DO $$
+DECLARE bad text;
+BEGIN
+  SELECT string_agg(format('%s (expected %s, actual %s)', table_name, expected, actual), '; ')
+    INTO bad
+    FROM _merge_counts
+   WHERE expected IS DISTINCT FROM actual;
+  IF bad IS NOT NULL THEN
+    RAISE EXCEPTION 'MERGE FAILED VERIFICATION: imported row counts do not match the source: %. Nothing has been committed.', bad;
+  END IF;
+END $$;
+
+-- Referential integrity, re-checked with explicit anti-joins rather than by
+-- trusting the constraints that already enforced it during the insert — a
+-- check that re-runs the logic can fail, a re-validation of an already-valid
+-- constraint cannot. Composite-key rows with NULLs (media metadata rows) are
+-- exempt from their FK by SQL semantics and are skipped the same way here.
+DO $$
+DECLARE
+  new_id integer := (SELECT id FROM _merge_new_account);
+  n bigint;
+BEGIN
+  SELECT count(*) INTO n FROM messages m
+   WHERE m.account_id = new_id
+     AND NOT EXISTS (SELECT 1 FROM chats c WHERE c.account_id = m.account_id AND c.id = m.chat_id);
+  IF n > 0 THEN RAISE EXCEPTION 'MERGE FAILED VERIFICATION: % imported message(s) reference a missing chat. Nothing has been committed.', n; END IF;
+
+  SELECT count(*) INTO n FROM sync_status ss
+   WHERE ss.account_id = new_id
+     AND NOT EXISTS (SELECT 1 FROM chats c WHERE c.account_id = ss.account_id AND c.id = ss.chat_id);
+  IF n > 0 THEN RAISE EXCEPTION 'MERGE FAILED VERIFICATION: % imported sync cursor(s) reference a missing chat. Nothing has been committed.', n; END IF;
+
+  SELECT count(*) INTO n FROM forum_topics ft
+   WHERE ft.account_id = new_id
+     AND NOT EXISTS (SELECT 1 FROM chats c WHERE c.account_id = ft.account_id AND c.id = ft.chat_id);
+  IF n > 0 THEN RAISE EXCEPTION 'MERGE FAILED VERIFICATION: % imported forum topic(s) reference a missing chat. Nothing has been committed.', n; END IF;
+
+  SELECT count(*) INTO n FROM chat_folder_members m
+   WHERE m.account_id = new_id
+     AND (NOT EXISTS (SELECT 1 FROM chat_folders f WHERE f.account_id = m.account_id AND f.id = m.folder_id)
+          OR NOT EXISTS (SELECT 1 FROM chats c WHERE c.account_id = m.account_id AND c.id = m.chat_id));
+  IF n > 0 THEN RAISE EXCEPTION 'MERGE FAILED VERIFICATION: % imported folder membership(s) reference a missing folder or chat. Nothing has been committed.', n; END IF;
+
+  SELECT count(*) INTO n FROM media md
+   WHERE md.account_id = new_id
+     AND md.message_id IS NOT NULL AND md.chat_id IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM messages m
+                      WHERE m.account_id = md.account_id AND m.id = md.message_id AND m.chat_id = md.chat_id);
+  IF n > 0 THEN RAISE EXCEPTION 'MERGE FAILED VERIFICATION: % imported media row(s) reference a missing message. Nothing has been committed.', n; END IF;
+
+  SELECT count(*) INTO n FROM message_versions v
+   WHERE v.account_id = new_id
+     AND NOT EXISTS (SELECT 1 FROM messages m
+                      WHERE m.account_id = v.account_id AND m.id = v.message_id AND m.chat_id = v.chat_id);
+  IF n > 0 THEN RAISE EXCEPTION 'MERGE FAILED VERIFICATION: % imported edit version(s) reference a missing message. Nothing has been committed.', n; END IF;
+
+  SELECT count(*) INTO n FROM reactions r
+   WHERE r.account_id = new_id
+     AND NOT EXISTS (SELECT 1 FROM messages m
+                      WHERE m.account_id = r.account_id AND m.id = r.message_id AND m.chat_id = r.chat_id);
+  IF n > 0 THEN RAISE EXCEPTION 'MERGE FAILED VERIFICATION: % imported reaction(s) reference a missing message. Nothing has been committed.', n; END IF;
+
+  SELECT count(*) INTO n FROM reactions r
+   WHERE r.account_id = new_id
+     AND r.user_id IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM users u WHERE u.id = r.user_id);
+  IF n > 0 THEN RAISE EXCEPTION 'MERGE FAILED VERIFICATION: % imported reaction(s) reference a missing user. Nothing has been committed.', n; END IF;
+
+  -- Refs must still be globally unique (uq_chats_ref enforced this during the
+  -- insert; this recount is the independent proof).
+  IF (SELECT count(*) FROM chats) <> (SELECT count(DISTINCT ref) FROM chats) THEN
+    RAISE EXCEPTION 'MERGE FAILED VERIFICATION: chat refs are not globally unique after the import. Nothing has been committed.';
+  END IF;
+END $$;
+
+-- Media roots: compares the directory prefix up to and including '/media/' of
+-- one stored media path from each archive, reported as yes/no only (paths
+-- carry chat ids and are never printed). A NO means the imported media rows
+-- point at paths the target install does not serve — the media section of
+-- docs/MERGING-ARCHIVES.md tells you how to remap them before starting.
+DO $$
+DECLARE t text; s text;
+BEGIN
+  SELECT substring(file_path from '^(.*/media/)') INTO t
+    FROM media WHERE file_path LIKE '%/media/%'
+   LIMIT 1;
+  SELECT substring(file_path from '^(.*/media/)') INTO s
+    FROM merge_source.media WHERE file_path LIKE '%/media/%'
+   LIMIT 1;
+  IF t IS NULL OR s IS NULL THEN
+    RAISE NOTICE 'media roots match: n/a (no stored media paths to compare)';
+  ELSIF t = s THEN
+    RAISE NOTICE 'media roots match: yes';
+  ELSE
+    RAISE WARNING 'media roots match: NO — imported media rows point at a different directory root than the target serves. See the media section of docs/MERGING-ARCHIVES.md before starting the containers.';
+  END IF;
+END $$;
+
+\echo ''
+\echo '=== Imported rows, per table (counts only) ==='
+SELECT table_name, expected, actual,
+       CASE WHEN expected IS NOT DISTINCT FROM actual THEN 'ok' ELSE 'MISMATCH' END AS status
+FROM _merge_counts;
+
+\echo '=== Summary ==='
+SELECT (SELECT id FROM _merge_new_account) AS imported_account_row,
+       (SELECT count(*) FROM accounts)     AS accounts_total;
+
+-- ---------------------------------------------------------------------------
+-- Take the plumbing down again and keep the merge. Reaching this line at all
+-- means every guard and every verification above passed; any earlier failure
+-- rolled everything — data and plumbing alike — back.
+-- ---------------------------------------------------------------------------
+DROP FOREIGN TABLE merge_source.remote_activity;
+DROP SCHEMA merge_source CASCADE;
+DROP SERVER ta_merge_source_srv CASCADE;
+
+COMMIT;
+
+\echo ''
+\echo 'MERGE COMMITTED. Next steps (docs/MERGING-ARCHIVES.md): copy the media'
+\echo 'files, move the session file, declare the TG_ACCOUNT_<N>_* variables,'
+\echo 'then start the target and watch its first sweep.'

--- a/scripts/merge/merge_postgres.sql
+++ b/scripts/merge/merge_postgres.sql
@@ -468,10 +468,10 @@ END $$;
 DO $$
 DECLARE t text; s text;
 BEGIN
-  SELECT substring(file_path from '^(.*/media/)') INTO t
+  SELECT substring(file_path from '^(.*?/media/)') INTO t
     FROM media WHERE file_path LIKE '%/media/%'
    LIMIT 1;
-  SELECT substring(file_path from '^(.*/media/)') INTO s
+  SELECT substring(file_path from '^(.*?/media/)') INTO s
     FROM merge_source.media WHERE file_path LIKE '%/media/%'
    LIMIT 1;
   IF t IS NULL OR s IS NULL THEN

--- a/scripts/merge/merge_sqlite.sql
+++ b/scripts/merge/merge_sqlite.sql
@@ -1,0 +1,408 @@
+-- merge_sqlite.sql — import a second single-account SQLite archive into this one.
+--
+-- Companion to docs/MERGING-ARCHIVES.md. Read that page first: it explains the
+-- preconditions (both installs upgraded to the same 8.0.x release and started
+-- once, both containers stopped, both databases backed up) and every step that
+-- comes before and after this script (media files, the session file, the env).
+--
+-- How to run it — interactively, on a COPY-VERIFIED-BACKED-UP target:
+--
+--     sqlite3 /path/to/target/data/backups/telegram_backup.db
+--     sqlite> .bail on
+--     sqlite> ATTACH DATABASE '/path/to/source/telegram_backup.db' AS source;
+--     sqlite> .read scripts/merge/merge_sqlite.sql
+--     ... preflight, import, per-table counts, verdict ...
+--     sqlite> COMMIT;      -- ONLY if the verdict line says OK
+--     sqlite> ROLLBACK;    -- otherwise, or whenever in doubt
+--
+-- THIS SCRIPT DOES NOT COMMIT. Everything below runs inside one transaction
+-- that is left open on purpose, so the last word is yours: read the summary and
+-- the verdict, then type COMMIT; yourself — or ROLLBACK; and the target is
+-- byte-for-byte what it was. Quitting sqlite3 without committing also rolls
+-- everything back. There is no state in between.
+--
+-- Failure model: every precondition below is checked by inserting into a guard
+-- table wired to a trigger that RAISEs with a message naming the failed check.
+-- With .bail on (line 1 below sets it), the first failed check stops the script
+-- immediately — nothing after it runs, and the open transaction means nothing
+-- is kept. If sqlite3 drops back to its prompt after an error, type ROLLBACK;
+-- if it exits, the rollback already happened.
+--
+-- Privacy: this script prints table names and row counts only — never chat
+-- ids, titles, phone numbers or message content, same as the rest of the
+-- project. The one path-shaped output is the media root comparison, and it is
+-- reported as yes/no, never as the paths themselves.
+
+.bail on
+.headers on
+.mode box
+
+.print ''
+.print '=== Telegram-Archive merge (SQLite): preflight ==='
+
+-- ---------------------------------------------------------------------------
+-- Guard plumbing. _guard is a scratch table; each named trigger below fires on
+-- a failed check and aborts with a message that says exactly what failed and
+-- what to do about it. Temporary objects, private to this session. The DROPs
+-- make a second run in the same sqlite3 session start clean (dropping _guard
+-- drops its triggers with it).
+-- ---------------------------------------------------------------------------
+DROP TABLE IF EXISTS temp._guard;
+DROP TABLE IF EXISTS temp._fk_baseline;
+DROP TABLE IF EXISTS temp._merge_counts;
+DROP TABLE IF EXISTS temp._new_account;
+
+CREATE TEMP TABLE _guard (check_name TEXT NOT NULL, ok INTEGER NOT NULL);
+
+CREATE TEMP TRIGGER guard_source_attached BEFORE INSERT ON _guard
+WHEN NEW.check_name = 'source_attached' AND NEW.ok = 0
+BEGIN SELECT RAISE(ABORT, 'MERGE ABORTED: no database is attached as "source". Run ATTACH DATABASE ''/path/to/source/telegram_backup.db'' AS source; before .read, as the guide shows. Nothing has been changed.'); END;
+
+CREATE TEMP TRIGGER guard_source_is_not_target BEFORE INSERT ON _guard
+WHEN NEW.check_name = 'source_is_not_target' AND NEW.ok = 0
+BEGIN SELECT RAISE(ABORT, 'MERGE ABORTED: the attached "source" is the same file as the target. Attach the OTHER install''s database. Nothing has been changed.'); END;
+
+CREATE TEMP TRIGGER guard_target_revision BEFORE INSERT ON _guard
+WHEN NEW.check_name = 'target_revision' AND NEW.ok = 0
+BEGIN SELECT RAISE(ABORT, 'MERGE ABORTED: the TARGET database is not at schema revision 023, the revision this script was written for. Upgrade the target install to the release this script shipped with, start it once, stop it, and re-run. Nothing has been changed.'); END;
+
+CREATE TEMP TRIGGER guard_source_revision BEFORE INSERT ON _guard
+WHEN NEW.check_name = 'source_revision' AND NEW.ok = 0
+BEGIN SELECT RAISE(ABORT, 'MERGE ABORTED: the SOURCE database is not at schema revision 023, the revision this script was written for. Upgrade the source install to the same release as the target, start it once, stop it, and re-run. Nothing has been changed.'); END;
+
+CREATE TEMP TRIGGER guard_target_claimed BEFORE INSERT ON _guard
+WHEN NEW.check_name = 'target_claimed' AND NEW.ok = 0
+BEGIN SELECT RAISE(ABORT, 'MERGE ABORTED: the TARGET has an account row with no Telegram user id, which means an account has never completed a start under 8.0. Start the target backup container once (it claims its row on login), stop it, and re-run. Nothing has been changed.'); END;
+
+CREATE TEMP TRIGGER guard_source_single_account BEFORE INSERT ON _guard
+WHEN NEW.check_name = 'source_single_account' AND NEW.ok = 0
+BEGIN SELECT RAISE(ABORT, 'MERGE ABORTED: the SOURCE archive holds more than one account (or none). This script merges a single-account archive; a multi-account source is out of scope — see docs/MERGING-ARCHIVES.md. Nothing has been changed.'); END;
+
+CREATE TEMP TRIGGER guard_source_claimed BEFORE INSERT ON _guard
+WHEN NEW.check_name = 'source_claimed' AND NEW.ok = 0
+BEGIN SELECT RAISE(ABORT, 'MERGE ABORTED: the SOURCE account row has no Telegram user id, so the merged rows could never be matched to a login. Start the source backup container once under 8.0 (it claims its row on login), stop it, and re-run. Nothing has been changed.'); END;
+
+CREATE TEMP TRIGGER guard_source_rows_one_account BEFORE INSERT ON _guard
+WHEN NEW.check_name = 'source_rows_one_account' AND NEW.ok = 0
+BEGIN SELECT RAISE(ABORT, 'MERGE ABORTED: the SOURCE archive has data rows under an account_id that is not its single account row — it is not the clean single-account archive this script expects. Nothing has been changed.'); END;
+
+CREATE TEMP TRIGGER guard_identities_distinct BEFORE INSERT ON _guard
+WHEN NEW.check_name = 'identities_distinct' AND NEW.ok = 0
+BEGIN SELECT RAISE(ABORT, 'MERGE ABORTED: the source account''s Telegram user id already exists in the target. These are two archives of the SAME Telegram account; merging them is message-level deduplication, a different problem this script refuses to guess at. Nothing has been changed.'); END;
+
+CREATE TEMP TRIGGER guard_no_ref_collision BEFORE INSERT ON _guard
+WHEN NEW.check_name = 'no_ref_collision' AND NEW.ok = 0
+BEGIN SELECT RAISE(ABORT, 'MERGE ABORTED: a chat ref in the source already exists in the target. Refs are 128-bit random values, so this does not happen to honestly generated archives — one of these databases has hand-copied rows. Nothing has been changed.'); END;
+
+-- Post-import triggers: same mechanism, applied to the verification checks.
+CREATE TEMP TRIGGER guard_counts_match BEFORE INSERT ON _guard
+WHEN NEW.check_name = 'counts_match' AND NEW.ok = 0
+BEGIN SELECT RAISE(ABORT, 'MERGE FAILED VERIFICATION: at least one table''s imported row count does not match the source (see the counts table above). Type ROLLBACK; — nothing is committed.'); END;
+
+CREATE TEMP TRIGGER guard_no_new_fk_violations BEFORE INSERT ON _guard
+WHEN NEW.check_name = 'no_new_fk_violations' AND NEW.ok = 0
+BEGIN SELECT RAISE(ABORT, 'MERGE FAILED VERIFICATION: the import introduced foreign key violations that exist in neither original archive. Type ROLLBACK; — nothing is committed.'); END;
+
+CREATE TEMP TRIGGER guard_refs_unique_after BEFORE INSERT ON _guard
+WHEN NEW.check_name = 'refs_unique_after' AND NEW.ok = 0
+BEGIN SELECT RAISE(ABORT, 'MERGE FAILED VERIFICATION: chat refs are not globally unique after the import. Type ROLLBACK; — nothing is committed.'); END;
+
+-- ---------------------------------------------------------------------------
+-- Attachment checks (no transaction needed; they read catalog state only).
+-- ---------------------------------------------------------------------------
+INSERT INTO _guard
+SELECT 'source_attached',
+       EXISTS (SELECT 1 FROM pragma_database_list WHERE name = 'source');
+
+INSERT INTO _guard
+SELECT 'source_is_not_target',
+       (SELECT file FROM pragma_database_list WHERE name = 'main')
+       IS NOT (SELECT file FROM pragma_database_list WHERE name = 'source');
+
+-- ---------------------------------------------------------------------------
+-- Open the one transaction everything runs in. IMMEDIATE takes the write lock
+-- now: if another process is writing the target, this fails right here with
+-- "database is locked" instead of half way through. (A reader — a still-running
+-- viewer — does not show up here in WAL mode, which is why the guide's first
+-- step is stopping both installs'' containers.)
+-- ---------------------------------------------------------------------------
+BEGIN IMMEDIATE;
+
+-- ---------------------------------------------------------------------------
+-- Preflight guards. Every one of these aborts the script with a specific
+-- message (see the triggers above) rather than importing into a wrong state.
+-- ---------------------------------------------------------------------------
+
+-- Both databases must be at the schema revision this script was written for.
+-- Equal is not enough: equal-but-older would mean the multi-account keys this
+-- import depends on do not exist yet.
+INSERT INTO _guard
+SELECT 'target_revision',
+       (SELECT count(*) FROM main.alembic_version WHERE version_num = '023') = 1
+       AND (SELECT count(*) FROM main.alembic_version) = 1;
+
+INSERT INTO _guard
+SELECT 'source_revision',
+       (SELECT count(*) FROM source.alembic_version WHERE version_num = '023') = 1
+       AND (SELECT count(*) FROM source.alembic_version) = 1;
+
+-- The target must have started at least once under 8.0: every account row
+-- claimed (telegram_user_id filled in on first login). An unclaimed row would
+-- later be claimed by env index 1 and could swallow the imported history.
+INSERT INTO _guard
+SELECT 'target_claimed',
+       (SELECT count(*) FROM main.accounts) >= 1
+       AND (SELECT count(*) FROM main.accounts WHERE telegram_user_id IS NULL) = 0;
+
+-- The source must be exactly one account, and that account must have logged in
+-- at least once under 8.0 — its telegram_user_id is what the target's first
+-- start will match on to ADOPT the imported rows (src/db/adapter.py,
+-- ensure_account: a row already carrying the user id wins outright).
+INSERT INTO _guard
+SELECT 'source_single_account', (SELECT count(*) FROM source.accounts) = 1;
+
+INSERT INTO _guard
+SELECT 'source_claimed',
+       (SELECT telegram_user_id FROM source.accounts) IS NOT NULL;
+
+-- Every data row in the source must belong to that single account.
+INSERT INTO _guard
+SELECT 'source_rows_one_account',
+       (
+         (SELECT count(*) FROM source.chats               WHERE account_id <> (SELECT id FROM source.accounts))
+       + (SELECT count(*) FROM source.messages            WHERE account_id <> (SELECT id FROM source.accounts))
+       + (SELECT count(*) FROM source.message_versions    WHERE account_id <> (SELECT id FROM source.accounts))
+       + (SELECT count(*) FROM source.media               WHERE account_id <> (SELECT id FROM source.accounts))
+       + (SELECT count(*) FROM source.reactions           WHERE account_id <> (SELECT id FROM source.accounts))
+       + (SELECT count(*) FROM source.sync_status         WHERE account_id <> (SELECT id FROM source.accounts))
+       + (SELECT count(*) FROM source.forum_topics        WHERE account_id <> (SELECT id FROM source.accounts))
+       + (SELECT count(*) FROM source.chat_folders        WHERE account_id <> (SELECT id FROM source.accounts))
+       + (SELECT count(*) FROM source.chat_folder_members WHERE account_id <> (SELECT id FROM source.accounts))
+       ) = 0;
+
+-- Two archives of the same Telegram account are not a merge — refuse.
+INSERT INTO _guard
+SELECT 'identities_distinct',
+       NOT EXISTS (
+         SELECT 1 FROM main.accounts t
+         JOIN source.accounts s ON t.telegram_user_id = s.telegram_user_id
+       );
+
+-- Imported chats KEEP their refs (they are 128-bit random, and the source
+-- install's share links die with that install either way), so a collision must
+-- be impossible rather than improbable: checked here, and re-checked after.
+INSERT INTO _guard
+SELECT 'no_ref_collision',
+       NOT EXISTS (SELECT 1 FROM source.chats s JOIN main.chats t ON t.ref = s.ref);
+
+.print 'preflight OK — importing'
+
+-- ---------------------------------------------------------------------------
+-- Baselines for the foreign-key verdict. Archives can legally carry old orphan
+-- rows (migration 022 carries them over too), so the bar is "the import adds
+-- no NEW violations": afterwards, main must show at most the violations it
+-- already had plus the ones the source already had.
+-- ---------------------------------------------------------------------------
+CREATE TEMP TABLE _fk_baseline AS
+SELECT
+  (SELECT count(*) FROM pragma_foreign_key_check) AS target_before,
+  ( (SELECT count(*) FROM pragma_foreign_key_check('messages',            'source'))
+  + (SELECT count(*) FROM pragma_foreign_key_check('message_versions',    'source'))
+  + (SELECT count(*) FROM pragma_foreign_key_check('media',               'source'))
+  + (SELECT count(*) FROM pragma_foreign_key_check('reactions',           'source'))
+  + (SELECT count(*) FROM pragma_foreign_key_check('sync_status',         'source'))
+  + (SELECT count(*) FROM pragma_foreign_key_check('forum_topics',        'source'))
+  + (SELECT count(*) FROM pragma_foreign_key_check('chat_folder_members', 'source'))
+  ) AS source_before;
+
+-- ---------------------------------------------------------------------------
+-- Expected row counts, captured BEFORE anything is written so the final
+-- comparison is against a snapshot the import cannot have influenced.
+-- For users (a global table — a Telegram user is the same person in both
+-- archives) the expectation is "every source sender exists in the target
+-- afterwards"; rows the target already had are kept as they are.
+-- ---------------------------------------------------------------------------
+CREATE TEMP TABLE _merge_counts (table_name TEXT NOT NULL, expected INTEGER NOT NULL, actual INTEGER);
+
+INSERT INTO _merge_counts (table_name, expected)
+SELECT 'users (new senders)', count(*) FROM source.users s
+WHERE NOT EXISTS (SELECT 1 FROM main.users t WHERE t.id = s.id);
+
+INSERT INTO _merge_counts (table_name, expected) SELECT 'chats',               count(*) FROM source.chats;
+INSERT INTO _merge_counts (table_name, expected) SELECT 'messages',            count(*) FROM source.messages;
+INSERT INTO _merge_counts (table_name, expected) SELECT 'message_versions',    count(*) FROM source.message_versions;
+INSERT INTO _merge_counts (table_name, expected) SELECT 'media',               count(*) FROM source.media;
+INSERT INTO _merge_counts (table_name, expected) SELECT 'reactions',           count(*) FROM source.reactions;
+INSERT INTO _merge_counts (table_name, expected) SELECT 'sync_status',         count(*) FROM source.sync_status;
+INSERT INTO _merge_counts (table_name, expected) SELECT 'forum_topics',        count(*) FROM source.forum_topics;
+INSERT INTO _merge_counts (table_name, expected) SELECT 'chat_folders',        count(*) FROM source.chat_folders;
+INSERT INTO _merge_counts (table_name, expected) SELECT 'chat_folder_members', count(*) FROM source.chat_folder_members;
+
+-- ---------------------------------------------------------------------------
+-- The imported account row. id is deliberately omitted: accounts.id is an
+-- INTEGER PRIMARY KEY, so SQLite assigns the next free id — the id the source
+-- used (1) already belongs to the target's own first account. The label rides
+-- along as-is; it is cosmetic, and the first start rewrites it from the env's
+-- TG_ACCOUNT_<N>_LABEL anyway. _new_account captures the assigned id; every
+-- INSERT below stamps it over the source's account_id.
+-- ---------------------------------------------------------------------------
+INSERT INTO main.accounts (label, telegram_user_id)
+SELECT label, telegram_user_id FROM source.accounts;
+
+CREATE TEMP TABLE _new_account AS SELECT last_insert_rowid() AS id;
+
+-- ---------------------------------------------------------------------------
+-- The import. Parents before children (users/chats/folders before messages
+-- before media/reactions/versions), every column named explicitly — a migrated
+-- schema and a freshly created one can order columns differently, and this
+-- script must work identically on both.
+--
+-- users: target rows always win. The users table is global by design (see
+-- src/db/models.py) with last-writer-wins display names; a merge keeps the
+-- target's version of anyone both archives know.
+-- ---------------------------------------------------------------------------
+INSERT INTO main.users (id, username, first_name, last_name, phone, is_bot, created_at, updated_at)
+SELECT s.id, s.username, s.first_name, s.last_name, s.phone, s.is_bot, s.created_at, s.updated_at
+FROM source.users s
+WHERE NOT EXISTS (SELECT 1 FROM main.users t WHERE t.id = s.id);
+
+INSERT INTO main.chats (account_id, id, ref, type, title, username, first_name, last_name, phone,
+                        description, participants_count, is_forum, is_archived,
+                        last_synced_message_id, created_at, updated_at)
+SELECT (SELECT id FROM _new_account), s.id, s.ref, s.type, s.title, s.username, s.first_name,
+       s.last_name, s.phone, s.description, s.participants_count, s.is_forum, s.is_archived,
+       s.last_synced_message_id, s.created_at, s.updated_at
+FROM source.chats s;
+
+INSERT INTO main.chat_folders (account_id, id, title, emoticon, sort_order, created_at, updated_at)
+SELECT (SELECT id FROM _new_account), s.id, s.title, s.emoticon, s.sort_order, s.created_at, s.updated_at
+FROM source.chat_folders s;
+
+INSERT INTO main.messages (account_id, id, chat_id, sender_id, sender_name, date, text,
+                           reply_to_msg_id, reply_to_top_id, reply_to_text, forward_from_id,
+                           edit_date, raw_data, created_at, is_outgoing, is_pinned,
+                           is_deleted, deleted_at)
+SELECT (SELECT id FROM _new_account), s.id, s.chat_id, s.sender_id, s.sender_name, s.date, s.text,
+       s.reply_to_msg_id, s.reply_to_top_id, s.reply_to_text, s.forward_from_id,
+       s.edit_date, s.raw_data, s.created_at, s.is_outgoing, s.is_pinned,
+       s.is_deleted, s.deleted_at
+FROM source.messages s;
+
+INSERT INTO main.forum_topics (account_id, id, chat_id, title, icon_color, icon_emoji_id,
+                               icon_emoji, is_closed, is_pinned, is_hidden, date,
+                               created_at, updated_at)
+SELECT (SELECT id FROM _new_account), s.id, s.chat_id, s.title, s.icon_color, s.icon_emoji_id,
+       s.icon_emoji, s.is_closed, s.is_pinned, s.is_hidden, s.date, s.created_at, s.updated_at
+FROM source.forum_topics s;
+
+-- sync_status is what makes the first merged sweep incremental: the imported
+-- last_message_id cursors mean account 2 resumes where the source install
+-- stopped, instead of re-capturing every chat from message 1.
+INSERT INTO main.sync_status (account_id, chat_id, last_message_id, last_sync_date, message_count)
+SELECT (SELECT id FROM _new_account), s.chat_id, s.last_message_id, s.last_sync_date, s.message_count
+FROM source.sync_status s;
+
+INSERT INTO main.chat_folder_members (account_id, folder_id, chat_id)
+SELECT (SELECT id FROM _new_account), s.folder_id, s.chat_id
+FROM source.chat_folder_members s;
+
+INSERT INTO main.media (account_id, id, message_id, chat_id, type, file_path, file_name,
+                        file_size, mime_type, width, height, duration, content_hash,
+                        downloaded, download_attempts, download_date, created_at)
+SELECT (SELECT id FROM _new_account), s.id, s.message_id, s.chat_id, s.type, s.file_path,
+       s.file_name, s.file_size, s.mime_type, s.width, s.height, s.duration, s.content_hash,
+       s.downloaded, s.download_attempts, s.download_date, s.created_at
+FROM source.media s;
+
+-- message_versions and reactions have their own autoincrement ids in each
+-- archive; the source's values would collide with the target's, so the id is
+-- omitted and SQLite assigns fresh ones. Nothing references these ids.
+INSERT INTO main.message_versions (account_id, message_id, chat_id, text, date, change_hash, captured_at)
+SELECT (SELECT id FROM _new_account), s.message_id, s.chat_id, s.text, s.date, s.change_hash, s.captured_at
+FROM source.message_versions s;
+
+INSERT INTO main.reactions (account_id, message_id, chat_id, emoji, user_id, "count", created_at, removed_at)
+SELECT (SELECT id FROM _new_account), s.message_id, s.chat_id, s.emoji, s.user_id, s."count", s.created_at, s.removed_at
+FROM source.reactions s;
+
+.print 'import done — verifying'
+
+-- ---------------------------------------------------------------------------
+-- Verification. Actual counts are RE-COUNTED from the target — never assumed
+-- from the statements above — and compared to the pre-import snapshot.
+-- ---------------------------------------------------------------------------
+UPDATE _merge_counts SET actual =
+  expected - (SELECT count(*) FROM source.users s
+              WHERE NOT EXISTS (SELECT 1 FROM main.users t WHERE t.id = s.id))
+WHERE table_name = 'users (new senders)';
+
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM main.chats               WHERE account_id = (SELECT id FROM _new_account)) WHERE table_name = 'chats';
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM main.messages            WHERE account_id = (SELECT id FROM _new_account)) WHERE table_name = 'messages';
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM main.message_versions    WHERE account_id = (SELECT id FROM _new_account)) WHERE table_name = 'message_versions';
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM main.media               WHERE account_id = (SELECT id FROM _new_account)) WHERE table_name = 'media';
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM main.reactions           WHERE account_id = (SELECT id FROM _new_account)) WHERE table_name = 'reactions';
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM main.sync_status         WHERE account_id = (SELECT id FROM _new_account)) WHERE table_name = 'sync_status';
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM main.forum_topics        WHERE account_id = (SELECT id FROM _new_account)) WHERE table_name = 'forum_topics';
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM main.chat_folders        WHERE account_id = (SELECT id FROM _new_account)) WHERE table_name = 'chat_folders';
+UPDATE _merge_counts SET actual = (SELECT count(*) FROM main.chat_folder_members WHERE account_id = (SELECT id FROM _new_account)) WHERE table_name = 'chat_folder_members';
+
+.print ''
+.print '=== Imported rows, per table (counts only) ==='
+SELECT table_name, expected, actual,
+       CASE WHEN expected IS actual THEN 'ok' ELSE 'MISMATCH' END AS status
+FROM _merge_counts;
+
+-- These three inserts ARE the verification: each aborts loudly via its trigger
+-- if its check fails, and their survival is what the verdict below reports.
+INSERT INTO _guard
+SELECT 'counts_match',
+       NOT EXISTS (SELECT 1 FROM _merge_counts WHERE expected IS NOT actual);
+
+INSERT INTO _guard
+SELECT 'no_new_fk_violations',
+       (SELECT count(*) FROM pragma_foreign_key_check)
+       <= (SELECT target_before + source_before FROM _fk_baseline);
+
+INSERT INTO _guard
+SELECT 'refs_unique_after',
+       (SELECT count(*) FROM main.chats) = (SELECT count(DISTINCT ref) FROM main.chats);
+
+-- ---------------------------------------------------------------------------
+-- Summary and verdict. Counts and yes/no indicators only.
+-- The media-roots line compares the directory prefix up to and including
+-- '/media/' of one stored media path from each archive — if they differ, the
+-- imported media rows point at paths the target install does not serve, and
+-- the media section of docs/MERGING-ARCHIVES.md tells you how to remap them.
+-- ---------------------------------------------------------------------------
+.print ''
+.print '=== Summary ==='
+SELECT
+  (SELECT id FROM _new_account)                                          AS imported_account_row,
+  (SELECT count(*) FROM main.accounts)                                   AS accounts_total,
+  (SELECT target_before FROM _fk_baseline)                               AS fk_violations_target_before,
+  (SELECT source_before FROM _fk_baseline)                               AS fk_violations_source_before,
+  (SELECT count(*) FROM pragma_foreign_key_check)                        AS fk_violations_after,
+  CASE
+    WHEN (SELECT count(*) FROM main.media   WHERE file_path IS NOT NULL AND instr(file_path, '/media/') > 0) = 0
+      OR (SELECT count(*) FROM source.media WHERE file_path IS NOT NULL AND instr(file_path, '/media/') > 0) = 0
+    THEN 'n/a'
+    WHEN (SELECT substr(file_path, 1, instr(file_path, '/media/') + 6) FROM main.media
+          WHERE file_path IS NOT NULL AND instr(file_path, '/media/') > 0 LIMIT 1)
+       = (SELECT substr(file_path, 1, instr(file_path, '/media/') + 6) FROM source.media
+          WHERE file_path IS NOT NULL AND instr(file_path, '/media/') > 0 LIMIT 1)
+    THEN 'yes'
+    ELSE 'NO - see the media section of docs/MERGING-ARCHIVES.md'
+  END                                                                    AS media_roots_match;
+
+.print ''
+.print '=== VERDICT ==='
+SELECT CASE
+  WHEN (SELECT count(*) FROM _guard WHERE ok = 0) = 0
+   AND (SELECT count(*) FROM _guard) = 13
+  THEN 'OK — every check passed. Type COMMIT; now to keep the merge.'
+  ELSE 'FAILED — do NOT commit. Type ROLLBACK; now.'
+END AS verdict;
+
+.print ''
+.print 'This script never commits. COMMIT; keeps the merge, ROLLBACK; (or just'
+.print 'quitting sqlite3) leaves the target exactly as it was.'


### PR DESCRIPTION
## The problem

8.0 lets one archive hold many accounts, but the upgrade guide only covers adding a **fresh** second account — which starts from zero: a new login re-captures what Telegram still has, silently loses every message deleted since, every edit version, and re-downloads years of media. The other real story — two people each ran their own single-account install for years and now want ONE archive — had no path at all.

## What this adds

**docs/MERGING-ARCHIVES.md** + executable companion SQL under **scripts/merge/**, linked from the upgrade guide's multi-account section:

- **PostgreSQL→PostgreSQL and SQLite→SQLite fully**, mixed backends routed through the existing SQLite→PostgreSQL mover (verified 8.0-schema-aware end to end).
- The procedure is **auditable SQL the user can read** before running it on the only copy of their history — not a tool. One transaction per backend; explicit-column INSERT..SELECT remapped into a freshly assigned account row; per-table expected-vs-actual recounts; FK re-verification.
- **Every unsafe state aborts loudly with a named fix**: mismatched schema revisions, an install never started (unclaimed account row), two archives of the same Telegram account (that's message-level dedupe — refused honestly), a chat ref collision, another connection holding the database.
- **SQLite deliberately does not commit**: the script ends with a verdict line and the last word is the human's — `COMMIT;` on OK, `ROLLBACK;` otherwise, and quitting rolls back too. PostgreSQL commits only if every DO-block check passed.
- What merging preserves over a fresh login is stated up front: deleted-message history, edit versions, already-downloaded media, and sync cursors — so the merged account's first sweep is incremental instead of a years-long re-capture.
- Media transfer (`rsync -a --ignore-existing`, shared-store symlinks, path-prefix remap), the session-file **move** (never copy — a session used from two processes is burned), env declaration, first-start log verification (counts only), and viewer re-grants are all in the doc.

## Evidence

Two lanes, both green. The author proved the procedure live on synthetic two-account archives on both backends plus the mixed path — including the shared-group case (same chat, overlapping message ids, identical edit hashes in both archives: 022's motivating collision) — with target-side rows byte-stable under per-table digests and `PRAGMA foreign_key_check` / anti-join FK checks clean. An independent reviewer then **executed the committed doc verbatim** on their own fixtures, both backends, all green. Every guard was watched go red: three sabotage runs per backend (wrong revision, same-account, planted ref collision) each aborted with the target byte-identical, a missing-parameter control caught a silent-exit bug (fixed to a raising DO block), and a mutation control with a crippled script proved the count verification refuses commit. All script output is counts-only — no chat ids, titles, or content.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added tools for safely merging a single-account archive into an existing multi-account archive.
  - Supports SQLite and PostgreSQL databases with validation, integrity checks, account remapping, and rollback protection.
  - Preserves historical data, media references, users, and chat relationships during the merge.
  - Provides clear commit-or-rollback verification for SQLite and automatic transaction rollback for PostgreSQL.

- **Documentation**
  - Added comprehensive merge instructions, including prerequisites, backups, verification, recovery guidance, and permissions.
  - Updated the 8.0 upgrade guide to direct users with existing archives to the merge workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->