### PR TITLE
perf(capture): media hashing and thumbnailing leave the event loop

### DIFF
--- a/src/listener.py
+++ b/src/listener.py
@@ -40,7 +40,7 @@ from .db import DatabaseAdapter, create_adapter
 from .db.models import account_metadata_key
 from .message_utils import (
     build_media_filename,
-    compute_file_hash,
+    compute_file_hash_async,
     describe_exception,
     download_and_shard_media,
     extract_media_attributes,
@@ -919,7 +919,7 @@ class TelegramListener:
                 resolved = file_path
                 if os.path.islink(file_path):
                     resolved = os.path.realpath(file_path)
-                content_hash = compute_file_hash(resolved) if os.path.exists(resolved) else None
+                content_hash = await compute_file_hash_async(resolved) if os.path.exists(resolved) else None
 
             # Return the path as stored in DB (relative to media root)
             return f"{self.config.media_path}/{chat_id}/{file_name}", file_name, content_hash

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -298,7 +298,7 @@ async def deduplicate_shared_file(
     element is True when the path points to a pre-existing canonical blob
     that must NOT be moved/deleted by the caller.
     """
-    content_hash = compute_file_hash(shared_file_path)
+    content_hash = await compute_file_hash_async(shared_file_path)
     if not content_hash:
         return shared_file_path, content_hash, False
 
@@ -328,6 +328,45 @@ async def deduplicate_shared_file(
 
     logger.debug("Content-hash dedup: matched existing file")
     return existing_shared, content_hash, True
+
+
+_HASH_CACHE_MAX_ENTRIES = 4096
+# path -> (mtime, size, sha256). The shared store re-hashes the same canonical
+# blob for every new duplicate reference; (mtime, size) validation keeps a hit
+# exactly as trustworthy as re-reading the file.
+_hash_cache: dict[str, tuple[float, int, str]] = {}
+
+
+def compute_file_hash_cached(filepath: str) -> str | None:
+    """compute_file_hash with an (mtime, size)-validated memo (9t6.6.7).
+
+    A changed file misses (stat differs); a failed hash is never stored, so a
+    patched-or-flaky read cannot poison the cache. The bound is a simple
+    clear-and-refill — refilling is cheap next to the hashing it avoids.
+    """
+    try:
+        st = os.stat(filepath)
+    except OSError:
+        return None
+    hit = _hash_cache.get(filepath)
+    if hit is not None and hit[0] == st.st_mtime and hit[1] == st.st_size:
+        return hit[2]
+    digest = compute_file_hash(filepath)
+    if digest:
+        if len(_hash_cache) >= _HASH_CACHE_MAX_ENTRIES:
+            _hash_cache.clear()
+        _hash_cache[filepath] = (st.st_mtime, st.st_size, digest)
+    return digest
+
+
+async def compute_file_hash_async(filepath: str) -> str | None:
+    """The awaitable form every async capture path must use (9t6.5.28/9t6.6.6).
+
+    Whole-file SHA-256 of a large video takes seconds; computed inline it
+    stalls the event loop the realtime listener and the Telethon transport
+    share. One worker-thread hop, memoized via compute_file_hash_cached.
+    """
+    return await asyncio.to_thread(compute_file_hash_cached, filepath)
 
 
 def compute_file_hash(filepath: str, chunk_size: int = 65536) -> str | None:
@@ -406,12 +445,12 @@ async def download_and_shard_media(
         # Chat symlink already exists — resolve hash if possible
         content_hash = None
         if shared_file_path and os.path.exists(shared_file_path):
-            content_hash = compute_file_hash(shared_file_path)
+            content_hash = await compute_file_hash_async(shared_file_path)
         return shared_file_path, content_hash
 
     if shared_file_path:
         # File exists in shared — create symlink. Hash only when target resolves.
-        content_hash = compute_file_hash(shared_file_path) if os.path.exists(shared_file_path) else None
+        content_hash = await compute_file_hash_async(shared_file_path) if os.path.exists(shared_file_path) else None
         try:
             rel_path = os.path.relpath(shared_file_path, chat_media_dir)
             try:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -56,7 +56,7 @@ from .folder_utils import FolderChat, FolderRules, resolve_folder_member_ids
 from .media_errors import is_media_location_error
 from .message_utils import (
     build_media_filename,
-    compute_file_hash,
+    compute_file_hash_async,
     describe_exception,
     download_and_shard_media,
     extract_media_attributes,
@@ -3379,7 +3379,7 @@ class TelegramBackup:
                 if os.path.exists(actual_path):
                     file_size = os.path.getsize(actual_path)
                     if not content_hash:
-                        content_hash = compute_file_hash(actual_path)
+                        content_hash = await compute_file_hash_async(actual_path)
             else:
                 # No deduplication - download directly to chat directory.
                 # lexists short-circuits the download when a symlink is
@@ -3401,7 +3401,7 @@ class TelegramBackup:
                 # Update file_size and compute hash from disk
                 if os.path.exists(file_path):
                     file_size = os.path.getsize(file_path)
-                    content_hash = compute_file_hash(file_path)
+                    content_hash = await compute_file_hash_async(file_path)
 
             # Extract media metadata via the SHARED extractor (#263). The listener
             # writes the same columns from the same helper, so this sweep's upsert
@@ -3424,7 +3424,9 @@ class TelegramBackup:
 
             # Pre-generate thumbnail for instant gallery loading
             try:
-                _pre_generate_thumbnail(file_path, self.config.media_path)
+                # PIL decode+resize is CPU work; inline it stalls the shared loop
+                # (same invariant as the hashing above).
+                await asyncio.to_thread(_pre_generate_thumbnail, file_path, self.config.media_path)
             except Exception:
                 pass  # Non-critical, viewer generates on-demand as fallback
 

--- a/tests/test_hashing_offloop.py
+++ b/tests/test_hashing_offloop.py
@@ -1,0 +1,82 @@
+"""Off-loop, memoized media hashing (9t6.5.28 / 9t6.6.6 / 9t6.6.7).
+
+Whole-file SHA-256 of large media ran inline on the event loop the realtime
+listener and Telethon transport share, and the shared store re-hashed the
+same canonical blob for every duplicate reference. These pin the worker-hop
+contract, the (mtime, size)-validated memo, and the converted call sites.
+"""
+
+import asyncio
+import unittest.mock
+from pathlib import Path
+
+import src.message_utils as mu
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+class TestMemo:
+    def setup_method(self):
+        mu._hash_cache.clear()
+
+    def test_same_unchanged_file_hashes_once(self, tmp_path):
+        f = tmp_path / "blob.bin"
+        f.write_bytes(b"payload")
+        with unittest.mock.patch.object(mu, "compute_file_hash", wraps=mu.compute_file_hash) as spy:
+            first = mu.compute_file_hash_cached(str(f))
+            second = mu.compute_file_hash_cached(str(f))
+        assert first == second and first is not None
+        assert spy.call_count == 1
+
+    def test_changed_file_invalidates(self, tmp_path):
+        f = tmp_path / "blob.bin"
+        f.write_bytes(b"payload")
+        first = mu.compute_file_hash_cached(str(f))
+        f.write_bytes(b"different payload")
+        second = mu.compute_file_hash_cached(str(f))
+        assert first != second
+
+    def test_failed_hash_is_never_stored(self, tmp_path):
+        f = tmp_path / "blob.bin"
+        f.write_bytes(b"payload")
+        with unittest.mock.patch.object(mu, "compute_file_hash", return_value=None) as spy:
+            assert mu.compute_file_hash_cached(str(f)) is None
+            assert mu.compute_file_hash_cached(str(f)) is None
+        assert spy.call_count == 2  # a patched/flaky read cannot poison the cache
+
+    def test_missing_file_is_none(self, tmp_path):
+        assert mu.compute_file_hash_cached(str(tmp_path / "gone")) is None
+
+
+class TestOffLoopContract:
+    async def test_async_form_hops_through_a_worker_thread(self, tmp_path):
+        mu._hash_cache.clear()
+        f = tmp_path / "blob.bin"
+        f.write_bytes(b"payload")
+
+        calls = []
+        real_to_thread = asyncio.to_thread
+
+        async def counting_to_thread(fn, *args, **kwargs):
+            calls.append(fn.__name__)
+            return await real_to_thread(fn, *args, **kwargs)
+
+        with unittest.mock.patch.object(mu.asyncio, "to_thread", counting_to_thread):
+            digest = await mu.compute_file_hash_async(str(f))
+        assert digest is not None
+        assert calls == ["compute_file_hash_cached"]
+
+
+class TestCallSiteConversion:
+    def test_no_inline_hashing_remains_on_async_capture_paths(self):
+        listener = (REPO / "src" / "listener.py").read_text()
+        backup = (REPO / "src" / "telegram_backup.py").read_text()
+        for src, name in ((listener, "listener"), (backup, "telegram_backup")):
+            assert "= compute_file_hash(" not in src, name
+            assert "compute_file_hash_async" in src, name
+        # Thumbnail generation moved off-loop too.
+        assert "asyncio.to_thread(_pre_generate_thumbnail" in backup
+
+    def test_dedup_and_reuse_paths_await_the_async_form(self):
+        src = (REPO / "src" / "message_utils.py").read_text()
+        assert src.count("await compute_file_hash_async(") == 3


### PR DESCRIPTION
## Summary

- **Media hashing and thumbnail generation leave the event loop** (audit beads 9t6.5.28 + 9t6.6.6). Whole-file SHA-256 of a large video takes seconds and ran inline on the loop the realtime listener and the Telethon transport share — every big download froze live capture for its duration, violating the off-loop invariant the codebase already states (and this session already enforced for PBKDF2). `compute_file_hash_async` is the awaitable form all five async capture sites now use (dedup, symlink reuse ×2, listener realtime path, sweep verification ×2); PIL thumbnail pre-generation rides the same worker-thread rule.
- **The shared store stops re-hashing the same blob per duplicate reference** (9t6.6.7): `compute_file_hash_cached` memoizes with `(mtime, size)` validation — a changed file misses, a failed hash is never stored (so the existing test that patches the primitive to `None` cannot poison it), and the bound is a cheap clear-and-refill.
- The sync primitive remains unchanged for sync contexts and existing patches.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change

## Database Changes

- [x] No database changes

## Data Consistency Checklist

- [ ] All `chat_id` values use marked format (via `_get_marked_id()`) — n/a
- [ ] All datetime values pass through `_strip_tz()` before DB operations — n/a
- [x] INSERT and UPDATE operations handle the same fields identically — hash values flow into the same fields as before; only the execution context and memoization changed

## Testing

- [x] Tests pass locally (`python -m pytest tests/`) — 3339 passed, 123 skipped, 0 failed; new: memo semantics (hash-once, mtime/size invalidation, no-poisoning, missing-file), worker-hop contract, and call-site conversion guards (zero inline hash calls left on async paths; thumbnails via to_thread)
- [x] Linting passes (`ruff check .`) — CI's pinned 0.15.14
- [x] Formatting passes (`ruff format --check .`)
- [ ] Manually tested in development environment — mutation-checked instead: inlining the async form turns the worker-hop test red (watched)

## Security Checklist

- [x] No secrets or credentials committed
- [x] User input properly validated/sanitized — n/a
- [x] Authentication/authorization properly checked — n/a

## Deployment Notes

- Backup-container behavior only; no migration, no config. Ships with the next release; the visible effect is that live capture stays responsive while multi-hundred-MB media download and hash.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Media hashing now runs asynchronously, keeping downloads and message processing responsive.
  * Repeated file hashes are cached to reduce unnecessary processing.
  * Thumbnail generation runs without blocking other application tasks.

* **Bug Fixes**
  * Improved handling of missing files and unsuccessful hash operations.

* **Tests**
  * Added coverage for hash caching, cache invalidation, asynchronous processing, and media workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->