### PR TITLE
feat(viewer): tap a #hashtag or $cashtag to see everything using it

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -2759,6 +2759,7 @@ class DatabaseAdapter:
         outgoing_only: bool = False,
         limit: int = 50,
         offset: int = 0,
+        scan_cap: int = 3000,
     ) -> dict[str, Any]:
         """Messages carrying ``tag`` (#hashtag / $CASHTAG) as a whole token, newest first.
 
@@ -2771,22 +2772,31 @@ class DatabaseAdapter:
         (the This Chat tab); ``outgoing_only`` is My Messages (the archive
         owner's side of every conversation). Offset paging re-scans from the
         top by design — tag result sets are small, and each request bounds its
-        own scan (3000 prefilter rows) so no single call can walk the table.
+        own scan (``scan_cap`` prefilter rows) so no single call can walk the
+        table. When the cap truncates the scan, ``has_more`` stays False —
+        pages past the cap are unreachable through an offset API, and
+        advertising them would loop the client forever — and ``truncated``
+        turns True so the UI can say the search was cut short.
 
-        Returns ``{"results": [...], "has_more": bool}``; rows carry message
-        id/date/text/is_outgoing/sender_name plus chat_ref/chat_title/chat_type
-        so the viewer addresses the jump by ref, never by id.
+        Returns ``{"results": [...], "has_more": bool, "truncated": bool}``;
+        rows carry message id/date/text/is_outgoing/sender_name plus
+        chat_ref/chat_title/chat_type so the viewer addresses the jump by
+        ref, never by id.
         """
-        boundary = re.compile(rf"(?<![\w#$]){re.escape(tag)}(?!\w)", re.IGNORECASE)
+        # Hashtags search case-insensitively (official behavior); cashtags are
+        # uppercase-only entities, so '$TSLA' must not match '$tsla' in text.
+        flags = re.IGNORECASE if tag.startswith("#") else 0
+        boundary = re.compile(rf"(?<![\w#$]){re.escape(tag)}(?!\w)", flags)
         escaped = tag.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
         needed = offset + limit + 1  # one extra row proves has_more
         matched: list[dict[str, Any]] = []
         scanned = 0
         cursor: tuple[Any, ...] | None = None
         chunk = max(limit * 3, 60)
+        exhausted = False
 
         async with self.db_manager.async_session_factory() as session:
