### PR TITLE
fix(ops): docker stop no longer ends in SIGKILL, and logs stop filling the disk

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,15 @@ services:
     image: drumsergio/telegram-archive:8.1.0
     container_name: telegram-backup
     restart: unless-stopped
+    # A stop during a long sweep needs time to finish in-flight writes and
+    # disconnect cleanly; without this docker waits 10s then SIGKILLs.
+    stop_grace_period: 90s
+    # Unattended deployments must not fill the host disk with container logs.
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     command: ["python", "-m", "src", "schedule"]
 
     environment:
@@ -156,6 +165,15 @@ services:
     image: drumsergio/telegram-archive-viewer:8.1.0
     container_name: telegram-viewer
     restart: unless-stopped
+    # A stop during a long sweep needs time to finish in-flight writes and
+    # disconnect cleanly; without this docker waits 10s then SIGKILLs.
+    stop_grace_period: 90s
+    # Unattended deployments must not fill the host disk with container logs.
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
     ports:
       # Bind to localhost by default. Put this behind a reverse proxy with auth
       # configured before exposing it publicly.

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -591,15 +591,29 @@ class BackupScheduler:
             # path, not an error — teardown runs in finally either way.
             logger.info("Shutdown requested; tearing down gracefully...")
         finally:
-            for signum in registered_signals:
-                with contextlib.suppress(Exception):
-                    loop.remove_signal_handler(signum)
             heartbeat_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await heartbeat_task
-            await self._stop_listener()
-            self.stop()
-            await self._disconnect()
+            # Teardown steps are independent: one failing must not skip the
+            # rest, or a raised listener close leaves connections open.
+            try:
+                await self._stop_listener()
+            except Exception as e:
+                logger.warning(f"Listener teardown failed: {type(e).__name__}")
+            try:
+                self.stop()
+            except Exception as e:
+                logger.warning(f"Scheduler stop failed: {type(e).__name__}")
+            try:
+                await self._disconnect()
+            except Exception as e:
+                logger.warning(f"Disconnect failed: {type(e).__name__}")
+            # Removing a loop handler restores SIG_DFL, so this runs LAST:
+            # a second signal during the steps above stays a logged no-op
+            # (idempotent _request_shutdown) instead of an instant kill.
+            for signum in registered_signals:
+                with contextlib.suppress(Exception):
+                    loop.remove_signal_handler(signum)
 
 
 async def main():

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -113,7 +113,12 @@ class BackupScheduler:
         and docker's grace period still ends in SIGKILL.
         """
         logger.info(f"Received signal {signum}, shutting down gracefully...")
-        self.stop()
+        try:
+            self.stop()
+        except Exception as e:
+            # A wedged scheduler must not prevent the cancel below — the
+            # cancel IS the shutdown; stop() is retried in the teardown.
+            logger.warning(f"Scheduler stop failed during shutdown request: {type(e).__name__}")
         if not main_task.done() and not self._shutdown_requested:
             self._shutdown_requested = True
             main_task.cancel()

--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -96,9 +96,27 @@ class BackupScheduler:
         signal.signal(signal.SIGTERM, self._signal_handler)
 
     def _signal_handler(self, signum, frame):
-        """Handle shutdown signals."""
+        """Sync fallback for shutdown signals (non-asyncio contexts).
+
+        Only flips ``running`` via stop(); while run_forever is active the
+        asyncio-native handler below supersedes this and actually interrupts
+        the in-flight await (9t6.8.9).
+        """
         logger.info(f"Received signal {signum}, shutting down gracefully...")
         self.stop()
+
+    def _request_shutdown(self, main_task: asyncio.Task, signum: int) -> None:
+        """Asyncio-native shutdown: cancel run_forever so teardown runs.
+
+        Idempotent — a second signal must not re-cancel the task while its
+        finally-teardown is awaiting, or the teardown itself gets truncated
+        and docker's grace period still ends in SIGKILL.
+        """
+        logger.info(f"Received signal {signum}, shutting down gracefully...")
+        self.stop()
+        if not main_task.done() and not self._shutdown_requested:
+            self._shutdown_requested = True
+            main_task.cancel()
 
     async def _resolve_account_rows(self) -> None:
         """Resolve each connected account's ``accounts`` row id, once.
