### PR TITLE
fix(viewer): a broken media volume no longer reports "Database temporarily unavailable"

### DIFF
--- a/src/web/main.py
+++ b/src/web/main.py
@@ -879,7 +879,13 @@ def _is_db_connection_error(exc: Exception) -> bool:
     for _ in range(10):
         if current is None:
             break
-        if isinstance(current, OSError):
+        # Only connection-shaped OS errors count. Bare OSError is the base of
+        # every filesystem fault (NotADirectoryError, PermissionError, ENOSPC),
+        # and matching it here sent operators to debug the database while the
+        # media volume or thumbnail cache was the broken part. DB connect and
+        # DNS failures on database paths arrive wrapped in OperationalError,
+        # which the next branch already catches.
+        if isinstance(current, ConnectionError | TimeoutError):
             return True
         if isinstance(current, OperationalError):
             return True

--- a/tests/test_sender_avatars.py
+++ b/tests/test_sender_avatars.py
@@ -503,7 +503,7 @@ class TestMemberAvatarAclEndpoint(unittest.IsolatedAsyncioTestCase):
     async def test_db_error_fails_closed_no_bytes(self):
         """A DB error in the sender lookup serves no bytes: a connection-shaped
         error answers 503 (the redacting handler's split), never the avatar."""
-        self.mock_db.get_message_sender_id = AsyncMock(side_effect=OSError("db down"))
+        self.mock_db.get_message_sender_id = AsyncMock(side_effect=ConnectionRefusedError("db down"))
         async with self._client() as client:
             resp = await client.get(f"/media/avatar/{self.VISIBLE_REF}/1")
         self.assertEqual(resp.status_code, 503)

--- a/tests/test_viewer_acl_hardening.py
+++ b/tests/test_viewer_acl_hardening.py
@@ -542,7 +542,7 @@ class TestExceptionHandlerRedaction(unittest.TestCase):
         return response, "\n".join(captured.output)
 
     def test_database_error_branch_logs_no_identifiers(self):
-        response, logged = self._drive_failing_request(OSError(20, "Not a directory", "/cache/thumbs"))
+        response, logged = self._drive_failing_request(ConnectionRefusedError(111, "Connection refused"))
         self.assertEqual(503, response.status_code)
         self.assertNotIn(self.CHAT_FOLDER, logged)
         self.assertNotIn(self.CHAT_REF, logged)
@@ -582,13 +582,13 @@ class TestExceptionHandlerRedaction(unittest.TestCase):
         self.assertIn("TimeoutExpired", logged)
         self.assertIn('File "', logged)
 
-    def test_oserror_with_a_media_path_stays_clean_on_the_503_branch(self):
-        """An OSError carrying the media path classifies as a connection error;
-        its 503 branch must keep refusing the exception text (which stringifies
-        with the offending filename) and must never grow an exc_info."""
+    def test_oserror_with_a_media_path_stays_clean_on_the_500_branch(self):
+        """A filesystem OSError carrying the media path is no longer classified
+        as a database outage; its 500 branch must keep refusing the exception
+        text (which stringifies with the offending filename)."""
         attack = FileNotFoundError(2, "No such file or directory", f"/data/media/{self.CHAT_FOLDER}/{self.FILE_NAME}")
         response, logged = self._drive_failing_request(attack)
-        self.assertEqual(503, response.status_code)
+        self.assertEqual(500, response.status_code)
         self.assertNotIn(self.CHAT_FOLDER, logged)
         self.assertNotIn(self.CHAT_REF, logged)
         self.assertNotIn("Maria", logged)
@@ -699,7 +699,7 @@ class TestUnhandledExceptionNeverReachesTheServer(unittest.TestCase):
 
     def test_db_connection_error_still_answers_503_without_reraise(self):
         """The 503-for-DB branch keeps its status and its redaction under the middleware."""
-        response, logged = self._drive(OSError(20, "Not a directory", "/cache/thumbs"))
+        response, logged = self._drive(ConnectionRefusedError(111, "Connection refused"))
         self.assertEqual(503, response.status_code)
         self.assertNotIn(self.CHAT_FOLDER, logged)
         self.assertNotIn("Maria", logged)

--- a/tests/test_web_coverage.py
+++ b/tests/test_web_coverage.py
@@ -1283,7 +1283,7 @@ class TestPushEndpointEdgeCases(_WebTestBase):
         """push_subscribe returns 503 on DB connection error."""
         mock_pm = MagicMock()
         mock_pm.is_enabled = True
