### PR TITLE
fix(ci): a dispatch republish rebuilds the tagged commit, never re-stamps a version onto main

### DIFF
--- a/.github/workflows/docker-publish-viewer.yml
+++ b/.github/workflows/docker-publish-viewer.yml
@@ -20,7 +20,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Optional tag to use (e.g., v3.0.6). If not provided, uses latest from main.'
+        description: 'Republish an existing release tag (e.g., v3.0.6): rebuilds THAT tagged commit. Leave empty to build main.'
         required: false
         type: string
 
@@ -60,7 +60,24 @@ jobs:
       # create their own telegram_archive_pytest / _parity_* databases on it.
       TEST_POSTGRES_URL: postgresql://telegram:ci-not-a-secret@localhost:5432/telegram_archive_ci
     steps:
+      # A dispatch republish must rebuild the TAGGED commit, never re-stamp a
+      # version onto whatever ref the run happened to use. Refuse inputs that
+      # are not existing git tags before anything builds. The input reaches the
+      # shell via env, never inline interpolation.
+      - name: Refuse a dispatch tag that is not a real git tag
+        if: github.event.inputs.tag != ''
+        env:
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          git ls-remote --exit-code --tags "https://github.com/${{ github.repository }}" "refs/tags/$DISPATCH_TAG" >/dev/null || {
+            echo "::error::'$DISPATCH_TAG' is not an existing git tag - the image tag and the git tag may never disagree"
+            exit 1
+          }
       - uses: actions/checkout@v7
+        with:
+          # Dispatch with a tag input builds that tag's commit; everything else
+          # keeps building the triggering ref exactly as before.
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
@@ -103,6 +120,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          # Same source rule as the test job: the dispatch tag input is
+          # authoritative for the content, not just the image label.
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0

--- a/.github/workflows/docker-publish-viewer.yml
+++ b/.github/workflows/docker-publish-viewer.yml
@@ -59,25 +59,42 @@ jobs:
       # tests/conftest.py, which never touch the database named here: they
       # create their own telegram_archive_pytest / _parity_* databases on it.
       TEST_POSTGRES_URL: postgresql://telegram:ci-not-a-secret@localhost:5432/telegram_archive_ci
+    outputs:
+      resolved_sha: ${{ steps.resolve.outputs.sha }}
     steps:
       # A dispatch republish must rebuild the TAGGED commit, never re-stamp a
       # version onto whatever ref the run happened to use. Refuse inputs that
       # are not existing git tags before anything builds. The input reaches the
       # shell via env, never inline interpolation.
-      - name: Refuse a dispatch tag that is not a real git tag
-        if: github.event.inputs.tag != ''
+      # Resolve the commit to build EXACTLY ONCE. Both jobs used to resolve
+      # the tag name independently, so a tag re-pointed between the test
+      # checkout and the build checkout published a commit the tests never
+      # saw. The build job consumes this job's resolved SHA instead.
+      - name: Resolve and pin the commit to build
+        id: resolve
         env:
           DISPATCH_TAG: ${{ github.event.inputs.tag }}
         run: |
