### PR TITLE
perf(backup): skip guaranteed-no-op reaction locks and sender re-upserts per message

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -2248,6 +2248,40 @@ class DatabaseAdapter:
             return [{"emoji": r.emoji, "user_id": r.user_id, "count": r.count} for r in result.scalars()]
 
     @retry_on_locked()
+    async def get_message_ids_with_reaction_rows(
+        self, chat_id: int, message_ids: list[int], *, account_id: int
+    ) -> set[int]:
+        """Return the subset of ``message_ids`` holding ANY reaction row (live
+        or tombstoned) in this chat.
+
+        One indexed probe per commit batch (idx_reactions_chat_message) lets the
+        sweep skip empty-snapshot reconciles for messages with no stored rows —
+        the overwhelming majority — where reconcile_reactions would take the
+        per-message row lock only to no-op. Messages that DO hold rows still
+        reconcile, so removals-to-zero keep tombstoning (#219).
+        """
+        if not message_ids:
+            return set()
+        found: set[int] = set()
+        async with self.db_manager.async_session_factory() as session:
+            # 500-id chunks keep the IN list under every backend's bind-parameter
+            # ceiling regardless of the caller's configured batch size.
+            for i in range(0, len(message_ids), 500):
+                result = await session.execute(
+                    select(Reaction.message_id)
+                    .where(
+                        and_(
+                            Reaction.account_id == account_id,
+                            Reaction.chat_id == chat_id,
+                            Reaction.message_id.in_(message_ids[i : i + 500]),
+                        )
+                    )
+                    .distinct()
+                )
+                found.update(result.scalars().all())
+        return found
+
+    @retry_on_locked()
     async def reconcile_reactions(
         self,
         message_id: int,

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -134,6 +134,9 @@ MESSAGE_MAX_PROCESS_ATTEMPTS = 2
 # Cap on the ids kept in a chat's give-up record so it cannot grow without bound.
 # The running total is stored separately and stays exact.
 MESSAGE_GIVE_UP_RECORD_LIMIT = 500
+# Bound on the instance-lifetime sender-fingerprint memo (~200 bytes/entry);
+# cleared wholesale when exceeded rather than LRU-tracked.
+SENDER_CACHE_MAX_ENTRIES = 50_000
 
 
 def _media_retry_backoff_seconds(attempt: int) -> float:
@@ -2141,18 +2144,30 @@ class TelegramBackup:
             if msg.get("_media_data"):
                 await self.db.insert_media(msg["_media_data"], account_id=self.account_id)
 
+        # Reconcile reactions for every processed message, including those whose
+        # snapshot is empty ([]), so removals-to-zero on re-fetched messages
+        # persist instead of leaving stale rows (#219). reconcile_reactions is
+        # idempotent (a stable message re-scans to a no-op) and preserves
+        # created_at. A None snapshot means extraction FAILED (shape drift) —
+        # skip rather than tombstone valid rows. An empty snapshot can only
+        # tombstone when stored rows exist, so one batched probe replaces the
+        # per-message lock+scan for the reaction-free majority, where the
+        # reconcile was a guaranteed no-op.
+        empty_ids = [msg["id"] for msg in batch_data if msg.get("reactions") == []]
+        stored_ids: set[int] = set()
+        if empty_ids:
+            stored_ids = await self.db.get_message_ids_with_reaction_rows(
+                chat_id, empty_ids, account_id=self.account_id
+            )
         for msg in batch_data:
-            # Reconcile reactions for every processed message, including those whose
-            # snapshot is empty ([]), so removals-to-zero on re-fetched messages
-            # persist instead of leaving stale rows (#219). reconcile_reactions is
-            # idempotent (a stable message re-scans to a no-op) and preserves
-            # created_at. A None snapshot means extraction FAILED (shape drift) —
-            # skip rather than tombstone valid rows.
             observed = msg.get("reactions")
-            if observed is not None:
-                await self.db.reconcile_reactions(
-                    msg["id"], chat_id, observed, mark_removed=True, account_id=self.account_id
-                )
+            if observed is None:
+                continue
+            if not observed and msg["id"] not in stored_ids:
+                continue
+            await self.db.reconcile_reactions(
+                msg["id"], chat_id, observed, mark_removed=True, account_id=self.account_id
+            )
 
     async def _fill_gap_range(self, entity, chat_id: int, gap_start: int, gap_end: int) -> int:
         """
@@ -2812,9 +2827,7 @@ class TelegramBackup:
 
         # Save sender information if available
         if sender:
-            sender_data = self._extract_user_data(sender)
-            if sender_data:
-                await self.db.upsert_user(sender_data)
+            await self._save_sender(sender)
 
         # Extract message data
         # v6.0.0: media_type, media_id, media_path removed - media stored in separate table
@@ -3630,6 +3643,35 @@ class TelegramBackup:
         chat_data["is_archived"] = 1 if is_archived else 0
 
         return chat_data
+
+    async def _save_sender(self, sender) -> None:
+        """Upsert the sender row unless an identical one was already written.
+
+        Senders repeat heavily within a chat, so an instance-lifetime
+        fingerprint memo skips the re-upsert once a byte-identical row is
+        stored; any profile change writes again. The fingerprint is recorded
+        only after a successful upsert so a failed write retries on the next
+        sighting.
+        """
+        sender_data = self._extract_user_data(sender)
+        if not sender_data:
+            return
+        fingerprint = (
+            sender_data["username"],
+            sender_data["first_name"],
+            sender_data["last_name"],
+            sender_data["phone"],
+            sender_data["is_bot"],
+        )
+        cache = getattr(self, "_sender_cache", None)
+        if cache is None:
+            cache = self._sender_cache = {}
+        if cache.get(sender_data["id"]) == fingerprint:
+            return
+        await self.db.upsert_user(sender_data)
+        if len(cache) >= SENDER_CACHE_MAX_ENTRIES:
+            cache.clear()
+        cache[sender_data["id"]] = fingerprint
 
     def _extract_user_data(self, user) -> dict | None:
         """Extract user data from user entity."""

--- a/tests/test_capture_throughput.py
+++ b/tests/test_capture_throughput.py
@@ -1,0 +1,181 @@
+"""Capture-throughput guards: batched reaction probe + sender-fingerprint memo.
+
+`_commit_batch` must keep #219's removals-to-zero (an empty snapshot with
+stored rows still reconciles) while skipping the guaranteed-no-op reconcile
+for messages with no stored rows. `_save_sender` must write a sender once per
+distinct profile, re-write on change, and never memoize a failed upsert.
+"""
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from telethon.tl.types import User
+
+from src.telegram_backup import TelegramBackup
+
+
+def _backup_with_mock_db() -> TelegramBackup:
+    backup = TelegramBackup.__new__(TelegramBackup)
+    backup.db = MagicMock()
+    backup.db.insert_messages_batch = AsyncMock()
+    backup.db.insert_media = AsyncMock()
+    backup.db.reconcile_reactions = AsyncMock()
+    backup.db.get_message_ids_with_reaction_rows = AsyncMock(return_value=set())
+    backup.db.upsert_user = AsyncMock()
+    backup.account_id = 1
+    return backup
+
+
+def _sender(user_id: int = 42, username: str | None = "sender") -> MagicMock:
+    user = MagicMock(spec=User)
+    user.id = user_id
+    user.username = username
+    user.first_name = "Sender"
+    user.last_name = None
+    user.phone = None
+    user.bot = False
+    return user
+
+
+class TestCommitBatchReactionProbe(unittest.TestCase):
+    def setUp(self):
+        self.backup = _backup_with_mock_db()
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_rowless_empty_snapshots_skip_reconcile(self):
+        """[] with no stored rows is a guaranteed no-op — never dispatched."""
+        batch = [
+            {"id": 1, "reactions": [{"emoji": "👍", "count": 2}]},
+            {"id": 2, "reactions": []},
+            {"id": 3, "reactions": None},
+        ]
+        self._run(self.backup._commit_batch(batch, -100500))
+
+        self.backup.db.get_message_ids_with_reaction_rows.assert_awaited_once_with(-100500, [2], account_id=1)
+        self.backup.db.reconcile_reactions.assert_awaited_once_with(
+            1, -100500, [{"emoji": "👍", "count": 2}], mark_removed=True, account_id=1
+        )
+
+    def test_empty_snapshot_with_stored_rows_still_reconciles(self):
+        """#219: removal-to-zero must reach reconcile when rows exist."""
+        self.backup.db.get_message_ids_with_reaction_rows.return_value = {2}
+        batch = [
+            {"id": 1, "reactions": [{"emoji": "👍", "count": 2}]},
+            {"id": 2, "reactions": []},
+        ]
+        self._run(self.backup._commit_batch(batch, -100500))
+
+        calls = self.backup.db.reconcile_reactions.await_args_list
+        self.assertEqual(len(calls), 2)
+        self.assertEqual(calls[1].args, (2, -100500, []))
+
+    def test_no_probe_without_empty_snapshots(self):
+        batch = [
+            {"id": 1, "reactions": [{"emoji": "👍", "count": 1}]},
+            {"id": 3, "reactions": None},
+        ]
+        self._run(self.backup._commit_batch(batch, -100500))
+
+        self.backup.db.get_message_ids_with_reaction_rows.assert_not_awaited()
+        self.backup.db.reconcile_reactions.assert_awaited_once()
+
+
+class TestSaveSenderMemo(unittest.TestCase):
+    def setUp(self):
+        self.backup = _backup_with_mock_db()
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_identical_sender_upserts_once(self):
+        self._run(self.backup._save_sender(_sender()))
+        self._run(self.backup._save_sender(_sender()))
+        self.backup.db.upsert_user.assert_awaited_once()
+
+    def test_profile_change_reupserts(self):
+        self._run(self.backup._save_sender(_sender(username="old")))
+        self._run(self.backup._save_sender(_sender(username="new")))
+        self.assertEqual(self.backup.db.upsert_user.await_count, 2)
+
+    def test_failed_upsert_is_not_memoized(self):
+        self.backup.db.upsert_user.side_effect = [RuntimeError("db down"), None]
+        with self.assertRaises(RuntimeError):
+            self._run(self.backup._save_sender(_sender()))
+        self._run(self.backup._save_sender(_sender()))
+        self.assertEqual(self.backup.db.upsert_user.await_count, 2)
+
+    def test_non_user_sender_is_ignored(self):
+        self._run(self.backup._save_sender(MagicMock()))  # not spec'd as User
+        self.backup.db.upsert_user.assert_not_awaited()
+
+    def test_cache_bound_clears_and_keeps_working(self):
+        with patch("src.telegram_backup.SENDER_CACHE_MAX_ENTRIES", 1):
+            self._run(self.backup._save_sender(_sender(user_id=1)))
+            self._run(self.backup._save_sender(_sender(user_id=2)))  # clears, re-adds
+            self._run(self.backup._save_sender(_sender(user_id=1)))  # evicted → writes
+        self.assertEqual(self.backup.db.upsert_user.await_count, 3)
+        self.assertEqual(len(self.backup._sender_cache), 1)
+
+
+async def _seed_message(adapter, chat_id: int, message_id: int) -> None:
+    from datetime import datetime
+
+    await adapter.insert_message(
+        {
+            "id": message_id,
+            "chat_id": chat_id,
+            "sender_id": 4242,
+            "date": datetime(2026, 1, 1, 12, 0, 0),
+            "text": "seed",
+            "is_outgoing": 0,
+            "sender_name": "Fixture Sender",
+            "raw_data": {},
+        },
+        account_id=1,
+    )
+
+
+class TestReactionRowProbeRealEngines:
+    async def test_probe_reports_live_and_tombstoned_rows(self, real_adapter):
+        chat_id = 920001
+        await real_adapter.upsert_chat({"id": chat_id, "type": "group", "title": "probe"}, account_id=1)
+        await _seed_message(real_adapter, chat_id, 1)
+        await _seed_message(real_adapter, chat_id, 2)
+        await real_adapter.reconcile_reactions(
+            1, chat_id, [{"emoji": "👍", "count": 3}], mark_removed=True, account_id=1
+        )
+
+        found = await real_adapter.get_message_ids_with_reaction_rows(chat_id, [1, 2], account_id=1)
+        assert found == {1}
+
+        # Tombstone the row (removal-to-zero); the probe must still report it so
+        # later empty snapshots keep reconciling instead of skipping.
+        await real_adapter.reconcile_reactions(1, chat_id, [], mark_removed=True, account_id=1)
+        found = await real_adapter.get_message_ids_with_reaction_rows(chat_id, [1, 2], account_id=1)
+        assert found == {1}
+
+        # Wrong account sees nothing.
+        found = await real_adapter.get_message_ids_with_reaction_rows(chat_id, [1, 2], account_id=9)
+        assert found == set()
+
+    async def test_probe_crosses_chunk_boundary_and_handles_empty_input(self, real_adapter):
+        chat_id = 920002
+        await real_adapter.upsert_chat({"id": chat_id, "type": "group", "title": "probe"}, account_id=1)
+        await _seed_message(real_adapter, chat_id, 7)
+        await real_adapter.reconcile_reactions(
+            7, chat_id, [{"emoji": "🔥", "count": 1}], mark_removed=True, account_id=1
+        )
+
+        # 501 ids place the hit in the second 500-id chunk.
+        probe_ids = list(range(10_000, 10_500)) + [7]
+        found = await real_adapter.get_message_ids_with_reaction_rows(chat_id, probe_ids, account_id=1)
+        assert found == {7}
+
+        assert await real_adapter.get_message_ids_with_reaction_rows(chat_id, [], account_id=1) == set()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -476,12 +476,14 @@ class TestBackupCheckpointing(unittest.TestCase):
     def test_commit_batch_called_correctly(self):
         """_commit_batch persists messages, media and reconciles reactions.
 
-        #219: an empty snapshot ([]) is reconciled (zero-clear); a None snapshot
-        (extraction failure) is skipped so it can't tombstone valid reactions.
+        #219: an empty snapshot ([]) is reconciled (zero-clear) when stored rows
+        exist for the message; a None snapshot (extraction failure) is skipped so
+        it can't tombstone valid reactions.
         """
         backup = TelegramBackup.__new__(TelegramBackup)
         backup.account_id = 1
         backup.db = AsyncMock()