@@ -489,6 +507,24 @@ class BackupScheduler:
         # Liveness heartbeat for the Docker healthcheck — first, so a slow
         # connect or an hours-long initial sweep never reads as dead.
         heartbeat_task = asyncio.create_task(self._heartbeat_loop(), name="health_heartbeat")
+        # asyncio-native shutdown (9t6.8.9): SIGTERM/SIGINT cancel THIS task,
+        # so a docker stop during connect or an hours-long initial sweep
+        # interrupts the in-flight await and the teardown in finally actually
+        # runs. The sync handlers from __init__ only flip `running`, which
+        # nothing checks until the keep-alive loop — during startup the grace
+        # period just expired into SIGKILL.
+        self._shutdown_requested = False
+        main_task = asyncio.current_task()
+        loop = asyncio.get_running_loop()
+        registered_signals: list[int] = []
+        for signum in (signal.SIGINT, signal.SIGTERM):
+            try:
+                loop.add_signal_handler(signum, self._request_shutdown, main_task, signum)
+                registered_signals.append(signum)
+            except NotImplementedError, RuntimeError:
+                # Platforms/threads without loop signal support keep the
+                # sync fallback from __init__.
+                break
         # The outer finally owns the heartbeat's lifetime: startup failures in
         # connect/start must not leave it ticking a "healthy" file behind.
         try:
@@ -550,14 +586,20 @@ class BackupScheduler:
 
             except KeyboardInterrupt:
                 logger.info("Keyboard interrupt received")
-            finally:
-                await self._stop_listener()
-                self.stop()
-                await self._disconnect()
+        except asyncio.CancelledError:
+            # A signal (or the embedder) cancelled us mid-await: the graceful
+            # path, not an error — teardown runs in finally either way.
+            logger.info("Shutdown requested; tearing down gracefully...")
         finally:
+            for signum in registered_signals:
+                with contextlib.suppress(Exception):
+                    loop.remove_signal_handler(signum)
             heartbeat_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
                 await heartbeat_task
+            await self._stop_listener()
+            self.stop()
+            await self._disconnect()
 
 
 async def main():

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -1,0 +1,78 @@
+"""Graceful shutdown (9t6.8.9): docker stop must not end in SIGKILL.
+
+The sync signal handlers only flip ``running``, which nothing checks until
+the keep-alive loop — so a SIGTERM during connect or an hours-long initial
+sweep used to ride out the grace period into SIGKILL, mid-write. The
+asyncio-native handler cancels run_forever so the finally teardown runs.
+"""
+
+import asyncio
+import unittest.mock
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _bare_scheduler(monkeypatch, tmp_path):
+    from src.scheduler import BackupScheduler
+
+    monkeypatch.setenv("HEARTBEAT_FILE", str(tmp_path / "beat"))
+    scheduler = BackupScheduler.__new__(BackupScheduler)
+    scheduler.running = True
+    scheduler.scheduler = unittest.mock.MagicMock()
+    scheduler._accounts = []
+    scheduler.config = unittest.mock.MagicMock()
+    scheduler.start = unittest.mock.MagicMock()
+    scheduler.stop = unittest.mock.MagicMock()
+    scheduler._start_listener = unittest.mock.AsyncMock()
+    scheduler._stop_listener = unittest.mock.AsyncMock()
+    scheduler._disconnect = unittest.mock.AsyncMock()
+    scheduler._backup_lock = asyncio.Lock()
+    return scheduler
+
+
+class TestGracefulCancel:
+    async def test_cancel_during_connect_runs_full_teardown(self, monkeypatch, tmp_path):
+        scheduler = _bare_scheduler(monkeypatch, tmp_path)
+        connect_started = asyncio.Event()
+
+        async def hanging_connect():
+            connect_started.set()
+            await asyncio.sleep(3600)
+
+        scheduler._connect = hanging_connect
+
+        task = asyncio.create_task(scheduler.run_forever())
+        await connect_started.wait()
+        scheduler._request_shutdown(task, 15)
+
+        # Clean return: the cancel is the graceful path, not an error.
+        await task
+        assert task.done() and not task.cancelled()
+        scheduler._stop_listener.assert_awaited()
+        scheduler._disconnect.assert_awaited()
+        lingering = [t for t in asyncio.all_tasks() if t.get_name() == "health_heartbeat" and not t.done()]
+        assert lingering == []
+
+    async def test_second_signal_does_not_recancel_during_teardown(self, monkeypatch, tmp_path):
+        scheduler = _bare_scheduler(monkeypatch, tmp_path)
+        scheduler._shutdown_requested = False
+        fake_task = unittest.mock.MagicMock()
+        fake_task.done.return_value = False
+
+        scheduler._request_shutdown(fake_task, 15)
+        scheduler._request_shutdown(fake_task, 15)
+
+        assert fake_task.cancel.call_count == 1
+
+
+class TestOpsWiring:
+    def test_compose_has_grace_period_and_log_rotation_on_both_services(self):
+        compose = (REPO / "docker-compose.yml").read_text()
+        assert compose.count("stop_grace_period: 90s") == 2
+        assert compose.count('max-size: "10m"') == 2
+
+    def test_run_forever_registers_loop_signal_handlers(self):
+        src = (REPO / "src" / "scheduler.py").read_text()
+        assert "loop.add_signal_handler(signum, self._request_shutdown, main_task, signum)" in src
+        assert "except asyncio.CancelledError:" in src.split("async def run_forever", 1)[1]

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -97,6 +97,40 @@ class TestTeardownRobustness:
 
         scheduler._disconnect.assert_awaited()
 
