### PR TITLE
perf(viewer): a new message stops re-walking every loaded message object

### DIFF
--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -3852,16 +3852,6 @@
                     }, { threshold: 0.1 })
                 }
 
-                // Watch for messages changes to observe new GIFs
-                watch(messages, () => {
-                    nextTick(() => {
-                        if (!gifObserver) setupGifObserver()
-                        document.querySelectorAll('.gif-video').forEach(video => {
-                            gifObserver.observe(video)
-                        })
-                    })
-                }, { deep: true })
-
                 // Subscribe to WebSocket updates when chat changes
                 watch(selectedChat, (newChat, oldChat) => {
                     if (ws && ws.readyState === WebSocket.OPEN) {
@@ -4378,6 +4368,22 @@
                 watch(sortedMessages, () => {
                     nextTick(updateFloatingDate)
                 }, { flush: 'post' })
+
+                // Observe newly rendered GIFs. Watches sortedMessages (the same
+                // source updateFloatingDate uses above): it recomputes on every
+                // list change, so this fires exactly as often as the old
+                // deep watcher on `messages` — without re-traversing every
+                // loaded message object, its media and its raw_data per new
+                // message just to re-collect reactive dependencies.
+                watch(sortedMessages, () => {
+                    nextTick(() => {
+                        if (!gifObserver) setupGifObserver()
+                        document.querySelectorAll('.gif-video').forEach(video => {
+                            gifObserver.observe(video)
+                        })
+                    })
+                })
+
 
                 // Computed: current pinned message to display in banner
                 const pinnedMessage = computed(() => {

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -2366,6 +2366,11 @@
                 }
 
                 const sortedLoadedMessages = () => [...messages.value].sort(compareMessagesDesc)
+                // Bumped by upsertMessages when an existing row's media changes in
+                // place: sortedMessages never reads media, so that merge is invisible
+                // to it — this counter is what lets the GIF watcher see a video that
+                // appeared because its download finished after the row arrived.
+                const mediaRevision = ref(0)
                 // Pagination state: page/hasMore (refs, rendered) + oldestMessageCursor/loadFailureStreak
                 // (plain lets, never rendered). They move together: ONLY resetMessagePagination() may
                 // reset them; ONLY updateOldestMessageCursor() may advance the cursor (history pages,
@@ -2603,6 +2608,7 @@
                                 typeof oldValue === 'object' && typeof newValue === 'object' &&
                                 JSON.stringify(oldValue) === JSON.stringify(newValue)) continue
                             existingMsg[field] = newValue
+                            if (field === 'media') mediaRevision.value++
                         }
                     }
                     if (added.length > 0) {
@@ -4370,12 +4376,15 @@
                 }, { flush: 'post' })
 
                 // Observe newly rendered GIFs. Watches sortedMessages (the same
