### PR TITLE
fix(capture): a peerless deletion can never tombstone a channel message

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -65,6 +65,11 @@ from .models import (
 
 logger = logging.getLogger(__name__)
 
+# Marked ids for channels and supergroups live below this ceiling (-100…).
+# Bare (peerless) events can only ever refer to the common message box, whose
+# ids sit above it — the same constant migration 022 types placeholders with.
+SUPERGROUP_ID_CEILING = -(10**12)
+
 
 def _strip_tz(dt: datetime | None) -> datetime | None:
     """Strip timezone info from datetime for PostgreSQL compatibility."""
@@ -1324,17 +1329,31 @@ class DatabaseAdapter:
 
     async def resolve_message_chat_id(self, message_id: int, *, account_id: int) -> int | None:
         """
-        Find which chat a message belongs to, within one account.
+        Find which chat a peerless event's message belongs to, within one account.
 
         Returns the chat_id if found in exactly one of the account's chats.
         Returns None if not found or ambiguous (same ID in multiple chats).
         Telegram message IDs are only unique within a chat — and another
         account's rows must never make this account's lookup ambiguous, nor
         resolve a deletion onto a chat this account never archived.
+
+        Channels and supergroups are excluded outright: Telegram omits the
+        peer exactly and only for the common message box (private chats and
+        basic groups); channel deletions always arrive with the channel id.
+        The two id spaces are disjoint, so a peerless event can never
+        legitimately name a -100… chat — and matching one there tombstoned a
+        message that was never deleted (9t6.5.4).
         """
         async with self.db_manager.async_session_factory() as session:
             result = await session.execute(
-                select(Message.chat_id).where(and_(Message.account_id == account_id, Message.id == message_id))
+                select(Message.chat_id).where(
+                    and_(
+                        Message.account_id == account_id,
+                        Message.id == message_id,
+                        # Marked channel/supergroup ids live below this ceiling.
+                        Message.chat_id > SUPERGROUP_ID_CEILING,
+                    )
+                )
             )
             chat_ids = [row[0] for row in result.fetchall()]
 

--- a/tests/test_account_isolation.py
+++ b/tests/test_account_isolation.py
@@ -212,17 +212,29 @@ class TestMessagesAreAccountIsolated:
         account 1.
         """
         await _seed_accounts(real_adapter)
-        await _seed_chat(real_adapter, -100706, accounts=(DEFAULT_ACCOUNT_ID,))
-        await _seed_chat(real_adapter, -100716, accounts=(OTHER_ACCOUNT,))
-        await _seed_chat(real_adapter, -100726, accounts=(OTHER_ACCOUNT,))
-        await real_adapter.insert_message(_message(-100706, 777), account_id=DEFAULT_ACCOUNT_ID)
-        await real_adapter.insert_message(_message(-100716, 777), account_id=OTHER_ACCOUNT)
-        await real_adapter.insert_message(_message(-100726, 777), account_id=OTHER_ACCOUNT)
-        await real_adapter.insert_message(_message(-100716, 888), account_id=OTHER_ACCOUNT)
+        await _seed_chat(real_adapter, -1001000000706, accounts=(DEFAULT_ACCOUNT_ID,))
+        await _seed_chat(real_adapter, -1001000000716, accounts=(OTHER_ACCOUNT,))
+        await _seed_chat(real_adapter, -1001000000726, accounts=(OTHER_ACCOUNT,))
+        # Common-box chats (basic groups): the peerless resolver only ever
+        # searches this id space — bare deletions cannot name a -100… chat.
+        await _seed_chat(real_adapter, -706, accounts=(DEFAULT_ACCOUNT_ID,))
+        await _seed_chat(real_adapter, -716, accounts=(OTHER_ACCOUNT,))
+        await _seed_chat(real_adapter, -726, accounts=(OTHER_ACCOUNT,))
+        await real_adapter.insert_message(_message(-1001000000706, 777), account_id=DEFAULT_ACCOUNT_ID)
+        await real_adapter.insert_message(_message(-1001000000716, 777), account_id=OTHER_ACCOUNT)
+        await real_adapter.insert_message(_message(-1001000000726, 777), account_id=OTHER_ACCOUNT)
+        await real_adapter.insert_message(_message(-1001000000716, 888), account_id=OTHER_ACCOUNT)
+        await real_adapter.insert_message(_message(-706, 779), account_id=DEFAULT_ACCOUNT_ID)
+        await real_adapter.insert_message(_message(-716, 779), account_id=OTHER_ACCOUNT)
+        await real_adapter.insert_message(_message(-726, 779), account_id=OTHER_ACCOUNT)
 
-        assert await real_adapter.resolve_message_chat_id(777, account_id=DEFAULT_ACCOUNT_ID) == -100706
-        assert await real_adapter.resolve_message_chat_id(777, account_id=OTHER_ACCOUNT) is None  # ambiguous for 2
-        assert await real_adapter.get_chat_id_for_message(777, account_id=DEFAULT_ACCOUNT_ID) == -100706
+        # Account isolation, in the id space the resolver actually serves:
+        assert await real_adapter.resolve_message_chat_id(779, account_id=DEFAULT_ACCOUNT_ID) == -706
+        assert await real_adapter.resolve_message_chat_id(779, account_id=OTHER_ACCOUNT) is None  # ambiguous for 2
+        # 9t6.5.4: an id that exists ONLY in channel space resolves to nothing —
+        # matching it there tombstoned a message that was never deleted.
+        assert await real_adapter.resolve_message_chat_id(777, account_id=DEFAULT_ACCOUNT_ID) is None
+        assert await real_adapter.get_chat_id_for_message(777, account_id=DEFAULT_ACCOUNT_ID) == -1001000000706
         assert await real_adapter.get_chat_id_for_message(888, account_id=DEFAULT_ACCOUNT_ID) is None
 
     async def test_sync_reads_return_only_their_accounts_ids(self, real_adapter):
@@ -593,3 +605,21 @@ class TestGapDetectionIsAccountScoped:
 
         assert await real_adapter.detect_message_gaps(-100723, account_id=DEFAULT_ACCOUNT_ID) == [(100, 400, 300)]
         assert await real_adapter.detect_message_gaps(-100723, account_id=OTHER_ACCOUNT) == []
+
+
+class TestPeerlessDeletionScope:
+    """9t6.5.4: bare deletions live in the common message box, never in -100… space."""
+
+    async def test_collision_resolves_to_the_common_box_row(self, real_adapter):
+        """A supergroup sharing the bare id must not shadow (or tombstone for) a private chat."""
+        await _seed_accounts(real_adapter)
+        await _seed_chat(real_adapter, -1001000000800, accounts=(DEFAULT_ACCOUNT_ID,))
+        await _seed_chat(real_adapter, 800555, accounts=(DEFAULT_ACCOUNT_ID,))
+        await real_adapter.insert_message(_message(-1001000000800, 4242), account_id=DEFAULT_ACCOUNT_ID)
+
+        # Channel-space only: excluded outright.
+        assert await real_adapter.resolve_message_chat_id(4242, account_id=DEFAULT_ACCOUNT_ID) is None
+
+        # The same bare id also exists in a private chat: unambiguous there.
+        await real_adapter.insert_message(_message(800555, 4242), account_id=DEFAULT_ACCOUNT_ID)
+        assert await real_adapter.resolve_message_chat_id(4242, account_id=DEFAULT_ACCOUNT_ID) == 800555


### PR DESCRIPTION
## Summary

- **A peerless deletion can never tombstone a channel or supergroup message** (audit bead 9t6.5.4). Telegram omits the peer exactly and only for the common message box — private chats and basic groups, whose bare message ids are unique per account; channel deletions always arrive with the channel id (`UpdateDeleteChannelMessages`). The two id spaces are disjoint, yet the resolver searched every archived chat, so a bare deletion whose id existed in a supergroup row marked a message deleted that never was — archive-truth corruption, the worst class for an archiver.
- `resolve_message_chat_id` now excludes the marked channel space outright (`chat_id > -10^12`, the same ceiling migration 022 already types placeholder chats with). A colliding bare id resolves unambiguously to its common-box row; a channel-only id resolves to nothing and the deletion is skipped, matching what official clients do with the update.
- The account-isolation test that accidentally pinned the buggy behavior used toy ids (`-100706`) that *look* channel-like but sit numerically in basic-group range; its fixtures are realistic marked ids now, the exclusion is pinned explicitly, and a new collision test covers the supergroup-shadows-private case.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change

## Database Changes

- [x] No database changes — one predicate on an existing query

## Data Consistency Checklist

- [x] All `chat_id` values use marked format (via `_get_marked_id()`) — the fix reasons in marked space; the ceiling constant matches migration 022's
- [ ] All datetime values pass through `_strip_tz()` before DB operations — n/a
- [ ] INSERT and UPDATE operations handle the same fields identically — n/a, read path only

## Testing

- [x] Tests pass locally (`python -m pytest tests/`) — 3312 passed, 123 skipped, 0 failed; dual-backend: isolation semantics re-proven in the correct id space, channel-only exclusion pinned, collision case added
- [x] Linting passes (`ruff check .`) — CI's pinned 0.15.14
- [x] Formatting passes (`ruff format --check .`)
- [ ] Manually tested in development environment — mutation-checked instead: dropping the ceiling predicate turns two tests red (watched)

## Security Checklist

- [x] No secrets or credentials committed
- [x] User input properly validated/sanitized — n/a
- [x] Authentication/authorization properly checked — n/a, capture-side only

## Deployment Notes

- Backup-container behavior change only (`LISTEN_DELETIONS=true` installs); no migration, no config. Ships with the next release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message lookup when chat identifiers overlap across channels, private chats, or accounts.
  * Prevented ambiguous deletions from targeting the wrong message.
  * Ensured channel and supergroup messages are excluded from unscoped lookups.
* **Tests**
  * Added coverage for account isolation, shared chats, channel identifiers, and conflicting message IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->