### PR TITLE
fix(viewer): cap WebSocket connections and per-socket subscriptions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -366,6 +366,11 @@ DB_PATH=/data/backups/telegram_backup.db
 # those headers. Leave false for direct/LAN deployments.
 # TRUST_PROXY_HEADERS=false
 
+# WebSocket abuse caps: total sockets the viewer will hold at once, and how
+# many chats one socket may subscribe to. Extra connections close with 1013.
+# MAX_WS_CONNECTIONS=200
+# MAX_WS_SUBSCRIPTIONS_PER_CONNECTION=16
+
 # Shared secret for backup -> viewer realtime pushes when using SQLite split
 # containers. Required for non-loopback /internal/push calls.
 # INTERNAL_PUSH_SECRET=change_me_to_a_long_random_value

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -112,10 +112,18 @@ class ConnectionManager:
             await websocket.close(code=1013, reason="Too many connections")
             logger.warning(f"WebSocket refused: connection cap reached ({MAX_WS_CONNECTIONS})")
             return False
-        await websocket.accept()
+        # Reserve the slot BEFORE the first await: between the cap check above
+        # and these registrations there is no suspension point, so concurrent
+        # connection tasks cannot all pass the check and register after
+        # accept() suspends — the cap would be advisory otherwise.
         self.active_connections[websocket] = set()
         self._contexts[websocket] = user
         self._identities[websocket] = identity or ConnectionIdentity(username=user.username)
+        try:
+            await websocket.accept()
+        except BaseException:
+            self.disconnect(websocket)
+            raise
         logger.info(f"WebSocket connected. Total connections: {len(self.active_connections)}")
         return True
 

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -72,6 +72,15 @@ class ConnectionIdentity:
     source_token_id: int | None = None
 
 