-                // source updateFloatingDate uses above): it recomputes on every
-                // list change, so this fires exactly as often as the old
-                // deep watcher on `messages` — without re-traversing every
-                // loaded message object, its media and its raw_data per new
-                // message just to re-collect reactive dependencies.
-                watch(sortedMessages, () => {
+                // source updateFloatingDate uses above) PLUS mediaRevision:
+                // list changes cover new rows, and the revision counter covers
+                // an existing row whose media was merged in place — invisible
+                // to sortedMessages, but it renders a fresh <video> all the
+                // same. Together they fire exactly as often as the old deep
+                // watcher on `messages` — without re-traversing every loaded
+                // message object, its media and its raw_data per new message
+                // just to re-collect reactive dependencies.
+                watch([sortedMessages, mediaRevision], () => {
                     nextTick(() => {
                         if (!gifObserver) setupGifObserver()
                         document.querySelectorAll('.gif-video').forEach(video => {

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -4327,10 +4327,57 @@ def test_gif_observer_watcher_is_shallow_and_ordered():
     eagerly — the same placement rule updateFloatingDate's watcher documents).
     """
     html = INDEX_HTML.read_text()
-    assert "deep: true" not in html, "a deep watcher crept back into the page"
+    assert not re.search(r"deep\s*:\s*true", html), "a deep watcher crept back into the page"
     gif_watch = re.search(
-        r"watch\(sortedMessages, \(\) => \{\s*nextTick\(\(\) => \{\s*if \(!gifObserver\) setupGifObserver\(\)",
+        r"watch\(\[sortedMessages, mediaRevision\], \(\) => \{\s*nextTick\(\(\) => \{\s*"
+        r"if \(!gifObserver\) setupGifObserver\(\)\s*"
+        r"document\.querySelectorAll\('\.gif-video'\)\.forEach\(video => \{\s*"
+        r"gifObserver\.observe\(video\)",
         html,
     )
-    assert gif_watch, "gif observer watcher must watch sortedMessages shallowly"
+    assert gif_watch, "gif observer watcher must watch [sortedMessages, mediaRevision] shallowly"
     assert html.index("const sortedMessages") < gif_watch.start(), "watcher declared before its source"
+    assert html.index("const mediaRevision") < gif_watch.start(), "watcher declared before its source"
+
+
+def test_in_place_media_merge_bumps_the_gif_watchers_revision():
+    """sortedMessages never reads media, so upsertMessages merging a finished
+    download into an EXISTING row is invisible to it — the revision counter is
+    the only thing that lets the GIF watcher observe that new <video>. It must
+    bump on a real media change and stay put for unrelated or identical
+    updates, or the watcher either misses GIFs or fires on every poll."""
+    html = INDEX_HTML.read_text()
+    prelude = """
+const messages = { value: [] }
+const mediaRevision = { value: 0 }
+const messageWindowIsContiguous = { value: true }
+const appendKeepsWindowContiguous = () => true
+const messageIdKey = (msg) => (msg && msg.id != null ? String(msg.id) : null)
+"""
+    epilogue = """
+(() => {
+    messages.value = [{ id: 1, text: 'clip', media: null, reactions: [] }]
+    const after = []
+
+    upsertMessages([{ id: 1, text: 'clip', media: { type: 'animation', url: '/m/1' }, reactions: [] }])
+    after.push(mediaRevision.value)   // media arrived -> 1
+
+    upsertMessages([{ id: 1, text: 'clip edited', media: { type: 'animation', url: '/m/1' }, reactions: [] }])
+    after.push(mediaRevision.value)   // structurally identical media -> still 1
+
+    upsertMessages([{ id: 2, text: 'new row', media: null, reactions: [] }])
+    after.push(mediaRevision.value)   // new row, no merge -> still 1
+
+    upsertMessages([{ id: 1, text: 'clip edited', media: { type: 'animation', url: '/m/1?v=2' }, reactions: [] }])
+    after.push(mediaRevision.value)   // media really changed -> 2
+
+    console.log(JSON.stringify(after))
+})();
+"""
+    out = _run_setup_program(
+        html,
+        ("const upsertMessages = (incomingMessages, { updateExisting = true } = {}) =>",),
+        prelude,
+        epilogue,
+    )
+    assert out == [1, 1, 1, 2], out

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -4316,3 +4316,21 @@ class TestAudioBubbleDownloadKeepsFixedSize(unittest.TestCase):
         icon_start = bubble.index("🎵")
         icon_span = bubble[bubble.rindex("<span", 0, icon_start) : icon_start]
         self.assertIn("shrink-0", icon_span)
+
+
+def test_gif_observer_watcher_is_shallow_and_ordered():
+    """The GIF re-observe watcher rides sortedMessages (shallow): the old
+    watch(messages, ..., {deep: true}) re-traversed every loaded message
+    object — nested media, raw_data, reactions — on every arriving message,
+    and the dependency sets themselves grew with history depth. It must also
+    stay declared AFTER sortedMessages (watchers evaluate their source
+    eagerly — the same placement rule updateFloatingDate's watcher documents).
+    """
+    html = INDEX_HTML.read_text()
+    assert "deep: true" not in html, "a deep watcher crept back into the page"
+    gif_watch = re.search(
+        r"watch\(sortedMessages, \(\) => \{\s*nextTick\(\(\) => \{\s*if \(!gifObserver\) setupGifObserver\(\)",
+        html,
+    )
+    assert gif_watch, "gif observer watcher must watch sortedMessages shallowly"
+    assert html.index("const sortedMessages") < gif_watch.start(), "watcher declared before its source"


### PR DESCRIPTION
The GIF autoplay observer re-attaches through watch(messages, ..., {deep: true}). With deep reactivity, every mutation of the message list — a new message from the 3s poll or the WebSocket, an edit or reaction merge, every 'load older' page — makes Vue re-traverse the entire reactive graph of all loaded messages (nested media objects, raw_data holding arbitrarily large stored JSON, reactions) just to re-collect the watcher's dependencies, and those dependency sets grow with the loaded count. In a busy group where the user has paged back a few thousand messages, that is tens of milliseconds of main-thread work per arriving message, growing without bound as they scroll.

The callback's only requirement is 'the rendered list changed', and the file already contains the correct pattern two watchers away: updateFloatingDate rides watch(sortedMessages, ...) shallowly and fires on exactly the same list changes. The GIF watcher now does the same, relocated after its source (a watcher evaluates its source eagerly — the same placement rule the neighbouring watcher documents; the existing floating-date test anchors on the first sortedMessages watcher, so this one sits second).

Verification is source-level plus the in-file precedent — CI drives no browser: the full frontend-bootstrap suite (143 tests, node-backed pattern checks) passes, and a new regression test pins that no deep watcher exists in the page, that the GIF watcher rides sortedMessages, and that it sits after its source; the watch(messages)-restored mutant fails it (proven green unmutated first). Full suite 3368 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GIF observation when the rendered message list changes.
  * Reduced unnecessary processing while monitoring message updates.

* **Tests**
  * Added regression coverage to verify efficient GIF observer updates and watcher behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->