### PR TITLE
fix(listener): a failed chat-list refresh no longer silently stops all real-time capture

### DIFF
--- a/src/listener.py
+++ b/src/listener.py
@@ -497,16 +497,16 @@ class TelegramListener:
     async def _load_followed_migration_ids(self) -> set[int]:
         """Read adopted-supergroup ids from the metadata KV (#228).
 
-        Empty unless FOLLOW_CHAT_MIGRATIONS is on. Never raises — a missing or
-        malformed value degrades to an empty set.
+        Empty unless FOLLOW_CHAT_MIGRATIONS is on. A missing or malformed
+        value degrades to an empty set — that is a real observation. A
+        DATABASE failure raises instead: swallowing it here would hand
+        _load_tracked_chats an empty set that looks like success, silently
+        dropping every followed supergroup from the live scope — the exact
+        failure mode its keep-previous-scope guard exists to stop.
         """
         if not getattr(self.config, "follow_chat_migrations", False):
             return set()
-        try:
-            raw = await self.db.get_metadata(account_metadata_key("followed_migrations", self.account_id))
-        except Exception as e:
-            logger.warning(f"Could not load followed migrations: {type(e).__name__}")
-            return set()
+        raw = await self.db.get_metadata(account_metadata_key("followed_migrations", self.account_id))
         if not raw:
             return set()
         try:

--- a/src/listener.py
+++ b/src/listener.py
@@ -465,18 +465,34 @@ class TelegramListener:
         """Load list of chat IDs we're backing up (to filter events)."""
         try:
             chats = await self.db.get_all_chats(account_id=self.account_id)
-            self._tracked_chat_ids = {chat["id"] for chat in chats}
+            tracked = {chat["id"] for chat in chats}
             # Supergroups adopted via FOLLOW_CHAT_MIGRATIONS (#228): keep them in
             # a dedicated set AND fold into the type-based tracked set, so the new
             # supergroup is captured live from listener start (even before its chat
             # row is persisted) in BOTH whitelist and type-based modes.
-            self._followed_live = await self._load_followed_migration_ids()
-            self._tracked_chat_ids |= self._followed_live
+            followed = await self._load_followed_migration_ids()
+            # Assigned only after BOTH loads succeed, so a failure part-way
+            # through cannot leave the two sets inconsistent.
+            self._followed_live = followed
+            self._tracked_chat_ids = tracked | followed
             logger.info(f"Tracking {len(self._tracked_chat_ids)} chats for real-time updates")
         except Exception as e:
