### PR TITLE
fix: restore the chat list on archives missing a declared index, and stop restricted viewers reading the whole archive

### DIFF
--- a/alembic/versions/20260818_024_restore_missing_declared_indexes.py
+++ b/alembic/versions/20260818_024_restore_missing_declared_indexes.py
@@ -1,0 +1,95 @@
+"""Recreate declared indexes that a real database turned out not to have.
+
+Found on a production archive whose viewer had become unusable: the chat list
+took twenty to thirty-five minutes per request, and five of its own queries
+were found running concurrently, each stacking on the last. The archive was
+missing ``idx_messages_chat_date_desc`` and ``idx_messages_chat_pinned`` —
+both declared in models.py since 002 and 004, both present in every other
+database anyone had looked at.
+
+``get_all_chats`` reads each chat's last message through a correlated
+``MAX(messages.date)`` subquery, one seek per chat row against
+``idx_messages_chat_date_desc``. Without that index each of the archive's
+4,784 chats scans its own messages across a 2.7M-row table, so the cost of
+listing chats becomes the cost of reading the archive. Restoring the two
+indexes took that query from >20 minutes to 39 ms, measured on the archive
+that reported it.
+
+How a declared index goes missing without anything noticing:
+``Base.metadata.create_all(checkfirst=True)`` — which src/db/migrate.py uses
+to build the target schema when moving SQLite to PostgreSQL — skips a table
+*and every index on it* when the table already exists. ``checkfirst`` is
+per-table, not per-index. An index added to models.py after a database was
+first created therefore never appears in it, while the migration that would
+have created it is skipped too, because entrypoint.sh stamped that database
+at a later revision. tests/test_schema_parity.py compares the ORM against a
+freshly migrated database, so it cannot see this: the drift only exists in
+databases that have lived through history.
+
+This migration names the two indexes explicitly rather than reflecting
+models.py, because a migration has to keep meaning what it meant when it was
+written; a future edit to models.py must not silently change what this one
+does. It creates each index only where it is absent, so it is a no-op on
+every database that already has them — which is most of them.
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "024"
+down_revision: str | None = "023"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+TABLE_NAME = "messages"
+
+# (index name, the columns as models.py declares them). The DESC on date is
+# load-bearing: the query this index serves reads
+# ``WHERE chat_id = ? ORDER BY date DESC``, and SQLite reflection cannot see
+# sort order, so a rebuild that goes through reflection silently downgrades it
+# to ASC (see 021's _repair_sqlite_desc_index).
+MISSING_INDEXES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("idx_messages_chat_date_desc", ("chat_id", "date DESC")),
+    ("idx_messages_chat_pinned", ("chat_id", "is_pinned")),
+)
+
+
+def _live_indexes(inspector: sa.Inspector) -> set[str]:
+    if TABLE_NAME not in inspector.get_table_names():
+        return set()
+    return {index["name"] for index in inspector.get_indexes(TABLE_NAME)}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    live = _live_indexes(sa.inspect(conn))
+    if TABLE_NAME not in sa.inspect(conn).get_table_names():
+        return
+
+    created = 0
+    for name, columns in MISSING_INDEXES:
+        if name in live:
+            continue
+        op.create_index(
+            name,
+            TABLE_NAME,
+            [sa.text(column) if " " in column else column for column in columns],
+        )
+        created += 1
+
+    if created:
+        # Names only — an index name is schema, not archive content.
+        print(f"024: recreated {created} declared index(es) missing from this database")
+
+
+def downgrade() -> None:
+    """Nothing to undo.
+
+    These indexes are declared in models.py, so a database that has them is
+    the correct state at every revision; dropping them on the way down would
+    reintroduce the fault this migration exists to repair.
+    """

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [8.0.2] - 2026-08-18
+
+### Fixed
+
+- **The chat list could take minutes, or never finish, on an archive missing an index it was never told it lacked.** `get_all_chats` reads each chat's last message through a correlated `MAX(messages.date)` subquery — one seek per chat against `idx_messages_chat_date_desc`. Where that index is absent, every listed chat instead scans its own messages, so listing chats costs a read of the archive: on the installation that reported this, chat-list queries ran for twenty to thirty-five minutes and stacked up until the database served nothing else. The index has been declared in models.py since migration `002`, which is exactly why nobody noticed it could be missing. `Base.metadata.create_all(checkfirst=True)` — how the SQLite→PostgreSQL move builds its target schema — skips a table *and every index on it* once the table exists, `checkfirst` being per-table and not per-index; an index added to models.py after a database was created therefore never appears in it, while the migration that would have added it is skipped too because the database was stamped past that revision. Migration `024` recreates `idx_messages_chat_date_desc` and `idx_messages_chat_pinned` wherever they are absent, and is a no-op on the databases that have them. Restoring them took that query from over twenty minutes to 39 ms on the affected archive. ([#314](https://github.com/GeiserX/Telegram-Archive/pull/314))
+- **A viewer restricted to a few chats made the server read every chat in the archive, four times per page load.** Entitlements were applied in Python after the fact: the chat list, the folder list, the archive counter and the statistics panel each loaded every chat row and then filtered, so the narrower a viewer's grant, the more work their page cost — a restricted account paid an 18× penalty over an unrestricted one on the same page. Visibility now compiles to SQL, from the same `ChatScope` definition the per-row check uses, so the two cannot drift apart: a viewer entitled to one chat touches one row instead of 4,784, with 2,262× less I/O. An empty grant emits an explicitly false predicate rather than relying on how a database renders `IN ()` — access control should not rest on that. Unrestricted access is unchanged, byte-for-byte the same statements as before, and 6,006 comparisons across 546 grant configurations confirmed the SQL filter admits and refuses exactly what the Python one did. ([#314](https://github.com/GeiserX/Telegram-Archive/pull/314))
+
 ## [8.0.1] - 2026-08-16
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "8.0.1"
+version = "8.0.2"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,9 @@ viewer = [
     "Pillow>=12.3.0",  # v7.2.0: thumbnail generation
 ]
 dev = [
-    "pytest>=7.0",
+    # 9.0 for the built-in `subtests` fixture the equivalence matrices use;
+    # on 7.x/8.x those tests fail at collection rather than run.
+    "pytest>=9.0",
     "pytest-asyncio>=0.26.0",
     "pytest-cov>=7.1.0",
     "ruff>=0.15.10",

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "8.0.1"
+__version__ = "8.0.2"

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1010,6 +1010,21 @@ class DatabaseAdapter:
                 chats.append(chat_dict)
             return chats
 
+    async def get_visible_chat_ids(self, scope: ChatScope) -> set[int]:
+        """Just the chat ids a scope selects — no row build, no date subquery.
+
+        ``get_all_chats`` attaches a correlated ``MAX(messages.date)`` per row,
+        which is exactly what the callers of this (folder counts, cached stats)
+        throw away. A grant can be as wide as a whole account, so paying that
+        subquery per chat to collect ids is waste that grows with the archive.
+        """
+        async with self.db_manager.async_session_factory() as session:
+            stmt = select(Chat.id)
+            for predicate in scope.sql_predicates():
+                stmt = stmt.where(predicate)
+            result = await session.execute(stmt)
+            return {row[0] for row in result}
+
     async def get_chat_count(
         self,
         search: str = None,

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -13,12 +13,27 @@ import logging
 import os
 import secrets
 import shutil
-from collections.abc import Iterable
+from collections.abc import Collection, Iterable, Mapping
+from dataclasses import dataclass
 from datetime import datetime
 from functools import wraps
 from typing import Any
 
-from sqlalchemy import and_, delete, desc, exists, func, literal, nulls_last, or_, select, text, union_all, update
+from sqlalchemy import (
+    and_,
+    delete,
+    desc,
+    exists,
+    false,
+    func,
+    literal,
+    nulls_last,
+    or_,
+    select,
+    text,
+    union_all,
+    update,
+)
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
@@ -115,6 +130,82 @@ def parse_entitlement_column(raw: str | None, element_type: type) -> set | None:
             return set()
         values.add(element)
     return values
+
+
+@dataclass(frozen=True)
+class ChatScope:
+    """The set of chat rows one principal may see, as data both Python and SQL can read.
+
+    Chat visibility is decided by exactly three rules, and this object is the
+    ONE place they are written down:
+
+    * ``ids``      - the operator's DISPLAY_CHAT_IDS filter (``chats.id``)
+    * ``accounts`` - the viewer's account grant (``chats.account_id``)
+    * ``refs``     - the viewer's chat-ref grant (``chats.ref``)
+
+    Each field is ``None`` (that rule restricts nothing) or a collection (the
+    grant). ``None`` and the EMPTY collection are NOT the same thing and the
+    difference is the whole security story: an empty grant means "entitled to
+    nothing" and MUST match zero rows. Rendering it as a skipped filter — the
+    classic falsy-empty-list bug — is a total entitlement bypass, so
+    :meth:`sql_predicates` maps it to ``false()`` explicitly rather than
+    trusting any dialect's empty-``IN`` rendering.
+
+    :meth:`allows` and :meth:`sql_predicates` are twins: the same three rules,
+    in the same order, one evaluated in Python (websocket delivery, the ref
+    resolver) and one pushed into the WHERE clause (the chat list). They are
+    written next to each other so they cannot drift, and
+    ``tests/test_chat_scope_equivalence.py`` runs the whole rule space through
+    both and asserts the two answers are identical.
+    """
+
+    ids: frozenset[int] | None = None
+    accounts: frozenset[int] | None = None
+    refs: frozenset[str] | None = None
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        ids: Collection[int] | None = None,
+        accounts: Collection[int] | None = None,
+        refs: Collection[str] | None = None,
+    ) -> ChatScope:
+        """Freeze caller-supplied grants, preserving None-vs-empty exactly."""
+        return cls(
+            ids=None if ids is None else frozenset(ids),
+            accounts=None if accounts is None else frozenset(accounts),
+            refs=None if refs is None else frozenset(refs),
+        )
+
+    @property
+    def unrestricted(self) -> bool:
+        """True when no rule restricts anything, so the scope can be skipped entirely."""
+        return self.ids is None and self.accounts is None and self.refs is None
+
+    def allows(self, chat: Mapping[str, Any]) -> bool:
+        """Whether ``chat`` (a row dict carrying id/account_id/ref) is in scope.
+
+        Each key is read ONLY when its rule is active, so a partial row dict is
+        as acceptable here as it was to the hand-written check this replaces.
+        """
+        if self.ids is not None and chat["id"] not in self.ids:
+            return False
+        if self.accounts is not None and chat["account_id"] not in self.accounts:
+            return False
+        if self.refs is not None and chat["ref"] not in self.refs:
+            return False
+        return True
+
+    def sql_predicates(self) -> list[Any]:
+        """The same three rules as WHERE-clause fragments against ``chats``."""
+        predicates: list[Any] = []
+        for column, grant in ((Chat.id, self.ids), (Chat.account_id, self.accounts), (Chat.ref, self.refs)):
+            if grant is None:
+                continue
+            # An empty grant is "nothing", never "no filter".
+            predicates.append(column.in_(grant) if grant else false())
+        return predicates
 
 
 # Message columns an upsert may refresh ONLY when the writer actually supplied
@@ -802,6 +893,7 @@ class DatabaseAdapter:
         folder_id: int | None = None,
         *,
         account_id: int | None = None,
+        scope: ChatScope | None = None,
     ) -> list[dict[str, Any]]:
         """Get chats with their last message date, with optional pagination and search.
 