-        mock_pm.subscribe = AsyncMock(side_effect=OSError("db down"))
+        mock_pm.subscribe = AsyncMock(side_effect=ConnectionRefusedError("db down"))
         web_main.push_manager = mock_pm
         with patch("src.web.push.socket.getaddrinfo", return_value=[(2, 1, 6, "", ("8.8.8.8", 443))]):
             async with self._client() as client:
@@ -1322,7 +1322,7 @@ class TestPushEndpointEdgeCases(_WebTestBase):
         """push_unsubscribe returns 503 on DB connection error."""
         mock_pm = MagicMock()
         mock_pm.is_enabled = True
-        mock_pm.unsubscribe = AsyncMock(side_effect=OSError("db down"))
+        mock_pm.unsubscribe = AsyncMock(side_effect=ConnectionRefusedError("db down"))
         web_main.push_manager = mock_pm
         async with self._client() as client:
             resp = await client.post(
@@ -1549,7 +1549,7 @@ class TestEndpointDbErrors(_MasterTestBase):
 
     async def test_folders_db_connection_error(self):
         """get_folders returns 503 on DB connection error."""
-        self.mock_db.get_all_folders = AsyncMock(side_effect=OSError("conn"))
+        self.mock_db.get_all_folders = AsyncMock(side_effect=ConnectionRefusedError("conn"))
         async with self._client() as client:
             resp = await client.get("/api/folders")
         self.assertEqual(resp.status_code, 503)
@@ -1563,7 +1563,7 @@ class TestEndpointDbErrors(_MasterTestBase):
 
     async def test_topics_db_connection_error(self):
         """get_chat_topics returns 503 on DB connection error."""
-        self.mock_db.get_forum_topics = AsyncMock(side_effect=OSError("conn"))
+        self.mock_db.get_forum_topics = AsyncMock(side_effect=ConnectionRefusedError("conn"))
         async with self._client() as client:
             resp = await client.get("/api/chats/1/topics")
         self.assertEqual(resp.status_code, 503)
@@ -1577,7 +1577,7 @@ class TestEndpointDbErrors(_MasterTestBase):
 
     async def test_pinned_db_connection_error(self):
         """get_pinned_messages returns 503 on DB connection error."""
-        self.mock_db.get_pinned_messages = AsyncMock(side_effect=OSError("conn"))
+        self.mock_db.get_pinned_messages = AsyncMock(side_effect=ConnectionRefusedError("conn"))
         async with self._client() as client:
             resp = await client.get("/api/chats/1/pinned")
         self.assertEqual(resp.status_code, 503)
@@ -1591,7 +1591,7 @@ class TestEndpointDbErrors(_MasterTestBase):
 
     async def test_archived_count_db_connection_error(self):
         """get_archived_count returns 503 on DB connection error."""
-        self.mock_db.get_archived_chat_count = AsyncMock(side_effect=OSError("conn"))
+        self.mock_db.get_archived_chat_count = AsyncMock(side_effect=ConnectionRefusedError("conn"))
         async with self._client() as client:
             resp = await client.get("/api/archived/count")
         self.assertEqual(resp.status_code, 503)
@@ -1605,7 +1605,7 @@ class TestEndpointDbErrors(_MasterTestBase):
 
     async def test_stats_db_connection_error(self):
         """get_stats returns 503 on DB connection error."""
-        self.mock_db.get_cached_statistics = AsyncMock(side_effect=OSError("conn"))
+        self.mock_db.get_cached_statistics = AsyncMock(side_effect=ConnectionRefusedError("conn"))
         async with self._client() as client:
             resp = await client.get("/api/stats")
         self.assertEqual(resp.status_code, 503)
@@ -1619,7 +1619,7 @@ class TestEndpointDbErrors(_MasterTestBase):
 
     async def test_refresh_stats_db_connection_error(self):
         """refresh_stats returns 503 on DB connection error."""
-        self.mock_db.calculate_and_store_statistics = AsyncMock(side_effect=OSError("conn"))
+        self.mock_db.calculate_and_store_statistics = AsyncMock(side_effect=ConnectionRefusedError("conn"))
         async with self._client() as client:
             resp = await client.post("/api/stats/refresh")
         self.assertEqual(resp.status_code, 503)
@@ -1633,7 +1633,7 @@ class TestEndpointDbErrors(_MasterTestBase):
 
     async def test_chat_stats_db_connection_error(self):
         """get_chat_stats returns 503 on DB connection error."""
-        self.mock_db.get_chat_stats = AsyncMock(side_effect=OSError("conn"))
+        self.mock_db.get_chat_stats = AsyncMock(side_effect=ConnectionRefusedError("conn"))
         async with self._client() as client:
             resp = await client.get("/api/chats/1/stats")
         self.assertEqual(resp.status_code, 503)
@@ -1654,7 +1654,7 @@ class TestEndpointDbErrors(_MasterTestBase):
 
     async def test_message_by_date_db_connection_error(self):
         """get_message_by_date returns 503 on DB connection error."""
-        self.mock_db.find_message_by_date_with_joins = AsyncMock(side_effect=OSError("conn"))
+        self.mock_db.find_message_by_date_with_joins = AsyncMock(side_effect=ConnectionRefusedError("conn"))
         async with self._client() as client:
             resp = await client.get("/api/chats/1/messages/by-date?date=2025-01-01")
         self.assertEqual(resp.status_code, 503)
@@ -1668,7 +1668,7 @@ class TestEndpointDbErrors(_MasterTestBase):
 
     async def test_message_dates_db_connection_error(self):
         """get_message_dates returns 503 on DB connection errors."""
-        self.mock_db.get_message_dates = AsyncMock(side_effect=OSError("conn"))
+        self.mock_db.get_message_dates = AsyncMock(side_effect=ConnectionRefusedError("conn"))
         async with self._client() as client:
             resp = await client.get("/api/chats/1/messages/dates?month=2026-03&timezone=UTC")
         self.assertEqual(resp.status_code, 503)
@@ -1682,7 +1682,7 @@ class TestEndpointDbErrors(_MasterTestBase):
 
     async def test_export_db_connection_error(self):
         """export_chat returns 503 on DB connection error."""
-        self.mock_db.get_chat_by_id = AsyncMock(side_effect=OSError("conn"))
+        self.mock_db.get_chat_by_id = AsyncMock(side_effect=ConnectionRefusedError("conn"))
         async with self._client() as client:
             resp = await client.get("/api/chats/1/export")
         self.assertEqual(resp.status_code, 503)

--- a/tests/test_web_main.py
+++ b/tests/test_web_main.py
@@ -330,18 +330,26 @@ class TestRecordLoginAttempt(unittest.TestCase):
 
 @_skip_unless_web_main
 class TestIsDbConnectionError(unittest.TestCase):
-    """Test _is_db_connection_error detects OSError in chain."""
+    """Connection-shaped errors are 503-retryable; filesystem faults are not."""
 
-    def test_returns_true_for_direct_oserror(self):
-        """_is_db_connection_error returns True for direct OSError."""
-        self.assertTrue(web_main._is_db_connection_error(OSError("conn refused")))
+    def test_returns_true_for_direct_connection_error(self):
+        """A refused DB socket is exactly what the predicate exists for."""
+        self.assertTrue(web_main._is_db_connection_error(ConnectionRefusedError("conn refused")))
 
-    def test_returns_true_for_chained_oserror(self):
-        """_is_db_connection_error returns True when OSError is in __cause__."""
-        inner = OSError("network down")
+    def test_returns_true_for_timeout(self):
+        self.assertTrue(web_main._is_db_connection_error(TimeoutError("connect timed out")))
+
+    def test_returns_true_for_chained_connection_error(self):
+        inner = ConnectionResetError("network down")
         outer = RuntimeError("query failed")
         outer.__cause__ = inner
         self.assertTrue(web_main._is_db_connection_error(outer))
+
+    def test_returns_false_for_filesystem_oserror(self):
+        """A thumbnail-cache mkdir failure is not a database outage (#9t6.4.19)."""
+        self.assertFalse(web_main._is_db_connection_error(NotADirectoryError(20, "Not a directory")))
+        self.assertFalse(web_main._is_db_connection_error(PermissionError(13, "Permission denied")))
+        self.assertFalse(web_main._is_db_connection_error(OSError(28, "No space left on device")))
 
     def test_returns_false_for_unrelated_error(self):
         """_is_db_connection_error returns False for non-connection errors."""
@@ -352,8 +360,8 @@ class TestIsDbConnectionError(unittest.TestCase):
         self.assertFalse(web_main._is_db_connection_error(TypeError("type")))
 
     def test_deep_chain_detection(self):
-        """_is_db_connection_error detects OSError several levels deep."""
-        e1 = OSError("root")
+        """Connection errors are found several wrap levels deep."""
+        e1 = ConnectionRefusedError("root")
         e2 = RuntimeError("mid")
         e2.__cause__ = e1
         e3 = Exception("outer")

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -436,7 +436,7 @@ class TestChatsEndpoint(_WebTestBase):
 
     async def test_chats_handles_db_connection_error(self):
         """get_chats returns 503 on db connection error."""
-        self.mock_db.get_all_chats = AsyncMock(side_effect=OSError("connection refused"))
+        self.mock_db.get_all_chats = AsyncMock(side_effect=ConnectionRefusedError("connection refused"))
         async with self._client() as client:
             resp = await client.get("/api/chats")
         self.assertEqual(resp.status_code, 503)
@@ -503,7 +503,7 @@ class TestMessagesEndpoint(_WebTestBase):
 
     async def test_messages_db_connection_error_returns_503(self):
         """get_messages returns 503 on db connection error."""
-        self.mock_db.get_messages_paginated = AsyncMock(side_effect=OSError("conn refused"))
+        self.mock_db.get_messages_paginated = AsyncMock(side_effect=ConnectionRefusedError("conn refused"))
         async with self._client() as client:
             resp = await client.get("/api/chats/1/messages")
         self.assertEqual(resp.status_code, 503)
@@ -566,7 +566,7 @@ class TestMessageVersionsEndpoint(_WebTestBase):
 
     async def test_db_connection_error_returns_503(self):
         """get_message_versions returns 503 on DB connection errors."""
-        self.mock_db.get_message_versions = AsyncMock(side_effect=OSError("conn refused"))
+        self.mock_db.get_message_versions = AsyncMock(side_effect=ConnectionRefusedError("conn refused"))
 
         async with self._client() as client:
             resp = await client.get("/api/chats/123/messages/42/versions")
@@ -1816,8 +1816,8 @@ class TestExceptionHandler(_WebTestBase):
     """Test the unhandled exception handler."""
 
     async def test_db_connection_error_returns_503(self):
-        """Unhandled OSError returns 503."""
-        self.mock_db.get_all_chats = AsyncMock(side_effect=OSError("conn error"))
+        """A connection-shaped error through the handler returns 503."""
+        self.mock_db.get_all_chats = AsyncMock(side_effect=ConnectionRefusedError("conn error"))
         async with self._client() as client:
             resp = await client.get("/api/chats")
         self.assertEqual(resp.status_code, 503)


### PR DESCRIPTION
_is_db_connection_error exists to split "the database is unreachable" (retryable 503) from everything else (500) — but its first branch matched bare OSError, the base class of every filesystem, permission and disk-full error in Python. A read-only media volume, a full disk, or a thumbnail-cache mkdir failure all answered 503 {"detail": "Database temporarily unavailable"}: the operator gets sent to debug Postgres, and uptime monitoring or client retry logic keyed on 503 points at the wrong subsystem. Reproduced in the original finding with a NotADirectoryError from the thumbnail cache.

The predicate now matches only connection-shaped errors — ConnectionError and its subclasses plus TimeoutError, which is what a dead DB socket actually raises. Real DB connect and DNS failures on database paths were never relying on the OSError branch: SQLAlchemy wraps them in OperationalError, which the next branch already catches (asyncpg's own connection errors have their dedicated branch too).

Filesystem faults now take the 500 branch. That branch redacts exactly like the 503 one — describe_exception refuses path-carrying exception text and only code frames are logged — so the move leaks nothing; the ACL redaction suite now pins the no-identifier property on the 500 branch for a FileNotFoundError carrying a full media path, and keeps pinning the 503 branch with a genuine connection error. Tests across the suite that simulated a dead database with a bare OSError stand-in now use ConnectionRefusedError, keeping their 503 intent with an honest fixture.

Mutation control: restoring the OSError branch fails the filesystem-fault tests. Full suite 3365 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database outage detection so filesystem and disk-related errors are no longer incorrectly treated as connectivity failures.
  - Preserved HTTP 503 responses for genuine database connection refusals, timeouts, resets, and related errors.
  - Filesystem “not found” errors now correctly return HTTP 500 responses.

- **Tests**
  - Expanded coverage for direct and chained database connection errors across web routes and exception handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->