### PR TITLE
fix(realtime): stop dropping live updates for chats two accounts share

### DIFF
--- a/src/listener.py
+++ b/src/listener.py
@@ -541,7 +541,7 @@ class TelegramListener:
                 return
 
             chat_id = data.get("chat_id", 0)
-            await self._notifier.notify(nt, chat_id, data)
+            await self._notifier.notify(nt, chat_id, data, account_id=self.account_id)
         except Exception as e:
             logger.debug(f"Failed to send notification: {e}")
 
@@ -1258,7 +1258,9 @@ class TelegramListener:
                         "username": sender_user["username"] if sender_user else None,
                         "media": ws_media,
                     }
-                    await self._notifier.notify(NotificationType.NEW_MESSAGE, chat_id, {"message": ws_message})
+                    await self._notifier.notify(
+                        NotificationType.NEW_MESSAGE, chat_id, {"message": ws_message}, account_id=self.account_id
+                    )
 
                 # Log the new message (no chat_id/msg_id/text — PII)
                 media_indicator = f" [{media_type}]" if media_type else ""

--- a/src/realtime.py
+++ b/src/realtime.py
@@ -122,7 +122,7 @@ class RealtimeNotifier:
 
     async def notify(
         self, notification_type: NotificationType, chat_id: int, data: dict, *, account_id: int | None = None
-    ):
+    ) -> None:
         """
         Send a notification.
 

--- a/src/realtime.py
+++ b/src/realtime.py
@@ -120,7 +120,9 @@ class RealtimeNotifier:
 
         self._initialized = True
 
-    async def notify(self, notification_type: NotificationType, chat_id: int, data: dict):
+    async def notify(
+        self, notification_type: NotificationType, chat_id: int, data: dict, *, account_id: int | None = None
+    ):
         """
         Send a notification.
 
@@ -128,6 +130,10 @@ class RealtimeNotifier:
             notification_type: Type of notification (new_message, edit, delete, etc.)
             chat_id: The chat ID associated with the notification
             data: Additional data (message content, etc.)