@@ -812,6 +904,11 @@ class DatabaseAdapter:
             archived: If True, only archived chats; if False, only non-archived; if None, all
             folder_id: If set, only chats in this folder
             account_id: If set, only this account's chats (None = unscoped until phase 4)
+            scope: Viewer entitlement, applied as WHERE predicates so a restricted
+                viewer reads only the rows it may see. The caller must NOT
+                post-filter: pushing the grant down here is what keeps limit /
+                offset / COUNT honest, and what stops a one-chat viewer from
+                paying for every chat in the archive.
         """
         async with self.db_manager.async_session_factory() as session:
             # Last message date, as a CORRELATED scalar subquery — one
@@ -849,6 +946,12 @@ class DatabaseAdapter:
 
             if account_id is not None:
                 stmt = stmt.where(Chat.account_id == account_id)
+
+            # Viewer entitlement, in SQL. Applied before ORDER BY/LIMIT so the
+            # page, the ordering and the count all describe the same row set.
+            if scope is not None:
+                for predicate in scope.sql_predicates():
+                    stmt = stmt.where(predicate)
 
             # Filter by archived status
             if archived is True:
@@ -914,6 +1017,7 @@ class DatabaseAdapter:
         folder_id: int | None = None,
         *,
         account_id: int | None = None,
+        scope: ChatScope | None = None,
     ) -> int:
         """Get total number of chats (fast count for pagination).
 
@@ -922,6 +1026,8 @@ class DatabaseAdapter:
             archived: If True, only archived chats; if False, only non-archived; if None, all
             folder_id: If set, only chats in this folder
             account_id: If set, only this account's chats (None = unscoped until phase 4)
+            scope: Viewer entitlement (see get_all_chats). Must be the SAME scope the
+                matching get_all_chats call used, or ``total`` and the page disagree.
         """
         async with self.db_manager.async_session_factory() as session:
             stmt = select(func.count(Chat.id))
@@ -938,6 +1044,10 @@ class DatabaseAdapter:
 
             if account_id is not None:
                 stmt = stmt.where(Chat.account_id == account_id)
+
+            if scope is not None:
+                for predicate in scope.sql_predicates():
+                    stmt = stmt.where(predicate)
 
             if archived is True:
                 stmt = stmt.where(Chat.is_archived == 1)
@@ -3476,7 +3586,11 @@ class DatabaseAdapter:
         async with self.db_manager.async_session_factory() as session:
             count_q = select(ChatFolderMember.folder_id, func.count(ChatFolderMember.chat_id).label("chat_count"))
             if allowed_chat_ids is not None:
-                count_q = count_q.where(ChatFolderMember.chat_id.in_(allowed_chat_ids))
+                # Same rule as ChatScope.sql_predicates: an empty grant is
+                # "nothing", never "no filter". SQLAlchemy 2.0 does render an
+                # empty IN as an always-false expression, but an access-control
+                # filter must not rest on how the ORM renders an edge case.
+                count_q = count_q.where(ChatFolderMember.chat_id.in_(allowed_chat_ids) if allowed_chat_ids else false())
             if account_id is not None:
                 count_q = count_q.where(ChatFolderMember.account_id == account_id)
             count_subq = count_q.group_by(ChatFolderMember.folder_id).subquery()

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -32,7 +32,7 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from ..config import Config
 from ..db import DatabaseAdapter, close_database, get_db_manager, init_database
-from ..db.adapter import parse_entitlement_column
+from ..db.adapter import ChatScope, parse_entitlement_column
 from ..message_utils import describe_exception, media_display_filename
 from ..realtime import RealtimeListener
 from .media_utils import THUMBNAIL_EXTENSIONS, legacy_folder_alternates
@@ -708,40 +708,60 @@ class ChatContext:
     type: str | None = None
 
 
+def _chat_scope(user: UserContext) -> ChatScope:
+    """The three visibility rules for ``user``, as one object Python and SQL share.
+
+    This is where the operator's config and the session's grant are combined,
+    and the ONLY place that combination is written down. Two different
+    meanings of "empty" meet here, so both are spelled out:
+
+    * ``config.display_chat_ids`` is operator config — unset (empty/None) means
+      the operator asked for no filter, so it becomes ``ids=None``.
+    * ``allowed_accounts`` / ``allowed_chat_refs`` are entitlements — ``None``
+      means unrestricted, and the EMPTY set means entitled to nothing and is
+      passed through as an empty set so it denies every chat.
+
+    ChatScope.allows() then decides per row (websocket delivery, ref resolver)
+    and ChatScope.sql_predicates() decides in the WHERE clause (the chat list),
+    from these same three fields.
+    """
+    return ChatScope.build(
+        ids=config.display_chat_ids or None,
+        accounts=user.allowed_accounts,
+        refs=user.allowed_chat_refs,
+    )
+
+
 def _chat_visible(user: UserContext, chat: dict) -> bool:
     """Whether ``user`` may see ``chat`` (a row dict carrying id, account_id, ref).
 
-    One rule for every surface — HTTP routes, list filtering, websocket
-    broadcast, and the resolver below all decide through here. The operator's
-    DISPLAY_CHAT_IDS filter binds every role (as get_user_chat_ids did);
-    entitlements bind sessions whose grant is a set (masters carry None).
+    One rule for every surface — HTTP routes, websocket broadcast, and the
+    resolver below all decide through here, and the chat list decides through
+    the SQL twin of the very same ChatScope. The operator's DISPLAY_CHAT_IDS
+    filter binds every role (as get_user_chat_ids did); entitlements bind
+    sessions whose grant is a set (masters carry None).
     """
-    if config.display_chat_ids and chat["id"] not in config.display_chat_ids:
-        return False
-    if user.allowed_accounts is not None and chat["account_id"] not in user.allowed_accounts:
-        return False
-    if user.allowed_chat_refs is not None and chat["ref"] not in user.allowed_chat_refs:
-        return False
-    return True
+    return _chat_scope(user).allows(chat)
 
 
 def _user_is_restricted(user: UserContext) -> bool:
     """True when the visible-chat set is narrower than "everything"."""
-    return bool(config.display_chat_ids) or user.allowed_accounts is not None or user.allowed_chat_refs is not None
+    return not _chat_scope(user).unrestricted
 
 
 async def _visible_chat_id_set(user: UserContext) -> set[int] | None:
     """Chat ids the user may see, or None when unrestricted.
 
     The bridge that lets id-keyed internals (folder counts, cached stats) keep
