### PR TITLE
fix(docker): stop shipping a 182MB C toolchain in every backup image pull

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-FROM python:3.14-slim
+# Builder stage: the C toolchain lives here and only here. Every compiled
+# dependency in uv.lock ships a cp314 manylinux wheel today, but keeping gcc
+# in the builder means a future sdist-only dependency still builds — without
+# publishing a 182 MB compiler layer the runtime never invokes.
+FROM python:3.14-slim AS builder
 
-# Set working directory
 WORKDIR /app
 
-# Install system dependencies (ffmpeg for video thumbnail extraction)
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc \
-    ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv for fast, reproducible dependency installation
@@ -17,6 +18,20 @@ COPY --from=ghcr.io/astral-sh/uv:0.11 /uv /bin/uv
 # instead of silently shipping an image that is missing a declared dependency.
 COPY pyproject.toml uv.lock ./
 RUN uv sync --locked --no-dev --no-install-project
+
+# Runtime stage: ffmpeg (video thumbnail extraction) is the only system
+# dependency the runtime actually invokes.
+FROM python:3.14-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+# The venv moves between stages verbatim: both are the same base image, so
+# the interpreter path the venv links against is identical.
+COPY --from=builder /app/.venv /app/.venv
 
 # Copy application code
 COPY src/ ./src/


### PR DESCRIPTION
The backup Dockerfile installed gcc before uv sync and, being single-stage, published it: every user pulls a full C compiler no code path ever invokes, plus apt-recommends packages the install never opted out of. Nothing needs it at build time today either — every compiled dependency in uv.lock resolves to a cp314 manylinux wheel, and the only sdist-only entries (http-ece, pyaes) are pure Python.

The build is now two-stage: dependencies resolve in a builder that keeps gcc (so a future sdist-only dependency still builds instead of betting it never happens), and the runtime stage copies the finished venv onto a clean python:3.14-slim with only ffmpeg, installed --no-install-recommends. Both stages share the same base image, so the venv's interpreter path is unchanged; PATH, the healthcheck and the entrypoint are untouched. The viewer image was already clean — no gcc, already --no-install-recommends.

Measured on a real build (Compose host, Docker 27): old image 1.24GB, new image 676MB. Runtime smoke on the built image: ffmpeg present, gcc absent, python -c imports telethon/PIL/sqlalchemy/cryptg/asyncpg/alembic cleanly. CI's build-and-push-dev exercises the same Dockerfile on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance & Deployment**
  * Reduced the production container size by separating build and runtime stages.
  * Limited the runtime environment to only the dependencies required to run the application.
  * Improved container efficiency and deployment reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->