### PR TITLE
test(viewer): drive the lifespan for real — restart must not widen a restricted session

### DIFF
--- a/tests/test_lifespan_restore.py
+++ b/tests/test_lifespan_restore.py
@@ -1,0 +1,106 @@
+"""The lifespan's session rehydration, driven for real through TestClient.
+
+The entire lifespan body ran dark in the suite (ASGITransport and bare
+TestClient(app) skip it), so a regression in the restore loop — expired rows
+restored, or no_download dropped — shipped green. no_download is the sole
+gate on original-file downloads for restricted share-token holders, and a
+container restart runs exactly this code.
+"""
+
+import importlib
+import os
+import tempfile
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault("BACKUP_PATH", tempfile.mkdtemp(prefix="ta_test_lifespan_"))
+
+try:
+    from fastapi.testclient import TestClient
+
+    _CLIENT_AVAILABLE = True
+except Exception:
+    _CLIENT_AVAILABLE = False
+
+pytestmark = pytest.mark.skipif(not _CLIENT_AVAILABLE, reason="fastapi TestClient import failed")
+
+
+def _session_rows(now: float) -> list[dict]:
+    base = {
+        "role": "viewer",
+        "allowed_accounts": None,
+        "allowed_chat_refs": None,
+        "allowed_chat_ids": None,
+        "source_token_id": None,
+        "last_accessed": now,
+    }
+    return [
+        # Long expired: must NOT be restored.
+        {**base, "token": "expired-token", "username": "old", "created_at": now - 10 * 365 * 86400},
+        # Live restricted share-token session: no_download must survive.
+        {
+            **base,
+            "token": "live-restricted",
+            "username": "guest",
+            "created_at": now - 60,
+            "no_download": 1,
+            "source_token_id": 7,
+        },
+        # Live row with an unconverted legacy grant: restores DENYING, not open.
+        {**base, "token": "legacy-grant", "username": "legacy", "created_at": now - 60, "allowed_chat_ids": "[1]"},
+    ]
+
+
+def _reload_main():
+    env = {
+        "VIEWER_USERNAME": "admin",
+        "VIEWER_PASSWORD": "test@value/here",
+        "ALLOW_ANONYMOUS_VIEWER": "false",
+    }
+    with patch.dict(os.environ, env):
+        import src.web.main as main_mod
+
+        return importlib.reload(main_mod)
+
+
+def test_lifespan_restores_only_live_sessions_and_keeps_no_download():
+    main_mod = _reload_main()
+    now = time.time()
+
+    adapter = AsyncMock()
+    adapter.load_all_sessions.return_value = _session_rows(now)
+    adapter.get_metadata.return_value = "2026-01-01T00:00:00"  # stats already cached
+    adapter.cleanup_expired_sessions.return_value = 0
+
+    listener = MagicMock()
+    listener.init = AsyncMock()
+    listener.start = AsyncMock()
+    listener.stop = AsyncMock()
+
+    with (
+        patch.object(main_mod, "init_database", AsyncMock(return_value=MagicMock())),
+        patch.object(main_mod, "DatabaseAdapter", MagicMock(return_value=adapter)),
+        patch.object(main_mod, "get_db_manager", AsyncMock(return_value=MagicMock())),
+        patch.object(main_mod, "RealtimeListener", MagicMock(return_value=listener)),
+        patch.object(main_mod, "_normalize_display_chat_ids", AsyncMock()),
+        TestClient(main_mod.app),
+    ):
+        sessions = dict(main_mod._sessions)
+
+    assert "expired-token" not in sessions, "expired session must not be rehydrated"
+    assert "live-restricted" in sessions and "legacy-grant" in sessions
+
+    restricted = sessions["live-restricted"]
+    assert restricted.no_download is True, "share-token download restriction lost on restart"
+    assert restricted.source_token_id == 7
+
+    legacy = sessions["legacy-grant"]
+    assert legacy.allowed_chat_refs == set() and legacy.allowed_accounts == set(), (
+        "unconverted legacy grant must restore DENYING, never unrestricted"
+    )
+    assert legacy.no_download is False
+
+    listener.init.assert_awaited_once()
+    listener.start.assert_awaited_once()

--- a/tests/test_lifespan_restore.py
+++ b/tests/test_lifespan_restore.py
@@ -15,19 +15,29 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-os.environ.setdefault("BACKUP_PATH", tempfile.mkdtemp(prefix="ta_test_lifespan_"))
-
+# Repo convention: web tests SKIP locally when the fastapi/pydantic versions
+# mismatch (they run on CI) — but only a missing dependency may skip; any other
+# import-time failure is a real regression and must fail the suite.
 try:
     from fastapi.testclient import TestClient
 
     _CLIENT_AVAILABLE = True
-except Exception:
+except ImportError:
     _CLIENT_AVAILABLE = False
 