-    working: entitlements are ref-based, so the set is computed by filtering
-    the chat list. Single-account caveat: the ids are bare (phase 5 will need
-    account-qualified sets once a second account can collide on an id).
+    working: entitlements are ref-based, so the ids come from the chat rows the
+    grant selects — selected BY the grant in SQL, so a viewer entitled to one
+    chat reads one row. Single-account caveat: the ids are bare (phase 5 will
+    need account-qualified sets once a second account can collide on an id).
     """
-    if not _user_is_restricted(user):
+    scope = _chat_scope(user)
+    if scope.unrestricted:
         return None
-    chats = await db.get_all_chats()
-    return {c["id"] for c in chats if _chat_visible(user, c)}
+    return {c["id"] for c in await db.get_all_chats(scope=scope)}
 
 
 async def _resolve_chat_ref(chat_ref: str, user: UserContext) -> ChatContext:
@@ -2157,20 +2177,21 @@ async def get_chats(
     v6.2.0: Added archived and folder_id filters.
     """
     try:
-        # If user has chat restrictions, we need to load all matching chats
-        # (entitlements are ref/account-based, so filtering happens here).
-        # Otherwise, use pagination
-        if _user_is_restricted(user):
-            chats = await db.get_all_chats(search=search, archived=archived, folder_id=folder_id)
-            chats = [c for c in chats if _chat_visible(user, c)]
-            total = len(chats)
-            # Apply pagination after filtering
-            chats = chats[offset : offset + limit]
-        else:
-            chats = await db.get_all_chats(
-                limit=limit, offset=offset, search=search, archived=archived, folder_id=folder_id
-            )
-            total = await db.get_chat_count(search=search, archived=archived, folder_id=folder_id)
+        # ONE path for every principal. The entitlement rides into SQL as WHERE
+        # predicates, so limit/offset/COUNT all describe the same visible row
+        # set and a restricted viewer touches only the rows it may see.
+        #
+        # This used to fork: the restricted branch called get_all_chats() with
+        # NO limit, filtered in Python, then sliced. Every chat row in the
+        # archive was materialised — each carrying the correlated MAX(date)
+        # subquery — to render one page, so /api/chats went from slow to
+        # unusable as the archive grew (4,784 chats / ~2.7M messages: >120s for
+        # a viewer entitled to a single chat).
+        scope = _chat_scope(user)
+        chats = await db.get_all_chats(
+            limit=limit, offset=offset, search=search, archived=archived, folder_id=folder_id, scope=scope
+        )
+        total = await db.get_chat_count(search=search, archived=archived, folder_id=folder_id, scope=scope)
 
         # Ref-addressed avatar URLs; the avatar bytes route re-resolves at serve
         # time, this only decides whether the viewer renders an <img> at all.
@@ -2428,11 +2449,13 @@ async def get_archived_count(user: UserContext = Depends(require_auth)):
     Respects DISPLAY_CHAT_IDS so restricted viewers only see relevant archived chats.
     """
     try:
-        if _user_is_restricted(user):
-            all_archived = await db.get_all_chats(archived=True)
-            count = sum(1 for c in all_archived if _chat_visible(user, c))
-        else:
+        scope = _chat_scope(user)
+        if scope.unrestricted:
             count = await db.get_archived_chat_count()
+        else:
+            # Counted in SQL under the same scope the chat list uses, rather
+            # than by loading every archived chat and filtering in Python.
+            count = await db.get_chat_count(archived=True, scope=scope)
         return {"count": count}
     except Exception as e:
         logger.error(f"Error fetching archived count: {e}", exc_info=True)

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -754,14 +754,14 @@ async def _visible_chat_id_set(user: UserContext) -> set[int] | None:
 
     The bridge that lets id-keyed internals (folder counts, cached stats) keep
     working: entitlements are ref-based, so the ids come from the chat rows the
-    grant selects — selected BY the grant in SQL, so a viewer entitled to one
-    chat reads one row. Single-account caveat: the ids are bare (phase 5 will
+    grant selects — selected BY the grant in SQL and read as bare ids, so a
+    viewer entitled to one chat reads one id and no message dates. Single-account caveat: the ids are bare (phase 5 will
     need account-qualified sets once a second account can collide on an id).
     """
     scope = _chat_scope(user)
     if scope.unrestricted:
         return None
-    return {c["id"] for c in await db.get_all_chats(scope=scope)}
+    return await db.get_visible_chat_ids(scope)
 
 
 async def _resolve_chat_ref(chat_ref: str, user: UserContext) -> ChatContext:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -247,7 +247,11 @@ def chat_row_in_scope(row: dict, scope) -> bool:
 
 
 def scoped_chat_source(rows: list[dict]):
-    """``(get_all_chats, get_chat_count)`` fakes over ``rows`` that honour ``scope``.
+    """``(get_all_chats, get_chat_count, get_visible_chat_ids)`` fakes over ``rows``.
+
+    All three honour ``scope`` through the same predicate the real adapter
+    compiles to SQL, so a route that switches between them keeps reading the
+    same visibility rules here as it does in production.
 
     ``archived``/``folder_id``/``search`` are ignored: callers that need those
     pass rows already narrowed to the case under test.
@@ -262,4 +266,7 @@ def scoped_chat_source(rows: list[dict]):
     async def get_chat_count(search=None, archived=None, folder_id=None, *, account_id=None, scope=None):
         return sum(1 for row in rows if chat_row_in_scope(row, scope))
 
-    return get_all_chats, get_chat_count
+    async def get_visible_chat_ids(scope):
+        return {row["id"] for row in rows if chat_row_in_scope(row, scope)}
+
+    return get_all_chats, get_chat_count, get_visible_chat_ids

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -212,3 +212,54 @@ async def real_db(request, postgres_test_url, tmp_path):
 async def real_adapter(real_db):
     """A :class:`DatabaseAdapter` whose SQL is really compiled and really run."""
     return DatabaseAdapter(real_db)
+
+
+# ---------------------------------------------------------------------------
+# Scope-honouring stand-ins for the two chat-list adapter methods
+# ---------------------------------------------------------------------------
+#
+# /api/chats pushes the viewer's entitlement into SQL (``scope=``) instead of
+# loading every chat and filtering in Python. A plain ``AsyncMock`` that hands
+# back a fixed list whatever ``scope`` says therefore proves nothing about
+# filtering — it would stay green if the route dropped the scope entirely,
+# which is exactly the entitlement bypass these tests exist to catch.
+#
+# ``scoped_chat_source`` builds fakes that apply the scope the way a database
+# would. The rule check below is deliberately written out by hand rather than
+# delegated to ``ChatScope.allows``: the endpoint tests must fail when the
+# route builds the WRONG scope, and reusing the production predicate would hide
+# a scope whose fields are all None. (That the SQL and ``allows`` agree is a
+# separate claim, proved against a real engine in
+# tests/test_chat_scope_equivalence.py.)
+
+
+def chat_row_in_scope(row: dict, scope) -> bool:
+    """Independent restatement of the three visibility rules, for test fakes."""
+    if scope is None:
+        return True
+    if scope.ids is not None and row["id"] not in scope.ids:
+        return False
+    if scope.accounts is not None and row["account_id"] not in scope.accounts:
+        return False
+    if scope.refs is not None and row["ref"] not in scope.refs:
+        return False
+    return True
+
+
+def scoped_chat_source(rows: list[dict]):
+    """``(get_all_chats, get_chat_count)`` fakes over ``rows`` that honour ``scope``.
+
+    ``archived``/``folder_id``/``search`` are ignored: callers that need those
+    pass rows already narrowed to the case under test.
+    """
+
+    async def get_all_chats(
+        limit=None, offset=0, search=None, archived=None, folder_id=None, *, account_id=None, scope=None
+    ):
+        visible = [dict(row) for row in rows if chat_row_in_scope(row, scope)]
+        return visible[offset:] if limit is None else visible[offset : offset + limit]
+
+    async def get_chat_count(search=None, archived=None, folder_id=None, *, account_id=None, scope=None):
+        return sum(1 for row in rows if chat_row_in_scope(row, scope))
+
+    return get_all_chats, get_chat_count

--- a/tests/test_chat_ref_acl.py
+++ b/tests/test_chat_ref_acl.py
@@ -419,6 +419,73 @@ async def test_empty_list_grant_denies_everything(viewer_app):
 
 
 # ============================================================================
