### PR TITLE
fix(ci): actually publish the multi-arch images the workflows set up QEMU for

### DIFF
--- a/.github/workflows/docker-publish-dev.yml
+++ b/.github/workflows/docker-publish-dev.yml
@@ -68,6 +68,9 @@ jobs:
         with:
           context: .
           file: Dockerfile
+          # Explicit, not inherited from the runner: dev stays amd64-only by
+          # decision (speed), not by accident of the builder's architecture.
+          platforms: linux/amd64
           push: true
           tags: ${{ env.DOCKER_IMAGE }}:dev
           cache-from: type=gha
@@ -79,6 +82,7 @@ jobs:
         with:
           context: .
           file: Dockerfile.viewer
+          platforms: linux/amd64
           push: true
           tags: ${{ env.DOCKER_IMAGE_VIEWER }}:dev
           cache-from: type=gha

--- a/.github/workflows/docker-publish-dev.yml
+++ b/.github/workflows/docker-publish-dev.yml
@@ -50,9 +50,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
-
+      # Dev images build on every PR: amd64-only keeps that loop fast. The
+      # release workflows (docker-publish, docker-publish-viewer) publish the
+      # multi-arch manifests; QEMU is set up there, not here.
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 

--- a/.github/workflows/docker-publish-viewer.yml
+++ b/.github/workflows/docker-publish-viewer.yml
@@ -133,6 +133,9 @@ jobs:
         with:
           context: .
           file: ./Dockerfile.viewer
+          # QEMU/buildx are set up above precisely for this: release manifests
+          # ship amd64 + arm64 (Raspberry Pi, ARM NAS, Apple Silicon, Ampere).
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -136,6 +136,9 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
+          # QEMU/buildx are set up above precisely for this: release manifests
+          # ship amd64 + arm64 (Raspberry Pi, ARM NAS, Apple Silicon, Ampere).
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Problem

All three publish workflows install QEMU and buildx — and then no build passes `platforms:`, so every published manifest is **amd64-only**. `docker compose up` on a Raspberry Pi, an ARM NAS, an Ampere VPS, or Apple Silicon without emulation pulls nothing usable, while the workflows carry cross-arch setup that does nothing.

## Fix

- `docker-publish.yml` (backup image) and `docker-publish-viewer.yml` now build `linux/amd64,linux/arm64`. Takes effect on the next version tag — release images become true multi-arch manifests.
- `docker-publish-dev.yml` builds on **every PR**, where arm64 emulation would roughly double the loop for images only used to test PRs: it stays amd64-only and **drops its unused QEMU step**, so setup matches output in all three workflows.

## Verification

- All three files pass yamllint (the scripted-edit YAML gate); the only complaints are pre-existing trailing spaces elsewhere in the dev file, untouched by this diff.
- Python 3.14 arm64 wheels for the dependency set resolve from the same uv.lock (cross-platform lockfile); the real multi-arch proof lands with the next tag build, which is deferred until the next release is called.

No release is triggered by this change — it only affects future tag builds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker release and viewer images now support both `linux/amd64` and `linux/arm64` platforms.
  * Development Docker images are now built for `linux/amd64`.

* **Improvements**
  * Updated image publishing workflows to clearly distinguish development builds from multi-platform release images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->