### PR TITLE
fix(listener): the realtime notifier rides the listener's own engine, not the process global

### DIFF
--- a/src/listener.py
+++ b/src/listener.py
@@ -448,11 +448,12 @@ class TelegramListener:
         # Load tracked chat IDs from database
         await self._load_tracked_chats()
 
-        # Initialize real-time notifier (auto-detects PostgreSQL vs SQLite)
-        from .db import get_db_manager
-
-        db_manager_instance = await get_db_manager()
-        self._notifier = RealtimeNotifier(db_manager_instance)
+        # Initialize real-time notifier (auto-detects PostgreSQL vs SQLite).
+        # Bound to THIS listener's own manager — never re-resolved from the
+        # process global: a cron backup starting inside connect()'s await
+        # window reassigns that global with a fresh engine, and its run-end
+        # dispose() would then tear the pool down under the notifier.
+        self._notifier = RealtimeNotifier(self.db.db_manager)
         await self._notifier.init()
         logger.info("Real-time notifier initialized")
 

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -2571,3 +2571,30 @@ class TestNotifyUpdateCapturingAccount:
 
         await listener._notify_update("edit", {"chat_id": 123})
         notifier.notify.assert_called_once_with(NotificationType.EDIT, 123, {"chat_id": 123}, account_id=7)
+
+
+class TestNotifierBindsToOwnManager:
+    """The notifier must ride the listener's own engine, not the process global."""
+
+    async def test_notifier_never_rebinds_to_the_process_global(self):
+        """A cron backup reassigning the global mid-connect() must not hand this
+        listener a manager some other component will dispose at run end."""
+        config = _make_config()
+        db = _make_db()
+        own_manager = MagicMock()
+        own_manager._is_sqlite = True
+        db.db_manager = own_manager
+
+        mock_client = AsyncMock()
+        mock_client.is_connected = MagicMock(return_value=True)
+        mock_client.get_me = AsyncMock(return_value=MagicMock(first_name="Test", phone="+1"))
+        mock_client.on = lambda event_type: lambda fn: fn
+        listener = TelegramListener(config, db, client=mock_client, account_id=1)
+
+        foreign_manager = MagicMock()
+        foreign_manager._is_sqlite = True
+        with patch("src.db.get_db_manager", new_callable=AsyncMock, return_value=foreign_manager) as global_resolver:
+            await listener.connect()
+
+        assert listener._notifier._db_manager is own_manager
+        global_resolver.assert_not_called()


### PR DESCRIPTION
TelegramListener.create() builds its adapter, then connect() — several awaits later (authorization check, chat-list load) — re-resolved the process-global db manager to hand the realtime notifier. Both long-lived components reassign that global: every scheduled backup run replaces it with a fresh engine and disposes it in its run-end close(). A backup starting inside connect()'s await window therefore bound the listener's notifier to an engine an unrelated component would tear down — on PostgreSQL that silently drops the pooled connections the notifier was using (SQLAlchemy lazily rebuilds after dispose, so it degrades to connection churn rather than hard failure).

The notifier now binds to self.db.db_manager — the exact manager the listener's own adapter already owns — so no other component's lifecycle can touch it, and the re-resolution window is gone entirely.

Deliberately NOT taken: the finding's larger remedy of moving both components off the global-mutating create_adapter() onto injected private managers. With each consumer now holding its own reference, what remains of the global-swap pattern costs reconnection churn, not correctness — a bootstrap refactor is not worth that residue. 

The regression test swaps the global mid-connect (a foreign manager behind a patched get_db_manager) and pins that the notifier still holds the listener's own manager and the global resolver is never consulted; the rebind-to-global mutant fails it (control proven green unmutated first). Full suite 3368 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved real-time notifications by ensuring they use the listener’s configured database connection.
  * Prevented notifications from incorrectly switching to a process-wide database connection, improving reliability in multi-connection environments.

* **Tests**
  * Added regression coverage to verify notifications remain bound to the listener’s own database manager and do not use a global connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->