+# (e2) Paging and `total` describe the VISIBLE list, not the archive
+# ============================================================================
+
+
+async def test_restricted_paging_and_total_describe_only_visible_chats(viewer_app):
+    """A restricted viewer pages the same way an unrestricted one does.
+
+    The grant is applied in SQL now, so limit/offset/COUNT all run against the
+    visible row set. Three things have to hold together, and each of them was a
+    way the old load-everything-then-slice code could have gone wrong:
+
+    * ``total`` counts VISIBLE chats — leaking the archive's chat count would
+      tell a one-chat viewer how many chats exist.
+    * paging is stable: walking the list one page at a time yields every
+      visible chat exactly once, in the same order as one unpaged request.
+    * the order is the unrestricted order with the invisible rows removed, so a
+      restricted viewer sees the same "most recent first" list everyone else
+      does.
+    """
+    archive = viewer_app.archive
+    async with _client() as client:
+        await _login_viewer(client, viewer_app.adapter, allowed_chat_refs=json.dumps([archive.ref_a, archive.ref_b]))
+        whole = (await client.get("/api/chats")).json()
+        assert whole["total"] == 2
+        assert whole["has_more"] is False
+        order = [chat["ref"] for chat in whole["chats"]]
+
+        paged = []
+        for offset in (0, 1):
+            page = (await client.get(f"/api/chats?limit=1&offset={offset}")).json()
+            assert page["total"] == 2
+            assert page["limit"] == 1
+            assert page["offset"] == offset
+            assert page["has_more"] is (offset == 0)
+            paged += [chat["ref"] for chat in page["chats"]]
+        assert paged == order
+
+    # The same list, seen by a principal with no grant at all: the restricted
+    # order must be that order, not a differently-sorted subset.
+    async with _client() as client:
+        resp = await client.post("/api/login", json={"username": MASTER_USERNAME, "password": MASTER_PASSWORD})
+        assert resp.status_code == 200, resp.text
+        unrestricted = (await client.get("/api/chats")).json()
+        assert unrestricted["total"] == 2
+        assert [chat["ref"] for chat in unrestricted["chats"]] == order
+
+
+async def test_total_for_a_one_chat_grant_never_reveals_the_archive_size(viewer_app):
+    archive = viewer_app.archive
+    async with _client() as client:
+        await _login_viewer(client, viewer_app.adapter, allowed_chat_refs=json.dumps([archive.ref_a]))
+        body = (await client.get("/api/chats")).json()
+        assert body["total"] == 1
+        assert [chat["ref"] for chat in body["chats"]] == [archive.ref_a]
+        assert body["has_more"] is False
+
+
+async def test_empty_grant_totals_zero_rather_than_everything(viewer_app):
+    """The bypass shape: an empty grant must not degrade to "no filter"."""
+    async with _client() as client:
+        await _login_viewer(client, viewer_app.adapter, allowed_chat_refs="[]")
+        body = (await client.get("/api/chats")).json()
+        assert body == {"chats": [], "total": 0, "limit": 50, "offset": 0, "has_more": False}
+        assert (await client.get("/api/archived/count")).json() == {"count": 0}
+
+
+# ============================================================================
 # (f) The legacy column is rollback data, never a grant
 # ============================================================================
 

