### PR TITLE
fix(backup): a vanished message finally counts against the media retry cap

### DIFF
--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -1814,10 +1814,18 @@ class TelegramBackup:
                     msg = msg_map.get(msg_id)
 
                     if not msg:
+                        # The message is gone on Telegram — the one provably
+                        # permanent failure. Count it, or this row re-requests
+                        # the id on every run forever and never converges on
+                        # MEDIA_MAX_DOWNLOAD_ATTEMPTS (#212's cap).
+                        await self.db.increment_media_download_attempts(record["id"], account_id=self.account_id)
                         skipped += 1
                         continue
 
                     if not msg.media:
+                        # Still exists but no longer carries media: equally
+                        # permanent for this pending row.
+                        await self.db.increment_media_download_attempts(record["id"], account_id=self.account_id)
                         skipped += 1
                         continue
 

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -3796,6 +3796,28 @@ class TestRetryPendingMediaCap(unittest.TestCase):
         _run(self.backup._retry_pending_media_downloads())
         self.backup.db.increment_media_download_attempts.assert_awaited_once_with("f1", account_id=1)
 
+    def test_increment_when_message_is_gone(self):
+        """A deleted message is the one provably PERMANENT failure — without
+        counting it, the row re-requests the id from Telegram on every run
+        forever and the cap never retires it."""
+        self.backup.client.get_messages = AsyncMock(return_value=[None])
+        self.backup._process_media = AsyncMock()
+        _run(self.backup._retry_pending_media_downloads())
+        self.backup.db.increment_media_download_attempts.assert_awaited_once_with("f1", account_id=1)
+        self.backup._process_media.assert_not_awaited()
+
+    def test_increment_when_message_lost_its_media(self):
+        """A message that still exists but no longer carries media is equally
+        permanent for this pending row."""
+        bare_msg = MagicMock()
+        bare_msg.id = 10
+        bare_msg.media = None
+        self.backup.client.get_messages = AsyncMock(return_value=[bare_msg])
+        self.backup._process_media = AsyncMock()
+        _run(self.backup._retry_pending_media_downloads())
+        self.backup.db.increment_media_download_attempts.assert_awaited_once_with("f1", account_id=1)
+        self.backup._process_media.assert_not_awaited()
+
     def test_no_increment_on_success(self):
         """A successful re-download does not bump the counter (row leaves the pending set)."""
         self.backup._process_media = AsyncMock(return_value={"downloaded": True, "id": "f1"})


### PR DESCRIPTION
The pending-media retry (#212's cap) counts each unsuccessful re-attempt so a permanently failing file stops being re-fetched once it hits MEDIA_MAX_DOWNLOAD_ATTEMPTS. Except: the two failure modes that are provably permanent — the message has been deleted on Telegram (get_messages returns None for its id), or it still exists but no longer carries media — took early-outs that bumped only a local counter. Those rows stayed at downloaded=0 with attempts forever below the cap: re-requested from Telegram on every single backup run, never draining from the pending list, and never surfacing in the given-up count.

Both early-outs now increment the attempt counter, so a vanished message converges on the cap exactly like a filename-too-long failure does. A transient None from get_messages is theoretically possible but costs one attempt out of the configured budget — transient network failures raise (and are handled separately at the chat level, which deliberately stays uncounted) rather than returning None.

Two tests pin the paths (message gone; media gone), both asserting the counter fires with the record id and that no download is attempted; the uncounted-early-out mutant fails (proven green unmutated first). Full suite: 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed pending media retries so deleted messages and messages without media count toward the retry limit.
  - Prevented these unavailable media items from being retried indefinitely.

- **Tests**
  - Added coverage for retry behavior when messages are deleted or no longer contain media.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->