### PR TITLE
fix(import): stop a partial export from silently amputating older history

### DIFF
--- a/src/telegram_import.py
+++ b/src/telegram_import.py
@@ -705,6 +705,7 @@ class TelegramImporter:
         msg_count = 0
         media_count = 0
         max_msg_id = 0
+        min_msg_id = 0
         batch: list[dict[str, Any]] = []
         media_batch: list[dict[str, Any]] = []
 
@@ -713,7 +714,6 @@ class TelegramImporter:
             if msg_id is None:
                 continue
 
-            max_msg_id = max(max_msg_id, msg_id)
             msg_type = msg.get("type", "message")
 
             if msg_type == "service":
@@ -741,6 +741,11 @@ class TelegramImporter:
             if date is None:
                 logger.warning(f"Skipping message {msg_id}: no valid date")
                 continue
+
+            # Cursor bounds track only messages actually accepted for insert: a
+            # skipped message must never advance the sweep cursor past itself.
+            max_msg_id = max(max_msg_id, msg_id)
+            min_msg_id = msg_id if min_msg_id == 0 else min(min_msg_id, msg_id)
 
             raw_data: dict[str, Any] = {}
             if msg.get("forwarded_from"):
@@ -827,7 +832,23 @@ class TelegramImporter:
             media_count += await self._flush_batch(batch, media_batch)
 
         if not dry_run and msg_count > 0:
-            await self.db.update_sync_status(chat_id, max_msg_id, msg_count, account_id=self.account_id)
+            # Advance the sweep cursor only when the export demonstrably covers
+            # the chat's head (Telegram ids start at 1). Desktop's exporter
+            # offers date ranges, so a partial export must not raise the
+            # cursor: every id below its maximum would be treated as already
+            # captured and the still-retrievable older history silently never
+            # fetched. Gap-fill cannot recover a missing head — it only sees
+            # holes BETWEEN stored rows — so this guard is the only protection.
+            # An existing higher cursor is never lowered either (merge case).
+            if min_msg_id > 1:
+                logger.warning(
+                    f"Export starts at message id {min_msg_id}, not the chat head - "
+                    "sweep cursor left unchanged so the next backup run can still fetch the older history"
+                )
+            else:
+                current = await self.db.get_last_message_id(chat_id, account_id=self.account_id)
+                if max_msg_id > (current or 0):
+                    await self.db.update_sync_status(chat_id, max_msg_id, msg_count, account_id=self.account_id)
 
         action = "Would import" if dry_run else "Imported"
         logger.info(f"{action} {msg_count} messages and {media_count} media files")

--- a/tests/test_telegram_import.py
+++ b/tests/test_telegram_import.py
@@ -292,6 +292,7 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
 
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir, dry_run=True))
@@ -314,6 +315,7 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
 
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 100}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -349,6 +351,7 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
 
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -381,6 +384,7 @@ class TestTelegramImporterRun(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -420,6 +424,7 @@ class TestTelegramImporterRun(unittest.TestCase):
 
         media_dir = os.path.join(self.temp_dir, "media")
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, media_dir, account_id=1)
 
@@ -457,6 +462,7 @@ class TestTelegramImporterRun(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -489,6 +495,7 @@ class TestTelegramImporterRun(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -520,6 +527,7 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
         media_dir = Path(self.temp_dir, "media")
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, str(media_dir), max_filename_bytes=143, account_id=1)
 
@@ -558,6 +566,7 @@ class TestTelegramImporterRun(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
         real_copy2 = shutil.copy2
@@ -607,6 +616,7 @@ class TestTelegramImporterRun(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -643,6 +653,7 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
 
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -653,6 +664,7 @@ class TestTelegramImporterRun(unittest.TestCase):
 
     def test_missing_result_json(self):
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         importer = TelegramImporter(db, "/tmp/media", account_id=1)
 
         with self.assertRaises(FileNotFoundError):
@@ -700,6 +712,7 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
 
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -721,6 +734,7 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
 
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -1209,6 +1223,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
     def test_html_import_requires_chat_id(self):
         self._write_html(SAMPLE_HTML_MESSAGE)
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         with self.assertRaises(ValueError) as ctx:
@@ -1218,6 +1233,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
     def test_html_import_basic(self):
         self._write_html(SAMPLE_HTML_MESSAGE)
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -1236,6 +1252,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
     def test_html_import_dry_run(self):
         self._write_html(SAMPLE_HTML_MESSAGE)
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir, chat_id_override=42, dry_run=True))
@@ -1255,6 +1272,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
 
         media_dir = os.path.join(self.temp_dir, "media")
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, media_dir, account_id=1)
 
