### PR TITLE
test: bind the trigram index assertion to the messages table

### DIFF
--- a/tests/test_db_adapter_real_engine.py
+++ b/tests/test_db_adapter_real_engine.py
@@ -162,8 +162,9 @@ class TestPaginationRealEngine:
     async def test_trgm_index_exists_on_postgresql(self, real_adapter):
         """idx_messages_text_trgm must be a real GIN/pg_trgm index, not just present by name.
 
-        #301: this is what makes the leading-wildcard ILIKE search's cost
-        independent of table size instead of scaling linearly with it. Checked
+        #301: this is what lets the planner satisfy a leading-wildcard ILIKE
+        from a bitmap index scan instead of reading every row, so the search
+        stops scaling linearly with the table. Checked
         against the catalog (not EXPLAIN) deliberately - on a near-empty test
         table the planner can rightfully prefer a seq scan over any index
         regardless of what exists, so asserting on the *chosen plan* here

--- a/tests/test_db_adapter_real_engine.py
+++ b/tests/test_db_adapter_real_engine.py
@@ -162,14 +162,18 @@ class TestPaginationRealEngine:
     async def test_trgm_index_exists_on_postgresql(self, real_adapter):
         """idx_messages_text_trgm must be a real GIN/pg_trgm index, not just present by name.
 
-        #295-perf: this is what makes the leading-wildcard ILIKE search's cost
+        #301: this is what makes the leading-wildcard ILIKE search's cost
         independent of table size instead of scaling linearly with it. Checked
         against the catalog (not EXPLAIN) deliberately - on a near-empty test
         table the planner can rightfully prefer a seq scan over any index
         regardless of what exists, so asserting on the *chosen plan* here
         would be a table-size-dependent flake, not a check of the fix.
-        SQLite has no gin_trgm_ops equivalent (see migration 022 / models.py's
+        SQLite has no gin_trgm_ops equivalent (see migration 023 / models.py's
         Index() dialect kwargs), so this only runs on PostgreSQL.
+
+        The catalog lookup is bound to ``messages`` by oid: a name alone is
+        unique per schema, not per database, so an index of the same name on
+        another table would otherwise answer for the one being asserted.
         """
         if real_adapter.db_manager.engine.dialect.name != "postgresql":
             import pytest
@@ -188,6 +192,7 @@ class TestPaginationRealEngine:
                         "JOIN pg_am am ON am.oid = i.relam "
                         "JOIN pg_opclass opc ON opc.oid = ANY(ix.indclass) "
                         "WHERE i.relname = 'idx_messages_text_trgm' "
+                        "AND ix.indrelid = 'messages'::regclass "
                         "GROUP BY am.amname"
                     )
                 )

--- a/tests/test_migration_022.py
+++ b/tests/test_migration_022.py
@@ -329,7 +329,7 @@ def sqlite_digest(path: Path) -> dict:
         if "chats" in live and "ref" in {c[1] for c in conn.execute("PRAGMA table_info(chats)")}:
             ref_to_chat = {row[0]: str(row[1]) for row in conn.execute("SELECT ref, id FROM chats") if row[0]}
 
-        def canonical(value):
+        def canonical(value: str) -> str:
             return f"<ref:{ref_to_chat.get(value, '?')}>" if value in ref_to_chat else value
 
         for table in DIGESTED_TABLES:


### PR DESCRIPTION
Follow-up to a CodeRabbit review that landed on #301 [three minutes after it was merged](https://github.com/GeiserX/Telegram-Archive/pull/301#pullrequestreview-4946229007), so its findings were never applied. All three still stood on main; two were real.

## The one that matters

`test_trgm_index_exists_on_postgresql` matched the index by `pg_class.relname` alone. A relation name is unique per schema, not per database, so any same-named index anywhere in the database satisfied it — the test could pass while `messages` carried no index at all, which is precisely the regression it exists to catch.

Watched it fail before fixing it, on PostgreSQL 18: a database with `messages` (no index) plus a decoy `idx_messages_text_trgm` on another schema's table.

```
-- old query (name only)
gin|{gin_trgm_ops}      <- full pass, messages has no index
-- new query (ix.indrelid = 'messages'::regclass)
(no rows)               <- assertion fails, as it should
```

## Also

- The docstring's marker pointed at `#295` — an unrelated FloodWait bug — instead of #301, and at `migration 022` instead of `023`, which is the migration that actually creates the index (`alembic/versions/20260816_023_add_message_text_trgm_index.py`).
- Annotated the digest helper's local `canonical()`, matching the module-level helpers in that file, which are all annotated.

CodeRabbit's remaining suggestion — annotating every fixture and test method in `test_migration_022.py` — is skipped deliberately: unannotated test signatures are the suite's prevailing style (198 of 2,617 test defs carry `-> None`), so annotating one file's methods would make it the outlier rather than the model. Module-level helpers, which the file does annotate consistently, are unaffected.

## Verification

`tests/test_db_adapter_real_engine.py` + `tests/test_migration_022.py`: 44 passed, 2 skipped (both by-design backend halves) against a real PostgreSQL 18; the `[postgresql]` variant of the trigram test confirmed running and passing, not skipping. Ruff check and format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved PostgreSQL index verification to ensure lookups target the correct table.
  * Added documentation explaining the performance rationale and SQLite exclusion.
  * Clarified type annotations in migration-related test helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->