-            while len(matched) < needed and scanned < 3000:
+            while len(matched) < needed and scanned < scan_cap:
                 stmt = (
                     select(
                         Message.id,
@@ -2844,11 +2854,16 @@ class DatabaseAdapter:
                     if len(matched) >= needed:
                         break
                 if len(rows) < chunk:
+                    exhausted = True
                     break
                 cursor = tuple(rows[-1][key] for key in ("date", "account_id", "chat_id", "id"))
 
-        has_more = len(matched) > offset + limit or (scanned >= 3000 and len(matched) < needed)
-        return {"results": matched[offset : offset + limit], "has_more": has_more}
+        truncated = not exhausted and scanned >= scan_cap and len(matched) < needed
+        return {
+            "results": matched[offset : offset + limit],
+            "has_more": len(matched) > offset + limit,
+            "truncated": truncated,
+        }
 
     async def get_messages_paginated(
         self,

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import secrets
 import shutil
 from collections.abc import Collection, Iterable, Mapping
@@ -31,6 +32,7 @@ from sqlalchemy import (
     or_,
     select,
     text,
+    tuple_,
     union_all,
     update,
 )
@@ -2746,6 +2748,107 @@ class DatabaseAdapter:
             msg["reply_to_media_type"] = reply_row["media_type"] if reply_row else None
             if reply_row and not msg.get("reply_to_text") and reply_row["text"]:
                 msg["reply_to_text"] = reply_row["text"][:100]
+
+    async def search_messages_by_tag(
+        self,
+        tag: str,
+        *,
+        scope: ChatScope,
+        chat_id: int | None = None,
+        account_id: int | None = None,
+        outgoing_only: bool = False,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> dict[str, Any]:
+        """Messages carrying ``tag`` (#hashtag / $CASHTAG) as a whole token, newest first.
+
+        The tag view's data source: the SQL side prefilters with ILIKE — served
+        by ``idx_messages_text_trgm`` on PostgreSQL — and a word-boundary
+        post-filter drops substring hits ('#tag' inside '#taglonger').
+        Entitlements arrive as ``scope`` and apply in the WHERE clause exactly
+        like the chat list, so a restricted viewer's tag search can only ever
+        touch entitled chats. ``chat_id``+``account_id`` narrow to one chat
+        (the This Chat tab); ``outgoing_only`` is My Messages (the archive
+        owner's side of every conversation). Offset paging re-scans from the
+        top by design — tag result sets are small, and each request bounds its
+        own scan (3000 prefilter rows) so no single call can walk the table.
+
+        Returns ``{"results": [...], "has_more": bool}``; rows carry message
+        id/date/text/is_outgoing/sender_name plus chat_ref/chat_title/chat_type
+        so the viewer addresses the jump by ref, never by id.
+        """
+        boundary = re.compile(rf"(?<![\w#$]){re.escape(tag)}(?!\w)", re.IGNORECASE)
+        escaped = tag.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+        needed = offset + limit + 1  # one extra row proves has_more
+        matched: list[dict[str, Any]] = []
+        scanned = 0
+        cursor: tuple[Any, ...] | None = None
+        chunk = max(limit * 3, 60)
+
+        async with self.db_manager.async_session_factory() as session:
+            while len(matched) < needed and scanned < 3000:
+                stmt = (
+                    select(
+                        Message.id,
+                        Message.date,
+                        Message.text,
+                        Message.is_outgoing,
+                        Message.sender_name,
+                        Message.account_id,
+                        Message.chat_id,
+                        Chat.ref.label("chat_ref"),
+                        Chat.title.label("chat_title"),
+                        Chat.first_name.label("chat_first_name"),
+                        Chat.last_name.label("chat_last_name"),
+                        Chat.type.label("chat_type"),
+                    )
+                    .join(Chat, and_(Chat.account_id == Message.account_id, Chat.id == Message.chat_id))
+                    .where(Message.text.isnot(None))
+                    .where(Message.text.ilike(f"%{escaped}%", escape="\\"))
+                )
+                if chat_id is not None:
+                    stmt = stmt.where(Message.chat_id == chat_id)
+                if account_id is not None:
+                    stmt = stmt.where(Message.account_id == account_id)
+                if outgoing_only:
+                    stmt = stmt.where(Message.is_outgoing == 1)
+                for predicate in scope.sql_predicates():
+                    stmt = stmt.where(predicate)
+                order_cols = (Message.date, Message.account_id, Message.chat_id, Message.id)
+                if cursor is not None:
+                    stmt = stmt.where(tuple_(*order_cols) < cursor)
+                stmt = stmt.order_by(*(col.desc() for col in order_cols)).limit(chunk)
+
+                rows = (await session.execute(stmt)).mappings().all()
+                scanned += len(rows)
+                for row in rows:
+                    if not boundary.search(row["text"] or ""):
+                        continue
+                    title = (
+                        row["chat_title"]
+                        or " ".join(part for part in (row["chat_first_name"], row["chat_last_name"]) if part)
+                        or "Unknown"
+                    )
+                    matched.append(
+                        {
+                            "id": row["id"],
+                            "date": row["date"],
+                            "text": row["text"],
+                            "is_outgoing": row["is_outgoing"],
+                            "sender_name": row["sender_name"],
+                            "chat_ref": row["chat_ref"],
+                            "chat_title": title,
+                            "chat_type": row["chat_type"],
+                        }
+                    )
+                    if len(matched) >= needed:
+                        break
+                if len(rows) < chunk:
+                    break
+                cursor = tuple(rows[-1][key] for key in ("date", "account_id", "chat_id", "id"))
+
+        has_more = len(matched) > offset + limit or (scanned >= 3000 and len(matched) < needed)
+        return {"results": matched[offset : offset + limit], "has_more": has_more}
 
     async def get_messages_paginated(
         self,

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -11,6 +11,7 @@ import hashlib
 import json
 import logging
 import os
+import re
 import secrets
 import time
 import traceback
@@ -19,7 +20,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import quote, urlparse
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -2287,6 +2288,50 @@ async def get_messages(
         if _is_db_connection_error(e):
             raise HTTPException(status_code=503, detail="Database temporarily unavailable")
         raise HTTPException(status_code=500, detail="Internal server error")
+
+
+# A tag is a #hashtag (word chars, at least one non-digit — Telegram excludes
+# pure numbers) or a $CASHTAG (1-8 latin letters, the official shape).
+_TAG_PATTERN = re.compile(r"^#(?!\d+$)\w{1,64}$|^\$[A-Z]{1,8}$")
+
+
+@app.get("/api/tags/{tag}")
+async def search_tag(
+    tag: str,
+    user: UserContext = Depends(require_auth),
+    scope: str = Query("all", pattern="^(chat|mine|all)$"),
+    chat_ref: str | None = None,
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+):
+    """Messages using a #hashtag or $cashtag, newest first — the tag view.
+
+    Mirrors the official clients' tag tabs mapped onto an archive:
+    ``scope=chat`` is This Chat (requires ``chat_ref``, entitlement-enforced by
+    the same resolver as every chat route), ``scope=mine`` is My Messages (the
+    archive's outgoing side), ``scope=all`` is the whole entitled archive.
+    Restricted viewers are filtered in SQL via the same ChatScope as the chat
+    list, so this route can never widen what a viewer sees.
+    """
+    if not _TAG_PATTERN.match(tag):
+        raise HTTPException(status_code=400, detail="Not a recognizable #hashtag or $cashtag")
+    kwargs: dict[str, Any] = {"scope": _chat_scope(user), "limit": limit, "offset": offset}
+    if scope == "chat":
+        if not chat_ref:
+            raise HTTPException(status_code=400, detail="scope=chat requires chat_ref")
+        chat = await _resolve_chat_ref(chat_ref, user)
+        kwargs.update(chat_id=chat.chat_id, account_id=chat.account_id)
+    elif scope == "mine":
+        kwargs["outgoing_only"] = True
+    try:
+        payload = await db.search_messages_by_tag(tag, **kwargs)
+    except Exception as e:
+        logger.error(f"Error searching tag: {describe_exception(e)}")
+        if _is_db_connection_error(e):
+            raise HTTPException(status_code=503, detail="Database temporarily unavailable")
+        raise HTTPException(status_code=500, detail="Internal server error")
+    payload["tag"] = tag
+    return payload
 
 
 @app.get("/api/chats/{chat_ref}/messages/{message_id}/versions")

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -2326,7 +2326,9 @@ async def search_tag(
     try:
         payload = await db.search_messages_by_tag(tag, **kwargs)
     except Exception as e:
-        logger.error(f"Error searching tag: {describe_exception(e)}")
+        # Type name only: SQLAlchemy exception text can echo statement
+        # parameters — the tag and the viewer's scope ids.
+        logger.error(f"Error searching tag: {type(e).__name__}")
         if _is_db_connection_error(e):
             raise HTTPException(status_code=503, detail="Database temporarily unavailable")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1871,10 +1871,11 @@
         <!-- Admin Panel (v7.0.0) -->
         <!-- Tag view: #hashtag / $cashtag click-through (official-app tab structure) -->
         <div v-if="tagView" class="fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-4" @click.self="closeTagView()">
-            <div class="bg-tg-sidebar border border-gray-700 rounded-lg w-full max-w-lg max-h-[80vh] flex flex-col">
+            <div role="dialog" aria-modal="true" aria-labelledby="tag-view-title"
+                class="bg-tg-sidebar border border-gray-700 rounded-lg w-full max-w-lg max-h-[80vh] flex flex-col">
                 <div class="flex items-center justify-between p-3 border-b border-gray-700/50">
-                    <span class="font-semibold truncate">{{ tagView.tag }}</span>
-                    <button @click="closeTagView()" class="text-gray-400 hover:text-white px-2 text-lg leading-none">&times;</button>
+                    <span id="tag-view-title" class="font-semibold truncate">{{ tagView.tag }}</span>
+                    <button @click="closeTagView()" aria-label="Close tag search" class="text-gray-400 hover:text-white px-2 text-lg leading-none">&times;</button>
                 </div>
                 <div class="flex border-b border-gray-700/50 text-sm">
                     <button v-for="t in tagTabs" :key="t.key" @click="setTagTab(t.key)"
@@ -1899,6 +1900,9 @@
                     <div v-if="tagView.has_more" class="p-3 text-center">
                         <button @click="loadTagResults(false)" :disabled="tagView.loading"
                             class="text-blue-400 text-sm hover:underline disabled:opacity-40">Load more</button>
+                    </div>
+                    <div v-if="tagView.truncated" class="p-2 text-center text-xs text-gray-500">
+                        Search stopped early — older matches may exist
                     </div>
                 </div>
             </div>
@@ -3260,7 +3264,8 @@
                     tagView.value = {
                         tag,
                         tab: selectedChat.value ? 'chat' : 'all',
-                        results: [], loading: false, has_more: false, offset: 0, error: null,
+                        results: [], loading: false, has_more: false, truncated: false,
+                        offset: 0, error: null, gen: 0,
                     }
                     loadTagResults(true)
                 }
@@ -3269,12 +3274,19 @@
                     const view = tagView.value
                     if (!view || view.tab === tab) return
                     if (tab === 'chat' && !selectedChat.value) return
-                    Object.assign(view, { tab, results: [], offset: 0, has_more: false, error: null })
+                    Object.assign(view, { tab, results: [], offset: 0, has_more: false, truncated: false, error: null })
                     loadTagResults(true)
                 }
                 const loadTagResults = async (reset) => {
                     const view = tagView.value
-                    if (!view || view.loading) return
+                    if (!view) return
+                    // A reset (open or tab switch) supersedes whatever is in
+                    // flight: bump the generation so the old response, which
+                    // still holds the same view object, cannot land under the
+                    // new tab. Only a load-more yields to an active request.
+                    if (view.loading && !reset) return
+                    const gen = ++view.gen
+                    const current = () => tagView.value === view && view.gen === gen
                     view.loading = true
                     try {
                         const params = new URLSearchParams({
@@ -3286,14 +3298,15 @@
                         const resp = await fetch(`/api/tags/${encodeURIComponent(view.tag)}?${params}`)
                         if (!resp.ok) throw new Error(`tag search ${resp.status}`)
                         const data = await resp.json()
-                        if (tagView.value !== view) return
+                        if (!current()) return
                         view.results = reset ? data.results : view.results.concat(data.results)
                         view.offset = view.results.length
                         view.has_more = data.has_more
+                        view.truncated = Boolean(data.truncated)
                     } catch (e) {
-                        if (tagView.value === view) view.error = 'Could not load results'
+                        if (current()) view.error = 'Could not load results'
                     } finally {
-                        if (tagView.value === view) view.loading = false
+                        if (current()) view.loading = false
                     }
                 }
                 const openTagResult = async (row) => {
@@ -5751,7 +5764,7 @@
                 // per sub-segment here, exactly once, same contract as linkifyText.
                 const TAG_TOKEN_RE = /([#$])([\p{L}\p{N}_]{1,64})/gu
                 const isTagToken = (sigil, body) => (sigil === '#'
-                    ? !/^\d+$/.test(body)
+                    ? !/^\p{Nd}+$/u.test(body)
                     : /^[A-Z]{1,8}$/.test(body))
                 const tagifyText = (raw) => {
                     let html = ''
@@ -5759,8 +5772,12 @@
                     for (const match of raw.matchAll(TAG_TOKEN_RE)) {
                         const token = match[0]
                         const prev = match.index > 0 ? raw[match.index - 1] : ''
+                        const next = raw[match.index + token.length]
                         if (!isTagToken(match[1], match[2])) continue
                         if (prev && /[\p{L}\p{N}_#$]/u.test(prev)) continue
+                        // A 64-char match with more word chars after it is a
+                        // truncated slice of a longer run, not a tag.
+                        if (next && /[\p{L}\p{N}_]/u.test(next)) continue
                         html += escapeHtml(raw.slice(last, match.index))
                         const escaped = escapeHtml(token)
                         html += `<a href="#" class="tag-link" data-tag="${escaped}">${escaped}</a>`

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1869,6 +1869,41 @@
         </div>
 
         <!-- Admin Panel (v7.0.0) -->
+        <!-- Tag view: #hashtag / $cashtag click-through (official-app tab structure) -->
+        <div v-if="tagView" class="fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-4" @click.self="closeTagView()">
+            <div class="bg-tg-sidebar border border-gray-700 rounded-lg w-full max-w-lg max-h-[80vh] flex flex-col">
+                <div class="flex items-center justify-between p-3 border-b border-gray-700/50">
+                    <span class="font-semibold truncate">{{ tagView.tag }}</span>
+                    <button @click="closeTagView()" class="text-gray-400 hover:text-white px-2 text-lg leading-none">&times;</button>
+                </div>
+                <div class="flex border-b border-gray-700/50 text-sm">
+                    <button v-for="t in tagTabs" :key="t.key" @click="setTagTab(t.key)"
+                        :disabled="t.key === 'chat' && !selectedChat"
+                        :class="['flex-1 py-2 disabled:opacity-40',
+                                 tagView.tab === t.key ? 'text-white border-b-2 border-blue-500' : 'text-gray-400 hover:text-white']">
+                        {{ t.label }}
+                    </button>
+                </div>
+                <div class="overflow-y-auto flex-1 min-h-[8rem]">
+                    <div v-if="tagView.loading && !tagView.results.length" class="p-4 text-center text-gray-400 text-sm">Loading…</div>
+                    <div v-else-if="tagView.error" class="p-4 text-center text-red-400 text-sm">{{ tagView.error }}</div>
+                    <div v-else-if="!tagView.results.length" class="p-4 text-center text-gray-400 text-sm">No messages with {{ tagView.tag }}</div>
+                    <button v-for="r in tagView.results" :key="r.chat_ref + ':' + r.id" @click="openTagResult(r)"
+                        class="block w-full text-left p-3 border-b border-gray-700/30 hover:bg-gray-700/30">
+                        <div class="flex justify-between text-xs text-gray-400 mb-1">
+                            <span class="truncate">{{ tagView.tab === 'chat' ? (r.sender_name || '') : r.chat_title }}</span>
+                            <span class="ml-2 shrink-0">{{ formatDate(r.date) }}</span>
+                        </div>
+                        <div class="text-sm line-clamp-2 break-words">{{ r.text }}</div>
+                    </button>
+                    <div v-if="tagView.has_more" class="p-3 text-center">
+                        <button @click="loadTagResults(false)" :disabled="tagView.loading"
+                            class="text-blue-400 text-sm hover:underline disabled:opacity-40">Load more</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <div v-if="showAdminPanel" class="fixed inset-0 z-50 bg-black bg-opacity-80 flex items-center justify-center p-4">
             <div class="bg-gray-800 rounded-lg w-full max-w-4xl max-h-[90vh] flex flex-col">
                 <!-- Header -->
@@ -3211,6 +3246,69 @@
                 // chat list (the listener is registered before the first await below,
                 // so it hears clicks from the very start). Until the app can act on a
                 // click it is parked here, then replayed exactly once — never dropped.
+                // ---- Tag view: #hashtag / $cashtag click-through ----
+                // Official-app tab structure mapped onto an archive: This Chat /
+                // My Messages (the archive's outgoing side) / All Chats.
+                const tagTabs = [
+                    { key: 'chat', label: 'This Chat' },
+                    { key: 'mine', label: 'My Messages' },
+                    { key: 'all', label: 'All Chats' },
+                ]
+                const tagView = ref(null)
+                const openTagView = (tag) => {
+                    if (!tag) return
+                    tagView.value = {
+                        tag,
+                        tab: selectedChat.value ? 'chat' : 'all',
+                        results: [], loading: false, has_more: false, offset: 0, error: null,
+                    }
+                    loadTagResults(true)
+                }
+                const closeTagView = () => { tagView.value = null }
+                const setTagTab = (tab) => {
+                    const view = tagView.value
+                    if (!view || view.tab === tab) return
+                    if (tab === 'chat' && !selectedChat.value) return
+                    Object.assign(view, { tab, results: [], offset: 0, has_more: false, error: null })
+                    loadTagResults(true)
+                }
+                const loadTagResults = async (reset) => {
+                    const view = tagView.value
+                    if (!view || view.loading) return
+                    view.loading = true
+                    try {
+                        const params = new URLSearchParams({
+                            scope: view.tab,
+                            limit: '50',
+                            offset: String(reset ? 0 : view.offset),
+                        })
+                        if (view.tab === 'chat' && selectedChat.value) params.set('chat_ref', selectedChat.value.ref)
+                        const resp = await fetch(`/api/tags/${encodeURIComponent(view.tag)}?${params}`)
+                        if (!resp.ok) throw new Error(`tag search ${resp.status}`)
+                        const data = await resp.json()
+                        if (tagView.value !== view) return
+                        view.results = reset ? data.results : view.results.concat(data.results)
+                        view.offset = view.results.length
+                        view.has_more = data.has_more
+                    } catch (e) {
+                        if (tagView.value === view) view.error = 'Could not load results'
+                    } finally {
+                        if (tagView.value === view) view.loading = false
+                    }
+                }
+                const openTagResult = async (row) => {
+                    closeTagView()
+                    await openNotificationTarget(row.chat_ref, row.id)
+                }
+                // One delegated listener: tag anchors are injected via v-html, so
+                // they cannot carry Vue handlers themselves.
+                document.addEventListener('click', (event) => {
+                    const link = event.target.closest ? event.target.closest('a.tag-link') : null
+                    if (!link) return
+                    event.preventDefault()
+                    openTagView(link.dataset.tag)
+                })
+
                 let pendingNotificationClick = null
                 let notificationClickReady = false
                 const flushPendingNotificationClick = async () => {
@@ -5646,6 +5744,31 @@
                     return [...url].map((char) => replacements[char] || char).join('')
                 }
 
+                // Telegram-style tag entities: #hashtags and $cashtags become
+                // clickable, mirroring the official apps (tap opens the tag view).
+                // Hashtags are word chars with at least one non-digit; cashtags are
+                // 1-8 uppercase latin letters — the official shapes. Escaping happens
+                // per sub-segment here, exactly once, same contract as linkifyText.
+                const TAG_TOKEN_RE = /([#$])([\p{L}\p{N}_]{1,64})/gu
+                const isTagToken = (sigil, body) => (sigil === '#'
+                    ? !/^\d+$/.test(body)
+                    : /^[A-Z]{1,8}$/.test(body))
+                const tagifyText = (raw) => {
+                    let html = ''
+                    let last = 0
+                    for (const match of raw.matchAll(TAG_TOKEN_RE)) {
+                        const token = match[0]
+                        const prev = match.index > 0 ? raw[match.index - 1] : ''
+                        if (!isTagToken(match[1], match[2])) continue
+                        if (prev && /[\p{L}\p{N}_#$]/u.test(prev)) continue
+                        html += escapeHtml(raw.slice(last, match.index))
+                        const escaped = escapeHtml(token)
+                        html += `<a href="#" class="tag-link" data-tag="${escaped}">${escaped}</a>`
+                        last = match.index + token.length
+                    }
+                    return html + escapeHtml(raw.slice(last))
+                }
+
                 const linkifyText = (text) => {
                     if (!text) return ''
                     // Split the RAW text on the url pattern. The capture group keeps the
@@ -5657,7 +5780,7 @@
                     return String(text)
                         .split(/(https?:\/\/\S+)/)
                         .map((part, index) => (index % 2 === 0
-                            ? escapeHtml(part)
+                            ? tagifyText(part)
                             : `<a href="${escapeUrlForAttr(part)}" target="_blank" rel="noopener noreferrer">${escapeHtml(part)}</a>`))
                         .join('')
                 }
@@ -7187,6 +7310,14 @@
                     isLightboxImage,
                     isLightboxVideo,
                     linkifyText,
+                    // Tag view
+                    tagView,
+                    tagTabs,
+                    openTagView,
+                    closeTagView,
+                    setTagTab,
+                    loadTagResults,
+                    openTagResult,
                     // Global audio player (#250)
                     audioTrack,
                     audioIsPlaying,

--- a/tests/test_linkify_escaping.py
+++ b/tests/test_linkify_escaping.py
@@ -114,6 +114,9 @@ def _rendered() -> dict[str, str]:
             _DOCUMENT_STUB,
             _setup_slice(html, "const escapeHtml = (text) =>"),
             _setup_slice(html, "const escapeUrlForAttr = (url) =>"),
+            _setup_slice(html, "const TAG_TOKEN_RE = "),
+            _setup_slice(html, "const isTagToken = (sigil, body) =>"),
+            _setup_slice(html, "const tagifyText = (raw) =>"),
             _setup_slice(html, "const linkifyText = (text) =>"),
             f"const payloads = {json.dumps(PAYLOADS)};",
             "const rendered = {};",
@@ -289,6 +292,9 @@ def test_message_without_a_url_is_plain_escaped_text() -> None:
             _DOCUMENT_STUB,
             _setup_slice(html, "const escapeHtml = (text) =>"),
             _setup_slice(html, "const escapeUrlForAttr = (url) =>"),
+            _setup_slice(html, "const TAG_TOKEN_RE = "),
+            _setup_slice(html, "const isTagToken = (sigil, body) =>"),
+            _setup_slice(html, "const tagifyText = (raw) =>"),
             _setup_slice(html, "const linkifyText = (text) =>"),
             "console.log(JSON.stringify(["
             "linkifyText('a <b>bold</b> & \"quoted\" claim'),"
@@ -325,3 +331,59 @@ def test_linkifier_never_decodes_what_it_escaped() -> None:
         assert "&gt;/g" not in source
     assert "escapeUrlForAttr(part)" in linkify
     assert "escapeHtml(part)" in linkify
+    # Plain-text segments route through the tag tokenizer, which escapes
+    # per sub-segment with the same escaper.
+    assert "tagifyText(part)" in linkify
+
+
+def test_tags_become_anchors_without_breaking_escaping() -> None:
+    """#hashtags and $cashtags render as tag anchors; escaping stays intact.
+
+    Executes the shipped tokenizer: official shapes only (a hashtag needs a
+    non-digit, a cashtag is 1-8 uppercase letters), never inside a URL (the
+    linkifier's URL branch wins), and markup around a tag is still escaped.
+    """
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node executable is not installed")
+
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    cases = {
+        "plain_hashtag": "launch day #news arrived",
+        "cashtag": "buy $TSLA now",
+        "digit_hashtag": "issue #123 stays plain",
+        "lowercase_cashtag": "$usd stays plain",
+        "mid_word": "word#glued stays plain",
+        "url_fragment": "see https://good.example/page#frag ok",
+        "markup_around_tag": "<b>#x</b>",
+    }
+    program = "\n".join(
+        [
+            '"use strict";',
+            _DOCUMENT_STUB,
+            _setup_slice(html, "const escapeHtml = (text) =>"),
+            _setup_slice(html, "const escapeUrlForAttr = (url) =>"),
+            _setup_slice(html, "const TAG_TOKEN_RE = "),
+            _setup_slice(html, "const isTagToken = (sigil, body) =>"),
+            _setup_slice(html, "const tagifyText = (raw) =>"),
+            _setup_slice(html, "const linkifyText = (text) =>"),
+            f"const cases = {json.dumps(cases)};",
+            "const rendered = {};",
+            "for (const name of Object.keys(cases)) rendered[name] = linkifyText(cases[name]);",
+            "console.log(JSON.stringify(rendered));",
+        ]
+    )
+    with tempfile.TemporaryDirectory() as tmp:
+        script = Path(tmp) / "tagify.js"
+        script.write_text(program, encoding="utf-8")
+        # SECURITY-REVIEW: the executable path is resolved locally and no
+        # untrusted input is ever passed to a shell.
+        result = subprocess.run([node, str(script)], capture_output=True, text=True, timeout=60)
+    assert result.returncode == 0, result.stderr
+    rendered = json.loads(result.stdout)
+
+    assert '<a href="#" class="tag-link" data-tag="#news">#news</a>' in rendered["plain_hashtag"]
+    assert 'data-tag="$TSLA"' in rendered["cashtag"]
+    for plain in ("digit_hashtag", "lowercase_cashtag", "mid_word", "url_fragment"):
+        assert "tag-link" not in rendered[plain], plain
+    assert rendered["markup_around_tag"] == ('&lt;b&gt;<a href="#" class="tag-link" data-tag="#x">#x</a>&lt;/b&gt;')

--- a/tests/test_linkify_escaping.py
+++ b/tests/test_linkify_escaping.py
@@ -356,6 +356,8 @@ def test_tags_become_anchors_without_breaking_escaping() -> None:
         "mid_word": "word#glued stays plain",
         "url_fragment": "see https://good.example/page#frag ok",
         "markup_around_tag": "<b>#x</b>",
+        "unicode_digit_hashtag": "arabic digits #\u0661\u0662\u0663 stay plain",
+        "overlong_hashtag": "#" + "a" * 70 + " no partial anchor",
     }
     program = "\n".join(
         [
@@ -384,6 +386,13 @@ def test_tags_become_anchors_without_breaking_escaping() -> None:
 
     assert '<a href="#" class="tag-link" data-tag="#news">#news</a>' in rendered["plain_hashtag"]
     assert 'data-tag="$TSLA"' in rendered["cashtag"]
-    for plain in ("digit_hashtag", "lowercase_cashtag", "mid_word", "url_fragment"):
+    for plain in (
+        "digit_hashtag",
+        "lowercase_cashtag",
+        "mid_word",
+        "url_fragment",
+        "unicode_digit_hashtag",
+        "overlong_hashtag",
+    ):
         assert "tag-link" not in rendered[plain], plain
     assert rendered["markup_around_tag"] == ('&lt;b&gt;<a href="#" class="tag-link" data-tag="#x">#x</a>&lt;/b&gt;')

--- a/tests/test_tag_search.py
+++ b/tests/test_tag_search.py
@@ -1,0 +1,135 @@
+"""Tag search (#hashtag / $cashtag view): adapter semantics on real engines.
+
+Boundary matching, entitlement scoping, the three tabs (chat / mine / all),
+ordering and paging for ``search_messages_by_tag`` — executed against real
+SQLite (and PostgreSQL when reachable), because ILIKE escaping and tuple
+cursors are dialect behavior a mock cannot vouch for.
+"""
+
+from datetime import datetime, timedelta
+
+from src.db.adapter import ChatScope
+
+BASE = datetime(2026, 1, 1, 12, 0, 0)
+
+UNRESTRICTED = ChatScope(ids=None, accounts=None, refs=None)
+
+
+async def _seed_chat(adapter, chat_id: int, title: str = "fixture chat") -> None:
+    await adapter.upsert_chat({"id": chat_id, "type": "group", "title": title}, account_id=1)
+
+
+async def _seed_message(
+    adapter,
+    chat_id: int,
+    message_id: int,
+    text: str,
+    *,
+    minutes: int = 0,
+    is_outgoing: int = 0,
+) -> None:
+    await adapter.insert_message(
+        {
+            "id": message_id,
+            "chat_id": chat_id,
+            "sender_id": 4242,
+            "date": BASE + timedelta(minutes=minutes),
+            "text": text,
+            "is_outgoing": is_outgoing,
+            "sender_name": "Fixture Sender",
+            "raw_data": {},
+        },
+        account_id=1,
+    )
+
+
+class TestTagBoundaries:
+    async def test_whole_token_only_and_case_insensitive(self, real_adapter):
+        await _seed_chat(real_adapter, 910001)
+        await _seed_message(real_adapter, 910001, 1, "launch day #news")
+        await _seed_message(real_adapter, 910001, 2, "not this one: #newsletter", minutes=1)
+        await _seed_message(real_adapter, 910001, 3, "shouting #NEWS!", minutes=2)
+        await _seed_message(real_adapter, 910001, 4, "mid-word x#news stays out", minutes=3)
+
+        payload = await real_adapter.search_messages_by_tag("#news", scope=UNRESTRICTED)
+        ids = [row["id"] for row in payload["results"]]
+        assert ids == [3, 1]  # newest first; #newsletter and x#news excluded
+        assert payload["has_more"] is False
+
+    async def test_cashtag_and_like_metachars_are_literal(self, real_adapter):
+        await _seed_chat(real_adapter, 910002)
+        await _seed_message(real_adapter, 910002, 1, "buy $TSLA now")
+        await _seed_message(real_adapter, 910002, 2, "percent %TSLA is not a tag", minutes=1)
+
+        payload = await real_adapter.search_messages_by_tag("$TSLA", scope=UNRESTRICTED)
+        assert [row["id"] for row in payload["results"]] == [1]
+
+    async def test_rows_carry_ref_and_title_for_the_jump(self, real_adapter):
+        await _seed_chat(real_adapter, 910003, title="Tagged Group")
+        await _seed_message(real_adapter, 910003, 1, "#anchor here")
+
+        row = (await real_adapter.search_messages_by_tag("#anchor", scope=UNRESTRICTED))["results"][0]
+        assert row["chat_title"] == "Tagged Group"
+        assert isinstance(row["chat_ref"], str) and len(row["chat_ref"]) > 10
+        assert row["sender_name"] == "Fixture Sender"
+
+
+class TestTagScoping:
+    async def test_chat_scope_restricts_in_sql(self, real_adapter):
+        """A restricted viewer's tag search can only ever touch entitled chats."""
+        await _seed_chat(real_adapter, 910010, title="entitled")
+        await _seed_chat(real_adapter, 910011, title="forbidden")
+        await _seed_message(real_adapter, 910010, 1, "#shared in the entitled chat")
+        await _seed_message(real_adapter, 910011, 1, "#shared in the forbidden chat", minutes=1)
+
+        restricted = ChatScope(ids=frozenset({910010}), accounts=None, refs=None)
+        payload = await real_adapter.search_messages_by_tag("#shared", scope=restricted)
+        assert [row["chat_ref"] for row in payload["results"]] == [
+            (await real_adapter.get_chat_by_id(910010, account_id=1))["ref"]
+        ]
+
+        empty = ChatScope(ids=frozenset(), accounts=None, refs=None)
+        assert (await real_adapter.search_messages_by_tag("#shared", scope=empty))["results"] == []
+
+    async def test_this_chat_and_mine_tabs(self, real_adapter):
+        await _seed_chat(real_adapter, 910020)
+        await _seed_chat(real_adapter, 910021)
+        await _seed_message(real_adapter, 910020, 1, "#tab here", is_outgoing=1)
+        await _seed_message(real_adapter, 910020, 2, "#tab theirs", minutes=1)
+        await _seed_message(real_adapter, 910021, 3, "#tab elsewhere", minutes=2)
+
+        one_chat = await real_adapter.search_messages_by_tag("#tab", scope=UNRESTRICTED, chat_id=910020, account_id=1)
+        assert [row["id"] for row in one_chat["results"]] == [2, 1]
+
+        mine = await real_adapter.search_messages_by_tag("#tab", scope=UNRESTRICTED, outgoing_only=True)
+        assert [row["id"] for row in mine["results"]] == [1]
+
+
+class TestTagPaging:
+    async def test_offset_paging_and_has_more(self, real_adapter):
+        await _seed_chat(real_adapter, 910030)
+        for i in range(7):
+            await _seed_message(real_adapter, 910030, i + 1, f"#page hit {i}", minutes=i)
+
+        first = await real_adapter.search_messages_by_tag("#page", scope=UNRESTRICTED, limit=3)
+        assert [row["id"] for row in first["results"]] == [7, 6, 5]
+        assert first["has_more"] is True
+
+        second = await real_adapter.search_messages_by_tag("#page", scope=UNRESTRICTED, limit=3, offset=3)
+        assert [row["id"] for row in second["results"]] == [4, 3, 2]
+        assert second["has_more"] is True
+
+        last = await real_adapter.search_messages_by_tag("#page", scope=UNRESTRICTED, limit=3, offset=6)
+        assert [row["id"] for row in last["results"]] == [1]
+        assert last["has_more"] is False
+
+    async def test_prefilter_chunking_survives_substring_noise(self, real_adapter):
+        """The internal cursor loop keeps scanning past ILIKE hits the boundary filter rejects."""
+        await _seed_chat(real_adapter, 910031)
+        for i in range(80):
+            await _seed_message(real_adapter, 910031, i + 1, f"#tagnoise{i} filler", minutes=i)
+        await _seed_message(real_adapter, 910031, 999, "the real #tag", minutes=200)
+
+        payload = await real_adapter.search_messages_by_tag("#tag", scope=UNRESTRICTED, limit=5)
+        assert [row["id"] for row in payload["results"]] == [999]
+        assert payload["has_more"] is False

--- a/tests/test_tag_search.py
+++ b/tests/test_tag_search.py
@@ -60,6 +60,7 @@ class TestTagBoundaries:
         await _seed_chat(real_adapter, 910002)
         await _seed_message(real_adapter, 910002, 1, "buy $TSLA now")
         await _seed_message(real_adapter, 910002, 2, "percent %TSLA is not a tag", minutes=1)
+        await _seed_message(real_adapter, 910002, 3, "lowercase $tsla is plain text, not an entity", minutes=2)
 
         payload = await real_adapter.search_messages_by_tag("$TSLA", scope=UNRESTRICTED)
         assert [row["id"] for row in payload["results"]] == [1]
@@ -133,3 +134,22 @@ class TestTagPaging:
         payload = await real_adapter.search_messages_by_tag("#tag", scope=UNRESTRICTED, limit=5)
         assert [row["id"] for row in payload["results"]] == [999]
         assert payload["has_more"] is False
+
+    async def test_scan_cap_reports_truncation_not_phantom_pages(self, real_adapter):
+        """At the cap: has_more must be False (offset paging cannot reach past it)."""
+        await _seed_chat(real_adapter, 910032)
+        # The match is the OLDEST row, behind 65 newer prefilter hits: one
+        # 60-row chunk exhausts the cap before the scan can reach it.
+        await _seed_message(real_adapter, 910032, 999, "beyond the cap #cap", minutes=0)
+        for i in range(65):
+            await _seed_message(real_adapter, 910032, i + 1, f"#capnoise{i} filler", minutes=i + 10)
+
+        payload = await real_adapter.search_messages_by_tag("#cap", scope=UNRESTRICTED, limit=5, scan_cap=10)
+        assert payload["results"] == []
+        assert payload["has_more"] is False
+        assert payload["truncated"] is True
+
+        # With the cap lifted the same search finds the match and is complete.
+        full = await real_adapter.search_messages_by_tag("#cap", scope=UNRESTRICTED, limit=5)
+        assert [row["id"] for row in full["results"]] == [999]
+        assert full["truncated"] is False

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -2051,3 +2051,62 @@ class TestRealtimeNotificationWithPush(_WebTestBase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+# ============================================================================
+# /api/tags/{tag} — the tag view endpoint (q00)
+# ============================================================================
+
+
+@_skip_unless_web
+class TestTagSearchEndpoint(_WebTestBase):
+    """Validation, tab routing and scope passthrough for the tag view."""
+
+    def setUp(self):
+        super().setUp()
+        self.mock_db.search_messages_by_tag = AsyncMock(return_value={"results": [], "has_more": False})
+
+    async def test_rejects_things_that_are_not_tags(self):
+        async with self._client() as client:
+            for bad in ("plainword", "%23123", "%24usd", "%24TOOLONGXX", "%23"):
+                resp = await client.get(f"/api/tags/{bad}")
+                self.assertEqual(resp.status_code, 400, bad)
+        self.mock_db.search_messages_by_tag.assert_not_awaited()
+
+    async def test_accepts_hashtag_and_cashtag_and_echoes_the_tag(self):
+        async with self._client() as client:
+            resp = await client.get("/api/tags/%23news")
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.json(), {"results": [], "has_more": False, "tag": "#news"})
+
+            resp = await client.get("/api/tags/%24TSLA")
+            self.assertEqual(resp.status_code, 200)
+            self.assertEqual(resp.json()["tag"], "$TSLA")
+
+    async def test_scope_chat_requires_a_ref(self):
+        async with self._client() as client:
+            resp = await client.get("/api/tags/%23news?scope=chat")
+        self.assertEqual(resp.status_code, 400)
+        self.mock_db.search_messages_by_tag.assert_not_awaited()
+
+    async def test_scope_chat_rides_the_entitlement_resolver(self):
+        """An unknown or forbidden ref answers 404 before any search runs."""
+        self.mock_db.get_chat_by_ref = AsyncMock(return_value=None)
+        async with self._client() as client:
+            resp = await client.get("/api/tags/%23news?scope=chat&chat_ref=ref00000000000000000042")
+        self.assertEqual(resp.status_code, 404)
+        self.mock_db.search_messages_by_tag.assert_not_awaited()
+
+    async def test_mine_maps_to_outgoing_only_and_all_does_not(self):
+        async with self._client() as client:
+            await client.get("/api/tags/%23news?scope=mine")
+            kwargs = self.mock_db.search_messages_by_tag.await_args.kwargs
+            self.assertTrue(kwargs["outgoing_only"])
+
+            await client.get("/api/tags/%23news?scope=all&limit=25&offset=50")
+            kwargs = self.mock_db.search_messages_by_tag.await_args.kwargs
+            self.assertNotIn("outgoing_only", kwargs)
+            self.assertEqual(kwargs["limit"], 25)
+            self.assertEqual(kwargs["offset"], 50)
+            # The viewer's entitlement rides in as a ChatScope, never recomputed downstream.
+            self.assertIsInstance(kwargs["scope"], web_main.ChatScope)


### PR DESCRIPTION
## Summary

- **Tap a `#hashtag` or `$CASHTAG` in any message to see everything using it** — the official-client behavior mapped onto an archive (Telegram-Archive-q00). Tags highlight in rendered messages; tapping opens a tag view with the official tab structure translated to an archive's universe: **This Chat** / **My Messages** (the archive's outgoing side) / **All Chats** (the whole entitled archive — our analog of Public Posts, archive-local only). Results are newest-first, so "when was the last mention of `$KEYWORD` in this group" is one tap; rows jump via `openNotificationTarget`, the deep-link path notifications already use.
- **No schema change.** Tag text already lives in `messages.text`, served by the 8.0.2 trigram index. `search_messages_by_tag` prefilters with escaped ILIKE, then a word-boundary post-filter drops substring hits (`#tag` never matches `#taglonger`), walking a keyset cursor in bounded chunks with a 3,000-row scan cap per request.
- **Entitlements cannot widen.** The new `/api/tags/{tag}` endpoint applies the viewer's `ChatScope` as SQL predicates — the same machinery as the chat list — and the This Chat tab resolves through the same ref resolver as every chat route (unknown/forbidden = the same 404). Proven by dual-backend adapter tests including an empty-grant case.
- **The tokenizer marks official shapes only** — hashtags need at least one non-digit, cashtags are 1-8 uppercase latin letters — never mid-word, never inside a URL (the linkifier's URL branch wins), and escapes each sub-segment exactly once under `linkifyText`'s existing contract. The executable escaping regressions now extract and run the tokenizer from the shipped template, including an XSS case asserting exact output around markup.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change

## Database Changes

- [x] No database changes

## Data Consistency Checklist

- [ ] All `chat_id` values use marked format (via `_get_marked_id()`) — n/a, read-only feature; ids never leave the server (rows are ref-addressed)
- [ ] All datetime values pass through `_strip_tz()` before DB operations — n/a, no datetime writes
- [ ] INSERT and UPDATE operations handle the same fields identically — n/a, no writes

## Testing

- [x] Tests pass locally (`python -m pytest tests/`) — 3294 passed, 117 skipped, 0 failed; new: 7 dual-backend adapter tests (boundaries, LIKE-metachar literalness, scoping incl. empty grant, tabs, paging, chunking past substring noise), 5 endpoint tests (tag validation, tab routing, scope passthrough, resolver 404), and the executable tokenizer test in the linkify harness
- [x] Linting passes (`ruff check .`) — with CI's pinned 0.15.14
- [x] Formatting passes (`ruff format --check .`)
- [ ] Manually tested in development environment — mutation-checked instead: removing the word-boundary anchors turns two adapter tests red

## Security Checklist

- [x] No secrets or credentials committed
- [x] User input properly validated/sanitized — tag validated against the official shapes at the route (400 otherwise); ILIKE metacharacters escaped; tokenizer output escaped per sub-segment (executable XSS regression)
- [x] Authentication/authorization properly checked — `require_auth` + ChatScope SQL predicates + the shared ref resolver for This Chat; the endpoint can never return a row from an unentitled chat

## Deployment Notes

- Viewer-only feature plus one read-only API route; no migration, no config. Ships with the next release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added hashtag and cashtag search across messages.
  * Click tags in messages to view matching results in “This Chat,” “My Messages,” or “All Chats” scopes.
  * Results support pagination, filtering, scan-limit notices, and navigation to the selected message.
  * Added accessible tag-results dialog with loading and error states.
* **Bug Fixes**
  * Improved tag matching to avoid false positives, handle case sensitivity correctly, and preserve escaped text safely.
  * Added validation for supported tag formats and clearer search error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->