+        backup.db.get_message_ids_with_reaction_rows.return_value = {1}
 
         batch = [
             {"id": 1, "chat_id": 100, "_media_data": {"file_path": "/a.jpg"}, "reactions": []},
@@ -1972,12 +1974,15 @@ class TestCommitBatchReactions(unittest.TestCase):
         )
 
     def test_empty_reactions_still_reconciled(self):
-        """#219 (F2): reconcile runs for an empty snapshot ([]) so removals-to-zero
-        on re-fetched messages persist — the opposite of the old skip-on-empty."""
+        """#219 (F2): reconcile runs for an empty snapshot ([]) when the message
+        holds stored rows, so removals-to-zero on re-fetched messages persist.
+        The batched probe decides which empty snapshots can skip."""
+        self.backup.db.get_message_ids_with_reaction_rows.return_value = {3}
         batch = [{"id": 3, "chat_id": 100, "reactions": []}]
 
         self._run(self.backup._commit_batch(batch, 100))
 
+        self.backup.db.get_message_ids_with_reaction_rows.assert_awaited_once_with(100, [3], account_id=1)
         self.backup.db.reconcile_reactions.assert_awaited_once_with(3, 100, [], mark_removed=True, account_id=1)
 
     def test_extraction_failure_skips_reconcile(self):