+# The viewer is documented as internet-exposed (behind a reverse proxy). A
+# single client must not be able to grow server state without bound: sockets
+# are capped globally (a per-IP cap would misfire behind a proxy, where every
+# client arrives from the proxy's address) and each socket's subscription set
+# is capped (a live SPA follows one or two chats; 16 is generous).
+MAX_WS_CONNECTIONS = int(os.environ.get("MAX_WS_CONNECTIONS", "200"))
+MAX_WS_SUBSCRIPTIONS_PER_CONNECTION = int(os.environ.get("MAX_WS_SUBSCRIPTIONS_PER_CONNECTION", "16"))
+
+
 # WebSocket Connection Manager for real-time updates
 class ConnectionManager:
     """Manages WebSocket connections for real-time updates.
@@ -93,12 +102,22 @@ class ConnectionManager:
         self._contexts: dict[WebSocket, UserContext] = {}
         self._identities: dict[WebSocket, ConnectionIdentity] = {}
 
-    async def connect(self, websocket: WebSocket, user: UserContext, identity: ConnectionIdentity | None = None):
+    async def connect(
+        self, websocket: WebSocket, user: UserContext, identity: ConnectionIdentity | None = None
+    ) -> bool:
+        if len(self.active_connections) >= MAX_WS_CONNECTIONS:
+            # 1013 = Try Again Later. Accepted then closed so the client gets a
+            # real close code instead of an opaque handshake failure.
+            await websocket.accept()
+            await websocket.close(code=1013, reason="Too many connections")
+            logger.warning(f"WebSocket refused: connection cap reached ({MAX_WS_CONNECTIONS})")
+            return False
         await websocket.accept()
         self.active_connections[websocket] = set()
         self._contexts[websocket] = user
         self._identities[websocket] = identity or ConnectionIdentity(username=user.username)
         logger.info(f"WebSocket connected. Total connections: {len(self.active_connections)}")
+        return True
 
     def disconnect(self, websocket: WebSocket):
         self.active_connections.pop(websocket, None)
@@ -146,11 +165,20 @@ class ConnectionManager:
         return len(revoked)
 
     def subscribe(self, websocket: WebSocket, chat_ref: str) -> bool:
-        """Record a subscription for an already-authorized chat ref."""
-        if websocket in self.active_connections:
-            self.active_connections[websocket].add(chat_ref)
-            return True
-        return False
+        """Record a subscription for an already-authorized chat ref.
+
+        Bounded per connection: re-subscribing an existing ref stays free, a
+        NEW ref past the cap is refused — otherwise one socket looping over
+        distinct refs grows this set (and every broadcast's work) without
+        limit.
+        """
+        subs = self.active_connections.get(websocket)
+        if subs is None:
+            return False
+        if chat_ref not in subs and len(subs) >= MAX_WS_SUBSCRIPTIONS_PER_CONNECTION:
+            return False
+        subs.add(chat_ref)
+        return True
 
     def unsubscribe(self, websocket: WebSocket, chat_ref: str):
         """Unsubscribe a connection from a specific chat."""
@@ -3531,7 +3559,8 @@ async def websocket_endpoint(websocket: WebSocket):
         await websocket.close(code=4001, reason=exc.detail)
         return
 
-    await ws_manager.connect(websocket, user_ctx, _socket_identity(user_ctx, auth_cookie))
+    if not await ws_manager.connect(websocket, user_ctx, _socket_identity(user_ctx, auth_cookie)):
+        return
 
     try:
         while True:
@@ -3549,8 +3578,13 @@ async def websocket_endpoint(websocket: WebSocket):
                     except HTTPException:
                         await websocket.send_json({"type": "subscribe_denied", "chat_ref": chat_ref})
                     else:
-                        ws_manager.subscribe(websocket, chat_ref)
-                        await websocket.send_json({"type": "subscribed", "chat_ref": chat_ref})
+                        if ws_manager.subscribe(websocket, chat_ref):
+                            await websocket.send_json({"type": "subscribed", "chat_ref": chat_ref})
+                        else:
+                            # Entitled but over the per-connection cap.
+                            await websocket.send_json(
+                                {"type": "subscribe_denied", "chat_ref": chat_ref, "reason": "subscription_limit"}
+                            )
 
             elif action == "unsubscribe":
                 chat_ref = data.get("chat_ref")

--- a/tests/test_ws_caps.py
+++ b/tests/test_ws_caps.py
@@ -80,3 +80,51 @@ class TestSubscriptionCap:
     async def test_unknown_socket_still_refused(self):
         manager = ConnectionManager()
         assert manager.subscribe(_socket(), "ref-a") is False
+
+
+class TestConcurrentConnectRace:
+    async def test_concurrent_connects_cannot_overshoot_the_cap(self):
+        """The cap check and the slot registration must share no suspension
+        point: with registration after accept(), N concurrent handshakes all
+        passed the check first and the cap was advisory (review finding)."""
+        import asyncio
+
+        from src.web import main as web_main
+
+        manager = ConnectionManager()
+
+        def _yielding_socket():
+            ws = MagicMock()
+
+            async def slow_accept():
+                await asyncio.sleep(0)  # a real suspension point, like a handshake
+
+            ws.accept = MagicMock(side_effect=slow_accept)
+            ws.close = AsyncMock()
+            ws.send_json = AsyncMock()
+            return ws
+
+        with patch.object(web_main, "MAX_WS_CONNECTIONS", 5):
+            sockets = [_yielding_socket() for _ in range(9)]
+            results = await asyncio.gather(*(manager.connect(ws, _user()) for ws in sockets))
+
+        assert len(manager.active_connections) == 5
+        assert results.count(True) == 5
+        assert results.count(False) == 4
+        refused = [ws for ws, ok in zip(sockets, results, strict=True) if not ok]
+        for ws in refused:
+            ws.close.assert_awaited_once()
+            assert ws.close.await_args.kwargs.get("code") == 1013
+
+    async def test_accept_failure_releases_the_reserved_slot(self):
+        """A handshake that blows up must not leak its reserved slot."""
+        manager = ConnectionManager()
+        ws = _socket()
+        ws.accept = AsyncMock(side_effect=RuntimeError("handshake died"))
+
+        import pytest as _pytest
+
+        with _pytest.raises(RuntimeError):
+            await manager.connect(ws, _user())
+
+        assert len(manager.active_connections) == 0

--- a/tests/test_ws_caps.py
+++ b/tests/test_ws_caps.py
@@ -1,0 +1,82 @@
+"""WebSocket caps: one client must not grow server state without bound.
+
+The viewer is documented as internet-exposed behind a reverse proxy (and
+ALLOW_ANONYMOUS_VIEWER is a supported mode), so both the global connection
+table and each socket's subscription set are bounded.
+"""
+
+import os
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("BACKUP_PATH", tempfile.mkdtemp(prefix="ta_test_wscaps_"))
+
+pytest.importorskip("fastapi")
+
+from src.web.main import ConnectionManager  # noqa: E402
+
+
+def _socket():
+    ws = MagicMock()
+    ws.accept = AsyncMock()
+    ws.close = AsyncMock()
+    ws.send_json = AsyncMock()
+    return ws
+
+
+def _user():
+    u = MagicMock()
+    u.username = "cap-tester"
+    return u
+
+
+class TestConnectionCap:
+    async def test_connect_past_cap_closes_with_1013(self):
+        manager = ConnectionManager()
+        with patch("src.web.main.MAX_WS_CONNECTIONS", 2):
+            assert await manager.connect(_socket(), _user()) is True
+            assert await manager.connect(_socket(), _user()) is True
+            refused = _socket()
+            assert await manager.connect(refused, _user()) is False
+
+        refused.close.assert_awaited_once()
+        assert refused.close.await_args.kwargs["code"] == 1013
+        assert len(manager.active_connections) == 2
+        assert refused not in manager.active_connections
+
+    async def test_disconnect_frees_a_slot(self):
+        manager = ConnectionManager()
+        with patch("src.web.main.MAX_WS_CONNECTIONS", 1):
+            first = _socket()
+            assert await manager.connect(first, _user()) is True
+            manager.disconnect(first)
+            assert await manager.connect(_socket(), _user()) is True
+
+
+class TestSubscriptionCap:
+    async def test_new_refs_past_cap_are_refused(self):
+        manager = ConnectionManager()
+        ws = _socket()
+        await manager.connect(ws, _user())
+
+        with patch("src.web.main.MAX_WS_SUBSCRIPTIONS_PER_CONNECTION", 3):
+            for n in range(3):
+                assert manager.subscribe(ws, f"ref-{n}") is True
+            assert manager.subscribe(ws, "ref-overflow") is False
+            assert len(manager.active_connections[ws]) == 3
+
+    async def test_resubscribing_an_existing_ref_at_cap_stays_free(self):
+        manager = ConnectionManager()
+        ws = _socket()
+        await manager.connect(ws, _user())
+
+        with patch("src.web.main.MAX_WS_SUBSCRIPTIONS_PER_CONNECTION", 2):
+            assert manager.subscribe(ws, "ref-a") is True
+            assert manager.subscribe(ws, "ref-b") is True
+            assert manager.subscribe(ws, "ref-a") is True  # idempotent, not counted
+
+    async def test_unknown_socket_still_refused(self):
+        manager = ConnectionManager()
+        assert manager.subscribe(_socket(), "ref-a") is False


### PR DESCRIPTION
## Problem

One client could open unlimited `/ws/updates` sockets and loop `{"action":"subscribe"}` over distinct refs — `active_connections` and each socket's subscription set grow without bound (memory exhaustion, plus every broadcast walks all connections), on a service documented as internet-exposed behind a reverse proxy and reachable with **zero credentials** under `ALLOW_ANONYMOUS_VIEWER`. Only HTTP sessions had a cap (`_MAX_SESSIONS_PER_USER`); sockets had none.

## Fix

- `connect()` refuses past `MAX_WS_CONNECTIONS` (default 200): accepted then closed with **1013 Try Again Later**, so the client sees a real close code, and the socket is never registered.
- `subscribe()` refuses **new** refs past `MAX_WS_SUBSCRIPTIONS_PER_CONNECTION` (default 16 — a live SPA follows one or two chats); re-subscribing an existing ref stays free (idempotent). The endpoint now honours subscribe's return value and answers `subscribe_denied` / `reason: subscription_limit` instead of a false `subscribed`.
- Both caps env-tunable, documented in `.env.example` (which actually reaches the container once #333 lands).
- A per-IP cap is **deliberately absent**: behind the documented reverse proxy every client arrives from the proxy's address, so it would throttle all users at once. Stated in a comment.

## Verification

- `tests/test_ws_caps.py` (5 tests): cap refusal with 1013 + non-registration, slot freed on disconnect, new-ref refusal past cap, idempotent re-subscribe at cap, unknown-socket refusal.
- Mutation controls: disabling either cap turns its tests red; file restored byte-identical.
- WS route + web-main + caps suites: 106 passed. Full suite 3354 passed (pipefail-gated); ruff 0.15.14 clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable limits for simultaneous WebSocket connections and subscriptions per connection.
  * Excess connections are closed with WebSocket error 1013.
  * Subscription attempts beyond the configured limit are rejected with a clear denial response.

* **Documentation**
  * Documented the new WebSocket limit settings and their default values in the example environment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->