### PR TITLE
perf(viewer): a gallery page stops sorting every media row in the chat

### DIFF
--- a/alembic/versions/20260821_026_add_media_gallery_index.py
+++ b/alembic/versions/20260821_026_add_media_gallery_index.py
@@ -1,0 +1,59 @@
+"""Add idx_media_gallery so a gallery page stops sorting the whole chat.
+
+GET /api/chats/{chat_id}/media orders by the media keyset pair and filters on
+(chat_id, downloaded), but no index carried both the filter and an ordering
+column: measured on a chat holding 120,000 downloaded media rows, every page
+fetched, joined and sorted all of them to return 51 (43 ms first page, 494 ms
+near the oldest row, linear in chat media count). This composite covers the
+filter, the cursor predicate and the ORDER BY in one seek, so a page costs
+O(page size) after the cursor.
+
+Named explicitly rather than reflecting models.py, matching 024/025's
+rationale: a migration has to keep meaning what it meant when it was written.
+Guarded both directions — the entrypoint stamping ladder tops out at 018 and
+relies on every later migration being idempotent, and a create_all() database
+already has this index from the model declaration.
+
+Revision ID: 026
+Revises: 025
+Create Date: 2026-08-21
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "026"
+down_revision: str | None = "025"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+TABLE_NAME = "media"
+INDEX_NAME = "idx_media_gallery"
+COLUMNS = ("chat_id", "downloaded", "message_id", "id")
+
+
+def _live_indexes(inspector: sa.Inspector) -> set[str]:
+    if TABLE_NAME not in inspector.get_table_names():
+        return set()
+    return {index["name"] for index in inspector.get_indexes(TABLE_NAME)}
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if TABLE_NAME not in inspector.get_table_names():
+        return
+    if INDEX_NAME in _live_indexes(inspector):
+        return
+    op.create_index(INDEX_NAME, TABLE_NAME, list(COLUMNS))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    if INDEX_NAME not in _live_indexes(inspector):
+        return
+    op.drop_index(INDEX_NAME, table_name=TABLE_NAME)

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1784,10 +1784,15 @@ class DatabaseAdapter:
 
         ``before_id``/``after_id`` are opaque ``Media.id`` tokens (the gallery
         round-trips the composite ``{chat}_{msg}_{type}`` string), but each is resolved
-        to the triple (Message.date, Media.message_id, Media.id) before use.
-        ``Media.id`` alone sorts lexically, so rows sharing a timestamp came back as
-        9, 99, 98, ..., 8, 89 — numerically meaningless; ``Media.message_id`` is an
-        integer and orders correctly.
+        to the pair (Media.message_id, Media.id) before use. ``Media.id`` alone sorts
+        lexically, so rows sharing a message came back as 9, 99, 98, ..., 8, 89 —
+        numerically meaningless; ``Media.message_id`` is an integer and orders
+        correctly. Ordering on the media pair rather than on ``Message.date`` is what
+        lets one covering index (``idx_media_gallery``) serve filter, cursor predicate
+        and ORDER BY in a single seek: per-chat Telegram message ids are assigned
+        monotonically in time (the same fact the message ``before_id`` cursor relies
+        on), so the pair yields the identical chronological order without dragging
+        the messages join into the sort.
 
         Two directions, one cursor shape:
 
@@ -1801,7 +1806,7 @@ class DatabaseAdapter:
         The two are MUTUALLY EXCLUSIVE: supplying both is a caller bug (there is no
         coherent page "before X and after Y" in this API) and raises ``ValueError``.
 
-        The ORDER BY and the cursor predicate MUST stay the same triple, in the same
+        The ORDER BY and the cursor predicate MUST stay the same pair, in the same
         direction: that identity is what guarantees a full walk yields every row
         exactly once (no skips, no duplicates). Change one and you must change the
         other — in both directions.
@@ -1823,22 +1828,13 @@ class DatabaseAdapter:
 
         async with self.db_manager.async_session_factory() as session:
             # Two-step page: pick the page's Media.ids from a NARROW statement
-            # (three sort keys, nothing else), then hydrate only those rows.
-            # The sort still walks the chat's media, but it no longer drags every
-            # media column — file_path, file_name, mime_type — plus the joined
-            # user columns through the sorter. Measured on a chat holding 120,000
-            # downloaded media: 112 ms -> 55 ms for an identical result set.
-            # (Making this O(page) needs the message timestamp denormalised onto
-            # media so one index can serve filter + cursor + ORDER BY; that is a
-            # schema change, not a query change.)
-            key_stmt = select(Media.id.label("page_media_id")).join(
-                Message,
-                and_(
-                    Media.account_id == Message.account_id,
-                    Media.message_id == Message.id,
-                    Media.chat_id == Message.chat_id,
-                ),
-            )
+            # (the two sort keys, nothing else), then hydrate only those rows.
+            # The key statement touches only media columns — filter (chat_id,
+            # downloaded), cursor predicate and ORDER BY are all on the media
+            # pair — so idx_media_gallery (chat_id, downloaded, message_id, id)
+            # serves the whole page as one index seek: O(page size) after the
+            # cursor, no temp sort, no messages join until hydration.
+            key_stmt = select(Media.id.label("page_media_id"))
             key_stmt = key_stmt.where(and_(Media.chat_id == chat_id, Media.downloaded == 1))
             if account_id is not None:
                 key_stmt = key_stmt.where(Media.account_id == account_id)
@@ -1847,17 +1843,8 @@ class DatabaseAdapter:
                 key_stmt = key_stmt.where(Media.type.in_(media_types))
 
             if cursor_token:
-                cursor_stmt = (
-                    select(Media.id, Media.message_id, Message.date)
-                    .join(
-                        Message,
-                        and_(
-                            Media.account_id == Message.account_id,
-                            Media.message_id == Message.id,
-                            Media.chat_id == Message.chat_id,
-                        ),
-                    )
-                    .where(and_(Media.id == cursor_token, Media.chat_id == chat_id))
+                cursor_stmt = select(Media.id, Media.message_id).where(
+                    and_(Media.id == cursor_token, Media.chat_id == chat_id)
                 )
                 if account_id is not None:
                     cursor_stmt = cursor_stmt.where(Media.account_id == account_id)
@@ -1865,44 +1852,32 @@ class DatabaseAdapter:
                 cursor_row = cursor_result.one_or_none()
                 if cursor_row is None:
                     return {"items": [], "has_more": False}
-                cursor_media_id, cursor_message_id, cursor_date = cursor_row
+                cursor_media_id, cursor_message_id = cursor_row
                 if forward:
                     key_stmt = key_stmt.where(
                         or_(
-                            Message.date > cursor_date,
+                            Media.message_id > cursor_message_id,
                             and_(
-                                Message.date == cursor_date,
-                                or_(
-                                    Media.message_id > cursor_message_id,
-                                    and_(
-                                        Media.message_id == cursor_message_id,
-                                        Media.id > cursor_media_id,
-                                    ),
-                                ),
+                                Media.message_id == cursor_message_id,
+                                Media.id > cursor_media_id,
                             ),
                         )
                     )
                 else:
                     key_stmt = key_stmt.where(
                         or_(
-                            Message.date < cursor_date,
+                            Media.message_id < cursor_message_id,
                             and_(
-                                Message.date == cursor_date,
-                                or_(
-                                    Media.message_id < cursor_message_id,
-                                    and_(
-                                        Media.message_id == cursor_message_id,
-                                        Media.id < cursor_media_id,
-                                    ),
-                                ),
+                                Media.message_id == cursor_message_id,
+                                Media.id < cursor_media_id,
                             ),
                         )
                     )
 
             if forward:
-                order_by = (Message.date.asc(), Media.message_id.asc(), Media.id.asc())
+                order_by = (Media.message_id.asc(), Media.id.asc())
             else:
-                order_by = (Message.date.desc(), Media.message_id.desc(), Media.id.desc())
+                order_by = (Media.message_id.desc(), Media.id.desc())
 
             page_keys = key_stmt.add_columns(Media.account_id.label("page_account_id")).order_by(*order_by)
             page_keys = page_keys.limit(limit + 1).subquery()

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1849,7 +1849,12 @@ class DatabaseAdapter:
                 if account_id is not None:
                     cursor_stmt = cursor_stmt.where(Media.account_id == account_id)
                 cursor_result = await session.execute(cursor_stmt)
-                cursor_row = cursor_result.one_or_none()
+                # first(), not one_or_none(): unscoped (account_id=None) calls
+                # can match BOTH accounts' copies of the same media id, and the
+                # copies share the same (message_id, id) pair — any matching
+                # row resolves the cursor identically, while one_or_none()
+                # would raise MultipleResultsFound on exactly that duplicate.
+                cursor_row = cursor_result.first()
                 if cursor_row is None:
                     return {"items": [], "has_more": False}
                 cursor_media_id, cursor_message_id = cursor_row

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -376,6 +376,10 @@ class Media(Base):
         Index("idx_media_type", "type"),
         Index("idx_media_content_hash", "content_hash"),
         Index("idx_media_chat_type", "chat_id", "type"),
+        # Serves the gallery page as ONE index seek: filter (chat_id, downloaded),
+        # keyset cursor and ORDER BY all live on this column order, so a page
+        # costs O(page size) instead of sorting every media row in the chat.
+        Index("idx_media_gallery", "chat_id", "downloaded", "message_id", "id"),
     )
 
 

--- a/tests/test_media_gallery_plan.py
+++ b/tests/test_media_gallery_plan.py
@@ -1,0 +1,116 @@
+"""The gallery key query must be served by idx_media_gallery, not a sort.
+
+Measured before this index existed: every gallery page fetched, joined and
+sorted every media row in the chat to return 51 (43 ms first page, 494 ms on a
+deep cursor at 120k rows, linear in chat size). These tests capture the exact
+SQL the adapter emits against real SQLite and EXPLAIN it: the media access must
+be an index seek on idx_media_gallery, never a full media scan. The tiny outer
+sort of one hydrated page (<= limit+1 rows) is O(page) and allowed.
+"""
+
+import os
+import sys
+from datetime import datetime, timedelta
+
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Base, Chat, Media, Message
+
+CHAT_ID = -1001234567890
+ROWS = 600  # enough that the planner never prefers a full scan
+
+
+async def _build() -> tuple[DatabaseAdapter, object]:
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db_manager = DatabaseManager.__new__(DatabaseManager)
+    db_manager.engine = engine
+    db_manager.database_url = "sqlite+aiosqlite://"
+    db_manager._is_sqlite = True
+    db_manager.async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with db_manager.async_session_factory() as session:
+        session.add(Chat(id=CHAT_ID, type="channel", title="Big Gallery"))
+        base_date = datetime(2026, 1, 1, 10)
+        for n in range(1, ROWS + 1):
+            session.add(Message(id=n, chat_id=CHAT_ID, date=base_date + timedelta(minutes=n), text=None))
+            session.add(
+                Media(
+                    id=f"{CHAT_ID}_{n}_photo",
+                    message_id=n,
+                    chat_id=CHAT_ID,
+                    type="photo",
+                    file_path=f"{CHAT_ID}/photo_{n}.jpg",
+                    file_name=f"photo_{n}.jpg",
+                    file_size=1000 + n,
+                    mime_type="image/jpeg",
+                    downloaded=1,
+                )
+            )
+        await session.commit()
+
+    return DatabaseAdapter(db_manager), engine
+
+
+@pytest_asyncio.fixture
+async def built():
+    return await _build()
+
+
+async def _explain_page_statements(adapter, engine, **page_kwargs) -> list[str]:
+    """Run one page call, EXPLAIN the SQL that selects the page keys."""
+    captured: list[tuple[str, tuple]] = []
+
+    def _capture(conn, cursor, statement, parameters, context, executemany):
+        captured.append((statement, parameters))
+
+    event.listen(engine.sync_engine, "before_cursor_execute", _capture)
+    try:
+        await adapter.get_media_paginated(CHAT_ID, **page_kwargs)
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _capture)
+
+    page_sql = [(s, p) for s, p in captured if "page_media_id" in s]
+    assert page_sql, "the page statement was not captured"
+    plans = []
+    async with engine.connect() as conn:
+        for statement, parameters in page_sql:
+            result = await conn.exec_driver_sql(f"EXPLAIN QUERY PLAN {statement}", parameters)
+            plans.append(" | ".join(str(row[-1]) for row in result.fetchall()))
+    return plans
+
+
+async def test_first_page_seeks_the_gallery_index(built):
+    adapter, engine = built
+    for plan in await _explain_page_statements(adapter, engine, limit=50):
+        assert "idx_media_gallery" in plan, f"gallery index unused: {plan}"
+        assert "SCAN media" not in plan, f"full media scan: {plan}"
+
+
+async def test_deep_cursor_page_stays_an_index_seek(built):
+    adapter, engine = built
+    # A cursor near the oldest row — the case measured at 494 ms pre-index.
+    deep_cursor = f"{CHAT_ID}_20_photo"
+    for plan in await _explain_page_statements(adapter, engine, limit=50, before_id=deep_cursor):
+        assert "idx_media_gallery" in plan, f"gallery index unused: {plan}"
+        assert "SCAN media" not in plan, f"full media scan: {plan}"
+
+
+async def test_forward_cursor_page_stays_an_index_seek(built):
+    adapter, engine = built
+    for plan in await _explain_page_statements(adapter, engine, limit=50, after_id=f"{CHAT_ID}_20_photo"):
+        assert "idx_media_gallery" in plan, f"gallery index unused: {plan}"
+        assert "SCAN media" not in plan, f"full media scan: {plan}"

--- a/tests/test_media_gallery_plan.py
+++ b/tests/test_media_gallery_plan.py
@@ -114,3 +114,36 @@ async def test_forward_cursor_page_stays_an_index_seek(built):
     for plan in await _explain_page_statements(adapter, engine, limit=50, after_id=f"{CHAT_ID}_20_photo"):
         assert "idx_media_gallery" in plan, f"gallery index unused: {plan}"
         assert "SCAN media" not in plan, f"full media scan: {plan}"
+
+
+async def test_unscoped_cursor_survives_duplicate_ids_across_accounts(built):
+    """Two accounts archiving the same chat store identical Media.id strings.
+    An unscoped cursor lookup matches both copies — they share the same
+    (message_id, id) pair, so any row resolves the cursor identically, and
+    the old one_or_none() raised MultipleResultsFound on exactly this."""
+    adapter, engine = built
+    from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        session.add(Chat(account_id=2, id=CHAT_ID, type="channel", title="Second copy"))
+        n = 30
+        session.add(Message(account_id=2, id=n, chat_id=CHAT_ID, date=datetime(2026, 2, 1, 10), text=None))
+        session.add(
+            Media(
+                account_id=2,
+                id=f"{CHAT_ID}_{n}_photo",
+                message_id=n,
+                chat_id=CHAT_ID,
+                type="photo",
+                file_path=f"{CHAT_ID}/photo_{n}.jpg",
+                file_name=f"photo_{n}.jpg",
+                file_size=1,
+                mime_type="image/jpeg",
+                downloaded=1,
+            )
+        )
+        await session.commit()
+
+    page = await adapter.get_media_paginated(CHAT_ID, limit=10, before_id=f"{CHAT_ID}_{n}_photo")
+    assert page["items"], "cursor resolution must survive the duplicate"

--- a/tests/test_migration_026.py
+++ b/tests/test_migration_026.py
@@ -1,0 +1,88 @@
+"""Migration 026 - idx_media_gallery, guarded both directions.
+
+The entrypoint stamping ladder tops out at 018 and relies on every later
+migration being idempotent: a create_all() database already has this index
+from the model declaration and must no-op here.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+_VERSIONS_DIR = Path(__file__).resolve().parent.parent / "alembic" / "versions"
+
+spec = importlib.util.spec_from_file_location(
+    "migration_026", _VERSIONS_DIR / "20260821_026_add_media_gallery_index.py"
+)
+migration_026 = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(migration_026)
+
+
+def _run(conn, func):
+    ctx = MigrationContext.configure(conn)
+    with Operations.context(ctx):
+        func()
+
+
+def _indexes(conn):
+    return {ix["name"] for ix in sa.inspect(conn).get_indexes("media")}
+
+
+def _create_media_table(conn):
+    conn.execute(
+        sa.text(
+            "CREATE TABLE media (id VARCHAR(255) NOT NULL PRIMARY KEY, chat_id BIGINT, "
+            "message_id BIGINT, type VARCHAR(50), downloaded INTEGER DEFAULT 0)"
+        )
+    )
+
+
+def test_revision_chain():
+    assert migration_026.revision == "026"
+    assert migration_026.down_revision == "025"
+
+
+def test_upgrade_creates_index_and_is_idempotent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_media_table(conn)
+
+        _run(conn, migration_026.upgrade)
+        assert "idx_media_gallery" in _indexes(conn)
+
+        _run(conn, migration_026.upgrade)  # re-run must be a no-op
+        assert "idx_media_gallery" in _indexes(conn)
+
+
+def test_upgrade_noop_when_index_already_exists():
+    """Simulates create_all(): the Media model already declares idx_media_gallery."""
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_media_table(conn)
+        conn.execute(sa.text("CREATE INDEX idx_media_gallery ON media (chat_id, downloaded, message_id, id)"))
+
+        _run(conn, migration_026.upgrade)  # must not raise
+        assert "idx_media_gallery" in _indexes(conn)
+
+
+def test_upgrade_noop_when_media_table_absent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _run(conn, migration_026.upgrade)  # no media table -> no-op, no raise
+        assert "media" not in sa.inspect(conn).get_table_names()
+
+
+def test_downgrade_drops_index_and_is_idempotent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_media_table(conn)
+        _run(conn, migration_026.upgrade)
+
+        _run(conn, migration_026.downgrade)
+        assert "idx_media_gallery" not in _indexes(conn)
+
+        _run(conn, migration_026.downgrade)  # idempotent
+        assert "idx_media_gallery" not in _indexes(conn)


