### PR TITLE
release: 8.0.3 - shared chats get live updates again

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [8.0.3] - 2026-08-19
+
+### Fixed
+
+- **Chats that two accounts share receive live updates again.** Since 8.0 a chat id can belong to two accounts, and the realtime path resolved each event by bare chat id: once a second account shared the chat, the lookup became ambiguous and the viewer dropped the frame. Dropping was the right refusal — a frame naming a chat a subscriber is not entitled to would leak it — but the consequence was that every shared chat went realtime-dead for everyone, steadily, until the next page load. Events now carry the account that captured them, the viewer resolves the (account, chat) pair — the primary key, which cannot be ambiguous — and the short-lived resolution cache keys on the same pair, so one account's ref is never served to the other account's subscribers. A payload without the account (an older backup container mid-upgrade) keeps the old drop-on-ambiguity guard, so a mixed-version deploy degrades to the previous behavior instead of ever leaking. ([#315](https://github.com/GeiserX/Telegram-Archive/issues/315), [#317](https://github.com/GeiserX/Telegram-Archive/pull/317))
+
+### Changed
+
+- **Dropped `idx_messages_chat_id`, an index no query plans against.** It shipped with the initial schema and is a strict prefix of two later composites — `(chat_id, id)` and `(chat_id, date DESC)` — either of which serves a bare chat-id predicate. Measured on two live archives, including a 1.78M-row production instance: zero steady-state scans; the only period it ever carried plans was while the composite indexes were accidentally absent, which is exactly the drift migration `024` now heals on its own. Migration `025` drops it where present, saving one index write per archived message plus its disk footprint, and `downgrade()` restores it. Contributed by [@jordanfelle](https://github.com/jordanfelle), with the `pg_stat_user_indexes` evidence to prove it. ([#316](https://github.com/GeiserX/Telegram-Archive/pull/316))
+
 ## [8.0.2] - 2026-08-18
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "8.0.2"
+version = "8.0.3"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "8.0.2"
+__version__ = "8.0.3"

--- a/uv.lock
+++ b/uv.lock
@@ -1192,7 +1192,7 @@ wheels = [
 
 [[package]]
 name = "telegram-archive"
-version = "8.0.2"
+version = "8.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- On a dual-account install, any chat both accounts are in received no live updates at all — for either account — because the realtime path resolved events by bare chat id and dropped every frame the moment that id became ambiguous. 8.0.3 ships the fix: events carry their capturing account and the viewer resolves the unambiguous (account, chat) pair, with the legacy drop-guard kept for mixed-version deploys. ([#315](https://github.com/GeiserX/Telegram-Archive/issues/315), [#317](https://github.com/GeiserX/Telegram-Archive/pull/317))
- Also carries [@jordanfelle](https://github.com/jordanfelle)'s migration `025`, dropping the redundant `idx_messages_chat_id` — zero steady-state scans on two live archives; one less index write per archived message. ([#316](https://github.com/GeiserX/Telegram-Archive/pull/316))
- Version declarations (`pyproject.toml`, `src/__init__.py`, `uv.lock`) and the changelog; no code changes beyond what is already on main.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Infrastructure/CI change

## Database Changes

- [x] No database changes — migration `025` is already on main via #316; this PR only cuts the release that carries it

## Data Consistency Checklist

- [ ] All `chat_id` values use marked format (via `_get_marked_id()`) — n/a, release metadata only
- [ ] All datetime values pass through `_strip_tz()` before DB operations — n/a
- [ ] INSERT and UPDATE operations handle the same fields identically — n/a

## Testing

- [x] Tests pass locally (`python -m pytest tests/`) — full suite verified green on both fixes as they merged (3246 passed on #317's branch; CI green on #316)
- [x] Linting passes (`ruff check .`) — no Python changes beyond the version string
- [x] Formatting passes (`ruff format --check .`)
- [ ] Manually tested in development environment — production verification happens at the deploy that follows the tag

## Security Checklist

- [x] No secrets or credentials committed
- [x] User input properly validated/sanitized — n/a
- [x] Authentication/authorization properly checked — n/a

## Deployment Notes

- Tag `v8.0.3` after merge; CI publishes the release and both images. Deploys pick up migration `025` (guarded drop, no-op where the index is already absent) via the normal `alembic upgrade head` at startup. Backup container and viewer should ship together for the realtime fix; ordering is safe in both directions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where new messages were not updating reliably in shared chats in real time.

* **Documentation**
  * Added release notes for version 8.0.3, including the realtime chat update fix.

* **Release**
  * Updated the application version to 8.0.3.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->