-          git ls-remote --exit-code --tags "https://github.com/${{ github.repository }}" "refs/tags/$DISPATCH_TAG" >/dev/null || {
-            echo "::error::'$DISPATCH_TAG' is not an existing git tag - the image tag and the git tag may never disagree"
-            exit 1
-          }
+          if [ -n "$DISPATCH_TAG" ]; then
+            LINES=$(git ls-remote --exit-code --tags \
+              "https://github.com/${{ github.repository }}" \
+              "refs/tags/$DISPATCH_TAG" "refs/tags/$DISPATCH_TAG^{}") || {
+              echo "::error::'$DISPATCH_TAG' is not an existing git tag - the image tag and the git tag may never disagree"
+              exit 1
+            }
+            # Annotated tags list a peeled ^{} line with the commit; prefer it.
+            SHA=$(printf '%s\n' "$LINES" | grep '\^{}' | cut -f1)
+            [ -n "$SHA" ] || SHA=$(printf '%s\n' "$LINES" | head -n1 | cut -f1)
+          else
+            SHA="${{ github.sha }}"
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v7
         with:
           # Dispatch with a tag input builds that tag's commit; everything else
           # keeps building the triggering ref exactly as before.
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          # The pinned commit: the dispatch tag's target, or the push's own SHA.
+          ref: ${{ steps.resolve.outputs.sha }}
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
@@ -123,7 +140,9 @@ jobs:
         with:
           # Same source rule as the test job: the dispatch tag input is
           # authoritative for the content, not just the image label.
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          # The exact commit the test job resolved and tested - never a second
+          # by-name resolution that could see a re-pointed tag.
+          ref: ${{ needs.test.outputs.resolved_sha }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -24,7 +24,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Optional tag to use (e.g., v3.0.6). If not provided, uses latest from main.'
+        description: 'Republish an existing release tag (e.g., v3.0.6): rebuilds THAT tagged commit. Leave empty to build main.'
         required: false
         type: string
 
@@ -64,7 +64,24 @@ jobs:
       # create their own telegram_archive_pytest / _parity_* databases on it.
       TEST_POSTGRES_URL: postgresql://telegram:ci-not-a-secret@localhost:5432/telegram_archive_ci
     steps:
+      # A dispatch republish must rebuild the TAGGED commit, never re-stamp a
+      # version onto whatever ref the run happened to use. Refuse inputs that
+      # are not existing git tags before anything builds. The input reaches the
+      # shell via env, never inline interpolation.
+      - name: Refuse a dispatch tag that is not a real git tag
+        if: github.event.inputs.tag != ''
+        env:
+          DISPATCH_TAG: ${{ github.event.inputs.tag }}
+        run: |
+          git ls-remote --exit-code --tags "https://github.com/${{ github.repository }}" "refs/tags/$DISPATCH_TAG" >/dev/null || {
+            echo "::error::'$DISPATCH_TAG' is not an existing git tag - the image tag and the git tag may never disagree"
+            exit 1
+          }
       - uses: actions/checkout@v7
+        with:
+          # Dispatch with a tag input builds that tag's commit; everything else
+          # keeps building the triggering ref exactly as before.
+          ref: ${{ github.event.inputs.tag || github.ref }}
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
@@ -107,6 +124,10 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          # Same source rule as the test job: the dispatch tag input is
+          # authoritative for the content, not just the image label.
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -63,25 +63,42 @@ jobs:
       # tests/conftest.py, which never touch the database named here: they
       # create their own telegram_archive_pytest / _parity_* databases on it.
       TEST_POSTGRES_URL: postgresql://telegram:ci-not-a-secret@localhost:5432/telegram_archive_ci
+    outputs:
+      resolved_sha: ${{ steps.resolve.outputs.sha }}
     steps:
       # A dispatch republish must rebuild the TAGGED commit, never re-stamp a
       # version onto whatever ref the run happened to use. Refuse inputs that
       # are not existing git tags before anything builds. The input reaches the
       # shell via env, never inline interpolation.
-      - name: Refuse a dispatch tag that is not a real git tag
-        if: github.event.inputs.tag != ''
+      # Resolve the commit to build EXACTLY ONCE. Both jobs used to resolve
+      # the tag name independently, so a tag re-pointed between the test
+      # checkout and the build checkout published a commit the tests never
+      # saw. The build job consumes this job's resolved SHA instead.
+      - name: Resolve and pin the commit to build
+        id: resolve
         env:
           DISPATCH_TAG: ${{ github.event.inputs.tag }}
         run: |
-          git ls-remote --exit-code --tags "https://github.com/${{ github.repository }}" "refs/tags/$DISPATCH_TAG" >/dev/null || {
-            echo "::error::'$DISPATCH_TAG' is not an existing git tag - the image tag and the git tag may never disagree"
-            exit 1
-          }
+          if [ -n "$DISPATCH_TAG" ]; then
+            LINES=$(git ls-remote --exit-code --tags \
+              "https://github.com/${{ github.repository }}" \
+              "refs/tags/$DISPATCH_TAG" "refs/tags/$DISPATCH_TAG^{}") || {
+              echo "::error::'$DISPATCH_TAG' is not an existing git tag - the image tag and the git tag may never disagree"
+              exit 1
+            }
+            # Annotated tags list a peeled ^{} line with the commit; prefer it.
+            SHA=$(printf '%s\n' "$LINES" | grep '\^{}' | cut -f1)
+            [ -n "$SHA" ] || SHA=$(printf '%s\n' "$LINES" | head -n1 | cut -f1)
+          else
+            SHA="${{ github.sha }}"
+          fi
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@v7
         with:
           # Dispatch with a tag input builds that tag's commit; everything else
           # keeps building the triggering ref exactly as before.
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          # The pinned commit: the dispatch tag's target, or the push's own SHA.
+          ref: ${{ steps.resolve.outputs.sha }}
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
@@ -127,7 +144,9 @@ jobs:
         with:
           # Same source rule as the test job: the dispatch tag input is
           # authoritative for the content, not just the image label.
-          ref: ${{ github.event.inputs.tag || github.ref }}
+          # The exact commit the test job resolved and tested - never a second
+          # by-name resolution that could see a re-pointed tag.
+          ref: ${{ needs.test.outputs.resolved_sha }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0


### PR DESCRIPTION
## Problem

The `workflow_dispatch` tag input stamped the typed version onto the image — while checkout ran **with no `ref:` at all**, so the content was whatever ref the dispatch happened to run on (main by default). "Republishing" `v7.30.0` from the Actions UI therefore silently pushed **main's HEAD** under that version tag. Docker Hub tags are mutable: every user who followed the project's own pin-semver advice pulls different code under the same version string, with no git tag, no GitHub release and no changelog entry recording it. The viewer workflow had the identical hole, so the two images could even end up at *different revisions* under one version.

## Fix

- Both workflows check out `ref: ${{ github.event.inputs.tag || github.ref }}` in **both** jobs — the test job runs against the tagged code too, not just the build job.
- A guard step refuses a dispatch tag that does not resolve to an existing git tag (`git ls-remote --exit-code --tags`, before any checkout; the input reaches the shell via `env`, never inline interpolation — no injection surface).
- The input description now states the contract: republish rebuilds THAT tagged commit; empty builds main (unversioned, as before).
- Tag pushes and plain-main dispatches behave exactly as before (`github.ref` fallback).

## Verification

- Both files pass yamllint (scripted-GHA-edit gate).
- Behavior change is dispatch-only and takes effect on the next dispatch/tag build; no release is triggered by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Manual container image publishing now supports rebuilding a specific existing tag.
  * Builds use the selected tag when provided, or the triggering revision by default.
  * Invalid tags are detected before the build begins, preventing unsuccessful publishing attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->