### PR TITLE
feat(backup): gap-fill finally sees history missing before the earliest archived message

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -244,12 +244,21 @@ async def run_fill_gaps_cmd(args) -> int:
         print(f"  Chats with gaps: {summary['chats_with_gaps']}")
         print(f"  Total gaps found: {summary['total_gaps']}")
         print(f"  Messages recovered: {summary['total_recovered']}")
+        if summary.get("chats_with_leading_holes"):
+            print(
+                f"  Chats with history missing before their earliest archived message: "
+                f"{summary['chats_with_leading_holes']} (reported only - "
+                "fill it deliberately with a targeted import or backup if wanted)"
+            )
         if summary["details"]:
             for detail in summary["details"]:
-                print(
+                line = (
                     f"  - {detail['chat_name']} (ID {detail['chat_id']}): "
                     f"{detail['gaps']} gaps, {detail['recovered']} recovered"
                 )
+                if detail.get("leading_missing"):
+                    line += f", ~{detail['leading_missing']} ids missing before id {detail['leading_hole_before_id']}"
+                print(line)
         return 0
     except Exception as e:
         print(f"Gap-fill failed: {e}", file=sys.stderr)

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -2461,6 +2461,20 @@ class DatabaseAdapter:
             row = result.scalar_one_or_none()
             return row if row else 0
 
+    async def get_earliest_message_id(self, chat_id: int, *, account_id: int) -> int:
+        """Smallest archived message id for one account's copy of a chat (0 when empty).
+
+        One indexed MIN() probe — the leading-hole check in gap-fill calls it
+        once per scanned chat.
+        """
+        async with self.db_manager.async_session_factory() as session:
+            stmt = select(func.min(Message.id)).where(
+                and_(Message.account_id == account_id, Message.chat_id == chat_id)
+            )
+            result = await session.execute(stmt)
+            row = result.scalar_one_or_none()
+            return row if row else 0
+
     @retry_on_locked()
     async def update_sync_status(
         self, chat_id: int, last_message_id: int, message_count: int, *, account_id: int

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -2343,7 +2343,11 @@ class TelegramBackup:
                     leading_missing = earliest - 1
                     summary["chats_with_leading_holes"] += 1
             except Exception as e:
-                logger.debug(f"Gap-fill: could not probe the leading range: {type(e).__name__}")
+                # A failed probe means leading-hole reporting was SKIPPED for a
+                # scanned chat — that is an error the summary must carry, or the
+                # final log claims completeness it does not have.
+                summary["errors"] += 1
+                logger.warning(f"Gap-fill: could not probe the leading range: {type(e).__name__}")
 
             if not gaps and not leading_missing:
                 continue

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -2272,6 +2272,7 @@ class TelegramBackup:
         summary = {
             "chats_scanned": 0,
             "chats_with_gaps": 0,
+            "chats_with_leading_holes": 0,
             "total_gaps": 0,
             "total_recovered": 0,
             "errors": 0,
@@ -2327,40 +2328,66 @@ class TelegramBackup:
                 summary["errors"] += 1
                 continue
 
-            if not gaps:
+            # A hole BEFORE the earliest archived id is structurally invisible
+            # to detect_message_gaps: LAG() has no predecessor row for the
+            # first id, so the leading range never appears. Report it — never
+            # auto-fetch it: hidden-history groups make the range unfetchable
+            # (auto-fill would hammer it every run), and a partial import can
+            # make it enormous. The summary carries the numbers; the operator
+            # decides what a missing head is worth.
+            leading_missing = 0
+            earliest = 0
+            try:
+                earliest = await self.db.get_earliest_message_id(cid, account_id=self.account_id)
+                if isinstance(earliest, int) and earliest > 1 and (earliest - 1) > threshold:
+                    leading_missing = earliest - 1
+                    summary["chats_with_leading_holes"] += 1
+            except Exception as e:
+                logger.debug(f"Gap-fill: could not probe the leading range: {type(e).__name__}")
+
+            if not gaps and not leading_missing:
                 continue
 
-            summary["chats_with_gaps"] += 1
             chat_recovered = 0
+            if gaps:
+                summary["chats_with_gaps"] += 1
 
-            logger.info(f"Gap-fill: chat has {len(gaps)} gap(s)")
+                logger.info(f"Gap-fill: chat has {len(gaps)} gap(s)")
 
-            for gap_start, gap_end, gap_size in gaps:
-                logger.info(f"  → Filling gap (size {gap_size})")
-                try:
-                    recovered = await self._fill_gap_range(entity, cid, gap_start, gap_end)
-                    chat_recovered += recovered
-                    logger.info(f"    Recovered {recovered} messages")
-                except Exception as e:
-                    logger.error(f"    Error filling gap (size {gap_size}): {type(e).__name__}")
-                    summary["errors"] += 1
+                for gap_start, gap_end, gap_size in gaps:
+                    logger.info(f"  → Filling gap (size {gap_size})")
+                    try:
+                        recovered = await self._fill_gap_range(entity, cid, gap_start, gap_end)
+                        chat_recovered += recovered
+                        logger.info(f"    Recovered {recovered} messages")
+                    except Exception as e:
+                        logger.error(f"    Error filling gap (size {gap_size}): {type(e).__name__}")
+                        summary["errors"] += 1
 
             summary["total_gaps"] += len(gaps)
             summary["total_recovered"] += chat_recovered
-            summary["details"].append(
-                {
-                    "chat_id": cid,
-                    "chat_name": chat_name,
-                    "gaps": len(gaps),
-                    "recovered": chat_recovered,
-                }
-            )
+            detail = {
+                "chat_id": cid,
+                "chat_name": chat_name,
+                "gaps": len(gaps),
+                "recovered": chat_recovered,
+            }
+            if leading_missing:
+                detail["leading_hole_before_id"] = earliest
+                detail["leading_missing"] = leading_missing
+            summary["details"].append(detail)
 
         status = "complete" if summary["errors"] == 0 else "complete with errors"
         logger.info(
             f"Gap-fill {status}: {summary['chats_scanned']} chats scanned, "
             f"{summary['total_gaps']} gaps found, {summary['total_recovered']} messages recovered"
             + (f", {summary['errors']} error(s)" if summary["errors"] else "")
+            + (
+                f"; {summary['chats_with_leading_holes']} chat(s) have history missing before "
+                "their earliest archived message (reported only, never auto-fetched)"
+                if summary["chats_with_leading_holes"]
+                else ""
+            )
         )
 
         return summary

--- a/tests/test_gap_fill.py
+++ b/tests/test_gap_fill.py
@@ -807,6 +807,30 @@ class TestLeadingHoleReporting:
         assert result["details"][0]["leading_missing"] == 499
         backup._fill_gap_range.assert_not_awaited()
 
+    async def test_probe_failure_counts_as_error_not_silent_skip(self):
+        """A failed probe means leading-hole reporting was skipped for a
+        scanned chat — the summary must say so, or the final log claims a
+        completeness it does not have (review finding)."""
+        db = AsyncMock()
+        db.get_chats_with_messages = AsyncMock(return_value=[-1001])
+        db.get_chats_for_folder_resolution = AsyncMock(return_value=_resolution_rows(-1001))
+        db.get_earliest_message_id = AsyncMock(side_effect=RuntimeError("db hiccup"))
+        db.detect_message_gaps = AsyncMock(return_value=[])
+
+        client = AsyncMock()
+        entity = MagicMock()
+        entity.title = "Probe-failed chat"
+        client.get_entity = AsyncMock(return_value=entity)
+
+        backup = _make_backup_instance(db_mock=db, client_mock=client)
+        backup._fill_gap_range = AsyncMock()
+
+        result = await backup._fill_gaps(chat_id=None)
+
+        assert result["errors"] == 1
+        assert result["chats_with_leading_holes"] == 0
+        backup._fill_gap_range.assert_not_awaited()
+
     async def test_small_lead_below_threshold_is_not_a_hole(self):
         """Telegram ids start at 1 but service messages can eat the first few:
         a lead smaller than the gap threshold is normal, not a hole."""

--- a/tests/test_gap_fill.py
+++ b/tests/test_gap_fill.py
@@ -305,6 +305,7 @@ class TestFillGaps:
         db = AsyncMock()
         db.get_chats_with_messages = AsyncMock(return_value=[-1001, -1002])
         db.get_chats_for_folder_resolution = AsyncMock(return_value=_resolution_rows(-1001, -1002))
+        db.get_earliest_message_id = AsyncMock(return_value=1)
         db.detect_message_gaps = AsyncMock(return_value=[])
 
         client = AsyncMock()
@@ -323,6 +324,7 @@ class TestFillGaps:
     async def test_fill_gaps_with_specific_chat_id(self):
         """When chat_id is provided, only that chat should be scanned."""
         db = AsyncMock()
+        db.get_earliest_message_id = AsyncMock(return_value=1)
         db.detect_message_gaps = AsyncMock(return_value=[])
 
         client = AsyncMock()
@@ -346,6 +348,7 @@ class TestFillGaps:
         This tests the critical `if chat_id is not None` fix (vs `if chat_id`).
         """
         db = AsyncMock()
+        db.get_earliest_message_id = AsyncMock(return_value=1)
         db.detect_message_gaps = AsyncMock(return_value=[])
 
         client = AsyncMock()
@@ -385,6 +388,7 @@ class TestFillGaps:
             return accessible_entity
 
         client.get_entity = AsyncMock(side_effect=fake_get_entity)
+        db.get_earliest_message_id = AsyncMock(return_value=1)
         db.detect_message_gaps = AsyncMock(return_value=[])
 
         backup = _make_backup_instance(db_mock=db, client_mock=client)
@@ -401,6 +405,7 @@ class TestFillGaps:
         db = AsyncMock()
         db.get_chats_with_messages = AsyncMock(return_value=[-1001])
         db.get_chats_for_folder_resolution = AsyncMock(return_value=_resolution_rows(-1001))
+        db.get_earliest_message_id = AsyncMock(return_value=1)
         db.detect_message_gaps = AsyncMock(
             return_value=[
                 (50, 100, 50),
@@ -435,6 +440,7 @@ class TestFillGaps:
         db = AsyncMock()
         db.get_chats_with_messages = AsyncMock(return_value=[-1001, -1002])
         db.get_chats_for_folder_resolution = AsyncMock(return_value=_resolution_rows(-1001, -1002))
+        db.get_earliest_message_id = AsyncMock(return_value=1)
         db.detect_message_gaps = AsyncMock(
             side_effect=[
                 [],  # chat -1001: no gaps
@@ -467,6 +473,7 @@ class TestFillGaps:
         db = AsyncMock()
         db.get_chats_with_messages = AsyncMock(return_value=[-1001])
         db.get_chats_for_folder_resolution = AsyncMock(return_value=_resolution_rows(-1001))
+        db.get_earliest_message_id = AsyncMock(return_value=1)
         db.detect_message_gaps = AsyncMock(return_value=[])
 
         client = AsyncMock()
@@ -707,6 +714,7 @@ class TestGapFillBotClassification:
         db = AsyncMock()
         db.get_chats_with_messages = AsyncMock(return_value=with_messages)
         db.get_chats_for_folder_resolution = AsyncMock(return_value=resolution_rows)
+        db.get_earliest_message_id = AsyncMock(return_value=1)
         db.detect_message_gaps = AsyncMock(return_value=[])
         client = AsyncMock()
         entity = MagicMock()
@@ -759,3 +767,63 @@ class TestGapFillBotClassification:
 
         assert result["chats_scanned"] == 0
         client.get_entity.assert_not_awaited()
+
+
+class TestLeadingHoleReporting:
+    """History missing BEFORE the earliest archived id is invisible to LAG();
+    it is reported in the summary and never auto-fetched (hidden-history
+    groups make it unfetchable; partial imports can make it enormous)."""
+
+    async def test_earliest_message_id_real_sql(self):
+        adapter, engine = await _create_in_memory_adapter()
+        try:
+            await _insert_chat(adapter, chat_id=-1001)
+            await _insert_messages(adapter, chat_id=-1001, msg_ids=[500, 501, 502])
+            assert await adapter.get_earliest_message_id(-1001, account_id=1) == 500
+            assert await adapter.get_earliest_message_id(-9999, account_id=1) == 0
+        finally:
+            await engine.dispose()
+
+    async def test_leading_hole_is_reported_not_fetched(self):
+        db = AsyncMock()
+        db.get_chats_with_messages = AsyncMock(return_value=[-1001])
+        db.get_chats_for_folder_resolution = AsyncMock(return_value=_resolution_rows(-1001))
+        db.get_earliest_message_id = AsyncMock(return_value=500)
+        db.detect_message_gaps = AsyncMock(return_value=[])
+
+        client = AsyncMock()
+        entity = MagicMock()
+        entity.title = "Head-missing chat"
+        client.get_entity = AsyncMock(return_value=entity)
+
+        backup = _make_backup_instance(db_mock=db, client_mock=client)
+        backup._fill_gap_range = AsyncMock()
+
+        result = await backup._fill_gaps(chat_id=None)
+
+        assert result["chats_with_leading_holes"] == 1
+        assert result["chats_with_gaps"] == 0
+        assert result["details"][0]["leading_hole_before_id"] == 500
+        assert result["details"][0]["leading_missing"] == 499
+        backup._fill_gap_range.assert_not_awaited()
+
+    async def test_small_lead_below_threshold_is_not_a_hole(self):
+        """Telegram ids start at 1 but service messages can eat the first few:
+        a lead smaller than the gap threshold is normal, not a hole."""
+        db = AsyncMock()
+        db.get_chats_with_messages = AsyncMock(return_value=[-1001])
+        db.get_chats_for_folder_resolution = AsyncMock(return_value=_resolution_rows(-1001))
+        db.get_earliest_message_id = AsyncMock(return_value=20)
+        db.detect_message_gaps = AsyncMock(return_value=[])
+
+        client = AsyncMock()
+        entity = MagicMock()
+        entity.title = "Nearly-complete chat"
+        client.get_entity = AsyncMock(return_value=entity)
+
+        backup = _make_backup_instance(db_mock=db, client_mock=client)
+
+        result = await backup._fill_gaps(chat_id=None)
+
+        assert result["chats_with_leading_holes"] == 0
+        assert result["details"] == []

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -1244,6 +1244,7 @@ class TestFillGaps(unittest.TestCase):
 
     def test_single_chat_with_gaps_fills_them(self):
         """Gap detected in a chat triggers _fill_gap_range."""
+        self.backup.db.get_earliest_message_id = AsyncMock(return_value=1)
         self.backup.db.detect_message_gaps = AsyncMock(return_value=[(10, 20, 10)])
         self.backup.client.get_entity = AsyncMock(return_value=MagicMock())
         self.backup._fill_gap_range = AsyncMock(return_value=5)
@@ -1256,6 +1257,7 @@ class TestFillGaps(unittest.TestCase):
 
     def test_no_gaps_found(self):
         """Chat with no gaps produces empty summary."""
+        self.backup.db.get_earliest_message_id = AsyncMock(return_value=1)
         self.backup.db.detect_message_gaps = AsyncMock(return_value=[])
         self.backup.client.get_entity = AsyncMock(return_value=MagicMock())
 
@@ -1284,6 +1286,7 @@ class TestFillGaps(unittest.TestCase):
     def test_detect_gaps_error_counts_as_error(self):
         """Exception in detect_message_gaps counts as error."""
         self.backup.client.get_entity = AsyncMock(return_value=MagicMock())
+        self.backup.db.get_earliest_message_id = AsyncMock(return_value=1)
         self.backup.db.detect_message_gaps = AsyncMock(side_effect=Exception("db fail"))
 
         summary = _run(self.backup._fill_gaps(chat_id=100))
@@ -1293,6 +1296,7 @@ class TestFillGaps(unittest.TestCase):
     def test_fill_gap_range_error_counts_as_error(self):
         """Exception in _fill_gap_range counts as error."""
         self.backup.client.get_entity = AsyncMock(return_value=MagicMock())
+        self.backup.db.get_earliest_message_id = AsyncMock(return_value=1)
         self.backup.db.detect_message_gaps = AsyncMock(return_value=[(10, 20, 10)])
         self.backup._fill_gap_range = AsyncMock(side_effect=Exception("range fail"))
 
@@ -1311,6 +1315,7 @@ class TestFillGaps(unittest.TestCase):
         )
         self.backup.config.should_backup_chat = MagicMock(side_effect=[True, False])
         self.backup.client.get_entity = AsyncMock(return_value=MagicMock())
+        self.backup.db.get_earliest_message_id = AsyncMock(return_value=1)
         self.backup.db.detect_message_gaps = AsyncMock(return_value=[])
 
         summary = _run(self.backup._fill_gaps(chat_id=None))


### PR DESCRIPTION
detect_message_gaps computes gaps as id − LAG(id) over stored ids: the leading range has no predecessor row, so a hole at the HEAD of the archive is structurally invisible — fill-gaps reports zero gaps for it, and the sweep's forward-only cursor never walks backwards. Everything older than the first stored id was permanently unreachable by both mechanisms, with the archive looking complete. The realistic route into this state is importing a date-ranged export that jumped the sync cursor (that cause is fixed forward by the import cursor guard in #335; this makes existing damage visible).

Gap-fill now probes each scanned chat's earliest archived id — one indexed MIN() per chat — and reports leads larger than the gap threshold: a chats_with_leading_holes summary counter, per-chat before-id and missing-count in the details, a count-only log line (no chat identifiers, per the PII rule), and the fill-gaps CLI prints both.

Deliberately REPORT-ONLY — never auto-fetched. Two reasons, both load-bearing: groups with hidden pre-join history make the leading range unfetchable, so an auto-fill would hammer an unfillable range on every run forever; and a partial import can make the range enormous (an entire chat history), which is not a download to start silently. The operator sees the numbers and decides — a targeted import or backup fills it deliberately.

Tests: real-SQL earliest-id probe (rows → min, empty → 0); a leading-hole chat reported with exact before-id/missing fields and _fill_gap_range never awaited; a small lead below the threshold reported as nothing (service messages eat the first ids legitimately). The report-suppressed mutant fails (green-then-red verified). All 13 pre-existing mocked fill-gaps tests re-seeded with the new probe. Full suite: 3407 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gap-filling reports chats with large missing message history before the earliest archived message.
  * Per-chat results now show the number of missing messages and the boundary message ID.
  * Existing internal gaps continue to be filled automatically, while leading history gaps are reported without being fetched.

* **Bug Fixes**
  * Small leading gaps below the configured threshold are no longer reported unnecessarily.

* **Tests**
  * Added coverage for leading-gap detection, reporting, and threshold handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->