### PR TITLE
fix(scheduler): run a late backup tick instead of silently dropping it

### DIFF
--- a/src/scheduler.py
+++ b/src/scheduler.py
@@ -264,6 +264,14 @@ class BackupScheduler:
                 id="telegram_backup",
                 name="Telegram Backup",
                 replace_existing=True,
+                # The shared event loop can be >1s late at the cron instant
+                # (CPU-bound stretches, DB contention); APScheduler's default
+                # 1-second misfire grace then SKIPS the run outright instead of
+                # starting late. An hour of grace turns a late tick into a late
+                # backup, and coalesce collapses several missed ticks into one
+                # catch-up run.
+                misfire_grace_time=3600,
+                coalesce=True,
             )
 
             logger.info(f"Backup scheduled with cron: {self.config.schedule}")

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -136,6 +136,9 @@ class TestBackupSchedulerStart:
             scheduler.start()
 
             scheduler.scheduler.add_job.assert_called_once()
+            job_kwargs = scheduler.scheduler.add_job.call_args.kwargs
+            assert job_kwargs["misfire_grace_time"] == 3600
+            assert job_kwargs["coalesce"] is True
             scheduler.scheduler.start.assert_called_once()
             assert scheduler.running is True
 


### PR DESCRIPTION
## Problem

APScheduler's default misfire grace is **one second**. Whenever the shared event loop is more than 1s late at the cron instant — a CPU-bound stretch, database contention, a burst of listener work — the scheduled backup is skipped outright with only a debug-level misfire note. A tick that should have produced a (possibly late) run produces **no run at all**, and nothing surfaces it.

## Fix

The backup job now registers with `misfire_grace_time=3600` and `coalesce=True`: a tick up to an hour late still starts, and several missed ticks collapse into one catch-up run. Overlap protection is unchanged — `max_instances` stays at its default of 1, so a run that fires while the previous one is still going is still refused.

## Verification

- `tests/test_scheduler.py` start test now asserts the job kwargs carry `misfire_grace_time=3600` and `coalesce=True` (49 passed).
- Mutation control: removing the two kwargs turns the test red; file restored byte-identical.
- `ruff check` + `ruff format --check` (0.15.14) clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scheduled backups are now more resilient to temporary delays and system load.
  * Delayed backup runs can start within one hour instead of being skipped, while multiple missed runs are consolidated into a single catch-up execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->