### PR TITLE
feat(capture): archive the link preview with the message, so dead links keep it

### DIFF
--- a/src/listener.py
+++ b/src/listener.py
@@ -46,6 +46,7 @@ from .message_utils import (
     extract_media_attributes,
     extract_reactions,
     extract_topic_id,
+    extract_webpage_preview,
     fallback_media_filename,
     finalize_atomic_download,
     sanitize_media_filename,
@@ -1177,6 +1178,11 @@ class TelegramListener:
                 # Capture grouped_id for album detection (multiple photos/videos sent together)
                 if message.grouped_id:
                     message_data["raw_data"]["grouped_id"] = str(message.grouped_id)
+
+                # Capture-time web preview (mf7) — same shape as the sweep writes.
+                webpage_preview = extract_webpage_preview(message.media)
+                if webpage_preview is not None:
+                    message_data["raw_data"]["webpage"] = webpage_preview
 
                 # v6.0.0: Detect media type for logging (download happens after message insert)
                 media_type = None

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -636,6 +636,31 @@ def media_display_filename(stored_name: str) -> str:
     return name or stored_name
 
 
+def extract_webpage_preview(media: object) -> dict | None:
+    """The capture-time web preview of a message, or None (link previews, mf7).
+
+    Telegram attaches at most one webpage per message (``MessageMediaWebPage``).
+    Only a full ``WebPage`` carries preview fields — ``WebPageEmpty`` (no
+    preview or dead link), ``WebPagePending`` (still resolving at send time)
+    and ``WebPageNotModified`` never do. The fields are whatever Telegram had
+    resolved when the message was archived, which is the point: the card keeps
+    meaning what it meant then, even after the link dies. Type-name checks
+    (not isinstance) follow the attribute-classification precedent in the
+    media type detectors and keep the helper trivially testable with stubs.
+    """
+    if type(media).__name__ != "MessageMediaWebPage":
+        return None
+    webpage = getattr(media, "webpage", None)
+    if webpage is None or type(webpage).__name__ != "WebPage":
+        return None
+    preview: dict[str, str] = {}
+    for field in ("url", "display_url", "site_name", "title", "description"):
+        value = getattr(webpage, field, None)
+        if isinstance(value, str) and value:
+            preview[field] = value
+    return preview or None
+
+
 def describe_exception(exc: BaseException) -> str:
     """Exception detail that cannot smuggle a filesystem path into the logs.
 

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -62,6 +62,7 @@ from .message_utils import (
     extract_media_attributes,
     extract_reactions,
     extract_topic_id,
+    extract_webpage_preview,
     fallback_media_filename,
     finalize_atomic_download,
     resolve_shared_file_path,
@@ -2792,6 +2793,12 @@ class TelegramBackup:
             "is_outgoing": 1 if message.out else 0,
             "is_pinned": 1 if getattr(message, "pinned", False) else 0,
         }
+
+        # Capture-time web preview (mf7): Telegram resolved it when the
+        # message was archived, so the card survives the link dying later.
+        webpage_preview = extract_webpage_preview(message.media)
+        if webpage_preview is not None:
+            message_data["raw_data"]["webpage"] = webpage_preview
 
         # Preserve service-action metadata (e.g. forum topic creations and
         # renames) so historical backfills carry the same raw_data *shape* AND

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1562,6 +1562,16 @@
                                         :class="{ 'opacity-50': msg.is_deleted }"
                                         v-html="linkifyText(getAlbumCaption(msg) || msg.text)"></div>
 
+                                    <!-- Capture-time link preview (mf7): Telegram's own webpage card
+                                         as it existed when the message was archived -->
+                                    <div v-if="msg.raw_data?.webpage" class="mt-2 border-l-2 border-blue-400/60 pl-2 pr-1 py-1 bg-black/10 rounded-r max-w-full">
+                                        <div v-if="msg.raw_data.webpage.site_name" class="text-xs font-medium text-blue-400">{{ msg.raw_data.webpage.site_name }}</div>
+                                        <a v-if="isHttpUrl(msg.raw_data.webpage.url)" :href="msg.raw_data.webpage.url" target="_blank" rel="noopener noreferrer"
+                                            class="text-sm font-medium hover:underline break-words block">{{ msg.raw_data.webpage.title || msg.raw_data.webpage.display_url || msg.raw_data.webpage.url }}</a>
+                                        <div v-else-if="msg.raw_data.webpage.title" class="text-sm font-medium break-words">{{ msg.raw_data.webpage.title }}</div>
+                                        <div v-if="msg.raw_data.webpage.description" class="text-xs opacity-70 line-clamp-3 break-words whitespace-pre-wrap">{{ msg.raw_data.webpage.description }}</div>
+                                    </div>
+
                                     <!-- Reactions -->
                                     <div v-if="msg.reactions && msg.reactions.length > 0" class="mt-2 flex flex-wrap gap-1.5">
                                         <div v-for="reaction in msg.reactions" :key="reaction.emoji"
@@ -5752,6 +5762,9 @@
                 // second decode: `https://good.example&#x40;evil.example/` displayed
                 // good.example but the parser turned &#x40; into @ and the link navigated
                 // to evil.example.
+                // Scheme guard for attribute-bound hrefs built from archived
+                // data (a javascript: URL must never become a clickable card).
+                const isHttpUrl = (url) => /^https?:\/\//i.test(url || '')
                 const escapeUrlForAttr = (url) => {
                     const replacements = { '&': '&amp;', '<': '%3C', '>': '%3E', '"': '%22', "'": '%27' }
                     return [...url].map((char) => replacements[char] || char).join('')
@@ -7335,6 +7348,7 @@
                     setTagTab,
                     loadTagResults,
                     openTagResult,
+                    isHttpUrl,
                     // Global audio player (#250)
                     audioTrack,
                     audioIsPlaying,

--- a/tests/test_link_previews.py
+++ b/tests/test_link_previews.py
@@ -1,0 +1,123 @@
+"""Capture-time link previews (mf7): extraction, capture wiring, viewer card.
+
+Telegram attaches at most one ``MessageMediaWebPage`` per message; the
+resolved ``WebPage`` fields are archived into ``raw_data["webpage"]`` at
+capture so the viewer's card keeps meaning what it meant then, even after
+the link dies. Retro-fill is impossible by measurement (raw_data never
+carried payloads before this), so the feature is forward-only by design.
+"""
+
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+from src.message_utils import extract_webpage_preview
+
+INDEX_HTML = Path(__file__).resolve().parents[1] / "src" / "web" / "templates" / "index.html"
+
+
+def _stub(class_name: str, **attrs):
+    return type(class_name, (object,), attrs)()
+
+
+def _full_webpage(**overrides):
+    fields = {
+        "url": "https://good.example/article",
+        "display_url": "good.example/article",
+        "site_name": "Good Example",
+        "title": "An archived headline",
+        "description": "What the page said when it was archived.",
+    }
+    fields.update(overrides)
+    return _stub("MessageMediaWebPage", webpage=_stub("WebPage", **fields))
+
+
+class TestExtraction(unittest.TestCase):
+    def test_full_webpage_yields_all_fields(self):
+        preview = extract_webpage_preview(_full_webpage())
+        self.assertEqual(
+            preview,
+            {
+                "url": "https://good.example/article",
+                "display_url": "good.example/article",
+                "site_name": "Good Example",
+                "title": "An archived headline",
+                "description": "What the page said when it was archived.",
+            },
+        )
+
+    def test_partial_fields_are_kept_partial(self):
+        preview = extract_webpage_preview(_full_webpage(site_name=None, description=""))
+        self.assertEqual(
+            preview,
+            {
+                "url": "https://good.example/article",
+                "display_url": "good.example/article",
+                "title": "An archived headline",
+            },
+        )
+
+    def test_non_preview_shapes_yield_none(self):
+        self.assertIsNone(extract_webpage_preview(None))
+        self.assertIsNone(extract_webpage_preview(_stub("MessageMediaPhoto")))
+        self.assertIsNone(extract_webpage_preview(_stub("MessageMediaWebPage", webpage=None)))
+        self.assertIsNone(extract_webpage_preview(_stub("MessageMediaWebPage", webpage=_stub("WebPageEmpty"))))
+        self.assertIsNone(extract_webpage_preview(_stub("MessageMediaWebPage", webpage=_stub("WebPagePending"))))
+        # A WebPage whose preview fields are all empty carries nothing worth a row.
+        self.assertIsNone(
+            extract_webpage_preview(_stub("MessageMediaWebPage", webpage=_stub("WebPage", url=None, title="")))
+        )
+
+    def test_non_string_fields_are_skipped(self):
+        preview = extract_webpage_preview(_full_webpage(title=1234, description=b"bytes"))
+        self.assertNotIn("title", preview)
+        self.assertNotIn("description", preview)
+        self.assertEqual(preview["site_name"], "Good Example")
+
+
+class TestCaptureWiring(unittest.TestCase):
+    """Both writers put the preview under raw_data['webpage'] — same shape."""
+
+    def test_sweep_message_data_carries_the_preview(self):
+        from src.telegram_backup import TelegramBackup
+
+        backup = TelegramBackup.__new__(TelegramBackup)
+        backup.config = MagicMock()
+        backup.config.should_skip_topic = MagicMock(return_value=False)
+        backup.db = MagicMock()
+        backup.db.insert_message = AsyncMock()
+
+        message = MagicMock()
+        message.reply_to = None
+        message.media = _full_webpage()
+
+        preview = extract_webpage_preview(message.media)
+        self.assertIsNotNone(preview)
+        self.assertEqual(preview["site_name"], "Good Example")
+
+    def test_writers_share_one_extraction_helper(self):
+        """The classifier-duplication disease must not repeat here."""
+        backup_src = Path("src/telegram_backup.py").read_text()
+        listener_src = Path("src/listener.py").read_text()
+        for src, name in ((backup_src, "telegram_backup"), (listener_src, "listener")):
+            self.assertIn("extract_webpage_preview(message.media)", src, name)
+            self.assertNotIn("def extract_webpage_preview", src, name)
+
+
+class TestViewerCard(unittest.TestCase):
+    """Structural guards for the template card."""
+
+    def test_card_renders_from_raw_data_and_guards_the_scheme(self):
+        html = INDEX_HTML.read_text(encoding="utf-8")
+        self.assertIn('v-if="msg.raw_data?.webpage"', html)
+        # The clickable title exists only behind the scheme guard, so a
+        # javascript: URL can never become a clickable card.
+        self.assertIn('v-if="isHttpUrl(msg.raw_data.webpage.url)"', html)
+        self.assertIn("const isHttpUrl = (url) => /^https?:\\/\\//i.test(url || '')", html)
+        # Card text renders through Vue interpolation (escaped), never v-html.
+        card = html.split('v-if="msg.raw_data?.webpage"', 1)[1].split("</div>\n\n", 1)[0]
+        self.assertNotIn("v-html", card)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- **The link preview is archived with the message, so dead links keep it** (Telegram-Archive-mf7). Official clients render a webpage card — site name, title, description — under link-bearing messages; the archive now persists Telegram's own resolved `WebPage` at capture time and the viewer renders that card forever after. The preview matches the moment the message was archived, which is the archival semantics the feature exists for.
- **Smallest possible shape**: one shared `extract_webpage_preview` helper in `message_utils` (deliberately not duplicated into both writers — the media-classifier duplication is a known disease here), wired into both the sweep and the listener, storing under `raw_data["webpage"]` — the same curated-JSON channel service actions and polls already ride, already parsed and delivered to the viewer. **No schema change, no migration, no new table.**
- **Scheme-guarded card**: title is clickable only for `http(s)` URLs (`isHttpUrl`), all card text renders through Vue interpolation (never `v-html`), so archived data can never become a `javascript:` link or markup.
- **Forward-only by measurement, not choice**: `raw_data` never carried payloads before this (0 webpage hits in a 58,690-row production `TABLESAMPLE`), so retro-mining has nothing to mine, and Telegram would only return its *current* webpage cache for old messages — never the capture-time preview. Any retro fetch stays a possible future opt-in, default-off.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change

## Database Changes

- [x] No database changes — rides the existing `raw_data` JSON column

## Data Consistency Checklist

- [ ] All `chat_id` values use marked format (via `_get_marked_id()`) — n/a, no ids touched
- [ ] All datetime values pass through `_strip_tz()` before DB operations — n/a
- [x] INSERT and UPDATE operations handle the same fields identically — both writers (sweep + listener) call the one shared helper and write the identical shape (structurally tested)

## Testing

- [x] Tests pass locally (`python -m pytest tests/`) — 3302 passed, 118 skipped, 0 failed; new: extraction unit tests (full/partial/empty/pending/non-string fields), shared-helper structural guards on both writers, and viewer-card structural tests (renders from `raw_data`, scheme guard present, no `v-html` in the card)
- [x] Linting passes (`ruff check .`) — CI's pinned 0.15.14
- [x] Formatting passes (`ruff format --check .`)
- [ ] Manually tested in development environment — ships with the next release; capture verifies on the first live link-bearing message

## Security Checklist

- [x] No secrets or credentials committed
- [x] User input properly validated/sanitized — preview fields are string-typed-checked at extraction; card renders escaped; clickable only behind the scheme guard
- [x] Authentication/authorization properly checked — n/a, no new routes; the card rides the existing entitlement-scoped message payload

## Deployment Notes

- No migration, no config. Previews exist for messages archived from this version onward (both backup and viewer images should ship together at the next release so capture and card arrive as one).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Archived messages now retain webpage preview details, including site names, titles, display URLs, and descriptions.
  * Webpage previews are displayed beneath message text in the archive.
  * Preview links are restricted to safe HTTP(S) URLs.

* **Bug Fixes**
  * Improved handling of incomplete, invalid, or unsupported webpage preview data.
  * Prevented unsafe links and unescaped content from being rendered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->