### PR TITLE
perf(backup): video thumbnails warm at capture time instead of first view

### DIFF
--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -185,7 +185,9 @@ def _pre_generate_thumbnail(source_path: str, media_root: str) -> None:
         from src.web.thumbnails import (
             _IMAGE_EXTENSIONS,
             _MAX_SOURCE_BYTES,
+            _VIDEO_EXTENSIONS,
             WEBP_QUALITY,
+            _generate_video_sync,
             _thumb_path,
         )
 
@@ -195,10 +197,14 @@ def _pre_generate_thumbnail(source_path: str, media_root: str) -> None:
         if not source.exists():
             return
 
-        if source.suffix.lower() not in _IMAGE_EXTENSIONS:
+        suffix = source.suffix.lower()
+        is_image = suffix in _IMAGE_EXTENSIONS
+        is_video = suffix in _VIDEO_EXTENSIONS
+        if not is_image and not is_video:
             return
 
-        if source.stat().st_size > _MAX_SOURCE_BYTES:
+        # Videos gate bytes inside _generate_video_sync (at 4x this limit).
+        if is_image and source.stat().st_size > _MAX_SOURCE_BYTES:
             return
 
         media_root_path = Path(media_root)
@@ -210,6 +216,16 @@ def _pre_generate_thumbnail(source_path: str, media_root: str) -> None:
         dest = _thumb_path(media_root_path, 200, folder, source.name)
 
         if dest.exists():
+            return
+
+        if is_video:
+            # The whole guard stack — ffmpeg availability, the 4x byte gate,
+            # -max_pixels, the atomic temp+replace save — lives inside
+            # _generate_video_sync. A False here costs nothing: the request
+            # path (with its failure cache) remains the fallback, exactly as
+            # for images. This runs in the backup's to_thread lane, so the
+            # ffmpeg wait never blocks the event loop.
+            _generate_video_sync(source, dest, 200)
             return
 
         dest.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_pre_generate_thumbnail.py
+++ b/tests/test_pre_generate_thumbnail.py
@@ -1,8 +1,11 @@
 """Tests for _pre_generate_thumbnail in telegram_backup.py."""
 
+import shutil
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from PIL import Image as PILImage
 
@@ -120,3 +123,60 @@ class TestPreGenerateThumbnail(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestPreGenerateVideoThumbnail(unittest.TestCase):
+    """Video thumbnails pre-generate at capture time, not first view (#9t6.6.11)."""
+
+    def test_video_extension_routes_to_video_generator(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            source = media_root / "chat1" / "clip.mp4"
+            source.parent.mkdir(parents=True)
+            source.write_bytes(b"fake-video-bytes")
+
+            with patch("src.web.thumbnails._generate_video_sync") as gen:
+                _pre_generate_thumbnail(str(source), str(media_root))
+
+            gen.assert_called_once()
+            called_source, called_dest, called_size = gen.call_args.args
+            self.assertEqual(called_source, source)
+            self.assertEqual(called_dest, media_root / ".thumbs" / "200" / "chat1" / "clip.webp")
+            self.assertEqual(called_size, 200)
+
+    def test_video_skipped_when_thumbnail_already_cached(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            source = media_root / "chat1" / "clip.mp4"
+            source.parent.mkdir(parents=True)
+            source.write_bytes(b"fake-video-bytes")
+            dest = media_root / ".thumbs" / "200" / "chat1" / "clip.webp"
+            dest.parent.mkdir(parents=True)
+            dest.write_bytes(b"existing")
+
+            with patch("src.web.thumbnails._generate_video_sync") as gen:
+                _pre_generate_thumbnail(str(source), str(media_root))
+
+            gen.assert_not_called()
+
+    @unittest.skipUnless(shutil.which("ffmpeg"), "ffmpeg not installed")
+    def test_real_video_end_to_end(self):
+        """A real 2s clip produces a real WebP through the actual ffmpeg lane."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            media_root = Path(tmpdir)
+            source = media_root / "chat1" / "real.mp4"
+            source.parent.mkdir(parents=True)
+            build = subprocess.run(
+                ["ffmpeg", "-y", "-f", "lavfi", "-i", "testsrc=duration=2:size=64x64:rate=10", str(source)],
+                capture_output=True,
+                timeout=30,
+            )
+            self.assertEqual(build.returncode, 0, build.stderr.decode()[-300:])
+
+            _pre_generate_thumbnail(str(source), str(media_root))
+
+            dest = media_root / ".thumbs" / "200" / "chat1" / "real.webp"
+            self.assertTrue(dest.exists())
+            with PILImage.open(dest) as thumb:
+                self.assertEqual(thumb.format, "WEBP")
+                self.assertLessEqual(thumb.width, 200)


### PR DESCRIPTION
The gallery emits /media/thumb/ URLs for videos, but the backup-side pre-generator returned early for any non-image — so every video thumbnail was extracted on the request path, at first view: ~600ms per healthy clip, and a cold grid of 24 videos took ~7 seconds to fill behind the 2-slot ffmpeg lane. (The other halves of this finding already shipped separately: failures are cached with a 5-minute TTL, and concurrent duplicates collapse to one generation.)

Downloaded videos now pre-generate through the exact _generate_video_sync the viewer uses — its ffmpeg-availability check, 4x byte gate, -max_pixels decoder cap and atomic temp+replace save all apply — inside the backup's existing to_thread lane, so the event loop never waits on ffmpeg and the common case is warm before any viewer asks. The request path remains the fallback for anything captured before this change. The backup image already ships ffmpeg.

Deliberately NOT taken from the finding: dropping the second ffmpeg seek attempt when the first fails. Distinguishing 'undecodable' from 'shorter than the 1s seek' by exit code alone is not reliable across containers, and guessing wrong permanently costs a short video its thumbnail to save 15 seconds once per bad file per 5-minute failure-cache window.

Tests: routing to the video generator with exact (source, dest, size) args; the cached-thumbnail skip; a real end-to-end run building a 2s clip with ffmpeg and asserting a valid WebP (skipped where ffmpeg is absent — CI has it). The image-only mutant fails both routing tests. Full suite: 3354 passed, 127 skipped, 451 warnings, 691 subtests passed in 90.68s (0:01:30)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic thumbnail generation for supported video files.
  * Video thumbnails are generated in WebP format and reuse existing cached thumbnails when available.
  * Large video files are handled with appropriate size safeguards.

* **Bug Fixes**
  * Improved thumbnail pre-generation so videos are no longer skipped when processing media backups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->