### PR TITLE
perf(viewer): a cold gallery grid decodes each missing thumbnail once, not once per request

### DIFF
--- a/src/web/thumbnails.py
+++ b/src/web/thumbnails.py
@@ -71,7 +71,7 @@ _recent_failures: dict[tuple[int, str], float] = {}
 # duplicate waits on the same per-destination lock and then finds the finished
 # file (or the cached failure). Entries are removed as soon as the generation
 # settles, so the dict stays bounded by in-flight distinct thumbnails.
-_inflight_locks: dict[str, asyncio.Lock] = {}
+_inflight_tasks: dict[str, asyncio.Task] = {}
 
 
 def _failure_cached(key: tuple[int, str]) -> bool:
@@ -318,24 +318,41 @@ async def ensure_thumbnail(
         return None
 
     dest_key = str(dest)
-    lock = _inflight_locks.setdefault(dest_key, asyncio.Lock())
-    try:
-        async with lock:
-            # A duplicate that waited here finds the owner's result: the file
-            # for a success, the failure cache for a failure. Either way the
-            # wait replaces a second decode of the same source.
-            if dest.exists():
-                return dest, resolved_folder
-            if _failure_cached(failure_key):
-                return None
-            sem = _video_semaphore if is_vid else _generation_semaphore
-            async with sem:
-                loop = asyncio.get_running_loop()
-                gen_fn = _generate_video_sync if is_vid else _generate_sync
-                ok = await loop.run_in_executor(None, gen_fn, source, dest, size)
-    finally:
-        _inflight_locks.pop(dest_key, None)
+    # ONE generation task per destination, shared by every concurrent caller.
+    # The work runs in its own task so no waiter's cancellation can reach it
+    # (a lock-based version had exactly that hole: a cancelled waiter popped
+    # the map entry while the owner still generated, letting the next request
+    # start a duplicate — and cancelling mid-executor released the semaphore
+    # while the worker thread kept decoding). The entry is removed only when
+    # the task settles, by the task's own done-callback.
+    task = _inflight_tasks.get(dest_key)
+    if task is None:
+        task = asyncio.create_task(_generate_shared(source, dest, size, is_vid, failure_key))
+        _inflight_tasks[dest_key] = task
+        task.add_done_callback(lambda _t, key=dest_key: _inflight_tasks.pop(key, None))
+    # shield: cancelling a waiter stops the WAIT, never the shared work.
+    ok = await asyncio.shield(task)
     if not ok:
-        _record_failure(failure_key)
         return None
     return dest, resolved_folder
+
+
+async def _generate_shared(source: Path, dest: Path, size: int, is_vid: bool, failure_key: tuple) -> bool:
+    """The single shared generation for one destination.
+
+    A duplicate that awaited the task finds the owner's result: the file for
+    a success, the failure cache for a failure. Either way the wait replaces
+    a second decode of the same source.
+    """
+    if dest.exists():
+        return True
+    if _failure_cached(failure_key):
+        return False
+    sem = _video_semaphore if is_vid else _generation_semaphore
+    async with sem:
+        loop = asyncio.get_running_loop()
+        gen_fn = _generate_video_sync if is_vid else _generate_sync
+        ok = await loop.run_in_executor(None, gen_fn, source, dest, size)
+    if not ok:
+        _record_failure(failure_key)
+    return ok

--- a/src/web/thumbnails.py
+++ b/src/web/thumbnails.py
@@ -64,6 +64,15 @@ _FAILURE_TTL_SECONDS = 300.0
 _MAX_FAILURE_ENTRIES = 1024
 _recent_failures: dict[tuple[int, str], float] = {}
 
+# Collapse duplicate concurrent generations: a cold gallery grid (or a reload
+# during first render) fires many requests for the same missing thumbnail, and
+# each one would decode the same source again — the semaphore caps how many run
+# at once, not how many run. The first request generates; every concurrent
+# duplicate waits on the same per-destination lock and then finds the finished
+# file (or the cached failure). Entries are removed as soon as the generation
+# settles, so the dict stays bounded by in-flight distinct thumbnails.
+_inflight_locks: dict[str, asyncio.Lock] = {}
+
 
 def _failure_cached(key: tuple[int, str]) -> bool:
     """True when this (size, source) failed recently enough to skip retrying."""
@@ -308,11 +317,24 @@ async def ensure_thumbnail(
     if _failure_cached(failure_key):
         return None
 
-    sem = _video_semaphore if is_vid else _generation_semaphore
-    async with sem:
-        loop = asyncio.get_running_loop()
-        gen_fn = _generate_video_sync if is_vid else _generate_sync
-        ok = await loop.run_in_executor(None, gen_fn, source, dest, size)
+    dest_key = str(dest)
+    lock = _inflight_locks.setdefault(dest_key, asyncio.Lock())
+    try:
+        async with lock:
+            # A duplicate that waited here finds the owner's result: the file
+            # for a success, the failure cache for a failure. Either way the
+            # wait replaces a second decode of the same source.
+            if dest.exists():
+                return dest, resolved_folder
+            if _failure_cached(failure_key):
+                return None
+            sem = _video_semaphore if is_vid else _generation_semaphore
+            async with sem:
+                loop = asyncio.get_running_loop()
+                gen_fn = _generate_video_sync if is_vid else _generate_sync
+                ok = await loop.run_in_executor(None, gen_fn, source, dest, size)
+    finally:
+        _inflight_locks.pop(dest_key, None)
     if not ok:
         _record_failure(failure_key)
         return None

--- a/tests/test_web_thumbnails.py
+++ b/tests/test_web_thumbnails.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import tempfile
+import threading
 import time
 import unittest
 from pathlib import Path
@@ -351,7 +352,7 @@ class TestConcurrentGenerationCollapse(unittest.IsolatedAsyncioTestCase):
         import src.web.thumbnails as mod
 
         mod._recent_failures.clear()
-        mod._inflight_locks.clear()
+        mod._inflight_tasks.clear()
         self.tmp = tempfile.TemporaryDirectory()
         self.addCleanup(self.tmp.cleanup)
         self.media_root = Path(self.tmp.name)
@@ -415,6 +416,43 @@ class TestConcurrentGenerationCollapse(unittest.IsolatedAsyncioTestCase):
         for result in results:
             self.assertIsNotNone(result)
 
+    async def test_cancelled_waiter_does_not_kill_or_duplicate_the_generation(self):
+        """A waiter's cancellation must stop only the WAIT: the shared task
+        keeps generating, surviving waiters get its result, and a request
+        arriving after the cancellation joins the same single decode (review
+        finding: the lock-based version popped the in-flight entry from a
+        cancelled waiter's finally and let a duplicate start)."""
+        calls = []
+        release = threading.Event()
+
+        def fake_generate(source, dest, size):
+            calls.append(str(dest))
+            release.wait(2)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"webp")
+            return True
+
+        with patch("src.web.thumbnails._generate_sync", side_effect=fake_generate):
+            first = asyncio.create_task(ensure_thumbnail(self.media_root, 200, "chat1", "photo.jpg"))
+            second = asyncio.create_task(ensure_thumbnail(self.media_root, 200, "chat1", "photo.jpg"))
+            await asyncio.sleep(0.05)  # both joined the shared generation
+
+            second.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await second
+
+            # A newcomer AFTER the cancellation must join, not restart.
+            third = asyncio.create_task(ensure_thumbnail(self.media_root, 200, "chat1", "photo.jpg"))
+            await asyncio.sleep(0.05)
+            release.set()
+
+            first_result = await first
+            third_result = await third
+
+        self.assertEqual(len(calls), 1, "cancelled waiter caused a duplicate decode")
+        self.assertIsNotNone(first_result)
+        self.assertIsNotNone(third_result)
+
     async def test_inflight_map_is_empty_after_completion(self):
         import src.web.thumbnails as mod
 
@@ -426,4 +464,4 @@ class TestConcurrentGenerationCollapse(unittest.IsolatedAsyncioTestCase):
         with patch("src.web.thumbnails._generate_sync", side_effect=fake_generate):
             await ensure_thumbnail(self.media_root, 200, "chat1", "photo.jpg")
 
-        self.assertEqual(mod._inflight_locks, {})
+        self.assertEqual(mod._inflight_tasks, {})

--- a/tests/test_web_thumbnails.py
+++ b/tests/test_web_thumbnails.py
@@ -1,6 +1,8 @@
 """Tests for thumbnail generation (src/web/thumbnails.py)."""
 
+import asyncio
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -340,3 +342,88 @@ class TestEnsureThumbnail(unittest.IsolatedAsyncioTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestConcurrentGenerationCollapse(unittest.IsolatedAsyncioTestCase):
+    """One missing thumbnail costs one generation, no matter how many ask."""
+
+    def setUp(self):
+        import src.web.thumbnails as mod
+
+        mod._recent_failures.clear()
+        mod._inflight_locks.clear()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.media_root = Path(self.tmp.name)
+        (self.media_root / "chat1").mkdir()
+        (self.media_root / "chat1" / "photo.jpg").write_bytes(b"not-a-real-jpeg")
+
+    async def test_concurrent_requests_for_same_thumb_generate_once(self):
+        calls = []
+
+        def fake_generate(source, dest, size):
+            calls.append(str(dest))
+            time.sleep(0.05)  # hold the window open so the duplicates really overlap
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"webp")
+            return True
+
+        with patch("src.web.thumbnails._generate_sync", side_effect=fake_generate):
+            results = await asyncio.gather(
+                *(ensure_thumbnail(self.media_root, 200, "chat1", "photo.jpg") for _ in range(6))
+            )
+
+        self.assertEqual(len(calls), 1)
+        for result in results:
+            self.assertIsNotNone(result)
+            self.assertEqual(result[0].name, "photo.webp")
+
+    async def test_concurrent_requests_share_one_failure(self):
+        calls = []
+
+        def fake_generate(source, dest, size):
+            calls.append(str(dest))
+            time.sleep(0.05)
+            return False
+
+        with patch("src.web.thumbnails._generate_sync", side_effect=fake_generate):
+            results = await asyncio.gather(
+                *(ensure_thumbnail(self.media_root, 200, "chat1", "photo.jpg") for _ in range(6))
+            )
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(results, [None] * 6)
+
+    async def test_distinct_thumbnails_generate_independently(self):
+        (self.media_root / "chat1" / "other.jpg").write_bytes(b"x")
+        calls = []
+
+        def fake_generate(source, dest, size):
+            calls.append(str(dest))
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"webp")
+            return True
+
+        with patch("src.web.thumbnails._generate_sync", side_effect=fake_generate):
+            results = await asyncio.gather(
+                ensure_thumbnail(self.media_root, 200, "chat1", "photo.jpg"),
+                ensure_thumbnail(self.media_root, 400, "chat1", "photo.jpg"),
+                ensure_thumbnail(self.media_root, 200, "chat1", "other.jpg"),
+            )
+
+        self.assertEqual(len(calls), 3)
+        for result in results:
+            self.assertIsNotNone(result)
+
+    async def test_inflight_map_is_empty_after_completion(self):
+        import src.web.thumbnails as mod
+
+        def fake_generate(source, dest, size):
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(b"webp")
+            return True
+
+        with patch("src.web.thumbnails._generate_sync", side_effect=fake_generate):
+            await ensure_thumbnail(self.media_root, 200, "chat1", "photo.jpg")
+
+        self.assertEqual(mod._inflight_locks, {})


