### PR TITLE
fix(backup): stop whitelist mode wiping every chat's archived flag with a fabricated 0

### DIFF
--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -1352,6 +1352,16 @@ class TelegramBackup:
                     has_synced_before = True
                     break
 
+            # Whitelist mode resolves entities without any dialog listing
+            # (#95: the full fetch can hang), so archived-folder membership
+            # comes from one batched GetPeerDialogs pass over exactly the
+            # resolved peers. None means the probe failed: no is_archived is
+            # written at all, preserving stored values instead of forcing a
+            # wrong 0 on every run.
+            archived_membership: set[int] | None = None
+            if self.config.whitelist_mode and filtered_dialogs:
+                archived_membership = await self._fetch_archived_membership([d.entity for d in filtered_dialogs])
+
             # Backup each dialog
             # v6.2.0: Check archived_chat_ids so chats in both INCLUDE_CHAT_IDS
             # and the archived folder get the correct is_archived flag immediately.
@@ -1362,11 +1372,14 @@ class TelegramBackup:
             for i, dialog in enumerate(filtered_dialogs, 1):
                 entity = dialog.entity
                 chat_id = self._get_marked_id(entity)
-                is_archived = chat_id in archived_chat_ids and chat_id not in seen_chat_ids
-                if chat_id in archived_chat_ids and chat_id in seen_chat_ids:
-                    logger.warning(
-                        "  Chat appears in both regular and archived dialog lists - treating as NOT archived"
-                    )
+                if self.config.whitelist_mode:
+                    is_archived = None if archived_membership is None else (chat_id in archived_membership)
+                else:
+                    is_archived = chat_id in archived_chat_ids and chat_id not in seen_chat_ids
+                    if chat_id in archived_chat_ids and chat_id in seen_chat_ids:
+                        logger.warning(
+                            "  Chat appears in both regular and archived dialog lists - treating as NOT archived"
+                        )
                 logger.info(f"[{i}/{len(filtered_dialogs)}] Backing up{' (archived)' if is_archived else ''}")
 
                 try:
@@ -1912,13 +1925,14 @@ class TelegramBackup:
             return False
         return True
 
