### PR TITLE
release: 8.1.0 - each account captures its own scope

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [8.1.0] - 2026-08-19
+
+### Added
+
+- **Capture filters resolve per account.** 8.0 made credentials per-account but left every capture filter global, so an account added to a whitelisted install captured only the intersection of that whitelist with its own dialogs — observed shrinking a real second account from 2,057 chats to 312, silently. Every filter can now be overridden per account the way sessions already resolve: `TG_ACCOUNT_<N>_CHAT_IDS`, `TG_ACCOUNT_<N>_CHAT_TYPES`, the include/exclude lists (global and per-type), `TG_ACCOUNT_<N>_PRIORITY_CHAT_IDS` and `TG_ACCOUNT_<N>_SKIP_MEDIA_CHAT_IDS` — the indexed variable wins for that account, the global one is the fallback, so an install without overrides behaves exactly as before. An empty indexed value inherits (Compose's `${VAR:-}` idiom injects empty strings, and silently clearing a whitelist would widen capture); the literal token `none` is the explicit-empty override, so `TG_ACCOUNT_2_CHAT_IDS=none` runs account 2 type-based while account 1 keeps its whitelist. Startup logs each account's effective scope as counts, so an inherited filter is visible on day one. ([#313](https://github.com/GeiserX/Telegram-Archive/issues/313), [#319](https://github.com/GeiserX/Telegram-Archive/pull/319))
+
+### Fixed
+
+- **Per-account state no longer collides between accounts.** Five metadata caches were keyed globally while chat ids stopped being globally unique in 8.0: followed-migration ids leaked from one account's sweep into the other's live-accept set, two whitelisted accounts overwrote each other's unresolved-id suppression, reaction-resweep cursors and per-chat failure records crossed accounts, and one account's listener stopping cleared the "listener active" flag while the other still listened. All five are account-scoped now — account 1 keeps the bare legacy keys, so existing installs read their history unchanged — and the viewer reports listener status across accounts (active when any listener is up, since the earliest). ([#319](https://github.com/GeiserX/Telegram-Archive/pull/319))
+
 ## [8.0.3] - 2026-08-19
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "8.0.3"
+version = "8.1.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "8.0.3"
+__version__ = "8.1.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1192,7 +1192,7 @@ wheels = [
 
 [[package]]
 name = "telegram-archive"
-version = "8.0.3"
+version = "8.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
## Summary

- Cuts **8.1.0**, whose feature is per-account capture filters (#313, #319): a second account no longer inherits the first account's whitelist — `TG_ACCOUNT_<N>_<FILTER>` wins per account, the global variable is the fallback, empty inherits and the literal `none` is the explicit-empty override. Also carries the account-scoping of five metadata caches that collided between accounts, with account 1 on legacy keys and the viewer aggregating listener status.
- Version declarations (`pyproject.toml`, `src/__init__.py`, `uv.lock`) and the changelog; no code beyond what is on main.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [x] Documentation update
- [ ] Infrastructure/CI change

## Database Changes

- [x] No database changes

## Data Consistency Checklist

- [ ] All `chat_id` values use marked format (via `_get_marked_id()`) — n/a, release metadata only
- [ ] All datetime values pass through `_strip_tz()` before DB operations — n/a
- [ ] INSERT and UPDATE operations handle the same fields identically — n/a

## Testing

- [x] Tests pass locally (`python -m pytest tests/`) — 3281 passed, 110 skipped, 0 failed on the feature merge
- [x] Linting passes (`ruff check .`)
- [x] Formatting passes (`ruff format --check .`)
- [ ] Manually tested in development environment — production rollout with `TG_ACCOUNT_2_CHAT_IDS=none` follows the tag

## Security Checklist

- [x] No secrets or credentials committed
- [x] User input properly validated/sanitized — n/a
- [x] Authentication/authorization properly checked — n/a

## Deployment Notes

- Tag `v8.1.0` after merge; CI publishes the release and both images. No migration. Installs without per-account overrides behave identically (equivalence-tested); consolidated installs opt the second account out of the inherited whitelist with `TG_ACCOUNT_2_CHAT_IDS=none` and confirm via the startup `Capture scope [account N]` lines.