### PR DESCRIPTION
## Problem

Every message the scheduled sweep commits pays two hidden database round-trips that almost never do anything:

- `_commit_batch` calls `reconcile_reactions` for **every** message with a successfully extracted snapshot — including the reaction-free majority, where the snapshot is `[]` and no rows are stored. Each of those calls opens a session, takes `SELECT … FOR UPDATE` on the parent message row, scans the reactions table, finds nothing, and returns `"noop"`. On a large sweep that is tens of thousands of wasted lock round-trips per cycle.
- `_process_message` upserts the sender's `users` row for **every** message, even though senders repeat heavily inside a chat and the row is byte-identical almost every time. The official clients keep peer data in a session cache and write on change; we re-wrote it unconditionally.

## Fix

**Reactions** — one indexed existence probe per batch instead of a per-message lock+scan: `get_message_ids_with_reaction_rows(chat_id, ids, account_id=…)` (served by `idx_reactions_chat_message`, 500-id chunks to stay under bind-parameter ceilings) returns which empty-snapshot messages actually hold rows. Empty snapshots reconcile **only** for those, so #219 removals-to-zero still tombstone exactly as before; non-empty snapshots always reconcile; `None` (extraction failure) still skips.

**Senders** — `_save_sender` memoizes an instance-lifetime fingerprint (username, first/last name, phone, bot flag) per user id: first sighting writes, any profile change writes again, a failed upsert is never memoized (retries next sighting), and the memo is bounded (cleared wholesale past 50k entries). Observable drift: `users.updated_at` no longer bumps on every sighting — nothing in the codebase consumes it as last-seen.

## Verification

- New `tests/test_capture_throughput.py`: probe dispatch semantics (skip / stored-rows / no-probe cases), memo semantics (identical / changed / failed / non-User / bound), and the probe against real engines — live rows, tombstoned rows, wrong account, the 500-id chunk boundary, empty input.
- Mutation controls: dropping the stored-rows exception, memoizing before the upsert, and removing the cache bound each turn the suite red.
- Two existing tests encoding the old always-dispatch contract updated to the probe contract, keeping their #219 dispatch assertions.
- Full suite: 3347+ passed locally; `ruff check` + `ruff format --check` (0.15.14) clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved message processing efficiency by reducing repeated sender updates during retries.
  * Optimized reaction reconciliation, including large message batches.

* **Bug Fixes**
  * Ensured stored and previously removed reactions are correctly reconciled.
  * Preserved reaction data when extraction fails, while safely skipping truly empty snapshots.
  * Improved account and chat isolation when checking stored reactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->