### PR DESCRIPTION
Opening the media gallery ran a query whose filter lives on media (chat_id, downloaded) but whose sort lived on the joined messages.date — no single index can serve that, so SQLite fetched, joined and sorted every media row in the chat to return 51. Measured on a chat with 120,000 downloaded media: 43 ms for page one, 494 ms with a cursor near the oldest row (the temp b-tree gets worse the deeper you go, not better), cost linear in chat media count, and each request holds a DB connection for the whole sort.

Per-chat Telegram message ids are assigned monotonically in time — the exact fact the message before_id cursor already relies on — so ordering on the media pair (message_id, id) yields the identical chronological order without touching messages. The new idx_media_gallery (chat_id, downloaded, message_id, id) then serves filter, cursor predicate and ORDER BY as a single index seek: O(page size) after the cursor, and the messages join disappears from the key query entirely (it remains only in the per-page hydration step). The cursor token clients round-trip is the same opaque Media.id, so nothing changes for the frontend.

Migration 026 creates the index guarded in both directions — the entrypoint stamping ladder deliberately tops out at 018 and relies on later migrations being idempotent, and a create_all() database already has the index from the model declaration. No entrypoint change needed.

Evidence: the full 54-test cursor/gallery contract suite passes unchanged (exactly-once walks both directions, tie-breaks, type filters, cross-chat token oracle); new EXPLAIN QUERY PLAN tests capture the adapter's real SQL at 600 rows and assert the gallery index seek with no media scan on first, deep-backward and forward pages — all three fail with the index removed (verified); migration 026 has the full idempotency matrix; full suite 3359 passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved media gallery pagination for faster first-page and deep-page retrieval.
  * Added an optimized database index to reduce media table scanning.
* **Bug Fixes**
  * Improved cursor-based navigation and ordering for consistent gallery results.
* **Tests**
  * Added coverage for pagination performance, cursor navigation, and database migration behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->