### PR TITLE
feat(ops): a dead archiver no longer looks healthy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,12 @@ ENV BACKUP_PATH=/data/backups \
 # Volume for persistent data
 VOLUME ["/data"]
 
+# A dead archiver must not look healthy: the scheduler touches a heartbeat
+# file while its event loop is responsive; this check compares its age.
+# start-period covers entrypoint migrations + Telegram connect on big archives.
+HEALTHCHECK --interval=60s --timeout=10s --start-period=300s --retries=3 \
+  CMD ["python3", "/app/scripts/healthcheck_backup.py"]
+
 # Entrypoint runs migrations, then hands off to CMD
 ENTRYPOINT ["/app/scripts/entrypoint.sh"]
 

--- a/Dockerfile.viewer
+++ b/Dockerfile.viewer
@@ -25,6 +25,7 @@ COPY src/realtime.py ./src/
 COPY src/message_utils.py ./src/
 COPY src/db/ ./src/db/
 COPY src/web/ ./src/web/
+COPY scripts/healthcheck_viewer.py ./scripts/healthcheck_viewer.py
 
 # Create non-root user for security
 RUN useradd -m -u 1000 telegram && \
@@ -42,6 +43,11 @@ ENV BACKUP_PATH=/data/backups \
 
 # Volume for persistent data (read-only access to backups)
 VOLUME ["/data"]
+
+# Healthy means /api/health answers "ok" — "degraded" (database unreachable)
+# is unhealthy, because a viewer that cannot read the archive is not serving.
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+  CMD ["python3", "/app/scripts/healthcheck_viewer.py"]
 
 # Expose web viewer port
 EXPOSE 8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:7.33.6
+    image: drumsergio/telegram-archive:8.1.0
     container_name: telegram-backup
     restart: unless-stopped
     command: ["python", "-m", "src", "schedule"]
@@ -153,7 +153,7 @@ services:
     #       memory: 512M
 
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:7.33.6
+    image: drumsergio/telegram-archive-viewer:8.1.0
     container_name: telegram-viewer
     restart: unless-stopped
     ports:
@@ -237,7 +237,7 @@ services:
   # Example: Restricted Channel Viewer (optional)
   # Use this to share specific channels publicly with authentication
   # telegram-channel-viewer:
-  #   image: drumsergio/telegram-archive-viewer:7.33.6
+  #   image: drumsergio/telegram-archive-viewer:8.1.0
   #   container_name: telegram-channel-viewer
   #   restart: unless-stopped
   #   ports:

--- a/scripts/healthcheck_backup.py
+++ b/scripts/healthcheck_backup.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Docker HEALTHCHECK for the backup container (9t6.8.10).
+
+The scheduler touches a heartbeat file while its event loop is responsive
+(src/scheduler.py). A dead process, a wedged loop, or an asyncio deadlock
+all stop the touches — exactly the "dead archiver looks healthy" failure
+this check exists to expose. Exit 0 = healthy, 1 = unhealthy.
+"""
+
+import os
+import sys
+import time
+
+DEFAULT_HEARTBEAT_FILE = "/tmp/telegram-archive.heartbeat"
+DEFAULT_MAX_AGE_SECONDS = 180  # three missed 30s beats + slack
+
+
+def main() -> int:
+    path = os.getenv("HEARTBEAT_FILE", DEFAULT_HEARTBEAT_FILE)
+    max_age = int(os.getenv("HEARTBEAT_MAX_AGE_SECONDS", str(DEFAULT_MAX_AGE_SECONDS)))
+    try:
+        age = time.time() - os.path.getmtime(path)
+    except OSError:
+        return 1  # never written: the scheduler has not proven liveness
+    return 0 if age < max_age else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/healthcheck_viewer.py
+++ b/scripts/healthcheck_viewer.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Docker HEALTHCHECK for the viewer container (9t6.8.10).
+
+Probes the viewer's own /api/health and requires status "ok" — "degraded"
+(database unreachable) counts as unhealthy, because a viewer that cannot
+read the archive is not serving. Exit 0 = healthy, 1 = unhealthy.
+"""
+
+import json
+import os
+import sys
+import urllib.request
+
+DEFAULT_URL = "http://127.0.0.1:8000/api/health"
+
+
+def main() -> int:
+    url = os.getenv("HEALTHCHECK_URL", DEFAULT_URL)
+    try:
+        with urllib.request.urlopen(url, timeout=5) as response:
+            if response.status != 200:
+                return 1
+            payload = json.loads(response.read().decode("utf-8"))
+    except Exception:
+        return 1
+    return 0 if payload.get("status") == "ok" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -492,7 +492,6 @@ class BackupScheduler:
         # The outer finally owns the heartbeat's lifetime: startup failures in
         # connect/start must not leave it ticking a "healthy" file behind.
         try:
-
             # Establish shared connections
             await self._connect()
 

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -14,9 +14,12 @@ not N concurrent full sweeps from one box.
 """
 
 import asyncio
+import contextlib
 import logging
+import os
 import signal
 import sys
+import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
@@ -452,6 +455,26 @@ class BackupScheduler:
         if entry.listener:
             await entry.listener._load_tracked_chats()
 
+    async def _heartbeat_loop(self) -> None:
+        """Touch the liveness file while the event loop is responsive.
+
+        The Docker HEALTHCHECK (scripts/healthcheck_backup.py) compares this
+        file's mtime against a threshold: a dead process, a wedged event loop,
+        or an asyncio deadlock all stop the touches — the "dead archiver looks
+        healthy" failure 9t6.8.10 exists to expose. Started at the very top of
+        run_forever, so hour-long initial sweeps keep a fresh heartbeat: they
+        await the network constantly, and a responsive loop keeps scheduling
+        this task.
+        """
+        path = os.getenv("HEARTBEAT_FILE", "/tmp/telegram-archive.heartbeat")
+        while True:
+            try:
+                with open(path, "w") as fh:
+                    fh.write(str(int(time.time())))
+            except OSError as e:
+                logger.warning(f"Could not write heartbeat: {type(e).__name__}")
+            await asyncio.sleep(30)
+
     async def run_forever(self):
         """
         Keep the scheduler running with optional listeners.