-            logger.warning(f"Could not load tracked chats: {e}")
-            self._tracked_chat_ids = set()
-            self._followed_live = set()
+            # A transient refresh failure must not shrink the live capture
+            # scope: every handler gates on _tracked_chat_ids, so replacing a
+            # serving set with an empty one silently stops ALL real-time
+            # capture until the next scheduled backup reloads it (hours by
+            # default) — and edits/deletions in that window are exactly what
+            # the listener exists to catch. Keep the previous known-good sets.
+            if self._tracked_chat_ids:
+                logger.warning(
+                    f"Could not refresh tracked chats ({e.__class__.__name__}); "
+                    f"keeping the previous set of {len(self._tracked_chat_ids)} chats"
+                )
+            else:
+                logger.warning(
+                    f"Could not load tracked chats ({e.__class__.__name__}); "
+                    "real-time capture stays disabled until a load succeeds"
+                )
 
     async def _load_followed_migration_ids(self) -> set[int]:
         """Read adopted-supergroup ids from the metadata KV (#228).

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -1967,6 +1967,26 @@ class TestLoadTrackedChatsError:
         assert listener._tracked_chat_ids == previous_tracked
         assert listener._followed_live == previous_followed
 
+    async def test_metadata_failure_inside_the_loader_keeps_the_previous_scope(self):
+        """The loader must PROPAGATE a database failure, never convert it to an
+        empty set: swallowed, it reads as a successful 'no migrations' load and
+        silently drops every followed supergroup from the live scope — the
+        exact failure mode the keep-previous guard exists to stop."""
+        db = _make_db()
+        config = _make_config()
+        config.follow_chat_migrations = True
+        db.get_all_chats = AsyncMock(return_value=[{"id": -1001000000706}])
+        db.get_metadata = AsyncMock(return_value="[-1001000000888]")
+        listener = TelegramListener(config, db, account_id=1)
+        await listener._load_tracked_chats()
+        assert listener._followed_live == {-1001000000888}
+
+        db.get_metadata = AsyncMock(side_effect=Exception("metadata read failed"))
+        await listener._load_tracked_chats()
+
+        assert listener._followed_live == {-1001000000888}
+        assert -1001000000888 in listener._tracked_chat_ids
+
     async def test_exception_message_logs_type_only(self, caplog):
         """PII rule: the exception repr may spell out peer ids — log the class."""
         db = _make_db()

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -1920,17 +1920,65 @@ class TestLogStats:
 
 
 class TestLoadTrackedChatsError:
-    """Tests for _load_tracked_chats exception handling."""
+    """A failed refresh must never shrink the live capture scope: every
+    handler gates on _tracked_chat_ids, so clobbering a serving set with an
+    empty one silently stops ALL real-time capture until the next scheduled
+    backup (hours)."""
 
-    async def test_exception_sets_empty_tracked_chats(self):
-        """When get_all_chats raises, tracked_chat_ids is set to empty set."""
+    async def test_first_load_failure_leaves_scope_empty_and_says_so(self, caplog):
         db = _make_db()
         db.get_all_chats = AsyncMock(side_effect=Exception("db error"))
         listener = TelegramListener(_make_config(), db, account_id=1)
 
-        await listener._load_tracked_chats()
+        with caplog.at_level("WARNING", logger="src.listener"):
+            await listener._load_tracked_chats()
 
         assert listener._tracked_chat_ids == set()
+        assert any("capture stays disabled" in r.getMessage() for r in caplog.records)
+
+    async def test_refresh_failure_keeps_the_previous_scope(self, caplog):
+        db = _make_db()
+        db.get_all_chats = AsyncMock(return_value=[{"id": -1001000000706}, {"id": -1001000000707}])
+        listener = TelegramListener(_make_config(), db, account_id=1)
+        await listener._load_tracked_chats()
+        assert listener._tracked_chat_ids == {-1001000000706, -1001000000707}
+
+        db.get_all_chats.side_effect = Exception("postgres failover")
+        with caplog.at_level("WARNING", logger="src.listener"):
+            await listener._load_tracked_chats()
+
+        assert listener._tracked_chat_ids == {-1001000000706, -1001000000707}
+        assert any("keeping the previous set of 2 chats" in r.getMessage() for r in caplog.records)
+
+    async def test_partial_failure_cannot_leave_the_sets_inconsistent(self):
+        """get_all_chats succeeds but the followed-migration load raises: the
+        previous scope survives untouched (assignment is all-or-nothing)."""
+        db = _make_db()
+        db.get_all_chats = AsyncMock(return_value=[{"id": -1001000000706}])
+        listener = TelegramListener(_make_config(), db, account_id=1)
+        await listener._load_tracked_chats()
+        previous_tracked = set(listener._tracked_chat_ids)
+        previous_followed = set(listener._followed_live)
+
+        db.get_all_chats = AsyncMock(return_value=[{"id": -1001000000999}])
+        listener._load_followed_migration_ids = AsyncMock(side_effect=Exception("metadata read failed"))
+        await listener._load_tracked_chats()
+
+        assert listener._tracked_chat_ids == previous_tracked
+        assert listener._followed_live == previous_followed
+
+    async def test_exception_message_logs_type_only(self, caplog):
+        """PII rule: the exception repr may spell out peer ids — log the class."""
+        db = _make_db()
+        db.get_all_chats = AsyncMock(side_effect=ValueError("PeerUser(user_id=123456789)"))
+        listener = TelegramListener(_make_config(), db, account_id=1)
+
+        with caplog.at_level("WARNING", logger="src.listener"):
+            await listener._load_tracked_chats()
+
+        assert caplog.records
+        for r in caplog.records:
+            assert "123456789" not in r.getMessage()
 
 
 # ===========================================================================


### PR DESCRIPTION
## Problem

`_load_tracked_chats` replaced the live capture scope with an **empty set** whenever `get_all_chats` raised — a Postgres failover, a SQLite lock outliving `busy_timeout`, an adapter closed underneath it. Every event handler gates on that set first, so the listener kept running and kept reporting itself active (`listener_active_since`) while archiving **nothing**. It cannot self-heal from traffic (`on_new_message` only re-adds chats that already pass the gate), so recovery waited for the next scheduled backup — 6 hours by default — and edits/deletions in that window, exactly what the listener exists to catch, were gone for good (`SYNC_DELETIONS_EDITS` off by default). The reload path made it worse: the scheduler refreshes after every backup, so a known-good serving set was routinely at risk. The only signal was one WARNING that never said capture stopped.

## Fix

- The new sets are assigned **only after both loads succeed** — all-or-nothing, so a failure between `get_all_chats` and the followed-migration load cannot leave `_tracked_chat_ids`/`_followed_live` inconsistent.
- A failed **refresh** keeps the previous known-good scope: *"Could not refresh tracked chats (ClassName); keeping the previous set of N chats"*.
- A failed **first load** still leaves the scope empty (there is nothing better to keep) but now says so: *"real-time capture stays disabled until a load succeeds"*.
- The warning logs the exception class only — the repr can spell out peer ids (PII rule).

## Verification

- `TestLoadTrackedChatsError` rewritten to the new contract (4 tests): first-load failure, refresh keeps previous scope, partial-failure atomicity, type-only logging (asserts the peer id never appears).
- Mutation controls: restoring the empty-set clobber and making the assignment non-atomic each turn tests red; file restored byte-identical.
- Listener suite 129 passed; full suite green (pipefail-gated); ruff 0.15.14 clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when refreshing tracked chats and migrations.
  * Preserved existing tracking scope when refreshes fail.
  * Prevented incomplete tracking updates when only part of the data loads successfully.
  * Ensured tracking remains safely disabled after an initial loading failure.
  * Removed sensitive identifiers from error logs.

* **Tests**
  * Expanded coverage for loading failures, partial failures, refresh behavior, and privacy-safe logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->