+    async def test_failing_scheduler_stop_never_skips_disconnect(self, monkeypatch, tmp_path):
+        scheduler = _bare_scheduler(monkeypatch, tmp_path)
+        scheduler.stop = unittest.mock.MagicMock(side_effect=RuntimeError("apscheduler wedged"))
+        connect_started = asyncio.Event()
+
+        async def hanging_connect():
+            connect_started.set()
+            await asyncio.sleep(3600)
+
+        scheduler._connect = hanging_connect
+        task = asyncio.create_task(scheduler.run_forever())
+        await connect_started.wait()
+        scheduler._request_shutdown(task, 15)
+        await task
+
+        scheduler._disconnect.assert_awaited()
+
+    async def test_failing_disconnect_still_completes_cleanly(self, monkeypatch, tmp_path):
+        scheduler = _bare_scheduler(monkeypatch, tmp_path)
+        scheduler._disconnect = unittest.mock.AsyncMock(side_effect=RuntimeError("transport gone"))
+        connect_started = asyncio.Event()
+
+        async def hanging_connect():
+            connect_started.set()
+            await asyncio.sleep(3600)
+
+        scheduler._connect = hanging_connect
+        task = asyncio.create_task(scheduler.run_forever())
+        await connect_started.wait()
+        scheduler._request_shutdown(task, 15)
+        await task  # must not raise despite the failing disconnect
+
+        assert task.done() and not task.cancelled()
+
     def test_signal_handlers_are_removed_after_teardown(self):
         """Review finding: removal restores SIG_DFL, so it must run last."""
         src = (REPO / "src" / "scheduler.py").read_text()

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -76,3 +76,31 @@ class TestOpsWiring:
         src = (REPO / "src" / "scheduler.py").read_text()
         assert "loop.add_signal_handler(signum, self._request_shutdown, main_task, signum)" in src
         assert "except asyncio.CancelledError:" in src.split("async def run_forever", 1)[1]