@@ -1275,6 +1293,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
             f.write(b"\x00" * 50)
 
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -1286,6 +1305,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
     def test_html_import_forwarded(self):
         self._write_html(SAMPLE_HTML_FORWARDED)
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -1297,6 +1317,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
     def test_html_import_reply(self):
         self._write_html(SAMPLE_HTML_REPLY)
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -1326,6 +1347,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
             )
 
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -1337,6 +1359,7 @@ class TestHtmlImportIntegration(unittest.TestCase):
     def test_no_export_files_raises_error(self):
         """Neither result.json nor messages.html should raise FileNotFoundError."""
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         importer = TelegramImporter(db, "/tmp/media", account_id=1)
 
         with self.assertRaises(FileNotFoundError) as ctx:
@@ -1346,3 +1369,86 @@ class TestHtmlImportIntegration(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestImportCursorGuard(unittest.TestCase):
+    """The sweep cursor may only advance when the export covers the chat head.
+
+    Raising sync_status.last_message_id above unfetched history marks every id
+    below it 'already captured' forever; gap-fill is structurally blind to a
+    missing head (LAG only sees holes between stored rows)."""
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.export_dir = os.path.join(self.temp_dir, "export")
+        os.makedirs(self.export_dir)
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def _write_export(self, messages):
+        data = {"name": "Test Chat", "type": "private_supergroup", "id": 42, "messages": messages}
+        with open(os.path.join(self.export_dir, "result.json"), "w") as f:
+            json.dump(data, f)
+
+    def _msg(self, msg_id, date="2024-01-15T10:00:00"):
+        m = {"id": msg_id, "type": "message", "from": "Alice", "from_id": "user42", "text": "hi"}
+        if date is not None:
+            m["date"] = date
+        return m
+
+    def _import(self, db):
+        importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
+        return self._run(importer.run(self.export_dir))
+
+    def test_partial_export_leaves_cursor_untouched_and_warns(self):
+        self._write_export([self._msg(8000), self._msg(8001)])
+        db = AsyncMock()
+        db.get_last_message_id.return_value = 0
+        db.get_chat_stats.return_value = {"messages": 0}
+
+        with self.assertLogs("src.telegram_import", level="WARNING") as cm:
+            summary = self._run(
+                TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1).run(self.export_dir)
+            )
+
+        self.assertEqual(summary["total_messages"], 2)
+        db.update_sync_status.assert_not_called()
+        self.assertTrue(any("sweep cursor left unchanged" in r.getMessage() for r in cm.records))
+
+    def test_head_covering_export_advances_cursor(self):
+        self._write_export([self._msg(1), self._msg(2)])
+        db = AsyncMock()
+        db.get_last_message_id.return_value = 0
+        db.get_chat_stats.return_value = {"messages": 0}
+
+        self._import(db)
+
+        db.update_sync_status.assert_called_once_with(-1000000000042, 2, 2, account_id=1)
+
+    def test_existing_higher_cursor_is_never_lowered(self):
+        self._write_export([self._msg(1), self._msg(2)])
+        db = AsyncMock()
+        db.get_last_message_id.return_value = 99999
+        db.get_chat_stats.return_value = {"messages": 0}
+
+        self._import(db)
+
+        db.update_sync_status.assert_not_called()
+
+    def test_date_skipped_message_cannot_raise_the_cursor(self):
+        self._write_export([self._msg(1), self._msg(2), self._msg(3, date=None)])
+        db = AsyncMock()
+        db.get_last_message_id.return_value = 0
+        db.get_chat_stats.return_value = {"messages": 0}
+
+        self._import(db)
+
+        db.update_sync_status.assert_called_once_with(-1000000000042, 2, 2, account_id=1)