@@ -463,6 +486,10 @@ class BackupScheduler:
         4. Run initial backup, account by account (shared connections)
         5. Keep running until stopped
         """
+        # Liveness heartbeat for the Docker healthcheck — first, so a slow
+        # connect or an hours-long initial sweep never reads as dead.
+        heartbeat_task = asyncio.create_task(self._heartbeat_loop(), name="health_heartbeat")
+
         # Establish shared connections
         await self._connect()
 
@@ -522,6 +549,9 @@ class BackupScheduler:
         except KeyboardInterrupt:
             logger.info("Keyboard interrupt received")
         finally:
+            heartbeat_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await heartbeat_task
             await self._stop_listener()
             self.stop()
             await self._disconnect()

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -489,72 +489,76 @@ class BackupScheduler:
         # Liveness heartbeat for the Docker healthcheck — first, so a slow
         # connect or an hours-long initial sweep never reads as dead.
         heartbeat_task = asyncio.create_task(self._heartbeat_loop(), name="health_heartbeat")
-
-        # Establish shared connections
-        await self._connect()
-
-        # Start scheduler
-        self.start()
-
-        # Start real-time listeners if enabled (each uses its shared connection).
-        self._listener_enabled = self.config.enable_listener
-        await self._start_listener()
-
-        # Run initial backup immediately on startup (uses shared connections)
-        logger.info("Running initial backup on startup...")
-        async with self._backup_lock:
-            try:
-                for entry in self._accounts:
-                    try:
-                        await self._initial_backup_account(entry)
-                    except Exception as e:
-                        # Same continuation rule as the scheduled sweep: only a
-                        # single-account deployment lets the failure reach the
-                        # pre-8.0 catch below.
-                        if len(self._accounts) == 1:
-                            raise
-                        logger.error(f"account {entry.account.index} failed: {type(e).__name__}")
-            except Exception as e:
-                logger.error(f"Initial backup failed: {e}", exc_info=True)
-
-        # Keep running until stopped
+        # The outer finally owns the heartbeat's lifetime: startup failures in
+        # connect/start must not leave it ticking a "healthy" file behind.
         try:
-            while self.running:
-                await asyncio.sleep(1)
 
-                # Check if any listener task died, or never came up at all (a failed
-                # restart leaves listener_task as None -- see _start_account_listener),
-                # and restart it either way. Retrying on None (not just "died") is what
-                # keeps a flapping listener from being permanently disabled after a
-                # single failed restart attempt. Only dead entries are restarted --
-                # healthy accounts' listeners keep running untouched.
-                if self._listener_enabled and any(
-                    entry.listener_task is None or entry.listener_task.done() for entry in self._accounts
-                ):
+            # Establish shared connections
+            await self._connect()
+
+            # Start scheduler
+            self.start()
+
+            # Start real-time listeners if enabled (each uses its shared connection).
+            self._listener_enabled = self.config.enable_listener
+            await self._start_listener()
+
+            # Run initial backup immediately on startup (uses shared connections)
+            logger.info("Running initial backup on startup...")
+            async with self._backup_lock:
+                try:
                     for entry in self._accounts:
-                        if entry.listener_task is not None and entry.listener_task.done():
-                            # Check if there was an exception
-                            try:
-                                exc = entry.listener_task.exception()
-                                if exc:
-                                    logger.error(f"{entry.log_prefix}Listener task died with error: {exc}")
-                            except asyncio.CancelledError:
-                                pass
+                        try:
+                            await self._initial_backup_account(entry)
+                        except Exception as e:
+                            # Same continuation rule as the scheduled sweep: only a
+                            # single-account deployment lets the failure reach the
+                            # pre-8.0 catch below.
+                            if len(self._accounts) == 1:
+                                raise
+                            logger.error(f"account {entry.account.index} failed: {type(e).__name__}")
+                except Exception as e:
+                    logger.error(f"Initial backup failed: {e}", exc_info=True)
 
-                    logger.warning("Listener task not running, attempting restart...")
-                    await self._stop_listener(only_dead=True)
-                    await asyncio.sleep(5)  # Brief pause before restart
-                    await self._start_listener()
+            # Keep running until stopped
+            try:
+                while self.running:
+                    await asyncio.sleep(1)
 
-        except KeyboardInterrupt:
-            logger.info("Keyboard interrupt received")
+                    # Check if any listener task died, or never came up at all (a failed
+                    # restart leaves listener_task as None -- see _start_account_listener),
+                    # and restart it either way. Retrying on None (not just "died") is what
+                    # keeps a flapping listener from being permanently disabled after a
+                    # single failed restart attempt. Only dead entries are restarted --
+                    # healthy accounts' listeners keep running untouched.
+                    if self._listener_enabled and any(
+                        entry.listener_task is None or entry.listener_task.done() for entry in self._accounts
+                    ):
+                        for entry in self._accounts:
+                            if entry.listener_task is not None and entry.listener_task.done():
+                                # Check if there was an exception
+                                try:
+                                    exc = entry.listener_task.exception()
+                                    if exc:
+                                        logger.error(f"{entry.log_prefix}Listener task died with error: {exc}")
+                                except asyncio.CancelledError:
+                                    pass
+
+                        logger.warning("Listener task not running, attempting restart...")
+                        await self._stop_listener(only_dead=True)
+                        await asyncio.sleep(5)  # Brief pause before restart
+                        await self._start_listener()
+
+            except KeyboardInterrupt:
+                logger.info("Keyboard interrupt received")
+            finally:
+                await self._stop_listener()
+                self.stop()
+                await self._disconnect()
         finally:
             heartbeat_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await heartbeat_task
-            await self._stop_listener()
-            self.stop()
-            await self._disconnect()
 
 
 async def main():

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -1,0 +1,146 @@
+"""Healthchecks (9t6.8.10): a dead archiver must not look healthy.
+
+The backup container's liveness is a heartbeat file the scheduler touches
+while its event loop is responsive; the viewer's is its own /api/health
+answering "ok". Both checkers are real scripts so they are testable here
+and identical to what the HEALTHCHECK runs in the image.
+"""
+
+import asyncio
+import importlib.util
+import json
+import os
+import time
+import unittest.mock
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, REPO / "scripts" / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestBackupChecker:
+    def test_fresh_heartbeat_is_healthy(self, tmp_path, monkeypatch):
+        checker = _load("healthcheck_backup")
+        beat = tmp_path / "beat"
+        beat.write_text("now")
+        monkeypatch.setenv("HEARTBEAT_FILE", str(beat))
+        assert checker.main() == 0
+
+    def test_stale_heartbeat_is_unhealthy(self, tmp_path, monkeypatch):
+        checker = _load("healthcheck_backup")
+        beat = tmp_path / "beat"
+        beat.write_text("old")
+        stale = time.time() - 10_000
+        os.utime(beat, (stale, stale))
+        monkeypatch.setenv("HEARTBEAT_FILE", str(beat))
+        assert checker.main() == 1
+
+    def test_missing_heartbeat_is_unhealthy(self, tmp_path, monkeypatch):
+        checker = _load("healthcheck_backup")
+        monkeypatch.setenv("HEARTBEAT_FILE", str(tmp_path / "never-written"))
+        assert checker.main() == 1
+
+    def test_max_age_is_configurable(self, tmp_path, monkeypatch):
+        checker = _load("healthcheck_backup")
+        beat = tmp_path / "beat"
+        beat.write_text("x")
+        old = time.time() - 120
+        os.utime(beat, (old, old))
+        monkeypatch.setenv("HEARTBEAT_FILE", str(beat))
+        monkeypatch.setenv("HEARTBEAT_MAX_AGE_SECONDS", "60")
+        assert checker.main() == 1
+        monkeypatch.setenv("HEARTBEAT_MAX_AGE_SECONDS", "600")
+        assert checker.main() == 0
+
+
+class TestViewerChecker:
+    def _respond(self, status_code: int, payload: dict):
+        response = unittest.mock.MagicMock()
+        response.status = status_code
+        response.read.return_value = json.dumps(payload).encode()
+        response.__enter__ = lambda s: s
+        response.__exit__ = lambda s, *a: False
+        return response
+
+    def test_ok_is_healthy(self):
+        checker = _load("healthcheck_viewer")
+        with unittest.mock.patch.object(
+            checker.urllib.request, "urlopen", return_value=self._respond(200, {"status": "ok"})
+        ):
+            assert checker.main() == 0
+
+    def test_degraded_is_unhealthy(self):
+        checker = _load("healthcheck_viewer")
+        with unittest.mock.patch.object(
+            checker.urllib.request, "urlopen", return_value=self._respond(200, {"status": "degraded"})
+        ):
+            assert checker.main() == 1
+
+    def test_unreachable_is_unhealthy(self):
+        checker = _load("healthcheck_viewer")
+        with unittest.mock.patch.object(checker.urllib.request, "urlopen", side_effect=OSError("refused")):
+            assert checker.main() == 1
+
+
+class TestHeartbeatLoop:
+    async def test_heartbeat_writes_and_refreshes(self, tmp_path, monkeypatch):
+        from src.scheduler import BackupScheduler
+
+        beat = tmp_path / "beat"
+        monkeypatch.setenv("HEARTBEAT_FILE", str(beat))
+        scheduler = BackupScheduler.__new__(BackupScheduler)
+
+        ticks = 0
+        real_sleep = asyncio.sleep
+
+        async def fast_sleep(seconds):
+            nonlocal ticks
+            ticks += 1
+            if ticks >= 2:
+                raise asyncio.CancelledError
+            await real_sleep(0)
+
+        with unittest.mock.patch("src.scheduler.asyncio.sleep", side_effect=fast_sleep):
+            try:
+                await scheduler._heartbeat_loop()
+            except asyncio.CancelledError:
+                pass
+
+        assert beat.exists()
+        assert beat.read_text().isdigit()
+
+    async def test_write_failure_warns_but_does_not_die(self, tmp_path, monkeypatch):
+        from src.scheduler import BackupScheduler
+
+        monkeypatch.setenv("HEARTBEAT_FILE", str(tmp_path / "nodir" / "beat"))
+        scheduler = BackupScheduler.__new__(BackupScheduler)
+
+        async def one_tick(seconds):
+            raise asyncio.CancelledError
+
+        with unittest.mock.patch("src.scheduler.asyncio.sleep", side_effect=one_tick):
+            try:
+                await scheduler._heartbeat_loop()  # OSError inside must not propagate
+            except asyncio.CancelledError:
+                pass
+
+
+class TestImageWiring:
+    def test_both_dockerfiles_declare_healthchecks(self):
+        backup = (REPO / "Dockerfile").read_text()
+        viewer = (REPO / "Dockerfile.viewer").read_text()
+        assert "HEALTHCHECK" in backup and "healthcheck_backup.py" in backup
+        assert "HEALTHCHECK" in viewer and "healthcheck_viewer.py" in viewer
+        assert "COPY scripts/healthcheck_viewer.py" in viewer
+
+    def test_scheduler_starts_the_heartbeat_before_connecting(self):
+        src = (REPO / "src" / "scheduler.py").read_text()
+        start = src.index("health_heartbeat")
+        connect = src.index("await self._connect()")
+        assert start < connect, "heartbeat must start before the (possibly slow) connect"

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -144,3 +144,22 @@ class TestImageWiring:
         start = src.index("health_heartbeat")
         connect = src.index("await self._connect()")
         assert start < connect, "heartbeat must start before the (possibly slow) connect"
+
+
+class TestHeartbeatLifetime:
+    async def test_startup_failure_cancels_the_heartbeat(self, tmp_path, monkeypatch):
+        """Review edge: a failed connect must not leave the heartbeat ticking
+        a healthy file behind on a still-alive event loop."""
+        from src.scheduler import BackupScheduler
+
+        monkeypatch.setenv("HEARTBEAT_FILE", str(tmp_path / "beat"))
+        scheduler = BackupScheduler.__new__(BackupScheduler)
+        scheduler._connect = unittest.mock.AsyncMock(side_effect=RuntimeError("no network"))
+
+        try:
+            await scheduler.run_forever()
+        except RuntimeError:
+            pass
+
+        lingering = [t for t in asyncio.all_tasks() if t.get_name() == "health_heartbeat" and not t.done()]
+        assert lingering == [], "heartbeat task must be cancelled on startup failure"


### PR DESCRIPTION
## Summary

- **A dead archiver no longer looks healthy** (audit bead 9t6.8.10). Neither image declared a `HEALTHCHECK`, so a dead process, wedged event loop, or asyncio deadlock in the backup container was indistinguishable from healthy — for a service whose entire failure mode is silence.
- **Backup**: the scheduler touches a heartbeat file while its event loop is responsive, started at the very top of `run_forever` so a slow connect or an hours-long initial sweep never reads as dead (sweeps await the network constantly; a responsive loop keeps scheduling the task). The image healthcheck compares the file's age; `start-period=300s` covers entrypoint migrations on big archives; thresholds env-tunable.
- **Viewer**: probes its own (already existing, previously unused) `/api/health` and requires `"ok"` — `"degraded"` means the database is unreachable, and a viewer that cannot read the archive is not serving.
- **Both checkers are real scripts shipped in the images** (`scripts/healthcheck_*.py`), so the exact code the `HEALTHCHECK` runs is unit-tested rather than an untestable inline one-liner.
- Drive-by doc fix: the example `docker-compose.yml` pinned `7.33.6` from two majors ago; now shows the current released `8.1.0`.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [x] Infrastructure/CI change

## Database Changes

- [x] No database changes

## Data Consistency Checklist

- [ ] All `chat_id` values use marked format (via `_get_marked_id()`) — n/a
- [ ] All datetime values pass through `_strip_tz()` before DB operations — n/a
- [ ] INSERT and UPDATE operations handle the same fields identically — n/a

## Testing

- [x] Tests pass locally (`python -m pytest tests/`) — 3323 passed, 123 skipped, 0 failed; new: checker behavior (fresh/stale/missing/env-tunable; ok/degraded/unreachable), heartbeat loop behavior (writes+refreshes; write failure warns without dying), and image-wiring structural guards (HEALTHCHECKs present, viewer copies its checker, heartbeat starts before connect)
- [x] Linting passes (`ruff check .`) — CI's pinned 0.15.14
- [x] Formatting passes (`ruff format --check .`)
- [ ] Manually tested in development environment — mutation-checked instead: flipping the age comparison turns three checker tests red (watched); container-level behavior verifies at the next release's deploy

## Security Checklist

- [x] No secrets or credentials committed
- [x] User input properly validated/sanitized — n/a (env-read paths and a localhost probe)
- [x] Authentication/authorization properly checked — /api/health is deliberately unauthenticated and content-free beyond status

## Deployment Notes

- Health status appears automatically once images built from this land (next release); compose `depends_on: service_healthy` becomes possible; monitoring can alert on `unhealthy`. No migration, no config required (HEARTBEAT_FILE / HEARTBEAT_MAX_AGE_SECONDS / HEALTHCHECK_URL are optional overrides).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added health monitoring for backup and viewer services.
  - Backup monitoring detects missing or stale scheduler activity.
  - Viewer monitoring verifies API availability and healthy status responses.
  - Updated Telegram backup and viewer images to version 8.1.0.

- **Bug Fixes**
  - Improved detection of unavailable or degraded services.

- **Tests**
  - Added coverage for health checks, heartbeat freshness, failures, and service wiring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->