### PR TITLE
fix(backup): stream media verification instead of materialising the whole table

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -2022,34 +2022,60 @@ class DatabaseAdapter:
             await session.commit()
             return result.rowcount
 
-    async def get_media_for_verification(self, *, account_id: int) -> list[dict[str, Any]]:
-        """
-        Get one account's media records that should have files on disk.
-        Used by VERIFY_MEDIA to check for missing/corrupted files — the caller
-        re-downloads what is missing, and only this account's session can.
+    async def iter_media_for_verification(self, *, account_id: int, batch_size: int = 500):
+        """Yield batches of one account's media records that should have files
+        on disk (``downloaded=1`` OR ``file_path`` set). Used by VERIFY_MEDIA —
+        the caller re-downloads what is missing, and only this account's
+        session can.
 
-        Returns media where downloaded=1 OR file_path is not null.
+        Keyset-paginated on ``id`` (a string, unique within one account),
+        projecting only the columns verification consumes, so memory stays
+        bounded by ``batch_size`` regardless of archive size — materializing
+        this set as ORM rows OOM-killed the 256m backup container on large
+        archives, the same failure ``iter_media_paths_for_repair`` streams
+        around.
         """
-        async with self.db_manager.async_session_factory() as session:
-            stmt = (
-                select(Media)
-                .where(and_(Media.account_id == account_id, or_(Media.downloaded == 1, Media.file_path.isnot(None))))
-                .order_by(Media.chat_id, Media.message_id)
-            )
-            result = await session.execute(stmt)
-            return [
+        last_id: str | None = None
+        while True:
+            async with self.db_manager.async_session_factory() as session:
+                stmt = (
+                    select(
+                        Media.id,
+                        Media.message_id,
+                        Media.chat_id,
+                        Media.type,
+                        Media.file_path,
+                        Media.file_name,
+                        Media.file_size,
+                        Media.downloaded,
+                    )
+                    .where(
+                        and_(Media.account_id == account_id, or_(Media.downloaded == 1, Media.file_path.isnot(None)))
+                    )
+                    .order_by(Media.id)
+                    .limit(batch_size)
+                )
+                if last_id is not None:
+                    stmt = stmt.where(Media.id > last_id)
+                rows = (await session.execute(stmt)).all()
+            if not rows:
+                return
+            yield [
                 {
-                    "id": m.id,
-                    "message_id": m.message_id,
-                    "chat_id": m.chat_id,
-                    "type": m.type,
-                    "file_path": m.file_path,
-                    "file_name": m.file_name,
-                    "file_size": m.file_size,
-                    "downloaded": m.downloaded,
+                    "id": r[0],
+                    "message_id": r[1],
+                    "chat_id": r[2],
+                    "type": r[3],
+                    "file_path": r[4],
+                    "file_name": r[5],
+                    "file_size": r[6],
+                    "downloaded": r[7],
                 }
-                for m in result.scalars()
+                for r in rows
             ]
+            last_id = rows[-1][0]
+            if len(rows) < batch_size:
+                return
 
     async def iter_media_paths_for_repair(self, batch_size: int = 500):
         """Yield ``(account_id, id, file_path, file_name)`` batches for the #175 repair pass.
@@ -2060,9 +2086,9 @@ class DatabaseAdapter:
         — ``id`` alone stopped being unique in v8.0.0, and a strict ``>`` on a
         non-unique key silently skips the second account's copy of an id.
         Projects only the columns the repair needs, so memory stays bounded
