### PR TITLE
fix(backup): excluding a chat purges it from the archive no matter which folder it lives in

### DIFF
--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -978,6 +978,24 @@ class TelegramBackup:
             await self.client.disconnect()
             logger.info("Disconnected from Telegram")
 
+    def _is_explicitly_excluded(self, chat_id: int, entity) -> bool:
+        """True when the user put this chat in an exclude list (not merely filtered out).
+
+        THE single copy of the predicate: the regular and archived dialog
+        passes must agree, or exclusion means "purge" in one Telegram folder
+        and "keep forever" in the other.
+        """
+        is_bot = isinstance(entity, User) and entity.bot
+        is_user = isinstance(entity, User) and not entity.bot
+        is_group = isinstance(entity, Chat) or (isinstance(entity, Channel) and entity.megagroup)
+        is_channel = isinstance(entity, Channel) and not entity.megagroup
+        return (
+            chat_id in self.config.global_exclude_ids
+            or ((is_user or is_bot) and chat_id in self.config.private_exclude_ids)
+            or (is_group and chat_id in self.config.groups_exclude_ids)
+            or (is_channel and chat_id in self.config.channels_exclude_ids)
+        )
+
     async def backup_all(self):
         """
         Perform backup of all configured chats.
@@ -1246,15 +1264,7 @@ class TelegramBackup:
                     is_group = isinstance(entity, Chat) or (isinstance(entity, Channel) and entity.megagroup)
                     is_channel = isinstance(entity, Channel) and not entity.megagroup
 
-                    # Check if chat is explicitly in an exclude list (not just filtered out)
-                    is_explicitly_excluded = (
-                        chat_id in self.config.global_exclude_ids
-                        or ((is_user or is_bot) and chat_id in self.config.private_exclude_ids)
-                        or (is_group and chat_id in self.config.groups_exclude_ids)
-                        or (is_channel and chat_id in self.config.channels_exclude_ids)
-                    )
-
-                    if is_explicitly_excluded:
+                    if self._is_explicitly_excluded(chat_id, entity):
                         # Chat is explicitly excluded - mark for deletion
                         explicitly_excluded_chat_ids.add(chat_id)
                     elif self.config.should_backup_chat(chat_id, is_user, is_group, is_channel, is_bot):
@@ -1264,6 +1274,19 @@ class TelegramBackup:
                         # Adopted after a group→supergroup migration (#228): in
                         # scope even though it is not in any user include list.
                         filtered_dialogs.append(dialog)
+
+                # The SAME exclusion must purge a chat wherever it lives:
+                # this set was built from the regular dialog list only, so a
+                # chat the user had archived in Telegram was skipped by the
+                # archived loop below but never deleted — exclusion silently
+                # meant "keep everything" for exactly those chats, and the
+                # storage the user tried to reclaim never was.
+                for dialog in archived_dialogs:
+                    chat_id = self._get_marked_id(dialog.entity)
+                    if chat_id not in explicitly_excluded_chat_ids and self._is_explicitly_excluded(
+                        chat_id, dialog.entity
+                    ):
+                        explicitly_excluded_chat_ids.add(chat_id)
 
                 # Fetch explicitly included chats that weren't in dialogs
                 # This handles cases where chats don't appear in the dialog list

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -780,6 +780,37 @@ class TestBackupAllNonWhitelistMode(unittest.TestCase):
 
         self.backup.db.delete_chat_and_related_data.assert_awaited_once()
 
+    def test_archived_only_excluded_chat_is_also_deleted(self):
+        """Exclusion must mean the same thing in both Telegram folders: the
+        excluded set was built from the regular dialog list only, so a chat
+        living only in the archived folder was skipped but never purged."""
+        user_entity = self._make_entity(User, 100, bot=False)
+        dialog = self._make_dialog(user_entity)
+
+        self.backup.config.global_exclude_ids = {100}
+        self.backup._get_dialogs = AsyncMock(side_effect=[[], [dialog]])
+        self.backup.db.delete_chat_and_related_data = AsyncMock()
+
+        _run(self.backup.backup_all())
+
+        self.backup.db.delete_chat_and_related_data.assert_awaited_once()
+        args = self.backup.db.delete_chat_and_related_data.await_args.args
+        self.assertEqual(args[0], 100)
+
+    def test_archived_only_unexcluded_chat_is_not_deleted(self):
+        """Control: the archived pass must never delete a chat that is merely
+        filtered out, only ones in an explicit exclude list."""
+        user_entity = self._make_entity(User, 100, bot=False)
+        dialog = self._make_dialog(user_entity)
+
+        self.backup.config.global_exclude_ids = set()
+        self.backup._get_dialogs = AsyncMock(side_effect=[[], [dialog]])
+        self.backup.db.delete_chat_and_related_data = AsyncMock()
+
+        _run(self.backup.backup_all())
+
+        self.backup.db.delete_chat_and_related_data.assert_not_awaited()
+
     def test_delete_chat_exception_does_not_crash(self):
         """Exception during chat deletion should be caught."""
         user_entity = self._make_entity(User, 100, bot=False)


### PR DESCRIPTION
backup_all documents that putting a chat in an exclude list deletes it and its media from the archive, and the deletion loop does exactly that — for chats in the regular dialog list. The excluded set was built only there: a chat the user had archived in Telegram (folder 1) never entered it, so the archived loop just skipped the chat and moved on. The identical user action therefore meant two different things depending on which Telegram folder the chat sat in: full purge for a regular chat, silent keep-forever for an archived one, with every message row, reaction, media row and media file staying on disk — the storage the user was trying to reclaim.

The explicit-exclusion predicate now lives in one helper (_is_explicitly_excluded) applied to both dialog lists before the deletion loop runs, so the archived half is purged on the same run and can never drift from the regular half again. Excluded ids were already subtracted from the missing-include fetch, so that stays coherent.

Tests: an archived-only chat in global_exclude_ids is deleted (chat id asserted); a control pins that a merely filtered-out archived chat is never deleted. The no-archived-pass mutant fails the first test — verified with the unmutated selector proven green first. Full suite 3365 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Explicitly excluded chats are now consistently removed, including archived groups, channels, bots, and users.
  - Archived chats that are not excluded remain preserved during backups.
- **Tests**
  - Added coverage for handling excluded and non-excluded archived chats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->