### PR TITLE
fix(config): MAX_MEDIA_SIZE_MB=0 means no limit, not skip-every-file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,7 +73,7 @@ DOWNLOAD_MEDIA=true
 
 # Maximum media file size to download (in MB)
 # Files larger than this will be skipped
-MAX_MEDIA_SIZE_MB=100  # 0 = no size limit
+MAX_MEDIA_SIZE_MB=100  # 0 or negative = no size limit
 
 # Maximum usable filename byte budget for downloaded media (the file_id prefix
 # and extension are always preserved; only the decorative part is shortened).

--- a/.env.example
+++ b/.env.example
@@ -73,7 +73,7 @@ DOWNLOAD_MEDIA=true
 
 # Maximum media file size to download (in MB)
 # Files larger than this will be skipped
-MAX_MEDIA_SIZE_MB=100
+MAX_MEDIA_SIZE_MB=100  # 0 = no size limit
 
 # Maximum usable filename byte budget for downloaded media (the file_id prefix
 # and extension are always preserved; only the decorative part is shortened).

--- a/src/config.py
+++ b/src/config.py
@@ -6,6 +6,7 @@ Loads and validates settings from environment variables.
 import logging
 import os
 import re
+import sys
 from dataclasses import dataclass, field
 
 from dotenv import load_dotenv
@@ -1136,7 +1137,15 @@ class Config:
         return self.should_backup_chat_type(is_user, is_group, is_channel, is_bot)
 
     def get_max_media_size_bytes(self) -> int:
-        """Get maximum media file size in bytes."""
+        """Maximum media file size in bytes; 0 (or negative) means no limit.
+
+        0 disabling the cap is the meaning 0 already carries across this
+        config surface (DOWNLOAD_TIMEOUT_SECONDS, MEDIA_FLOOD_SLEEP_THRESHOLD,
+        WHITELIST_RESOLVE_DIALOG_LIMIT). It used to mean "skip every file
+        with a nonzero size" — silently, at DEBUG level.
+        """
+        if self.max_media_size_mb <= 0:
+            return sys.maxsize
         return self.max_media_size_mb * 1024 * 1024
 
     def should_download_media_for_chat(self, chat_id: int) -> bool:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1307,6 +1307,24 @@ class TestGetMaxMediaSizeBytes(unittest.TestCase):
             config = Config()
             self.assertEqual(config.get_max_media_size_bytes(), 50 * 1024 * 1024)
 
+    def test_zero_means_no_limit(self):
+        """0 disables the cap — the meaning it carries everywhere else in this
+        config. It used to mean 'skip every file with a nonzero size'."""
+        import sys
+
+        env_vars = {"CHAT_TYPES": "private", "BACKUP_PATH": self.temp_dir, "MAX_MEDIA_SIZE_MB": "0"}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertEqual(config.get_max_media_size_bytes(), sys.maxsize)
+
+    def test_negative_means_no_limit(self):
+        import sys
+
+        env_vars = {"CHAT_TYPES": "private", "BACKUP_PATH": self.temp_dir, "MAX_MEDIA_SIZE_MB": "-5"}
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            self.assertEqual(config.get_max_media_size_bytes(), sys.maxsize)
+
 
 class TestSetupLogging(unittest.TestCase):
     """Test setup_logging function (lines 618-625)."""


### PR DESCRIPTION
Setting MAX_MEDIA_SIZE_MB=0 to mean 'no size limit' — the meaning 0 carries for DOWNLOAD_TIMEOUT_SECONDS, MEDIA_FLOOD_SLEEP_THRESHOLD, WHITELIST_RESOLVE_DIALOG_LIMIT and the rest of this config surface — made get_max_media_size_bytes() return 0, and both download gates skip any file bigger than that. Every media file has a nonzero size, so the backup reported success while archiving zero media; the only trace was a DEBUG line invisible at the default LOG_LEVEL=INFO. Negative values behaved the same.

Zero and negative now disable the cap at the single conversion point (sys.maxsize keeps every int comparison working unchanged at both gates); positive values behave exactly as before. .env.example documents the semantics.

Tests pin 0 and -5 to unlimited alongside the existing positive-value conversions; the old-behaviour mutant fails both (proven green unmutated first). Full suite 3369 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Setting the media size limit to `0` now disables the limit.
  * Negative media size values also disable the limit.

* **Documentation**
  * Updated the sample configuration to explain that `0` disables the media size limit.

* **Bug Fixes**
  * Prevented non-positive size settings from creating invalid media limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->