-pytestmark = pytest.mark.skipif(not _CLIENT_AVAILABLE, reason="fastapi TestClient import failed")
+pytestmark = pytest.mark.skipif(not _CLIENT_AVAILABLE, reason="fastapi TestClient not importable")
+
+_BACKUP_PATH = None
 
 
-def _session_rows(now: float) -> list[dict]:
+def _backup_path() -> str:
+    global _BACKUP_PATH
+    if _BACKUP_PATH is None:
+        _BACKUP_PATH = tempfile.mkdtemp(prefix="ta_test_lifespan_")
+    return _BACKUP_PATH
+
+
+def _session_rows(now: float, session_seconds: float) -> list[dict]:
     base = {
         "role": "viewer",
         "allowed_accounts": None,
@@ -36,20 +46,30 @@ def _session_rows(now: float) -> list[dict]:
         "source_token_id": None,
         "last_accessed": now,
     }
+    # Both ages derive from the effective timeout, so the fixture stays
+    # correct whatever AUTH_SESSION_SECONDS is configured to be.
+    live_age = session_seconds / 2
+    expired_age = session_seconds * 2
     return [
-        # Long expired: must NOT be restored.
-        {**base, "token": "expired-token", "username": "old", "created_at": now - 10 * 365 * 86400},
+        # Expired: must NOT be restored.
+        {**base, "token": "expired-token", "username": "old", "created_at": now - expired_age},
         # Live restricted share-token session: no_download must survive.
         {
             **base,
             "token": "live-restricted",
             "username": "guest",
-            "created_at": now - 60,
+            "created_at": now - live_age,
             "no_download": 1,
             "source_token_id": 7,
         },
         # Live row with an unconverted legacy grant: restores DENYING, not open.
-        {**base, "token": "legacy-grant", "username": "legacy", "created_at": now - 60, "allowed_chat_ids": "[1]"},
+        {
+            **base,
+            "token": "legacy-grant",
+            "username": "legacy",
+            "created_at": now - live_age,
+            "allowed_chat_ids": "[1]",
+        },
     ]
 
 
@@ -58,6 +78,7 @@ def _reload_main():
         "VIEWER_USERNAME": "admin",
         "VIEWER_PASSWORD": "test@value/here",
         "ALLOW_ANONYMOUS_VIEWER": "false",
+        "BACKUP_PATH": _backup_path(),
     }
     with patch.dict(os.environ, env):
         import src.web.main as main_mod
@@ -70,7 +91,7 @@ def test_lifespan_restores_only_live_sessions_and_keeps_no_download():
     now = time.time()
 
     adapter = AsyncMock()
-    adapter.load_all_sessions.return_value = _session_rows(now)
+    adapter.load_all_sessions.return_value = _session_rows(now, main_mod.AUTH_SESSION_SECONDS)
     adapter.get_metadata.return_value = "2026-01-01T00:00:00"  # stats already cached
     adapter.cleanup_expired_sessions.return_value = 0
 
@@ -79,15 +100,23 @@ def test_lifespan_restores_only_live_sessions_and_keeps_no_download():
     listener.start = AsyncMock()
     listener.stop = AsyncMock()
 
-    with (
-        patch.object(main_mod, "init_database", AsyncMock(return_value=MagicMock())),
-        patch.object(main_mod, "DatabaseAdapter", MagicMock(return_value=adapter)),
-        patch.object(main_mod, "get_db_manager", AsyncMock(return_value=MagicMock())),
-        patch.object(main_mod, "RealtimeListener", MagicMock(return_value=listener)),
-        patch.object(main_mod, "_normalize_display_chat_ids", AsyncMock()),
-        TestClient(main_mod.app),
-    ):
-        sessions = dict(main_mod._sessions)
+    saved_sessions = dict(main_mod._sessions)
+    try:
+        with (
+            patch.object(main_mod, "init_database", AsyncMock(return_value=MagicMock())),
+            patch.object(main_mod, "DatabaseAdapter", MagicMock(return_value=adapter)),
+            patch.object(main_mod, "get_db_manager", AsyncMock(return_value=MagicMock())),
+            patch.object(main_mod, "RealtimeListener", MagicMock(return_value=listener)),
+            # The real close_database closes the process-wide manager other
+            # tests may hold; the restore under test never needs it.
+            patch.object(main_mod, "close_database", AsyncMock()),
+            patch.object(main_mod, "_normalize_display_chat_ids", AsyncMock()),
+            TestClient(main_mod.app),
+        ):
+            sessions = dict(main_mod._sessions)
+    finally:
+        main_mod._sessions.clear()
+        main_mod._sessions.update(saved_sessions)
 
     assert "expired-token" not in sessions, "expired session must not be rehydrated"
     assert "live-restricted" in sessions and "legacy-grant" in sessions


### PR DESCRIPTION
The viewer lifespan's session rehydration ran completely dark in the suite: ASGITransport and bare TestClient(app) both skip the lifespan, so the restore loop was never executed by any test. That loop is what decides, after every container restart, whether a share-token holder's session comes back with no_download intact — the sole gate on original-file downloads for restricted viewers — and whether expired rows stay dead.

These tests run the real lifespan through TestClient's context manager against a seeded sessions table and pin exactly that: valid rows restored with no_download preserved, expired rows not restored. Test-only change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for session restoration during application startup.
  * Verified expired sessions are excluded while active sessions retain sharing and download restrictions.
  * Confirmed legacy access grants restore with a denying policy.
  * Verified the realtime listener is initialized and started during application lifespan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->