-        regardless of table size. The full-table materialization in
-        ``get_media_for_verification`` OOM-killed the 256m backup container on
-        large archives; this streams instead.
+        regardless of table size. A full-table materialization of this table
+        once OOM-killed the 256m backup container on large archives; both this
+        repair pass and ``iter_media_for_verification`` stream instead.
         """
         last_key: tuple[int, str] | None = None
         while True:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -1548,47 +1548,52 @@ class TelegramBackup:
         logger.info("=" * 60)
         logger.info("Starting media verification...")
 
-        media_records = await self.db.get_media_for_verification(account_id=self.account_id)
-        logger.info(f"Found {len(media_records)} media records to verify")
-
         missing_files = []
         corrupted_files = []
         skipped_symlinks = 0
+        checked = 0
 
-        # Phase 1: Check which files need re-downloading
-        for record in media_records:
-            file_path = record.get("file_path")
-            if not file_path:
-                continue
+        # Phase 1: stream batches and keep only the records needing a
+        # re-download. The full-table materialization this replaces held every
+        # row in memory at once and OOM-killed the 256m backup container on
+        # large archives; the issue lists stay bounded by actual damage.
+        async for batch in self.db.iter_media_for_verification(account_id=self.account_id):
+            for record in batch:
+                checked += 1
+                file_path = record.get("file_path")
+                if not file_path:
+                    continue
 
-            # Detect "truly missing" via lexists so an existing symlink
-            # whose ultimate target is unreachable (e.g. git-annex object
-            # outside the bind mount) is not flagged for re-download.
-            # Re-downloading it would atomic-rename a regular file on top
-            # of the symlink, mutating an archived working tree (issue #143).
-            if not os.path.lexists(file_path):
-                missing_files.append(record)
-                continue
+                # Detect "truly missing" via lexists so an existing symlink
+                # whose ultimate target is unreachable (e.g. git-annex object
+                # outside the bind mount) is not flagged for re-download.
+                # Re-downloading it would atomic-rename a regular file on top
+                # of the symlink, mutating an archived working tree (issue #143).
+                if not os.path.lexists(file_path):
+                    missing_files.append(record)
+                    continue
 
-            # Trust symlinks: their content is managed externally and may
-            # be unreachable from this process. We cannot meaningfully
-            # check size or emptiness without following the link.
-            if os.path.islink(file_path):
-                skipped_symlinks += 1
-                continue
+                # Trust symlinks: their content is managed externally and may
+                # be unreachable from this process. We cannot meaningfully
+                # check size or emptiness without following the link.
+                if os.path.islink(file_path):
+                    skipped_symlinks += 1
+                    continue
 
-            # Check if file is empty (interrupted download)
-            if os.path.getsize(file_path) == 0:
-                corrupted_files.append(record)
-                continue
-
-            # Check file size matches (if we have the expected size)
-            expected_size = record.get("file_size")
-            if expected_size and expected_size > 0:
-                actual_size = os.path.getsize(file_path)
-                # Allow 1% tolerance for size differences (encoding variations)
-                if abs(actual_size - expected_size) > expected_size * 0.01:
+                # Check if file is empty (interrupted download)
+                if os.path.getsize(file_path) == 0:
                     corrupted_files.append(record)
+                    continue
+
+                # Check file size matches (if we have the expected size)
+                expected_size = record.get("file_size")
+                if expected_size and expected_size > 0:
+                    actual_size = os.path.getsize(file_path)
+                    # Allow 1% tolerance for size differences (encoding variations)
+                    if abs(actual_size - expected_size) > expected_size * 0.01:
+                        corrupted_files.append(record)
+
+        logger.info(f"Checked {checked} media records to verify")
 
         total_issues = len(missing_files) + len(corrupted_files)
         if total_issues == 0:

--- a/tests/test_account_isolation.py
+++ b/tests/test_account_isolation.py
@@ -434,8 +434,10 @@ class TestMediaAreAccountIsolated:
         assert [m["id"] for m in await real_adapter.get_media_for_chat(-100717, account_id=DEFAULT_ACCOUNT_ID)] == [
             "-100717_517_photo"
         ]
-        assert await real_adapter.get_media_for_verification(account_id=OTHER_ACCOUNT) == []
-        verify_one = await real_adapter.get_media_for_verification(account_id=DEFAULT_ACCOUNT_ID)
+        assert [b async for b in real_adapter.iter_media_for_verification(account_id=OTHER_ACCOUNT)] == []
+        verify_one = [
+            m async for b in real_adapter.iter_media_for_verification(account_id=DEFAULT_ACCOUNT_ID) for m in b
+        ]
         assert [m["file_path"] for m in verify_one] == ["media/account1.jpg"]
 
 

--- a/tests/test_poison_message_isolation.py
+++ b/tests/test_poison_message_isolation.py
@@ -62,6 +62,25 @@ def _poison_media():
     return MessageMediaDocument(document=DocumentEmpty(id=99887766))
 
 
+def _stream_verification_batches(db):
+    """Bridge the streaming verification API onto legacy list seeding.
+
+    Production consumes ``iter_media_for_verification`` (async batches); these
+    tests seed a flat list on ``db.get_media_for_verification.return_value``.
+    Read the seeded list at call time and yield it as a single batch.
+    """
+
+    def _iter(**_kwargs):
+        async def _gen():
+            records = db.get_media_for_verification.return_value
+            if isinstance(records, list) and records:
+                yield records
+
+        return _gen()
+
+    db.iter_media_for_verification = _iter
+
+
 class TestDocumentEmptyIsNotFatal(unittest.TestCase):
     """Both capture paths classify an expired document instead of raising."""
 
@@ -273,6 +292,7 @@ class TestPeerResolutionErrorsNeverReachTheLogs(unittest.TestCase):
         self.config.max_media_download_attempts = 3
 
         self.db = AsyncMock()
+        _stream_verification_batches(self.db)
         self.backup = TelegramBackup.__new__(TelegramBackup)
         self.backup.account_id = 1
         self.backup.config = self.config

--- a/tests/test_symlink_dedup.py
+++ b/tests/test_symlink_dedup.py
@@ -24,6 +24,25 @@ from src.telegram_backup import TelegramBackup
 pytestmark = pytest.mark.skipif(os.name == "nt", reason="Symlinks require administrator privileges on Windows")
 
 
+def _stream_verification_batches(db):
+    """Bridge the streaming verification API onto legacy list seeding.
+
+    Production consumes ``iter_media_for_verification`` (async batches); these
+    tests seed a flat list on ``db.get_media_for_verification.return_value``.
+    Read the seeded list at call time and yield it as a single batch.
+    """
+
+    def _iter(**_kwargs):
+        async def _gen():
+            records = db.get_media_for_verification.return_value
+            if isinstance(records, list) and records:
+                yield records
+
+        return _gen()
+
+    db.iter_media_for_verification = _iter
+
+
 class TestDanglingSymlinkDetection(unittest.TestCase):
     """Verify os.path.exists vs os.path.lexists behavior with dangling symlinks."""
 
@@ -325,6 +344,7 @@ class TestVerifyCleanupDanglingSymlink(unittest.TestCase):
         self.backup.config.deduplicate_media = True
         self.backup.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
         self.backup.db = AsyncMock()
+        _stream_verification_batches(self.backup.db)
         self.backup.client = AsyncMock()
 
     def tearDown(self):

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -48,6 +48,25 @@ def _run(coro):
         loop.close()
 
 
+def _stream_verification_batches(db):
+    """Bridge the streaming verification API onto legacy list seeding.
+
+    Production consumes ``iter_media_for_verification`` (async batches); these
+    tests seed a flat list on ``db.get_media_for_verification.return_value``.
+    Read the seeded list at call time and yield it as a single batch.
+    """
+
+    def _iter(**_kwargs):
+        async def _gen():
+            records = db.get_media_for_verification.return_value
+            if isinstance(records, list) and records:
+                yield records
+
+        return _gen()
+
+    db.iter_media_for_verification = _iter
+
+
 def _make_backup(**overrides):
     """Create a TelegramBackup instance via __new__ with sensible mock defaults."""
     backup = TelegramBackup.__new__(TelegramBackup)
@@ -60,6 +79,7 @@ def _make_backup(**overrides):
     backup.config.reaction_resweep_max_per_chat = 500
     backup.config.reaction_resweep_batch_delay_seconds = 0.0
     backup.db = overrides.get("db", AsyncMock())
+    _stream_verification_batches(backup.db)
     # Folder resolution reads the archived-chat snapshot; default to empty so
     # tests that exercise _backup_folders get an iterable, not a bare AsyncMock.
     backup.db.get_chats_for_folder_resolution = AsyncMock(return_value=[])

--- a/tests/test_verify_stream.py
+++ b/tests/test_verify_stream.py
@@ -1,0 +1,74 @@
+"""Streaming media verification: keyset batches on real engines.
+
+`iter_media_for_verification` replaced a full-table materialization that
+OOM-killed the 256m backup container. The keyset walk (string ids, unique per
+account) must return every row exactly once across batch boundaries, project
+the columns verification consumes, and stay account-scoped.
+"""
+
+from datetime import datetime
+
+
+async def _seed(adapter, chat_id: int, media_ids: list[str], *, account_id: int = 1) -> None:
+    await adapter.upsert_chat({"id": chat_id, "type": "group", "title": "vs"}, account_id=account_id)
+    for n, media_id in enumerate(media_ids, start=1):
+        await adapter.insert_message(
+            {
+                "id": n,
+                "chat_id": chat_id,
+                "sender_id": 4242,
+                "date": datetime(2026, 1, 1, 12, 0, 0),
+                "text": "seed",
+                "is_outgoing": 0,
+                "sender_name": "Fixture Sender",
+                "raw_data": {},
+            },
+            account_id=account_id,
+        )
+        await adapter.insert_media(
+            {
+                "id": media_id,
+                "message_id": n,
+                "chat_id": chat_id,
+                "type": "photo",
+                "file_path": f"media/{media_id}.jpg",
+                "file_size": 100 + n,
+                "downloaded": True,
+            },
+            account_id=account_id,
+        )
+
+
+class TestIterMediaForVerification:
+    async def test_keyset_batches_cover_every_row_exactly_once(self, real_adapter):
+        ids = [f"m{n}" for n in range(1, 6)]  # lexicographic == insertion order
+        await _seed(real_adapter, 930001, ids)
+
+        batches = [b async for b in real_adapter.iter_media_for_verification(account_id=1, batch_size=2)]
+
+        assert [len(b) for b in batches] == [2, 2, 1]
+        flat = [m["id"] for b in batches for m in b]
+        assert flat == ids  # no duplicates, no gaps, ordered by id
+        sample = batches[0][0]
+        assert set(sample) == {
+            "id",
+            "message_id",
+            "chat_id",
+            "type",
+            "file_path",
+            "file_name",
+            "file_size",
+            "downloaded",
+        }
+        assert sample["file_path"] == "media/m1.jpg"
+        assert sample["file_size"] == 101
+
+    async def test_scoping_and_exact_batch_multiple(self, real_adapter):
+        await _seed(real_adapter, 930002, ["a1", "a2"])
+
+        # Exact multiple of batch_size: the follow-up probe must return cleanly.
+        batches = [b async for b in real_adapter.iter_media_for_verification(account_id=1, batch_size=2)]
+        assert [m["id"] for b in batches for m in b] == ["a1", "a2"]
+
+        # Another account sees nothing.
+        assert [b async for b in real_adapter.iter_media_for_verification(account_id=9, batch_size=2)] == []


### PR DESCRIPTION
## Problem

`VERIFY_MEDIA` loaded **every media row of the account into memory at once** — full ORM instances plus a dict per row — before checking a single file. The adapter itself records the consequence: this exact materialisation OOM-killed the 256m backup container on a large archive. Repair (`iter_media_paths_for_repair`) was switched to keyset streaming for precisely that reason; verification kept the old path.

## Fix

`get_media_for_verification` is replaced by `iter_media_for_verification`: keyset pagination on the string media id (unique within one account — same proven pattern as the repair iterator), projecting only the eight columns verification consumes, yielded in 500-row batches. Phase 1 consumes the stream and keeps only records that actually need re-downloading, so resident memory is bounded by batch size plus actual damage, not archive size. Phase 2 (re-download) is untouched — it already groups the issue list by chat itself, so the changed row order is irrelevant.

The "Found N media records to verify" upfront log becomes "Checked N media records to verify" after the pass — the count isn't known until the stream ends.

## Verification

- New `tests/test_verify_stream.py` on real engines: exact-once keyset coverage across batch boundaries (`[2,2,1]` batches, ordered, no dups), column projection, an exact batch-size multiple (clean tail probe), account scoping.
- Existing verification behavior tests (missing / corrupted / symlink / poison / account isolation) all pass through a per-file bridge that yields their flat-list seeding as one batch — production consumes only the iterator.
- Mutation controls: advancing the keyset from the wrong end (duplicates) and dropping missing-file collection each turn tests red; files restored byte-identical.
- Full suite: 3351 passed; `ruff check` + `ruff format --check` (0.15.14) clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance**
  - Media verification now processes records in manageable batches, reducing memory usage and improving reliability for large media libraries.

- **Bug Fixes**
  - Preserved detection of missing files, broken symlinks, empty files, and file-size mismatches.
  - Verification remains correctly scoped to the selected account and processes each record exactly once.

- **Tests**
  - Added coverage for batching, ordering, account isolation, and large verification runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->