+            account_id: accounts.id of the capturing account. Since 8.0 a chat id
+                alone is ambiguous once two accounts share the chat (#315), so the
+                viewer scopes its lookup to (account_id, chat_id); None (legacy
+                senders) keeps the viewer's drop-on-ambiguity guard.
         """
         if not self._initialized:
             await self.init()
@@ -137,7 +143,7 @@ class RealtimeNotifier:
         _MAX_NOTIFY_TEXT = 500
         data = _truncate_notify_data(data, _MAX_NOTIFY_TEXT)
 
-        payload = {"type": notification_type.value, "chat_id": chat_id, "data": data}
+        payload = {"type": notification_type.value, "chat_id": chat_id, "account_id": account_id, "data": data}
 
         try:
             if self._is_postgresql:

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -3514,7 +3514,7 @@ async def websocket_endpoint(websocket: WebSocket):
 # ============================================================================
 
 
-async def broadcast_new_message(chat_id: int, message: dict, account_id: int | None = None):
+async def broadcast_new_message(chat_id: int, message: dict, account_id: int | None = None) -> None:
     """Broadcast a new message to subscribed clients (frames are ref-addressed)."""
     chat = await _broadcast_chat_row(chat_id, account_id)
     if chat is None:
@@ -3524,7 +3524,7 @@ async def broadcast_new_message(chat_id: int, message: dict, account_id: int | N
 
 async def broadcast_message_edit(
     chat_id: int, message_id: int, new_text: str, edit_date: str, account_id: int | None = None
-):
+) -> None:
     """Broadcast a message edit to subscribed clients (frames are ref-addressed)."""
     chat = await _broadcast_chat_row(chat_id, account_id)
     if chat is None:

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -283,31 +283,34 @@ push_manager: PushNotificationManager | None = None
 
 # The realtime/push side resolves a writer-side chat id to its row (ref, account,
 # title) once per event; a short TTL keeps a busy chat from re-querying per event.
-_broadcast_chat_cache: dict[int, tuple[float, dict | None]] = {}
+_broadcast_chat_cache: dict[tuple[int | None, int], tuple[float, dict | None]] = {}
 _BROADCAST_CHAT_CACHE_TTL_SECONDS = 60
 
 
-async def _broadcast_chat_row(chat_id: int) -> dict | None:
+async def _broadcast_chat_row(chat_id: int, account_id: int | None = None) -> dict | None:
     """Chat row for a realtime event's chat id, or None when it cannot be addressed.
 
     The writer side (listener/backup) speaks chat ids; every outward frame and
-    push payload speaks refs. An id that resolves to no row — or ambiguously,
-    once a second account shares it (phase 5) — drops the event rather than
-    emit a frame that names a chat id.
+    push payload speaks refs. Since 8.0 two accounts can share a chat id, so
+    the payload's capturing account (#315) scopes the lookup to the row that
+    was actually written. A legacy payload without account_id keeps the old
+    guard: an id that resolves to no row — or ambiguously — drops the event
+    rather than emit a frame that names a chat id.
     """
     if not db:
         return None
-    cached = _broadcast_chat_cache.get(chat_id)
+    cache_key = (account_id, chat_id)
+    cached = _broadcast_chat_cache.get(cache_key)
     if cached is not None and time.monotonic() - cached[0] <= _BROADCAST_CHAT_CACHE_TTL_SECONDS:
         return cached[1]
     try:
-        chat = await db.get_chat_by_id(chat_id)
+        chat = await db.get_chat_by_id(chat_id, account_id=account_id)
     except Exception as e:
         logger.warning(f"Realtime chat resolution failed ({type(e).__name__}); dropping event")
         return None
     if chat is not None and not chat.get("ref"):
         chat = None
-    _broadcast_chat_cache[chat_id] = (time.monotonic(), chat)
+    _broadcast_chat_cache[cache_key] = (time.monotonic(), chat)
     return chat
 
 
@@ -315,6 +318,12 @@ async def handle_realtime_notification(payload: dict):
     """Handle real-time notifications and broadcast to WebSocket clients + push notifications."""
     notification_type = payload.get("type")
     chat_id = payload.get("chat_id")
+    # The capturing account (in the payload since #315). bool is an int
+    # subclass, so exclude it explicitly; any non-int falls back to the
+    # legacy unscoped lookup and its drop-on-ambiguity guard.
+    account_id = payload.get("account_id")
+    if not isinstance(account_id, int) or isinstance(account_id, bool):
+        account_id = None
     data = payload.get("data", {})
 
     # Check if this chat is allowed (respects DISPLAY_CHAT_IDS restriction)
@@ -322,7 +331,7 @@ async def handle_realtime_notification(payload: dict):
         # This viewer is restricted to specific chats, ignore notifications for other chats
         return
 
-    chat = await _broadcast_chat_row(chat_id)
+    chat = await _broadcast_chat_row(chat_id, account_id)
     if chat is None:
         return
     chat_ref = chat["ref"]
@@ -3505,17 +3514,19 @@ async def websocket_endpoint(websocket: WebSocket):
 # ============================================================================
 
 
-async def broadcast_new_message(chat_id: int, message: dict):
+async def broadcast_new_message(chat_id: int, message: dict, account_id: int | None = None):
     """Broadcast a new message to subscribed clients (frames are ref-addressed)."""
-    chat = await _broadcast_chat_row(chat_id)
+    chat = await _broadcast_chat_row(chat_id, account_id)
     if chat is None:
         return
     await ws_manager.broadcast_to_chat(chat, {"type": "new_message", "chat_ref": chat["ref"], "message": message})
 
 
-async def broadcast_message_edit(chat_id: int, message_id: int, new_text: str, edit_date: str):
+async def broadcast_message_edit(
+    chat_id: int, message_id: int, new_text: str, edit_date: str, account_id: int | None = None
+):
     """Broadcast a message edit to subscribed clients (frames are ref-addressed)."""
-    chat = await _broadcast_chat_row(chat_id)
+    chat = await _broadcast_chat_row(chat_id, account_id)
     if chat is None:
         return
     await ws_manager.broadcast_to_chat(
@@ -3531,10 +3542,14 @@ async def broadcast_message_edit(chat_id: int, message_id: int, new_text: str, e
 
 
 async def broadcast_message_delete(
-    chat_id: int, message_id: int, deletion_mode: str = "hard", deleted_at: str | None = None
+    chat_id: int,
+    message_id: int,
+    deletion_mode: str = "hard",
+    deleted_at: str | None = None,
+    account_id: int | None = None,
 ) -> None:
     """Broadcast a message deletion to subscribed clients (frames are ref-addressed)."""
-    chat = await _broadcast_chat_row(chat_id)
+    chat = await _broadcast_chat_row(chat_id, account_id)
     if chat is None:
         return
     await ws_manager.broadcast_to_chat(

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -2562,7 +2562,7 @@ class TestRealtimeMediaAttributes:
 class TestNotifyUpdateCapturingAccount:
     """#315: _notify_update forwards the account whose rows were just written."""
 
-    async def test_notify_update_passes_capturing_account(self):
+    async def test_notify_update_passes_capturing_account(self) -> None:
         from src.realtime import NotificationType
 
         listener = TelegramListener(_make_config(), _make_db(), account_id=7)

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -971,7 +971,7 @@ class TestNotifyUpdate:
         listener._notifier = notifier
 
         await listener._notify_update("edit", {"chat_id": 123})
-        notifier.notify.assert_called_once_with(NotificationType.EDIT, 123, {"chat_id": 123})
+        notifier.notify.assert_called_once_with(NotificationType.EDIT, 123, {"chat_id": 123}, account_id=1)
 
     async def test_sends_delete_notification(self):
         """Sends delete notification with correct type mapping."""
@@ -982,7 +982,7 @@ class TestNotifyUpdate:
         listener._notifier = notifier
 
         await listener._notify_update("delete", {"chat_id": 456})
-        notifier.notify.assert_called_once_with(NotificationType.DELETE, 456, {"chat_id": 456})
+        notifier.notify.assert_called_once_with(NotificationType.DELETE, 456, {"chat_id": 456}, account_id=1)
 
     async def test_sends_new_message_notification(self):
         """Sends new_message notification with correct type mapping."""
@@ -993,7 +993,7 @@ class TestNotifyUpdate:
         listener._notifier = notifier
 
         await listener._notify_update("new_message", {"chat_id": 789})
-        notifier.notify.assert_called_once_with(NotificationType.NEW_MESSAGE, 789, {"chat_id": 789})
+        notifier.notify.assert_called_once_with(NotificationType.NEW_MESSAGE, 789, {"chat_id": 789}, account_id=1)
 
     async def test_sends_pin_notification(self):
         """Sends pin notification with correct type mapping."""
@@ -1004,7 +1004,7 @@ class TestNotifyUpdate:
         listener._notifier = notifier
 
         await listener._notify_update("pin", {"chat_id": 111})
-        notifier.notify.assert_called_once_with(NotificationType.PIN, 111, {"chat_id": 111})
+        notifier.notify.assert_called_once_with(NotificationType.PIN, 111, {"chat_id": 111}, account_id=1)
 
     async def test_unknown_type_returns_without_sending(self):
         """Unknown notification type logs warning and returns without sending."""
@@ -1034,7 +1034,7 @@ class TestNotifyUpdate:
         listener._notifier = notifier
 
         await listener._notify_update("edit", {})
-        notifier.notify.assert_called_once_with(NotificationType.EDIT, 0, {})
+        notifier.notify.assert_called_once_with(NotificationType.EDIT, 0, {}, account_id=1)
 
 
 # ===========================================================================
@@ -2557,3 +2557,17 @@ class TestRealtimeMediaAttributes:
         media_data = db.insert_media.call_args[0][0]
         assert media_data["file_size"] == 17
         assert media_data["duration"] == 3
+
+
+class TestNotifyUpdateCapturingAccount:
+    """#315: _notify_update forwards the account whose rows were just written."""
+
+    async def test_notify_update_passes_capturing_account(self):
+        from src.realtime import NotificationType
+
+        listener = TelegramListener(_make_config(), _make_db(), account_id=7)
+        notifier = AsyncMock()
+        listener._notifier = notifier
+
+        await listener._notify_update("edit", {"chat_id": 123})
+        notifier.notify.assert_called_once_with(NotificationType.EDIT, 123, {"chat_id": 123}, account_id=7)

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -970,3 +970,29 @@ class TestListenPostgres:
 
         with patch.dict("sys.modules", {"asyncpg": mock_asyncpg}):
             await listener._listen_postgres()
+
+
+class TestNotifierAccountIdPayload:
+    """#315: the payload names the capturing account so the viewer can scope its lookup."""
+
+    async def test_notify_includes_account_id(self):
+        mock_db = MagicMock()
+        mock_db._is_sqlite = False
+        notifier = RealtimeNotifier(db_manager=mock_db)
+        await notifier.init()
+
+        with patch.object(notifier, "_notify_postgres", new_callable=AsyncMock) as mock_pg:
+            await notifier.notify(NotificationType.NEW_MESSAGE, 123, {}, account_id=7)
+
+        assert mock_pg.call_args[0][0]["account_id"] == 7
+
+    async def test_notify_defaults_account_id_to_none(self):
+        """Legacy senders: the key is present and None, keeping the viewer ambiguity guard."""
+        notifier = RealtimeNotifier()
+        with patch.dict(os.environ, {"DB_TYPE": "sqlite"}, clear=True):
+            await notifier.init()
+
+        with patch.object(notifier, "_notify_http", new_callable=AsyncMock) as mock_http:
+            await notifier.notify(NotificationType.PIN, 789, {"msg_id": 5})
+
+        assert mock_http.call_args[0][0]["account_id"] is None

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -975,7 +975,7 @@ class TestListenPostgres:
 class TestNotifierAccountIdPayload:
     """#315: the payload names the capturing account so the viewer can scope its lookup."""
 
-    async def test_notify_includes_account_id(self):
+    async def test_notify_includes_account_id(self) -> None:
         mock_db = MagicMock()
         mock_db._is_sqlite = False
         notifier = RealtimeNotifier(db_manager=mock_db)
@@ -986,7 +986,7 @@ class TestNotifierAccountIdPayload:
 
         assert mock_pg.call_args[0][0]["account_id"] == 7
 
-    async def test_notify_defaults_account_id_to_none(self):
+    async def test_notify_defaults_account_id_to_none(self) -> None:
         """Legacy senders: the key is present and None, keeping the viewer ambiguity guard."""
         notifier = RealtimeNotifier()
         with patch.dict(os.environ, {"DB_TYPE": "sqlite"}, clear=True):

--- a/tests/test_web_main.py
+++ b/tests/test_web_main.py
@@ -1116,7 +1116,7 @@ class TestSharedChatRealtimeResolution(unittest.IsolatedAsyncioTestCase):
     class _Ambiguous(Exception):
         """Stands in for sqlalchemy MultipleResultsFound (handler catches Exception)."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self._saved_display = web_main.config.display_chat_ids
         self._saved_push = web_main.push_manager
         self._saved_db = web_main.db
@@ -1128,7 +1128,7 @@ class TestSharedChatRealtimeResolution(unittest.IsolatedAsyncioTestCase):
             (2, 42): _chat_row(42, "refShared2000000000042", account_id=2),
         }
 
-        async def scoped_lookup(chat_id, *, account_id=None, **kwargs):
+        async def scoped_lookup(chat_id: int, *, account_id: int | None = None, **kwargs: object) -> dict | None:
             if account_id is None:
                 raise self._Ambiguous("chat id is shared by two accounts")
             return rows.get((account_id, chat_id))
@@ -1136,13 +1136,13 @@ class TestSharedChatRealtimeResolution(unittest.IsolatedAsyncioTestCase):
         web_main.db.get_chat_by_id = AsyncMock(side_effect=scoped_lookup)
         web_main._broadcast_chat_cache.clear()
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         web_main.config.display_chat_ids = self._saved_display
         web_main.push_manager = self._saved_push
         web_main.db = self._saved_db
         web_main._broadcast_chat_cache.clear()
 
-    async def test_scoped_payload_resolves_the_capturing_accounts_row(self):
+    async def test_scoped_payload_resolves_the_capturing_accounts_row(self) -> None:
         with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock) as mock_bc:
             await web_main.handle_realtime_notification(
                 {"type": "new_message", "chat_id": 42, "account_id": 1, "data": {"message": {"id": 1}}}
@@ -1152,7 +1152,7 @@ class TestSharedChatRealtimeResolution(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(chat["account_id"], 1)
         self.assertEqual(frame["chat_ref"], "refShared1000000000042")
 
-    async def test_each_account_gets_its_own_ref_not_the_cached_other(self):
+    async def test_each_account_gets_its_own_ref_not_the_cached_other(self) -> None:
         """The cache must key on (account_id, chat_id), or account 2 gets account 1 refs."""
         with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock) as mock_bc:
             await web_main.handle_realtime_notification(
@@ -1164,14 +1164,14 @@ class TestSharedChatRealtimeResolution(unittest.IsolatedAsyncioTestCase):
         refs = [call.args[1]["chat_ref"] for call in mock_bc.await_args_list]
         self.assertEqual(refs, ["refShared1000000000042", "refShared2000000000042"])
 
-    async def test_legacy_payload_without_account_still_drops_ambiguous_ids(self):
+    async def test_legacy_payload_without_account_still_drops_ambiguous_ids(self) -> None:
         with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock) as mock_bc:
             await web_main.handle_realtime_notification(
                 {"type": "new_message", "chat_id": 42, "data": {"message": {"id": 1}}}
             )
         mock_bc.assert_not_awaited()
 
-    async def test_non_integer_account_id_is_treated_as_legacy(self):
+    async def test_non_integer_account_id_is_treated_as_legacy(self) -> None:
         for garbage in ("1", True, 1.5, [1]):
             with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock) as mock_bc:
                 await web_main.handle_realtime_notification(

--- a/tests/test_web_main.py
+++ b/tests/test_web_main.py
@@ -1096,3 +1096,85 @@ class TestSecurityHelpers(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ============================================================================
+# handle_realtime_notification — shared chat id across accounts (#315)
+# ============================================================================
+
+
+@_skip_unless_web_main
+class TestSharedChatRealtimeResolution(unittest.IsolatedAsyncioTestCase):
+    """#315: a chat id two accounts share resolves per capturing account.
+
+    Before the fix the unscoped lookup raised MultipleResultsFound and every
+    event for the shared chat was dropped for everyone. The payload now names
+    the capturing account, the lookup is scoped to it, and only a legacy
+    payload without account_id keeps the drop-on-ambiguity guard.
+    """
+
+    class _Ambiguous(Exception):
+        """Stands in for sqlalchemy MultipleResultsFound (handler catches Exception)."""
+
+    def setUp(self):
+        self._saved_display = web_main.config.display_chat_ids
+        self._saved_push = web_main.push_manager
+        self._saved_db = web_main.db
+        web_main.config.display_chat_ids = set()
+        web_main.push_manager = None
+        web_main.db = AsyncMock()
+        rows = {
+            (1, 42): _chat_row(42, "refShared1000000000042", account_id=1),
+            (2, 42): _chat_row(42, "refShared2000000000042", account_id=2),
+        }
+
+        async def scoped_lookup(chat_id, *, account_id=None, **kwargs):
+            if account_id is None:
+                raise self._Ambiguous("chat id is shared by two accounts")
+            return rows.get((account_id, chat_id))
+
+        web_main.db.get_chat_by_id = AsyncMock(side_effect=scoped_lookup)
+        web_main._broadcast_chat_cache.clear()
+
+    def tearDown(self):
+        web_main.config.display_chat_ids = self._saved_display
+        web_main.push_manager = self._saved_push
+        web_main.db = self._saved_db
+        web_main._broadcast_chat_cache.clear()
+
+    async def test_scoped_payload_resolves_the_capturing_accounts_row(self):
+        with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock) as mock_bc:
+            await web_main.handle_realtime_notification(
+                {"type": "new_message", "chat_id": 42, "account_id": 1, "data": {"message": {"id": 1}}}
+            )
+        mock_bc.assert_awaited_once()
+        chat, frame = mock_bc.call_args[0]
+        self.assertEqual(chat["account_id"], 1)
+        self.assertEqual(frame["chat_ref"], "refShared1000000000042")
+
+    async def test_each_account_gets_its_own_ref_not_the_cached_other(self):
+        """The cache must key on (account_id, chat_id), or account 2 gets account 1 refs."""
+        with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock) as mock_bc:
+            await web_main.handle_realtime_notification(
+                {"type": "new_message", "chat_id": 42, "account_id": 1, "data": {"message": {"id": 1}}}
+            )
+            await web_main.handle_realtime_notification(
+                {"type": "new_message", "chat_id": 42, "account_id": 2, "data": {"message": {"id": 1}}}
+            )
+        refs = [call.args[1]["chat_ref"] for call in mock_bc.await_args_list]
+        self.assertEqual(refs, ["refShared1000000000042", "refShared2000000000042"])
+
+    async def test_legacy_payload_without_account_still_drops_ambiguous_ids(self):
+        with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock) as mock_bc:
+            await web_main.handle_realtime_notification(
+                {"type": "new_message", "chat_id": 42, "data": {"message": {"id": 1}}}
+            )
+        mock_bc.assert_not_awaited()
+
+    async def test_non_integer_account_id_is_treated_as_legacy(self):
+        for garbage in ("1", True, 1.5, [1]):
+            with patch.object(web_main.ws_manager, "broadcast_to_chat", new_callable=AsyncMock) as mock_bc:
+                await web_main.handle_realtime_notification(
+                    {"type": "new_message", "chat_id": 42, "account_id": garbage, "data": {"message": {"id": 1}}}
+                )
+            mock_bc.assert_not_awaited()


### PR DESCRIPTION
## Summary

- Since 8.0 a chat id can belong to two accounts, and the realtime handler resolved events by bare id: `get_chat_by_id` raised `MultipleResultsFound` and the frame was dropped — **every chat both accounts are in got no live updates at all, for either account**, until the next page load (#315). On a real dual-account install this fires steadily on shared groups.
- The capturing account is known at emit time (each listener resolves `self.account_id` before any event handler registers), so the payload now names it, and the viewer scopes its lookup to `(account_id, chat_id)` — the chats primary key, so the lookup cannot be ambiguous. The 60s resolution cache keys on the same pair, so one account's ref is never served to the other account's subscribers.
- Live capture is dual-writer: each account's listener receives shared-chat events independently and writes its own rows (there is no live-path claiming). Scoping by capturing account is therefore complete — each account's subscribers get exactly their account's frames, ref-addressed as before. No cross-account fan-out, no duplicate frames.
- A payload without a usable `account_id` — an older backup container, or garbage arriving via the SQLite HTTP webhook — keeps the old drop-on-ambiguity guard, so a mixed-version deploy degrades to exactly the pre-fix behavior instead of ever emitting a frame that names a chat id.

Fixes #315

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change

## Database Changes

- [x] No database changes

## Data Consistency Checklist

- [ ] All `chat_id` values use marked format (via `_get_marked_id()`) — n/a, the payload's `chat_id` was already marked by the producer; this change adds no id read or write
- [ ] All datetime values pass through `_strip_tz()` before DB operations — n/a, no datetime values touched
- [ ] INSERT and UPDATE operations handle the same fields identically — n/a, no INSERT/UPDATE paths touched

## Testing

- [x] Tests pass locally (`python -m pytest tests/`) — 3246 passed, 110 skipped, 0 failed (84s)
- [x] Linting passes (`ruff check .`)
- [x] Formatting passes (`ruff format --check .`)
- [ ] Manually tested in development environment — unit-verified instead: payload schema tests (account_id present; None default for legacy senders), producer forwarding test, and a shared-id consumer suite covering scoped resolution per account, cache isolation between accounts (fails if the cache keys on bare chat_id), legacy-payload drop, and non-int `account_id` treated as legacy. Mutation check: reverting the consumer to the unscoped call turns the two scoped tests red. Production verification on a real dual-account install planned at the next deploy.

## Security Checklist

- [x] No secrets or credentials committed
- [x] User input properly validated/sanitized — `account_id` from the payload is type-checked (bool/str/float rejected) before it reaches the DB layer
- [x] Authentication/authorization properly checked — frames remain ref-addressed and entitlement-filtered per subscriber in `broadcast_to_chat`; the drop guard for unscoped ambiguous ids is preserved

## Deployment Notes

- Ship backup container and viewer together to get the fix; ordering is safe in both directions (an old viewer ignores the new payload key; a new viewer treats old payloads as legacy and keeps the drop guard). No migration, no image changes beyond code.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Realtime chat notifications now support account-specific identification.
  * New, edited, deleted, and pinned message events are routed to the correct account when account details are available.
  * Existing notification behavior remains compatible when account information is omitted.

* **Bug Fixes**
  * Prevented ambiguous chat updates when the same chat ID exists across multiple accounts.
  * Improved account-specific cache isolation.
  * Invalid or incomplete account information is safely excluded from broadcasts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->