### PR TITLE
fix(backup): gap-fill finally sees bot conversations

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -2559,13 +2559,23 @@ class DatabaseAdapter:
             return [(row[0], row[1], row[2]) for row in result.fetchall()]
 
     async def get_chats_with_messages(self, *, account_id: int) -> list[int]:
-        """Get one account's chat IDs from the chats table.
+        """One account's chat ids that have at least one stored message.
 
-        Queries the chats table directly instead of scanning the messages table,
-        which would be extremely slow on large databases.
+        The chats table drives the scan (never a wholesale messages sweep —
+        that is extremely slow on large databases); a correlated EXISTS probe
+        per chat row, served by the chat-leading messages index, keeps the
+        name honest. _backup_dialog upserts the chat row before any message
+        lands, so a bare chats query let message-less rows through — and in
+        gap-fill each of those cost a get_entity call and FloodWait exposure
+        for a chat that cannot have gaps.
         """
         async with self.db_manager.async_session_factory() as session:
-            stmt = select(Chat.id).where(Chat.account_id == account_id)
+            has_rows = (
+                select(Message.id)
+                .where(and_(Message.account_id == Chat.account_id, Message.chat_id == Chat.id))
+                .exists()
+            )
+            stmt = select(Chat.id).where(and_(Chat.account_id == account_id, has_rows))
             result = await session.execute(stmt)
             return [row[0] for row in result.fetchall()]
 

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -2252,18 +2252,24 @@ class TelegramBackup:
             chat_ids = [chat_id]
         else:
             # Only scan chats that current config would back up (respects
-            # CHAT_IDS whitelist, CHAT_TYPES, and all exclude lists)
-            all_chat_ids = await self.db.get_chats_with_messages(account_id=self.account_id)
+            # CHAT_IDS whitelist, CHAT_TYPES, and all exclude lists).
+            # Classification must mirror backup_all's live-entity one, and the
+            # chats table stores bot DMs as type "private" — bot-ness lives in
+            # the users table — so reading chats.type alone made is_bot
+            # unreachable: CHAT_TYPES=bots never gap-filled a single bot
+            # conversation, and configs without bots kept gap-filling
+            # previously archived bot chats.
+            with_messages = set(await self.db.get_chats_with_messages(account_id=self.account_id))
             chat_ids = []
-            for cid in all_chat_ids:
-                chat_info = await self.db.get_chat_by_id(cid, account_id=self.account_id)
-                if not chat_info:
+            for chat_info in await self.db.get_chats_for_folder_resolution(account_id=self.account_id):
+                cid = chat_info["id"]
+                if cid not in with_messages:
                     continue
                 ctype = chat_info.get("type", "")
-                is_user = ctype == "private"
+                is_bot = ctype == "private" and bool(chat_info.get("is_bot"))
+                is_user = ctype == "private" and not is_bot
                 is_group = ctype in ("group", "supergroup")
                 is_channel = ctype == "channel"
-                is_bot = ctype == "bot"
                 if self.config.should_backup_chat(cid, is_user, is_group, is_channel, is_bot):
                     chat_ids.append(cid)
 

--- a/tests/test_account_isolation.py
+++ b/tests/test_account_isolation.py
@@ -312,9 +312,17 @@ class TestChatsAreAccountIsolated:
         assert [ref for *_, ref in rows_after] == refs  # update branch never touches ref
 
     async def test_get_chats_with_messages_lists_only_that_accounts_chats(self, real_adapter):
+        """Scoping AND the with-messages gate: each account sees exactly its
+        own chats that actually hold messages — a bare chat row (upserted
+        before any message lands) does not pass."""
         await _seed_accounts(real_adapter)
         await _seed_chat(real_adapter, -100712)
         await _seed_chat(real_adapter, -100722, accounts=(OTHER_ACCOUNT,))
+        await real_adapter.insert_messages_batch([_message(-100712, 1)], account_id=DEFAULT_ACCOUNT_ID)
+        await real_adapter.insert_messages_batch([_message(-100712, 1)], account_id=OTHER_ACCOUNT)
+        await real_adapter.insert_messages_batch([_message(-100722, 1)], account_id=OTHER_ACCOUNT)
+        # A message-less chat row for the default account: must not appear.
+        await _seed_chat(real_adapter, -100733, accounts=(DEFAULT_ACCOUNT_ID,))
 
         assert await real_adapter.get_chats_with_messages(account_id=DEFAULT_ACCOUNT_ID) == [-100712]
         assert sorted(await real_adapter.get_chats_with_messages(account_id=OTHER_ACCOUNT)) == [-100722, -100712]

--- a/tests/test_gap_fill.py
+++ b/tests/test_gap_fill.py
@@ -287,6 +287,11 @@ def _make_backup_instance(db_mock=None, client_mock=None, config_mock=None):
     return backup
 
 
+def _resolution_rows(*chat_ids, chat_type="channel"):
+    """Rows shaped like adapter.get_chats_for_folder_resolution returns."""
+    return [{"id": cid, "type": chat_type, "is_bot": False, "is_archived": False} for cid in chat_ids]
+
+
 class TestFillGaps:
     """Exercise _fill_gaps logic with mocked DB and Telegram client."""
 
@@ -294,6 +299,7 @@ class TestFillGaps:
         """When chat_id=None, _fill_gaps should query all chats from DB."""
         db = AsyncMock()
         db.get_chats_with_messages = AsyncMock(return_value=[-1001, -1002])
+        db.get_chats_for_folder_resolution = AsyncMock(return_value=_resolution_rows(-1001, -1002))
         db.detect_message_gaps = AsyncMock(return_value=[])
 
         client = AsyncMock()
@@ -358,6 +364,7 @@ class TestFillGaps:
 
         db = AsyncMock()
         db.get_chats_with_messages = AsyncMock(return_value=[-1001, -1002, -1003])
+        db.get_chats_for_folder_resolution = AsyncMock(return_value=_resolution_rows(-1001, -1002, -1003))
 
         accessible_entity = MagicMock()
         accessible_entity.title = "Accessible"
@@ -388,6 +395,7 @@ class TestFillGaps:
         """When gaps are found, _fill_gap_range should be called for each."""
         db = AsyncMock()
         db.get_chats_with_messages = AsyncMock(return_value=[-1001])
+        db.get_chats_for_folder_resolution = AsyncMock(return_value=_resolution_rows(-1001))
         db.detect_message_gaps = AsyncMock(
             return_value=[
                 (50, 100, 50),
@@ -421,6 +429,7 @@ class TestFillGaps:
         """Chats with no gaps should not appear in the details list."""
         db = AsyncMock()
         db.get_chats_with_messages = AsyncMock(return_value=[-1001, -1002])
+        db.get_chats_for_folder_resolution = AsyncMock(return_value=_resolution_rows(-1001, -1002))
         db.detect_message_gaps = AsyncMock(
             side_effect=[
                 [],  # chat -1001: no gaps
@@ -452,6 +461,7 @@ class TestFillGaps:
         """The threshold passed to detect_message_gaps should come from config."""
         db = AsyncMock()
         db.get_chats_with_messages = AsyncMock(return_value=[-1001])
+        db.get_chats_for_folder_resolution = AsyncMock(return_value=_resolution_rows(-1001))
         db.detect_message_gaps = AsyncMock(return_value=[])
 
         client = AsyncMock()
@@ -661,3 +671,83 @@ class TestGapFillConfig:
             config = Config()
             assert config.fill_gaps is True
             assert config.gap_threshold == 200
+
+
+class TestGapFillBotClassification:
+    """Gap-fill classifies bot DMs the way backup_all does — from the users
+    table — never from chats.type, where a bot is stored as "private"."""
+
+    _BASE_ENV = {
+        "TELEGRAM_API_ID": "12345",
+        "TELEGRAM_API_HASH": "test@hash/value",
+        "TELEGRAM_PHONE": "+1000000",
+        # Config() creates BACKUP_PATH on init; the default /data is read-only here.
+        "BACKUP_PATH": tempfile.mkdtemp(prefix="ta_gapfill_"),
+    }
+
+    def _real_config(self, chat_types: str):
+        import os
+        from unittest.mock import patch as _patch
+
+        from src.config import Config
+
+        env = dict(self._BASE_ENV, CHAT_TYPES=chat_types)
+        with _patch.dict(os.environ, env, clear=True):
+            return Config()
+
+    def _backup(self, chat_types: str, resolution_rows, with_messages):
+        db = AsyncMock()
+        db.get_chats_with_messages = AsyncMock(return_value=with_messages)
+        db.get_chats_for_folder_resolution = AsyncMock(return_value=resolution_rows)
+        db.detect_message_gaps = AsyncMock(return_value=[])
+        client = AsyncMock()
+        entity = MagicMock()
+        entity.title = "chat"
+        client.get_entity = AsyncMock(return_value=entity)
+        backup = _make_backup_instance(db_mock=db, client_mock=client, config_mock=self._real_config(chat_types))
+        return backup, client
+
+    async def test_bots_only_config_scans_the_bot_dm(self):
+        rows = [
+            {"id": 777, "type": "private", "is_bot": True, "is_archived": False},
+            {"id": 888, "type": "private", "is_bot": False, "is_archived": False},
+        ]
+        backup, client = self._backup("bots", rows, with_messages=[777, 888])
+
+        result = await backup._fill_gaps(chat_id=None)
+
+        assert result["chats_scanned"] == 1
+        client.get_entity.assert_awaited_once_with(777)
+
+    async def test_private_only_config_excludes_the_bot_dm(self):
+        """The mirror case: an archived bot chat must stop being gap-filled."""
+        rows = [
+            {"id": 777, "type": "private", "is_bot": True, "is_archived": False},
+            {"id": 888, "type": "private", "is_bot": False, "is_archived": False},
+        ]
+        backup, client = self._backup("private", rows, with_messages=[777, 888])
+
+        result = await backup._fill_gaps(chat_id=None)
+
+        assert result["chats_scanned"] == 1
+        client.get_entity.assert_awaited_once_with(888)
+
+    async def test_groups_and_channels_classification_unchanged(self):
+        rows = [
+            {"id": -100200, "type": "group", "is_bot": False, "is_archived": False},
+            {"id": -1000000300, "type": "channel", "is_bot": False, "is_archived": False},
+        ]
+        backup, _client = self._backup("groups,channels", rows, with_messages=[-100200, -1000000300])
+
+        result = await backup._fill_gaps(chat_id=None)
+
+        assert result["chats_scanned"] == 2
+
+    async def test_chat_without_messages_is_not_scanned(self):
+        rows = [{"id": 777, "type": "private", "is_bot": True, "is_archived": False}]
+        backup, client = self._backup("bots", rows, with_messages=[])
+
+        result = await backup._fill_gaps(chat_id=None)
+
+        assert result["chats_scanned"] == 0
+        client.get_entity.assert_not_awaited()

--- a/tests/test_gap_fill.py
+++ b/tests/test_gap_fill.py
@@ -246,16 +246,20 @@ class TestDetectMessageGaps:
 class TestGetChatsWithMessages:
     """Exercise get_chats_with_messages with a real async SQLite database."""
 
-    async def test_returns_all_chat_ids(self):
-        """Should return all chat IDs from the chats table."""
+    async def test_returns_only_chats_that_hold_messages(self):
+        """_backup_dialog upserts the chat row before any message lands: a
+        message-less row must not pass this gate (each one cost gap-fill a
+        get_entity call and FloodWait exposure for a chat without gaps)."""
         adapter, engine = await _create_in_memory_adapter()
         try:
             await _insert_chat(adapter, chat_id=-1001, title="Chat A")
             await _insert_chat(adapter, chat_id=-1002, title="Chat B")
-            await _insert_chat(adapter, chat_id=-1003, title="Chat C")
+            await _insert_chat(adapter, chat_id=-1003, title="Empty row")
+            await _insert_messages(adapter, chat_id=-1001, msg_ids=[1, 2])
+            await _insert_messages(adapter, chat_id=-1002, msg_ids=[7])
 
             result = await adapter.get_chats_with_messages(account_id=1)
-            assert sorted(result) == [-1003, -1002, -1001]
+            assert sorted(result) == [-1002, -1001]
         finally:
             await engine.dispose()
 

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -1303,10 +1303,10 @@ class TestFillGaps(unittest.TestCase):
     def test_scan_all_chats_filters_by_config(self):
         """When chat_id is None, scans all chats filtered by should_backup_chat."""
         self.backup.db.get_chats_with_messages = AsyncMock(return_value=[1, 2])
-        self.backup.db.get_chat_by_id = AsyncMock(
-            side_effect=[
-                {"type": "private"},
-                {"type": "channel"},
+        self.backup.db.get_chats_for_folder_resolution = AsyncMock(
+            return_value=[
+                {"id": 1, "type": "private", "is_bot": False, "is_archived": False},
+                {"id": 2, "type": "channel", "is_bot": False, "is_archived": False},
             ]
         )
         self.backup.config.should_backup_chat = MagicMock(side_effect=[True, False])
@@ -1316,11 +1316,13 @@ class TestFillGaps(unittest.TestCase):
         summary = _run(self.backup._fill_gaps(chat_id=None))
 
         self.assertEqual(summary["chats_scanned"], 1)
+        self.backup.config.should_backup_chat.assert_any_call(1, True, False, False, False)
+        self.backup.config.should_backup_chat.assert_any_call(2, False, False, True, False)
 
     def test_scan_all_skips_chat_without_info(self):
-        """Chat without DB info is skipped during scan."""
+        """A chat with messages but no chats row never reaches the scan."""
         self.backup.db.get_chats_with_messages = AsyncMock(return_value=[1])
-        self.backup.db.get_chat_by_id = AsyncMock(return_value=None)
+        self.backup.db.get_chats_for_folder_resolution = AsyncMock(return_value=[])
 
         summary = _run(self.backup._fill_gaps(chat_id=None))
 


### PR DESCRIPTION
_fill_gaps promises to scan exactly the chats the current config would back up, but it classified each chat from the stored chats.type — and the chats table stores a bot DM as "private" (bot-ness lives in the users table; the adapter documents this on get_chats_for_folder_resolution). is_bot = ctype == "bot" was therefore unreachable: with CHAT_TYPES=bots, every bot conversation was dropped from the scan before gap detection ran, so gaps left by a failed or flood-aborted run were never detected and never refilled — permanently, on every scheduled and manual fill-gaps. The mirror case was wrong the same way: a config without bots kept gap-filling previously archived bot chats.

The scan now classifies through get_chats_for_folder_resolution — the users-table outer join built for exactly this — mirroring backup_all's live-entity classification (User + entity.bot). A side effect is that the N per-chat get_chat_by_id round trips collapse into one query plus the existing with-messages set.

Tests: real Config (no mocked should_backup_chat) proving CHAT_TYPES=bots scans the bot DM and skips the human DM, the mirror for CHAT_TYPES=private, groups/channels unchanged, and no-messages chats never scanned; the old-classification mutant fails both direction tests. Existing scan tests rewired to the new adapter call with their intent intact, plus exact-argument assertions on should_backup_chat. Full suite: 3355 passed, 127 skipped, 440 warnings, 691 subtests passed in 91.06s (0:01:31)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed gap filling for bot direct-message conversations when bot chats are enabled.
  - Prevented archived bot conversations from being restored when bot chats are excluded.
  - Preserved correct handling of groups and channels.
  - Excluded chats without messages from gap-filling.

- **Tests**
  - Added coverage for bot, user, group, and channel classification during gap filling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->