### PR DESCRIPTION
Opening a gallery on a cold cache fires many thumbnail requests at once, and a reload during first render duplicates them. Each duplicate for the same missing thumbnail passed the dest.exists() check together and ran its own full source decode — the Semaphore(8) caps how many generations run concurrently, but not how many times the same work runs. The earlier atomic-write fix means nobody ever saw a truncated file; the leftover cost was pure duplicated decode (CPU + peak memory), and for videos, duplicated 15s ffmpeg subprocess attempts even after the first one had already failed.

A per-destination asyncio lock now collapses the stampede: the first request generates, concurrent duplicates wait on the lock and then find either the finished file or the freshly cached failure. The lock map is popped as each generation settles, so it stays bounded by in-flight distinct thumbnails.

Four tests drive real overlapping requests through asyncio.gather with a slow patched generator: 6 requests → exactly 1 generation with all 6 served; a failure recorded once with no duplicate ffmpeg runs; distinct thumbs independent; the map empty afterwards. The no-collapse mutant (fresh lock per request) was verified red. Full suite 3355 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate thumbnail generation when multiple requests arrive simultaneously.
  * Concurrent requests now share the same generated thumbnail or failure result.
  * Cancelling one request no longer interrupts thumbnail generation for other waiting requests.
  * Independent thumbnails continue generating separately.
  * Improved cleanup after thumbnail generation completes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->