+
+
+class TestTeardownRobustness:
+    async def test_failing_listener_stop_never_skips_disconnect(self, monkeypatch, tmp_path):
+        """Review finding: teardown steps must be independent."""
+        scheduler = _bare_scheduler(monkeypatch, tmp_path)
+        scheduler._stop_listener = unittest.mock.AsyncMock(side_effect=RuntimeError("close failed"))
+        connect_started = asyncio.Event()
+
+        async def hanging_connect():
+            connect_started.set()
+            await asyncio.sleep(3600)
+
+        scheduler._connect = hanging_connect
+        task = asyncio.create_task(scheduler.run_forever())
+        await connect_started.wait()
+        scheduler._request_shutdown(task, 15)
+        await task
+
+        scheduler._disconnect.assert_awaited()
+
+    def test_signal_handlers_are_removed_after_teardown(self):
+        """Review finding: removal restores SIG_DFL, so it must run last."""
+        src = (REPO / "src" / "scheduler.py").read_text()
+        finally_block = src.split("async def run_forever", 1)[1]
+        assert finally_block.index("await self._disconnect()") < finally_block.index(
+            "loop.remove_signal_handler(signum)"
+        )

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -155,6 +155,10 @@ class TestHeartbeatLifetime:
         monkeypatch.setenv("HEARTBEAT_FILE", str(tmp_path / "beat"))
         scheduler = BackupScheduler.__new__(BackupScheduler)
         scheduler._connect = unittest.mock.AsyncMock(side_effect=RuntimeError("no network"))
+        # The consolidated finally now always runs full teardown.
+        scheduler._stop_listener = unittest.mock.AsyncMock()
+        scheduler._disconnect = unittest.mock.AsyncMock()
+        scheduler.stop = unittest.mock.MagicMock()
 
         try:
             await scheduler.run_forever()


### PR DESCRIPTION
## Summary

- **`docker stop` no longer ends in SIGKILL** (audit bead 9t6.8.9). The sync SIGTERM handler only flipped `running`, which nothing checks until the keep-alive loop — a stop during connect or an hours-long initial sweep rode out the grace period into SIGKILL, mid-write. `run_forever` now registers asyncio-native handlers that cancel the task itself: the in-flight await interrupts, the consolidated single-site `finally` teardown runs (listeners, scheduler, connections, heartbeat), and the process exits cleanly. A second signal during teardown is deliberately a no-op — re-cancelling would truncate the teardown it exists to protect. Sync handlers remain as the documented fallback for platforms without loop signal support.
- **Container logs stop filling the host disk** (audit bead 9t6.8.24): the example compose gains `json-file` rotation (10m × 3) on both services, plus `stop_grace_period: 90s` so long sweeps get room to unwind.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [x] Infrastructure/CI change

## Database Changes

- [x] No database changes

## Data Consistency Checklist

- [ ] All `chat_id` values use marked format (via `_get_marked_id()`) — n/a
- [ ] All datetime values pass through `_strip_tz()` before DB operations — n/a
- [ ] INSERT and UPDATE operations handle the same fields identically — n/a

## Testing

- [x] Tests pass locally (`python -m pytest tests/`) — 3328 passed, 123 skipped, 0 failed; new: cancel-during-connect runs the full teardown and returns cleanly (no CancelledError escape, no lingering heartbeat), second-signal idempotency, and compose/scheduler wiring guards
- [x] Linting passes (`ruff check .`) — CI's pinned 0.15.14
- [x] Formatting passes (`ruff format --check .`)
- [ ] Manually tested in development environment — container-level behavior verifies at the next release's deploy (`docker stop` timing)

## Security Checklist

- [x] No secrets or credentials committed
- [x] User input properly validated/sanitized — n/a
- [x] Authentication/authorization properly checked — n/a

## Deployment Notes

- Graceful stop takes effect with the next release's images; the compose grace period and log rotation are example-file guidance operators can copy today. No migration, no config.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added graceful shutdown handling so services can safely finish cleanup when interrupted.
  * Added a 90-second shutdown grace period for backup and viewer services.
  * Added bounded container log rotation to help manage disk usage.

* **Bug Fixes**
  * Improved cleanup of connections, listeners, schedulers, and heartbeat processes during shutdown.
  * Ensured cleanup continues even if one shutdown step fails.
  * Prevented repeated cancellation signals from disrupting teardown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->