### PR TITLE
fix(backup): MAX_MEDIA_SIZE_MB finally caps full-resolution photos

### DIFF
--- a/src/listener.py
+++ b/src/listener.py
@@ -39,6 +39,7 @@ from .config import AccountConfig, Config
 from .db import DatabaseAdapter, create_adapter
 from .db.models import account_metadata_key
 from .message_utils import (
+    _photo_size_bytes,
     build_media_filename,
     compute_file_hash_async,
     describe_exception,
@@ -820,9 +821,11 @@ class TelegramListener:
                 file_size = getattr(media.document, "size", 0)
             elif hasattr(media, "photo") and media.photo:
                 if hasattr(media.photo, "sizes") and media.photo.sizes:
-                    largest = max(media.photo.sizes, key=lambda s: getattr(s, "size", 0), default=None)
-                    if largest:
-                        file_size = getattr(largest, "size", 0)
+                    # PhotoSizeProgressive (the full rendition) has no scalar
+                    # .size, so max-by-getattr scored it 0 and a thumbnail won
+                    # — the size gate then measured kilobytes for a photo of
+                    # megabytes. _photo_size_bytes reads both shapes.
+                    file_size = max(_photo_size_bytes(s) for s in media.photo.sizes)
 
             max_size = self.config.get_max_media_size_bytes()
             if file_size > max_size:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -55,6 +55,7 @@ from .db.models import account_metadata_key
 from .folder_utils import FolderChat, FolderRules, resolve_folder_member_ids
 from .media_errors import is_media_location_error
 from .message_utils import (
+    _photo_size_bytes,
     build_media_filename,
     compute_file_hash_async,
     describe_exception,
@@ -3541,10 +3542,13 @@ class TelegramBackup:
         if hasattr(media, "photo") and media.photo:
             sizes = getattr(media.photo, "sizes", [])
             if sizes:
-                # Return size of the last one (usually the largest)
-                # Some Size types have 'size' field, others don't (like PhotoCachedSize)
-                largest = sizes[-1]
-                return getattr(largest, "size", 0)
+                # The full-resolution rendition is PhotoSizeProgressive, which
+                # carries NO scalar .size — only a list of progressive byte
+                # offsets. Reading .size off it scored the largest rendition
+                # as 0, so the MAX_MEDIA_SIZE_MB gate failed open for exactly
+                # the photos it exists to block. _photo_size_bytes reads both
+                # shapes; take the max across renditions.
+                return max(_photo_size_bytes(s) for s in sizes)
 
         # Fallback to direct attribute
         return getattr(media, "size", 0)

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -866,6 +866,30 @@ class TestDownloadMedia:
         result = await listener._download_media(msg, -100)
         assert result is None
 
+    async def test_download_media_progressive_photo_size_gate_holds(self):
+        """A full-resolution PhotoSizeProgressive has no scalar .size — the old
+        max-by-getattr scored it 0, let a thumbnail win, and downloaded a
+        9.5 MB photo through a 100-byte cap."""
+        from telethon.tl.types import MessageMediaPhoto, PhotoSize, PhotoSizeProgressive
+
+        listener = self._make_listener()
+        listener.config.get_max_media_size_bytes.return_value = 100
+
+        msg = MagicMock()
+        media = MagicMock(spec=MessageMediaPhoto)
+        media.photo = MagicMock()
+        media.photo.id = 790
+        media.photo.sizes = [
+            PhotoSize(type="m", w=320, h=240, size=90),  # under the cap on its own
+            PhotoSizeProgressive(type="y", w=2560, h=1440, sizes=[12_000, 9_500_000]),
+        ]
+        msg.media = media
+        msg.id = 4
+
+        result = await listener._download_media(msg, -100)
+        assert result is None
+        listener.client.download_media.assert_not_called()
+
 
 # ===========================================================================
 # _download_avatar

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -1884,6 +1884,37 @@ class TestGetMediaSize(unittest.TestCase):
         media.photo.sizes = [size1, size2]
         self.assertEqual(self.backup._get_media_size(media), 500)
 
+    def test_progressive_photo_measures_the_full_rendition(self):
+        """PhotoSizeProgressive (the full-resolution rendition) carries no
+        scalar .size — reading it as 0 made the MAX_MEDIA_SIZE_MB gate fail
+        open for exactly the photos it exists to block."""
+        from telethon.tl.types import PhotoSize, PhotoSizeProgressive
+
+        media = MagicMock()
+        media.document = None
+        del media.document
+        media.photo = MagicMock()
+        media.photo.sizes = [
+            PhotoSize(type="m", w=320, h=240, size=12_000),
+            PhotoSize(type="x", w=800, h=600, size=90_000),
+            PhotoSizeProgressive(type="y", w=2560, h=1440, sizes=[12_000, 40_000, 9_500_000]),
+        ]
+        self.assertEqual(self.backup._get_media_size(media), 9_500_000)
+
+    def test_progressive_rendition_wins_regardless_of_position(self):
+        """max across renditions, never a positional sizes[-1] read."""
+        from telethon.tl.types import PhotoSize, PhotoSizeProgressive
+
+        media = MagicMock()
+        media.document = None
+        del media.document
+        media.photo = MagicMock()
+        media.photo.sizes = [
+            PhotoSizeProgressive(type="y", w=2560, h=1440, sizes=[9_500_000]),
+            PhotoSize(type="m", w=320, h=240, size=12_000),
+        ]
+        self.assertEqual(self.backup._get_media_size(media), 9_500_000)
+
     def test_photo_no_sizes_returns_zero(self):
         """Photo with empty sizes list falls through to fallback which returns 0."""
         media = MagicMock(spec=[])


### PR DESCRIPTION
An operator capping disk usage with MAX_MEDIA_SIZE_MB gets no cap on photos at all. Telegram delivers a big photo's full-resolution rendition as PhotoSizeProgressive, which has no scalar .size — only a sizes list of progressive byte offsets. The backup path read getattr(sizes[-1], 'size', 0) → 0, and the listener picked the largest rendition by getattr(s, 'size', 0) → the progressive entry scores 0 and a small thumbnail wins. Either way a 9.5 MB photo measures as 0 bytes (backup) or ~90 KB (listener) and sails through a 5 MB cap. Secondary effect: _should_parallelize receives file_size=0, so parallel download never engages for large photos.

The repository already contains the correct answer: message_utils._photo_size_bytes, whose docstring documents exactly this progressive shape (it is what fixed the same scoring bug for dimension metadata). Both ingest paths now use it, taking the max across renditions instead of trusting list position. Three implementations of one question became one.

Tests build the real Telethon types (PhotoSize + PhotoSizeProgressive, the finding's exact 9.5 MB scenario) on both paths, including a progressive-first ordering and a listener gate that must refuse the download outright. Both old implementations, restored as mutants, fail the new tests. Full suite: 3366 passed, 127 skipped, 447 warnings, 691 subtests passed in 88.47s (0:01:28)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved photo size detection across all available renditions, including progressive photos.
  * Media-size limits now correctly prevent downloads when the full-resolution photo exceeds the configured cap.

* **Tests**
  * Added coverage for progressive photo sizes and varying rendition order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->