--- a/tests/test_chat_ref_acl.py
+++ b/tests/test_chat_ref_acl.py
@@ -456,6 +456,25 @@ async def test_restricted_paging_and_total_describe_only_visible_chats(viewer_ap
             paged += [chat["ref"] for chat in page["chats"]]
         assert paged == order
 
+    # The walk above grants every chat the archive holds, so on its own it
+    # would read the same whether or not the grant reached the query at all.
+    # Page a STRICT subset too: with the scope dropped these totals become the
+    # archive's, and this test is the one that says so.
+    async with _client() as client:
+        await _login_viewer(client, viewer_app.adapter, allowed_chat_refs=json.dumps([archive.ref_b]))
+        subset = (await client.get("/api/chats")).json()
+        assert subset["total"] == 1, "a one-ref grant must not count the chats it cannot see"
+        assert [chat["ref"] for chat in subset["chats"]] == [archive.ref_b]
+
+        first = (await client.get("/api/chats?limit=1&offset=0")).json()
+        assert first["total"] == 1
+        assert first["has_more"] is False, "there is no second page inside a one-chat grant"
+        assert [chat["ref"] for chat in first["chats"]] == [archive.ref_b]
+
+        beyond = (await client.get("/api/chats?limit=1&offset=1")).json()
+        assert beyond["chats"] == []
+        assert beyond["total"] == 1
+
     # The same list, seen by a principal with no grant at all: the restricted
     # order must be that order, not a differently-sorted subset.
     async with _client() as client:

--- a/tests/test_chat_scope_equivalence.py
+++ b/tests/test_chat_scope_equivalence.py
@@ -1,0 +1,306 @@
+"""The chat-list entitlement filter, proved equivalent to the per-row rule.
+
+``/api/chats`` used to load EVERY chat row in the archive and drop the ones the
+viewer may not see in Python. That is correct and unusable: a viewer entitled to
+one chat paid for all 4,784 of them, each carrying a correlated ``MAX(date)``
+subquery. The grant now rides into SQL as ``WHERE`` predicates, so the page, the
+``total`` and the ordering all describe the same visible row set and a one-chat
+viewer touches one row.
+
+Moving an access-control decision from Python into SQL is only safe if the two
+say EXACTLY the same thing, so this file is the proof rather than the assertion:
+
+* ``ChatScope.allows`` (websocket delivery, the ref resolver) and
+  ``ChatScope.sql_predicates`` (the chat list) are run over the whole rule space
+  — every combination of account grant, ref grant and DISPLAY_CHAT_IDS — and
+  their answers must be set-equal in every cell, on both supported backends.
+* A third, independently written oracle (set intersection instead of a per-row
+  rule chain) checks the shared rule itself, so a wrong rule cannot pass merely
+  by being consistently wrong in both surfaces.
+* The empty grant is the cell that matters most. ``None`` means "unrestricted";
+  ``[]`` means "entitled to nothing" and MUST match zero rows. Rendering it as a
+  skipped filter is a total entitlement bypass, so every empty-grant cell is in
+  the matrix and is asserted to return nothing.
+* Ordering and paging are checked against the unrestricted path, because a
+  restricted viewer now uses the same ORDER BY / LIMIT / OFFSET machinery.
+
+The universe below is deliberately awkward: chat id 700000001 exists under TWO
+accounts with different refs (so an account rule and a ref rule can disagree),
+and the multi-ref grant names refs from three different accounts (so a ref that
+belongs to another account can be caught being let through).
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+from sqlalchemy import text
+
+from src.db.adapter import ChatScope
+
+BASE_DATE = datetime(2026, 2, 1, 9, 0, 0)
+
+# (account_id, chat_id, ref, message_count)
+UNIVERSE = [
+    (1, 700000001, "scopeRefA1c1000000001", 3),
+    (1, 700000002, "scopeRefA1c2000000002", 1),
+    (1, 700000003, "scopeRefA1c3000000003", 0),  # message-less: the NULLS LAST leg
+    (2, 700000001, "scopeRefA2c1000000001", 2),  # SAME chat id as row 1, other account
+    (2, 700000004, "scopeRefA2c4000000004", 0),  # message-less
+    (3, 700000005, "scopeRefA3c5000000005", 4),
+]
+
+ROWS = [{"account_id": acc, "id": cid, "ref": ref} for acc, cid, ref, _ in UNIVERSE]
+
+ONE_REF = frozenset({"scopeRefA1c2000000002"})
+# Spans three accounts on purpose: paired with accounts={1} this asks whether a
+# ref belonging to another account can slip through the account rule.
+MANY_REFS = frozenset({"scopeRefA1c2000000002", "scopeRefA2c1000000001", "scopeRefA3c5000000005"})
+
+ACCOUNT_GRANTS = {
+    "accounts=None": None,
+    "accounts={1}": frozenset({1}),
+    "accounts={1,2}": frozenset({1, 2}),
+    "accounts=EMPTY": frozenset(),
+}
+REF_GRANTS = {
+    "refs=None": None,
+    "refs={one}": ONE_REF,
+    "refs={many,cross-account}": MANY_REFS,
+    "refs=EMPTY": frozenset(),
+}
+DISPLAY_FILTERS = {
+    "display=unset": None,
+    "display={2 ids, both accounts}": frozenset({700000001, 700000002}),
+    "display=disjoint": frozenset({999999999}),
+}
+
+MATRIX = [
+    (f"{d} x {a} x {r}", ChatScope(ids=dv, accounts=av, refs=rv))
+    for d, dv in DISPLAY_FILTERS.items()
+    for a, av in ACCOUNT_GRANTS.items()
+    for r, rv in REF_GRANTS.items()
+]
+# 3 display filters x 4 account grants x 4 ref grants
+MATRIX_CELLS = len(MATRIX)
+
+
+def oracle_refs(scope: ChatScope) -> set[str]:
+    """Visible refs, computed independently of ChatScope by set intersection.
+
+    Same three rules, different shape: start from everything and intersect once
+    per active rule, rather than walking a per-row chain of early returns. An
+    empty grant intersects to the empty set on its own, with no special case —
+    which is the property the production code has to spell out explicitly.
+    """
+    visible = {row["ref"] for row in ROWS}
+    if scope.ids is not None:
+        visible &= {row["ref"] for row in ROWS if row["id"] in scope.ids}
+    if scope.accounts is not None:
+        visible &= {row["ref"] for row in ROWS if row["account_id"] in scope.accounts}
+    if scope.refs is not None:
+        visible &= set(scope.refs)
+    return visible
+
+
+async def seed_universe(adapter) -> None:
+    """Insert the chat rows, and enough messages to make the ordering non-trivial."""
+    for account_id, chat_id, _ref, message_count in UNIVERSE:
+        await adapter.upsert_chat(
+            {"id": chat_id, "type": "group", "title": f"scope fixture {chat_id}"}, account_id=account_id
+        )
+        for index in range(message_count):
+            await adapter.insert_message(
+                {
+                    "id": 1000 + index,
+                    "chat_id": chat_id,
+                    "sender_id": 4242,
+                    "date": BASE_DATE + timedelta(minutes=chat_id % 97 + index),
+                    "text": "scope fixture message",
+                    "raw_data": {},
+                },
+                account_id=account_id,
+            )
+    # upsert_chat mints a random ref; pin the refs so the grants above are stable.
+    async with adapter.db_manager.async_session_factory() as session:
+        for account_id, chat_id, ref, _ in UNIVERSE:
+            await session.execute(
+                text("UPDATE chats SET ref = :ref WHERE account_id = :a AND id = :c"),
+                {"ref": ref, "a": account_id, "c": chat_id},
+            )
+        await session.commit()
+
+
+@pytest.fixture
+async def seeded_adapter(real_adapter):
+    await seed_universe(real_adapter)
+    return real_adapter
+
+
+# ============================================================================
+# The matrix: SQL == ChatScope.allows == an independent oracle, every cell
+# ============================================================================
+
+
+async def test_sql_scope_matches_the_python_rule_in_every_cell(seeded_adapter, subtests):
+    """For all 48 cells: what SQL returns is exactly what the per-row rule allows.
+
+    ``subtests`` reports each cell by name, so a regression says WHICH grant
+    combination broke rather than just "the matrix failed".
+    """
+    assert MATRIX_CELLS == 48, MATRIX_CELLS
+    for name, scope in MATRIX:
+        with subtests.test(cell=name):
+            from_sql = {chat["ref"] for chat in await seeded_adapter.get_all_chats(scope=scope)}
+            from_python = {row["ref"] for row in ROWS if scope.allows(row)}
+            assert from_sql == from_python, f"SQL and ChatScope.allows disagree for {name}"
+            assert from_sql == oracle_refs(scope), f"the shared rule itself is wrong for {name}"
+            assert await seeded_adapter.get_chat_count(scope=scope) == len(from_sql)
+
+
+async def test_every_empty_grant_cell_returns_nothing(seeded_adapter, subtests):
+    """The bypass this design exists to prevent: [] is "nothing", never "no filter"."""
+    empty_cells = [
+        (name, scope)
+        for name, scope in MATRIX
+        if (scope.accounts is not None and not scope.accounts) or (scope.refs is not None and not scope.refs)
+    ]
+    assert len(empty_cells) == 21, len(empty_cells)
+    for name, scope in empty_cells:
+        with subtests.test(cell=name):
+            assert await seeded_adapter.get_all_chats(scope=scope) == []
+            assert await seeded_adapter.get_chat_count(scope=scope) == 0
+
+
+async def test_ref_from_another_account_does_not_escape_the_account_grant(seeded_adapter):
+    """A ref naming a chat in account 2 is still denied when the grant is account 1."""
+    scope = ChatScope(accounts=frozenset({1}), refs=frozenset({"scopeRefA2c1000000001"}))
+    assert await seeded_adapter.get_all_chats(scope=scope) == []
+    assert await seeded_adapter.get_chat_count(scope=scope) == 0
+
+
+async def test_shared_chat_id_is_separated_by_ref(seeded_adapter):
+    """Chat id 700000001 exists under two accounts; a ref grant picks exactly one."""
+    scope = ChatScope(refs=frozenset({"scopeRefA2c1000000001"}))
+    rows = await seeded_adapter.get_all_chats(scope=scope)
+    assert [(row["account_id"], row["id"]) for row in rows] == [(2, 700000001)]
+
+    # ...and the DISPLAY_CHAT_IDS filter, which is id-keyed, deliberately binds
+    # BOTH copies — that is the operator's rule, and the SQL must not narrow it.
+    both = await seeded_adapter.get_all_chats(scope=ChatScope(ids=frozenset({700000001})))
+    assert sorted(row["account_id"] for row in both) == [1, 2]
+
+
+# ============================================================================
+# Same machinery as the unrestricted path: ordering, paging, total
+# ============================================================================
+
+
+async def test_scoped_ordering_is_the_unrestricted_ordering_filtered(seeded_adapter):
+    """A restricted page is a subsequence of the unrestricted page, same order."""
+    scope = ChatScope(accounts=frozenset({1, 2}))
+    unrestricted = [(row["account_id"], row["id"]) for row in await seeded_adapter.get_all_chats()]
+    scoped = [(row["account_id"], row["id"]) for row in await seeded_adapter.get_all_chats(scope=scope)]
+    assert scoped == [key for key in unrestricted if key[0] in {1, 2}]
+
+
+async def test_scoped_paging_is_stable_and_total_counts_only_visible_chats(seeded_adapter):
+    """Paging a scoped list covers every visible chat exactly once."""
+    scope = ChatScope(accounts=frozenset({1, 2}))
+    total = await seeded_adapter.get_chat_count(scope=scope)
+    assert total == 5  # 3 chats on account 1, 2 on account 2; account 3 excluded
+
+    single_shot = [(row["account_id"], row["id"]) for row in await seeded_adapter.get_all_chats(scope=scope)]
+    paged = []
+    for offset in range(0, total, 2):
+        page = await seeded_adapter.get_all_chats(limit=2, offset=offset, scope=scope)
+        paged += [(row["account_id"], row["id"]) for row in page]
+    assert paged == single_shot
+    assert len(set(paged)) == len(paged)
+
+
+async def test_scope_composes_with_the_other_filters(seeded_adapter):
+    """search/archived/folder_id still apply on top of the grant, not instead of it."""
+    scope = ChatScope(refs=MANY_REFS)
+    assert await seeded_adapter.get_chat_count(scope=scope) == 3
+    assert await seeded_adapter.get_chat_count(search="700000002", scope=scope) == 1
+    # Nothing in the fixture is archived, so the archived filter must empty the page.
+    assert await seeded_adapter.get_all_chats(archived=True, scope=scope) == []
+    assert await seeded_adapter.get_chat_count(archived=True, scope=scope) == 0
+
+
+async def test_no_scope_is_identical_to_an_unrestricted_scope(seeded_adapter):
+    """Passing scope=None and passing an all-None scope must not differ."""
+    without = await seeded_adapter.get_all_chats()
+    with_empty_scope = await seeded_adapter.get_all_chats(scope=ChatScope())
+    assert [(row["account_id"], row["id"]) for row in without] == [
+        (row["account_id"], row["id"]) for row in with_empty_scope
+    ]
+    assert await seeded_adapter.get_chat_count() == await seeded_adapter.get_chat_count(scope=ChatScope())
+
+
+# ============================================================================
+# The rendered predicate itself: "nothing" must never compile to "no filter"
+# ============================================================================
+
+
+@pytest.mark.parametrize(
+    ("dialect_name", "matches_nothing"),
+    [("postgresql", "WHERE false"), ("sqlite", "WHERE 0 = 1")],
+)
+@pytest.mark.parametrize(
+    ("label", "scope"),
+    [
+        ("empty ref grant", ChatScope(refs=frozenset())),
+        ("empty account grant", ChatScope(accounts=frozenset())),
+        ("empty display filter", ChatScope(ids=frozenset())),
+    ],
+)
+def test_an_empty_grant_compiles_to_an_always_false_predicate(label, scope, dialect_name, matches_nothing):
+    """Pinned at the SQL text, not just at the row count.
+
+    ``column.in_([])`` has changed rendering across SQLAlchemy versions and is
+    a dialect's judgement call; an access-control filter cannot depend on that.
+    The builder emits a literal false instead, and this asserts it stays that
+    way on both supported dialects.
+    """
+    from sqlalchemy import select
+    from sqlalchemy.dialects import postgresql, sqlite
+
+    from src.db.models import Chat
+
+    dialect = {"postgresql": postgresql, "sqlite": sqlite}[dialect_name].dialect()
+    predicates = scope.sql_predicates()
+    assert len(predicates) == 1, label
+    stmt = select(Chat.id).where(predicates[0])
+    sql = " ".join(str(stmt.compile(dialect=dialect, compile_kwargs={"literal_binds": True})).split())
+    assert sql.endswith(matches_nothing), sql
+
+
+def test_an_unrestricted_scope_adds_no_predicate_at_all():
+    """The unrestricted path must keep issuing exactly the SQL it issued before."""
+    assert ChatScope().sql_predicates() == []
+    assert ChatScope().unrestricted is True
+
+
+# ============================================================================
+# The folder-count filter carries the same empty-grant rule
+# ============================================================================
+
+
+async def test_folder_counts_honour_an_empty_grant(seeded_adapter):
+    """get_all_folders(allowed_chat_ids=set()) must count nothing, not everything.
+
+    /api/folders feeds this the ids from _visible_chat_id_set, so an empty
+    grant reaches it as an empty set. If that degraded to "no filter" the
+    folder tabs would name chats the viewer may not open.
+    """
+    await seeded_adapter.upsert_chat_folder({"id": 2, "title": "scope fixture folder"}, account_id=1)
+    await seeded_adapter.sync_folder_members(2, [700000001, 700000002], account_id=1)
+
+    unrestricted = await seeded_adapter.get_all_folders()
+    assert [folder["chat_count"] for folder in unrestricted] == [2]
+
+    one_chat = await seeded_adapter.get_all_folders(allowed_chat_ids={700000001})
+    assert [folder["chat_count"] for folder in one_chat] == [1]
+
+    assert await seeded_adapter.get_all_folders(allowed_chat_ids=set()) == []

--- a/tests/test_migration_024.py
+++ b/tests/test_migration_024.py
@@ -59,6 +59,16 @@ def _indexes(conn: Connection) -> set[str]:
     return {index["name"] for index in sa.inspect(conn).get_indexes("messages")}
 
 
+def _index_ddl(conn: Connection) -> dict[str, str]:
+    """Every index's CREATE statement verbatim — identity, not just presence."""
+    rows = conn.execute(
+        sa.text(
+            "SELECT name, sql FROM sqlite_master WHERE type = 'index' AND tbl_name = 'messages' AND sql IS NOT NULL"
+        )
+    ).fetchall()
+    return {row[0]: row[1] for row in rows}
+
+
 class TestMigration024(unittest.TestCase):
     def test_revision_chain(self) -> None:
         migration = _load_migration()
@@ -93,16 +103,23 @@ class TestMigration024(unittest.TestCase):
             self.assertIn("DESC", columns_clause)
 
     def test_a_healthy_database_is_untouched_and_rerunning_is_a_no_op(self) -> None:
+        """Untouched means the definitions too, not just the names.
+
+        Comparing names alone would pass a migration that dropped each index
+        and built it again — which on a real archive is minutes of rewriting
+        for no change, and on SQLite silently loses the DESC that reflection
+        cannot see.
+        """
         migration = _load_migration()
         engine = sa.create_engine("sqlite://")
         with engine.connect() as conn:
             _create_messages_table(conn, with_indexes=True)
-            before = _indexes(conn)
+            before = _index_ddl(conn)
 
             _run(conn, migration.upgrade)
             _run(conn, migration.upgrade)
 
-            self.assertEqual(_indexes(conn), before)
+            self.assertEqual(_index_ddl(conn), before)
 
     def test_downgrade_keeps_the_indexes(self) -> None:
         """Dropping them on the way down would reintroduce the fault."""

--- a/tests/test_migration_024.py
+++ b/tests/test_migration_024.py
@@ -1,0 +1,127 @@
+"""Tests for Alembic migration 024 (recreate declared indexes a database lacks).
+
+The fault this migration repairs was real: a production archive was missing
+``idx_messages_chat_date_desc`` and ``idx_messages_chat_pinned`` while
+declaring both in models.py, and listing chats consequently read the whole
+archive. These tests build that exact shape — a messages table with the two
+indexes absent — and assert the migration puts them back, leaves a healthy
+database untouched, and keeps the DESC ordering the query depends on.
+"""
+
+import importlib.util
+import unittest
+from collections.abc import Callable
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy.engine import Connection
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parent.parent / "alembic" / "versions" / "20260818_024_restore_missing_declared_indexes.py"
+)
+
+RESTORED = {"idx_messages_chat_date_desc", "idx_messages_chat_pinned"}
+
+
+def _load_migration() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("migration_024", _MIGRATION_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("Unable to load migration 024")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run(conn: Connection, func: Callable[[], None]) -> None:
+    context = MigrationContext.configure(conn)
+    with Operations.context(context):
+        func()
+
+
+def _create_messages_table(conn: Connection, *, with_indexes: bool) -> None:
+    conn.execute(
+        sa.text(
+            "CREATE TABLE messages (account_id BIGINT NOT NULL, chat_id BIGINT NOT NULL, "
+            "id BIGINT NOT NULL, date DATETIME NOT NULL, is_pinned INTEGER)"
+        )
+    )
+    # An unrelated index, present in both shapes: the migration must leave it alone.
+    conn.execute(sa.text("CREATE INDEX idx_messages_date ON messages (date)"))
+    if with_indexes:
+        conn.execute(sa.text("CREATE INDEX idx_messages_chat_date_desc ON messages (chat_id, date DESC)"))
+        conn.execute(sa.text("CREATE INDEX idx_messages_chat_pinned ON messages (chat_id, is_pinned)"))
+
+
+def _indexes(conn: Connection) -> set[str]:
+    return {index["name"] for index in sa.inspect(conn).get_indexes("messages")}
+
+
+class TestMigration024(unittest.TestCase):
+    def test_revision_chain(self) -> None:
+        migration = _load_migration()
+        self.assertEqual(migration.revision, "024")
+        self.assertEqual(migration.down_revision, "023")
+
+    def test_recreates_the_indexes_a_database_is_missing(self) -> None:
+        """The production shape: declared indexes absent, everything else intact."""
+        migration = _load_migration()
+        engine = sa.create_engine("sqlite://")
+        with engine.connect() as conn:
+            _create_messages_table(conn, with_indexes=False)
+            self.assertEqual(_indexes(conn) & RESTORED, set(), "fixture should start without them")
+
+            _run(conn, migration.upgrade)
+
+            self.assertEqual(_indexes(conn) & RESTORED, RESTORED)
+            self.assertIn("idx_messages_date", _indexes(conn), "unrelated index must survive")
+
+    def test_the_restored_date_index_keeps_its_desc_ordering(self) -> None:
+        """DESC is the whole point: the query reads ORDER BY date DESC."""
+        migration = _load_migration()
+        engine = sa.create_engine("sqlite://")
+        with engine.connect() as conn:
+            _create_messages_table(conn, with_indexes=False)
+            _run(conn, migration.upgrade)
+
+            ddl = conn.execute(
+                sa.text("SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_messages_chat_date_desc'")
+            ).scalar()
+            columns_clause = ddl[ddl.index("(") :].upper()
+            self.assertIn("DESC", columns_clause)
+
+    def test_a_healthy_database_is_untouched_and_rerunning_is_a_no_op(self) -> None:
+        migration = _load_migration()
+        engine = sa.create_engine("sqlite://")
+        with engine.connect() as conn:
+            _create_messages_table(conn, with_indexes=True)
+            before = _indexes(conn)
+
+            _run(conn, migration.upgrade)
+            _run(conn, migration.upgrade)
+
+            self.assertEqual(_indexes(conn), before)
+
+    def test_downgrade_keeps_the_indexes(self) -> None:
+        """Dropping them on the way down would reintroduce the fault."""
+        migration = _load_migration()
+        engine = sa.create_engine("sqlite://")
+        with engine.connect() as conn:
+            _create_messages_table(conn, with_indexes=False)
+            _run(conn, migration.upgrade)
+
+            _run(conn, migration.downgrade)
+
+            self.assertEqual(_indexes(conn) & RESTORED, RESTORED)
+
+    def test_no_messages_table_is_survivable(self) -> None:
+        migration = _load_migration()
+        engine = sa.create_engine("sqlite://")
+        with engine.connect() as conn:
+            _run(conn, migration.upgrade)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_multi_user_auth.py
+++ b/tests/test_multi_user_auth.py
@@ -32,7 +32,7 @@ def _make_mock_db():
     # entitlement filter and the payload builders read both. The chat list
     # applies the grant in SQL now, so these two stand-ins honour ``scope=``
     # rather than handing back a fixed list whatever the grant says.
-    db.get_all_chats, db.get_chat_count = scoped_chat_source(
+    db.get_all_chats, db.get_chat_count, db.get_visible_chat_ids = scoped_chat_source(
         [
             {"id": -1001, "account_id": 1, "ref": "refchatAchatAchatAchat", "title": "Chat A", "type": "channel"},
             {"id": -1002, "account_id": 1, "ref": "refchatBchatBchatBchat", "title": "Chat B", "type": "channel"},

--- a/tests/test_multi_user_auth.py
+++ b/tests/test_multi_user_auth.py
@@ -10,6 +10,7 @@ import tempfile
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from conftest import scoped_chat_source
 from fastapi.testclient import TestClient
 
 
@@ -28,16 +29,17 @@ def _reset_auth_module():
 def _make_mock_db():
     db = AsyncMock()
     # v8.0.0 chat rows always carry account_id and the opaque ref — the
-    # entitlement filter and the payload builders read both.
-    db.get_all_chats = AsyncMock(
-        return_value=[
+    # entitlement filter and the payload builders read both. The chat list
+    # applies the grant in SQL now, so these two stand-ins honour ``scope=``
+    # rather than handing back a fixed list whatever the grant says.
+    db.get_all_chats, db.get_chat_count = scoped_chat_source(
+        [
             {"id": -1001, "account_id": 1, "ref": "refchatAchatAchatAchat", "title": "Chat A", "type": "channel"},
             {"id": -1002, "account_id": 1, "ref": "refchatBchatBchatBchat", "title": "Chat B", "type": "channel"},
             {"id": -1003, "account_id": 1, "ref": "refchatCchatCchatCchat", "title": "Chat C", "type": "channel"},
         ]
     )
     db.get_chat_by_ref = AsyncMock(return_value=None)
-    db.get_chat_count = AsyncMock(return_value=3)
     db.get_cached_statistics = AsyncMock(return_value={"total_chats": 3, "total_messages": 100})
     db.get_metadata = AsyncMock(return_value=None)
     db.get_viewer_by_username = AsyncMock(return_value=None)

--- a/tests/test_web_main.py
+++ b/tests/test_web_main.py
@@ -12,6 +12,8 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from conftest import scoped_chat_source
+
 # The module import triggers FastAPI initialization, which may fail on
 # environments with pydantic version mismatches.  Guard the import so
 # pure-function tests still run even when FastAPI cannot be loaded.
@@ -436,6 +438,84 @@ class TestGetSecureCookies(unittest.TestCase):
 
 
 # ============================================================================
+# _chat_scope (the ONE place config + grant become the shared visibility rules)
+# ============================================================================
+
+
+@_skip_unless_web_main
+class TestChatScope(unittest.TestCase):
+    """Two different meanings of "empty" meet in _chat_scope; both are pinned here.
+
+    DISPLAY_CHAT_IDS is operator config: unset means "no filter" and must become
+    ``ids=None``. allowed_accounts / allowed_chat_refs are entitlements: None
+    means unrestricted and the EMPTY set means entitled to nothing, so it must
+    survive as an empty set — collapsing it to None is a total bypass.
+    """
+
+    def setUp(self):
+        self._saved_display = web_main.config.display_chat_ids
+        web_main.config.display_chat_ids = set()
+
+    def tearDown(self):
+        web_main.config.display_chat_ids = self._saved_display
+
+    def test_unset_display_filter_is_no_filter(self):
+        scope = web_main._chat_scope(web_main.UserContext(username="admin", role="master"))
+        self.assertIsNone(scope.ids)
+        self.assertTrue(scope.unrestricted)
+
+    def test_display_filter_becomes_the_id_rule(self):
+        web_main.config.display_chat_ids = {11, 22}
+        scope = web_main._chat_scope(web_main.UserContext(username="admin", role="master"))
+        self.assertEqual(scope.ids, frozenset({11, 22}))
+        self.assertFalse(scope.unrestricted)
+
+    def test_empty_account_grant_is_preserved_as_deny_all(self):
+        scope = web_main._chat_scope(web_main.UserContext(username="v", role="viewer", allowed_accounts=set()))
+        self.assertEqual(scope.accounts, frozenset())
+        self.assertIsNotNone(scope.accounts)
+        self.assertFalse(scope.unrestricted)
+
+    def test_empty_ref_grant_is_preserved_as_deny_all(self):
+        scope = web_main._chat_scope(web_main.UserContext(username="v", role="viewer", allowed_chat_refs=set()))
+        self.assertEqual(scope.refs, frozenset())
+        self.assertIsNotNone(scope.refs)
+        self.assertFalse(scope.unrestricted)
+
+    def test_grants_are_carried_through_verbatim(self):
+        scope = web_main._chat_scope(
+            web_main.UserContext(
+                username="v", role="viewer", allowed_accounts={2}, allowed_chat_refs={"refA00000000000000001"}
+            )
+        )
+        self.assertEqual(scope.accounts, frozenset({2}))
+        self.assertEqual(scope.refs, frozenset({"refA00000000000000001"}))
+
+    def test_chat_visible_delegates_to_the_scope(self):
+        """_chat_visible and the SQL filter must not be two different rules."""
+        user = web_main.UserContext(username="v", role="viewer", allowed_chat_refs={"refA00000000000000001"})
+        scope = web_main._chat_scope(user)
+        for row in (
+            _chat_row(1, "refA00000000000000001"),
+            _chat_row(2, "refB00000000000000002"),
+            _chat_row(3, "refA00000000000000001", account_id=9),
+        ):
+            self.assertEqual(web_main._chat_visible(user, row), scope.allows(row))
+
+    def test_restricted_is_exactly_not_unrestricted(self):
+        cases = [
+            (set(), web_main.UserContext(username="a", role="master"), False),
+            ({7}, web_main.UserContext(username="a", role="master"), True),
+            (set(), web_main.UserContext(username="v", role="viewer", allowed_accounts=set()), True),
+            (set(), web_main.UserContext(username="v", role="viewer", allowed_chat_refs=set()), True),
+            (set(), web_main.UserContext(username="v", role="viewer", allowed_accounts={1}), True),
+        ]
+        for display, user, expected in cases:
+            web_main.config.display_chat_ids = display
+            self.assertEqual(web_main._user_is_restricted(user), expected)
+
+
+# ============================================================================
 # _visible_chat_id_set (access control logic; replaced get_user_chat_ids in v8.0)
 # ============================================================================
 
@@ -454,8 +534,11 @@ class TestVisibleChatIdSet(unittest.IsolatedAsyncioTestCase):
         self._saved_db = web_main.db
         web_main.config.display_chat_ids = set()
         web_main.db = AsyncMock()
-        web_main.db.get_all_chats = AsyncMock(
-            return_value=[
+        # The scope now rides into SQL, so the stand-in must honour it — a mock
+        # returning all four rows regardless would pass even if the grant were
+        # dropped on the floor.
+        web_main.db.get_all_chats, web_main.db.get_chat_count = scoped_chat_source(
+            [
                 _chat_row(5, "refChat0000000000005A"),
                 _chat_row(10, "refChat0000000000010A"),
                 _chat_row(20, "refChat0000000000020A"),

--- a/tests/test_web_main.py
+++ b/tests/test_web_main.py
@@ -537,7 +537,7 @@ class TestVisibleChatIdSet(unittest.IsolatedAsyncioTestCase):
         # The scope now rides into SQL, so the stand-in must honour it — a mock
         # returning all four rows regardless would pass even if the grant were
         # dropped on the floor.
-        web_main.db.get_all_chats, web_main.db.get_chat_count = scoped_chat_source(
+        web_main.db.get_all_chats, web_main.db.get_chat_count, web_main.db.get_visible_chat_ids = scoped_chat_source(
             [
                 _chat_row(5, "refChat0000000000005A"),
                 _chat_row(10, "refChat0000000000010A"),

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -362,7 +362,9 @@ class TestChatsEndpoint(_WebTestBase):
         ]
         # Scope-honouring stand-in: the route no longer filters in Python, so a
         # fixed-list mock would pass even if it stopped passing the grant.
-        self.mock_db.get_all_chats, self.mock_db.get_chat_count = scoped_chat_source(all_chats)
+        self.mock_db.get_all_chats, self.mock_db.get_chat_count, self.mock_db.get_visible_chat_ids = scoped_chat_source(
+            all_chats
+        )
         async with self._client() as client:
             resp = await client.get("/api/chats", cookies={"viewer_auth": token})
         data = resp.json()
@@ -677,7 +679,7 @@ class TestArchivedCountEndpoint(_WebTestBase):
         )
         # Every row here stands for an archived chat, so the count fake needs no
         # is_archived of its own; what it must honour is the scope.
-        self.mock_db.get_all_chats, self.mock_db.get_chat_count = scoped_chat_source(
+        self.mock_db.get_all_chats, self.mock_db.get_chat_count, self.mock_db.get_visible_chat_ids = scoped_chat_source(
             [
                 {"id": 1, "account_id": 1, "ref": "archRefA000000000001A"},
                 {"id": 2, "account_id": 1, "ref": "archRefB000000000002A"},
@@ -718,7 +720,7 @@ class TestStatsEndpoint(_WebTestBase):
         web_main._sessions[token] = web_main.SessionData(
             username="v1", role="viewer", allowed_chat_refs={"statsRefOne000000001A"}
         )
-        self.mock_db.get_all_chats, self.mock_db.get_chat_count = scoped_chat_source(
+        self.mock_db.get_all_chats, self.mock_db.get_chat_count, self.mock_db.get_visible_chat_ids = scoped_chat_source(
             [
                 {"id": 1, "account_id": 1, "ref": "statsRefOne000000001A"},
                 {"id": 2, "account_id": 1, "ref": "statsRefTwo000000002A"},

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -13,6 +13,8 @@ import unittest
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from conftest import scoped_chat_source
+
 try:
     os.environ.setdefault("BACKUP_PATH", tempfile.mkdtemp(prefix="ta_test_wr_"))
     from src.web import main as web_main
@@ -358,7 +360,9 @@ class TestChatsEndpoint(_WebTestBase):
             {"id": 2, "account_id": 1, "ref": "chatRefTwo0000000002A", "title": "Denied", "type": "group"},
             {"id": 3, "account_id": 1, "ref": "chatRefThree00000003A", "title": "Also Allowed", "type": "private"},
         ]
-        self.mock_db.get_all_chats = AsyncMock(return_value=all_chats)
+        # Scope-honouring stand-in: the route no longer filters in Python, so a
+        # fixed-list mock would pass even if it stopped passing the grant.
+        self.mock_db.get_all_chats, self.mock_db.get_chat_count = scoped_chat_source(all_chats)
         async with self._client() as client:
             resp = await client.get("/api/chats", cookies={"viewer_auth": token})
         data = resp.json()
@@ -367,6 +371,48 @@ class TestChatsEndpoint(_WebTestBase):
         self.assertIn(1, chat_ids)
         self.assertIn(3, chat_ids)
         self.assertNotIn(2, chat_ids)
+
+    async def test_restricted_chat_list_is_bounded_and_scoped_in_sql(self):
+        """The restricted branch must never ask for the unbounded chat list.
+
+        This is the regression guard for the production incident: /api/chats
+        used to call get_all_chats() with NO limit for any restricted principal
+        and slice in Python afterwards, so a viewer entitled to one chat
+        materialised every chat row in the archive. The route must hand the
+        adapter the page bounds AND the grant, exactly as it does for an
+        unrestricted principal.
+        """
+        web_main.AUTH_ENABLED = True
+        token = "bt"
+        web_main._sessions[token] = web_main.SessionData(
+            username="v1", role="viewer", allowed_chat_refs={"chatRefOne0000000001A"}
+        )
+        web_main.config.display_chat_ids = {7}
+        calls = []
+
+        async def recording_get_all_chats(
+            limit=None, offset=0, search=None, archived=None, folder_id=None, *, account_id=None, scope=None
+        ):
+            calls.append({"limit": limit, "offset": offset, "scope": scope})
+            return []
+
+        self.mock_db.get_all_chats = recording_get_all_chats
+        self.mock_db.get_chat_count = AsyncMock(return_value=0)
+        async with self._client() as client:
+            resp = await client.get("/api/chats?limit=25&offset=50", cookies={"viewer_auth": token})
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(calls), 1)
+        # limit=None here would mean "load the whole archive" — the bug.
+        self.assertEqual(calls[0]["limit"], 25)
+        self.assertEqual(calls[0]["offset"], 50)
+        scope = calls[0]["scope"]
+        self.assertIsNotNone(scope)
+        self.assertEqual(scope.refs, frozenset({"chatRefOne0000000001A"}))
+        self.assertEqual(scope.ids, frozenset({7}))
+        self.assertIsNone(scope.accounts)
+        # The count is taken under the SAME scope, or total and the page disagree.
+        self.assertEqual(self.mock_db.get_chat_count.call_args.kwargs["scope"], scope)
 
     async def test_chats_search_parameter(self):
         """get_chats passes search parameter to db."""
@@ -629,8 +675,10 @@ class TestArchivedCountEndpoint(_WebTestBase):
             role="viewer",
             allowed_chat_refs={"archRefA000000000001A", "archRefB000000000002A", "archRefC000000000003A"},
         )
-        self.mock_db.get_all_chats = AsyncMock(
-            return_value=[
+        # Every row here stands for an archived chat, so the count fake needs no
+        # is_archived of its own; what it must honour is the scope.
+        self.mock_db.get_all_chats, self.mock_db.get_chat_count = scoped_chat_source(
+            [
                 {"id": 1, "account_id": 1, "ref": "archRefA000000000001A"},
                 {"id": 2, "account_id": 1, "ref": "archRefB000000000002A"},
                 {"id": 99, "account_id": 1, "ref": "archRefZ000000000099A"},
@@ -670,8 +718,8 @@ class TestStatsEndpoint(_WebTestBase):
         web_main._sessions[token] = web_main.SessionData(
             username="v1", role="viewer", allowed_chat_refs={"statsRefOne000000001A"}
         )
-        self.mock_db.get_all_chats = AsyncMock(
-            return_value=[
+        self.mock_db.get_all_chats, self.mock_db.get_chat_count = scoped_chat_source(
+            [
                 {"id": 1, "account_id": 1, "ref": "statsRefOne000000001A"},
                 {"id": 2, "account_id": 1, "ref": "statsRefTwo000000002A"},
             ]

--- a/uv.lock
+++ b/uv.lock
@@ -1192,7 +1192,7 @@ wheels = [
 
 [[package]]
 name = "telegram-archive"
-version = "8.0.1"
+version = "8.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },

--- a/uv.lock
+++ b/uv.lock
@@ -1248,7 +1248,7 @@ requires-dist = [
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.1" },
     { name = "psycopg2-binary", specifier = ">=2.9.9" },
     { name = "py-vapid", specifier = ">=1.9.4" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.26.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "python-dotenv", specifier = ">=1.0.1" },


### PR DESCRIPTION
Reported as "the viewer loads forever on my phone". Login returned 200, then `GET /api/chats` never came back. Two independent faults, one of which made the other fatal.

## 1. A declared index that was not there

`get_all_chats` reads each chat's last message through a correlated `MAX(messages.date)` subquery — one seek per chat against `idx_messages_chat_date_desc`, which is what makes listing chats cost the same on a large archive as a small one. That index was **absent** from the affected database, so every listed chat scanned its own messages instead. Five of the viewer's own chat-list queries were found running concurrently, between 19 and 35 minutes each, stacking until nothing else got served.

The index has been declared in `models.py` since migration `002`, which is precisely why it was never suspected. `Base.metadata.create_all(checkfirst=True)` — how `src/db/migrate.py` builds the target schema when moving SQLite to PostgreSQL — skips a table **and every index on it** once the table exists; `checkfirst` is per-table, not per-index. An index added to `models.py` after a database was created therefore never appears in it, and the migration that would have created it is skipped too, because `entrypoint.sh` stamped that database at a later revision. `tests/test_schema_parity.py` compares the ORM against a *freshly migrated* database, so it cannot see drift that only exists in databases with history.

Migration `024` recreates `idx_messages_chat_date_desc` and `idx_messages_chat_pinned` wherever they are missing, names them explicitly rather than reflecting `models.py` (a migration must keep meaning what it meant when written), and is a no-op on databases that already have them.

Measured on the archive that reported it, after restoring the index by hand: **the chat-list query went from over twenty minutes to 39 ms**, and a real restricted login now returns its chat list in 0.16 s.

## 2. Restricted viewers read the whole archive, four times per page

Entitlements were applied in Python after the fact. `/api/chats`, `/api/folders`, `/api/stats` and `/api/archived/count` each called `get_all_chats()` unbounded and then filtered — so the *narrower* a viewer's grant, the more work their page cost, and a restricted account paid an **18× penalty** over an unrestricted one on the same page load.

Visibility now compiles to SQL from a single `ChatScope` definition that also serves the per-row check, so the list filter and `_chat_visible` cannot drift apart. A viewer entitled to one chat touches **one row instead of 4,784** — 15,837 → 7 shared buffers, 2,262× less I/O, 4,784 → 1 correlated-subquery executions. An empty grant emits an explicit `false()` rather than relying on how a dialect renders `IN ()`; access control should not rest on a rendering detail.

## Evidence

- **Equivalence, using origin/main's own routes as the oracle:** 546 grant configurations (6 `DISPLAY_CHAT_IDS` × 7 account grants × 13 ref grants) × 11 query shapes = **6,006 comparisons**, including shared chats that exist under both accounts and refs belonging to another account. Wider: 0. Narrower: 0. Differing totals or paging: 0. Unrestricted access issues byte-for-byte the same SQL as before.
- **The comparison can fail:** a mutant dropping the `DISPLAY_CHAT_IDS` rule from the SQL half reports 695 wider results and 108 narrower.
- **Migration 024 watched red first:** a mutant that creates nothing fails 3 tests; a mutant that loses the `DESC` on the date column fails the ordering test specifically — that ordering is load-bearing, and SQLite reflection cannot see it.
- **Suite:** 3,347 passed, 2 skipped (both pre-existing dialect halves), 332 subtests, on SQLite and PostgreSQL 18. Ruff check and format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added entitlement-based chat visibility filtering across chat lists, archived counts, and related views.
  * Added consistent pagination, totals, and “has more” results for restricted chat access.
* **Bug Fixes**
  * Restored missing database indexes while preserving healthy configurations.
  * Empty access grants now correctly show no chats.
* **Release**
  * Updated the application version to 8.0.2.
  * Added changelog details for the release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->