-    async def _backup_dialog(self, dialog, is_archived: bool = False) -> int:
+    async def _backup_dialog(self, dialog, is_archived: bool | None = False) -> int:
         """
         Backup a single dialog (chat).
 
         Args:
             dialog: Dialog object from Telegram
-            is_archived: Whether this dialog is from the archived folder
+            is_archived: Whether this dialog is from the archived folder;
+                None means unknown — the chat row keeps its stored value
 
         Returns:
             Number of new messages backed up
@@ -3611,12 +3625,41 @@ class TelegramBackup:
         }
         return extensions.get(media_type, "bin")
 
-    def _extract_chat_data(self, entity, is_archived: bool = False) -> dict:
+    async def _fetch_archived_membership(self, entities) -> set[int] | None:
+        """Which of these peers live in Telegram's archived folder (folder 1).
+
+        Whitelist mode never lists dialogs — the full fetch can hang on large
+        accounts (#95) — so archived status comes from batched GetPeerDialogs
+        requests covering exactly the given peers: bounded by the whitelist
+        size, not the account's dialog count. Returns None when any batch
+        fails; the caller must then write no is_archived at all rather than
+        claim 0.
+        """
+        from telethon.tl.functions.messages import GetPeerDialogsRequest
+        from telethon.tl.types import InputDialogPeer
+
+        archived: set[int] = set()
+        for start in range(0, len(entities), 100):
+            batch = entities[start : start + 100]
+            try:
+                peers = [InputDialogPeer(await self.client.get_input_entity(e)) for e in batch]
+                result = await call_with_flood_retry(self.client, GetPeerDialogsRequest(peers=peers))
+                for dlg in getattr(result, "dialogs", []):
+                    if getattr(dlg, "folder_id", None) == 1:
+                        archived.add(get_peer_id(dlg.peer))
+            except Exception as e:
+                # Type only — never peer ids (PII rule).
+                logger.warning(f"Could not determine archived status for whitelisted chats: {e.__class__.__name__}")
+                return None
+        return archived
+
+    def _extract_chat_data(self, entity, is_archived: bool | None = False) -> dict:
         """Extract chat data from entity.
 
         Args:
             entity: Telegram entity (User, Chat, Channel)
-            is_archived: Whether this chat is from the archived folder
+            is_archived: Whether this chat is from the archived folder;
+                None means unknown and omits the key entirely
         """
         # Use marked ID (with -100 prefix for channels/supergroups) for consistency
         chat_data = {"id": self._get_marked_id(entity)}
@@ -3639,8 +3682,11 @@ class TelegramBackup:
             if getattr(entity, "forum", False):
                 chat_data["is_forum"] = 1
 
-        # v6.2.0: Track archived status (always set explicitly)
-        chat_data["is_archived"] = 1 if is_archived else 0
+        # v6.2.0: Track archived status. Set explicitly when known; on None
+        # (unknown) the key is omitted so the adapter's presence guard keeps
+        # whatever an earlier run recorded instead of overwriting it with 0.
+        if is_archived is not None:
+            chat_data["is_archived"] = 1 if is_archived else 0
 
         return chat_data
 

--- a/tests/test_whitelist_archived.py
+++ b/tests/test_whitelist_archived.py
@@ -1,0 +1,169 @@
+"""Whitelist mode and is_archived: never fabricate 0, fetch real membership.
+
+Whitelist mode skips get_dialogs (#95), so it used to write is_archived=0 for
+every chat on every run — emptying the viewer's Archived section and
+destroying values a type-based run had computed. Membership now comes from
+batched GetPeerDialogs over exactly the resolved peers; a failed probe yields
+None and the chat row keeps its stored value (upsert_chat's presence guard).
+"""
+
+import asyncio
+import os
+import shutil
+import tempfile
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from telethon.tl.types import Channel, PeerChannel, PeerChat, PeerUser
+
+from src.telegram_backup import TelegramBackup
+
+
+async def _passthrough(coro_fn, *args, **kwargs):
+    return await coro_fn(*args, **kwargs)
+
+
+def _channel(cid: int = 2701160643) -> Channel:
+    return Channel(id=cid, title="Test Channel", access_hash=12345, date=None, photo=None)
+
+
+class TestFetchArchivedMembership(unittest.TestCase):
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_only_folder_one_counts_and_ids_are_marked(self):
+        resp = MagicMock()
+        resp.dialogs = [
+            MagicMock(folder_id=1, peer=PeerChannel(2701160643)),
+            MagicMock(folder_id=None, peer=PeerUser(42)),
+            MagicMock(folder_id=0, peer=PeerChat(77)),
+        ]
+        self.backup.client = AsyncMock(return_value=resp)
+        self.backup.client.get_input_entity = AsyncMock(side_effect=lambda e: e)
+
+        with patch("src.telegram_backup.call_with_flood_retry", _passthrough):
+            got = self._run(self.backup._fetch_archived_membership([_channel()]))
+
+        self.assertEqual(got, {-1002701160643})
+
+    def test_batches_of_one_hundred(self):
+        resp = MagicMock()
+        resp.dialogs = []
+        self.backup.client = AsyncMock(return_value=resp)
+        self.backup.client.get_input_entity = AsyncMock(side_effect=lambda e: e)
+
+        with patch("src.telegram_backup.call_with_flood_retry", _passthrough):
+            got = self._run(self.backup._fetch_archived_membership([_channel(i) for i in range(1, 102)]))
+
+        self.assertEqual(got, set())
+        self.assertEqual(self.backup.client.await_count, 2)
+        first, second = self.backup.client.await_args_list
+        self.assertEqual(len(first.args[0].peers), 100)
+        self.assertEqual(len(second.args[0].peers), 1)
+
+    def test_failure_returns_none_not_empty(self):
+        self.backup.client = AsyncMock(side_effect=RuntimeError("api down"))
+        self.backup.client.get_input_entity = AsyncMock(side_effect=lambda e: e)
+
+        with patch("src.telegram_backup.call_with_flood_retry", _passthrough):
+            got = self._run(self.backup._fetch_archived_membership([_channel()]))
+
+        self.assertIsNone(got)
+
+
+class TestExtractChatDataTriState(unittest.TestCase):
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+
+    def test_none_omits_the_key_entirely(self):
+        data = self.backup._extract_chat_data(_channel(), is_archived=None)
+        self.assertNotIn("is_archived", data)
+
+    def test_known_values_still_written(self):
+        self.assertEqual(self.backup._extract_chat_data(_channel(), is_archived=True)["is_archived"], 1)
+        self.assertEqual(self.backup._extract_chat_data(_channel(), is_archived=False)["is_archived"], 0)
+
+
+class TestWhitelistBackupUsesMembership(unittest.TestCase):
+    """backup_all in whitelist mode feeds the fetched membership (or None on
+    probe failure) into _backup_dialog instead of a fabricated False."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.config = MagicMock()
+        self.config.whitelist_mode = True
+        self.config.chat_ids = {-1002701160643}
+        self.config.priority_chat_ids = set()
+        self.config.media_path = os.path.join(self.temp_dir, "media")
+        self.config.verify_media = False
+        self.config.fill_gaps = False
+        self.config.skip_media_chat_ids = set()
+        self.config.skip_media_delete_existing = False
+        self.config.reaction_resweep_days = 0.0
+        os.makedirs(self.config.media_path, exist_ok=True)
+
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
+        self.backup.config = self.config
+        self.backup.db = AsyncMock()
+        self.backup._owns_client = False
+        self.backup._cleaned_media_chats = set()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def _wire(self, raw_response):
+        entity = _channel()
+        client = (
+            AsyncMock(return_value=raw_response)
+            if raw_response is not None
+            else AsyncMock(side_effect=RuntimeError("probe down"))
+        )
+        client.get_entity = AsyncMock(return_value=entity)
+        client.get_input_entity = AsyncMock(side_effect=lambda e: e)
+        client.start = AsyncMock()
+        client.get_me = AsyncMock(return_value=MagicMock(first_name="Test", id=123))
+        self.backup.client = client
+        self.backup.db.get_last_message_id = AsyncMock(return_value=0)
+        self.backup.db.backfill_is_outgoing = AsyncMock()
+        self.backup.db.set_metadata = AsyncMock()
+        self.backup.db.upsert_chat = AsyncMock()
+        self.backup.db.calculate_and_store_statistics = AsyncMock(
+            return_value={"chats": 1, "messages": 0, "media_files": 0, "total_size_mb": 0}
+        )
+        self.backup._backup_dialog = AsyncMock(return_value=0)
+        self.backup._backup_folders = AsyncMock()
+        self.backup._backup_forum_topics = AsyncMock()
+
+    def test_archived_member_reaches_backup_dialog_as_true(self):
+        resp = MagicMock()
+        resp.dialogs = [MagicMock(folder_id=1, peer=PeerChannel(2701160643))]
+        self._wire(resp)
+
+        with patch("src.telegram_backup.call_with_flood_retry", _passthrough):
+            self._run(self.backup.backup_all())
+
+        self.assertIs(self.backup._backup_dialog.await_args.kwargs["is_archived"], True)
+
+    def test_probe_failure_passes_none_never_false(self):
+        self._wire(None)
+
+        with patch("src.telegram_backup.call_with_flood_retry", _passthrough):
+            self._run(self.backup.backup_all())
+
+        self.assertIsNone(self.backup._backup_dialog.await_args.kwargs["is_archived"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Whitelist mode skips `get_dialogs` on purpose (#95: the full fetch can hang on large accounts) and declared empty placeholders (`archived_chat_ids = set()`) so the shared downstream code would run. The side effect: `is_archived` computed `False` for **every** whitelisted chat on **every** run and was written unconditionally. Consequences:

- the viewer's Archived section is permanently empty in whitelist mode (`/api/archived/count` returns 0);
- switching from type-based mode to `CHAT_IDS` destroys the correctly-computed flags on the next run;
- the adapter guard that exists precisely to protect `is_archived` from partial writers was defeated by the key simply being present.

## Fix

- **Real membership, no dialog listing:** one batched `GetPeerDialogs` pass over exactly the resolved peers (100 per request, flood-wrapped) — bounded by whitelist size, not account dialog count, so the #95 constraint holds. `folder_id == 1` → archived.
- **Tri-state `is_archived`:** `True`/`False` write `1`/`0` exactly as before; `None` (probe failed) omits the key entirely, so `upsert_chat`'s presence guard preserves stored values — never a fabricated 0. New chats take the schema default (0) on the insert branch.
- Type-based mode's computation (including the both-folders warning) is untouched.

## Verification

- New `tests/test_whitelist_archived.py` (7 tests): folder-1-only marking with realistic marked ids, 100-per-request batching (101 peers → 2 calls), probe failure → `None` (never an empty set), tri-state extraction (None omits the key), and `backup_all` end-to-end in whitelist mode feeding `True` / `None` into `_backup_dialog`.
- Mutation controls: counting any folder as archived, unconditional key write, and hardcoding `False` in the loop each turn tests red; file restored byte-identical.
- Existing whitelist (#95), chat-migration and `_extract_chat_data` suites: 174 passed. Full suite + ruff 0.15.14 clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved whitelist backup handling for archived chats and folders.
  * Preserved existing archived status when archived-folder checks cannot be completed.
  * Prevented unavailable archived status from being incorrectly recorded as unarchived.
* **Tests**
  * Added coverage for folder filtering, large peer sets, lookup failures, and archived-status handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->