--- a/tests/test_telegram_import_extended.py
+++ b/tests/test_telegram_import_extended.py
@@ -541,6 +541,7 @@ class TestTelegramImporterClose(unittest.TestCase):
         """TelegramImporter.close delegates to close_database."""
         mock_close_db.return_value = None
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         importer = TelegramImporter(db, "/tmp/media", account_id=1)
 
         self._run(importer.close())
@@ -574,6 +575,7 @@ class TestImporterRunEdgeCases(unittest.TestCase):
         """run raises ValueError when export has no chats (line 558)."""
         self._write_export({"chats": {"list": []}})
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         with self.assertRaises(ValueError) as ctx:
@@ -599,6 +601,7 @@ class TestImporterRunEdgeCases(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
         summary = self._run(importer.run(self.export_dir))
@@ -633,6 +636,7 @@ class TestImporterRunEdgeCases(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -655,6 +659,7 @@ class TestImporterRunEdgeCases(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -676,6 +681,7 @@ class TestImporterRunEdgeCases(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -703,6 +709,7 @@ class TestImporterRunEdgeCases(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -737,6 +744,7 @@ class TestImporterRunEdgeCases(unittest.TestCase):
         )
 
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -760,6 +768,7 @@ class TestImporterRunEdgeCases(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 500}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 


### PR DESCRIPTION
## Problem

Import wrote `sync_status.last_message_id = max(export ids)` unconditionally. Telegram Desktop's exporter offers **date ranges**, so importing "the last N months" — ids 8000..9000 of a chat whose history starts at id 1 — raised the sweep cursor to 9000. Every scheduled run thereafter calls `iter_messages(min_id=9000)`, so the still-retrievable older history is **never fetched, permanently and silently**: the log prints "Imported N messages" and backups stay green. Gap-fill is structurally blind to it — `LAG()` only sees holes *between* stored rows, never a missing head. A narrower variant: a message skipped for having no valid date could still raise the cursor past itself, because `max_msg_id` was tracked before the skip.

## Fix

- Cursor bounds (`max`/`min`) now track only messages actually **accepted for insert** (below the date skip).
- The cursor advances only when the export demonstrably covers the chat head (lowest imported id ≤ 1 — Telegram ids start at 1), and only **forward**: an existing higher cursor is never lowered on `--merge`.
- A partial export leaves `sync_status` untouched and warns: *"Export starts at message id N, not the chat head — sweep cursor left unchanged so the next backup run can still fetch the older history."* The next sweep then upserts over the imported rows (idempotent) and fills the head.

## Verification

- New `TestImportCursorGuard` (4 tests): partial export → no cursor write + warning; head-covering export → cursor written; existing higher cursor → never lowered; date-skipped max message → cursor capped at the highest *inserted* id.
- Mutation controls: restoring the unconditional write and re-hoisting the max above the skip each turn tests red; file restored byte-identical.
- Import suite: 99 passed. Full suite green locally; ruff 0.15.14 check+format clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Telegram import synchronization for partial exports.
  * Prevented sync progress from moving backward or advancing when message dates are invalid.
  * Ensured sync status advances only when an import includes the beginning of the chat history.

* **Tests**
  * Added coverage for cursor handling across JSON and HTML imports, including partial exports, existing higher cursors, and undated messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->