### PR TITLE
fix(backup): quoted-reply excerpts are finally captured

### DIFF
--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -2972,13 +2972,17 @@ class TelegramBackup:
         if hasattr(message, "post_author") and message.post_author:
             message_data["raw_data"]["post_author"] = message.post_author
 
-        # Get reply text if this is a reply
+        # Quote-reply excerpt. MessageReplyHeader has NO ``message`` attribute
+        # (the old hasattr guard could never fire, so reply_to_text was always
+        # None from the sweep): its text field is ``quote_text``, set exactly
+        # when the sender quoted part of the target. That excerpt is what the
+        # official clients render and it cannot be reconstructed at read time
+        # — the viewer's backfill can only fetch the target's FULL text.
         if message.reply_to_msg_id and message.reply_to:
-            reply_msg = message.reply_to
-            if hasattr(reply_msg, "message"):
-                # Truncate to first 100 chars like Telegram does
-                reply_text = (reply_msg.message or "")[:100]
-                message_data["reply_to_text"] = reply_text
+            quote_text = getattr(message.reply_to, "quote_text", None)
+            if quote_text:
+                # Truncate to first 100 chars like Telegram's own preview
+                message_data["reply_to_text"] = quote_text[:100]
 
         # Handle media
         if message.media:

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -1795,17 +1795,34 @@ class TestProcessMessage(unittest.TestCase):
 
         self.assertEqual(result["reactions"][0]["emoji"], "custom_12345")
 
-    def test_reply_to_text_truncated(self):
-        """Reply text is truncated to 100 characters."""
+    def test_quote_reply_excerpt_stored_and_truncated(self):
+        """A quote-reply's excerpt (MessageReplyHeader.quote_text — the field
+        Telethon actually has; the old code read a non-existent .message via a
+        MagicMock-only test) is stored, truncated to Telegram's 100-char
+        preview."""
+        from telethon.tl.types import MessageReplyHeader
+
         msg = self._make_message(11)
         msg.reply_to_msg_id = 5
-        msg.reply_to = MagicMock()
-        msg.reply_to.message = "a" * 200
-        msg.reply_to.forum_topic = False
+        msg.reply_to = MessageReplyHeader(reply_to_msg_id=5, quote=True, quote_text="a" * 200)
 
         result = self._run(self.backup._process_message(msg, 100))
 
         self.assertEqual(len(result["reply_to_text"]), 100)
+        self.assertEqual(result["reply_to_text"], "a" * 100)
+
+    def test_plain_reply_stores_no_excerpt(self):
+        """A non-quote reply carries no quote_text: reply_to_text stays None and
+        the viewer's read-time backfill supplies the target's text instead."""
+        from telethon.tl.types import MessageReplyHeader
+
+        msg = self._make_message(12)
+        msg.reply_to_msg_id = 5
+        msg.reply_to = MessageReplyHeader(reply_to_msg_id=5)
+
+        result = self._run(self.backup._process_message(msg, 100))
+
+        self.assertIsNone(result["reply_to_text"])
 
     def test_forward_from_id_resolves_channel_title(self):
         """Forward from channel resolves title via get_entity."""


### PR DESCRIPTION
The sweep's reply-preview branch read reply_to.message — an attribute telethon's MessageReplyHeader has never had (verified against 1.43.2: its text field is quote_text) — so the hasattr guard could never fire and the sweep stored reply_to_text as None for every reply. The branch read as working code, and its only covering test kept it green by building the impossible shape with a bare MagicMock — the exact truthiness pitfall this repo's CLAUDE.md documents.

For plain replies the damage is masked: the viewer backfills the preview at read time from the local reply row, failing only when the target isn't archived. But a QUOTE reply — where the sender quoted a fragment of the target, which official clients render as the excerpt — cannot be reconstructed from the target's full text, so that excerpt was lost outright, permanently.

The branch now stores quote_text truncated to Telegram's own 100-char preview length, exactly when the sender actually quoted. The test is rewritten against the real MessageReplyHeader: the quote case pins content and truncation, the plain-reply case pins None (backfill's domain). The restored dead-branch mutant fails the quote test (proven green unmutated first). Full suite 3368 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reply previews now correctly capture quoted text, preserving up to 100 characters.
  * Ordinary replies no longer display incorrect reply text when no quote is included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->