### PR TITLE
fix(import): HTML imports no longer shift every message by the exporter's timezone

### DIFF
--- a/src/telegram_import.py
+++ b/src/telegram_import.py
@@ -256,7 +256,12 @@ def _build_service_text(msg: dict) -> str:
 # ---------------------------------------------------------------------------
 
 
-_HTML_DATE_OFFSET = re.compile(r"^UTC([+-]\d{2}:\d{2})$")
+# Real UTC offsets only (-12:00 .. +14:00): a malformed token like UTC+24:00
+# would make fromisoformat raise (losing the date entirely, worse than the old
+# naive fallback) and UTC+02:60 would be silently normalized to +03:00 —
+# anything unmatched degrades to the old behavior instead: offset dropped,
+# wall-clock kept naive.
+_HTML_DATE_OFFSET = re.compile(r"^UTC([+-](?:0\d|1[0-3]):[0-5]\d|[+-]14:00)$")
 
 
 def parse_html_date(date_str: str) -> str | None:

--- a/src/telegram_import.py
+++ b/src/telegram_import.py
@@ -137,9 +137,12 @@ def parse_date(msg: dict) -> datetime | None:
             pass
     if "date" in msg:
         try:
-            return datetime.fromisoformat(msg["date"]).replace(tzinfo=None)
+            parsed = datetime.fromisoformat(msg["date"])
         except ValueError, TypeError:
-            pass
+            return None
+        if parsed.tzinfo is not None:
+            return parsed.astimezone(UTC).replace(tzinfo=None)
+        return parsed
     return None
 
 
@@ -152,9 +155,12 @@ def parse_edited_date(msg: dict) -> datetime | None:
             pass
     if "edited" in msg:
         try:
-            return datetime.fromisoformat(msg["edited"]).replace(tzinfo=None)
+            parsed = datetime.fromisoformat(msg["edited"])
         except ValueError, TypeError:
-            pass
+            return None
+        if parsed.tzinfo is not None:
+            return parsed.astimezone(UTC).replace(tzinfo=None)
+        return parsed
     return None
 
 
@@ -250,20 +256,32 @@ def _build_service_text(msg: dict) -> str:
 # ---------------------------------------------------------------------------
 
 
+_HTML_DATE_OFFSET = re.compile(r"^UTC([+-]\d{2}:\d{2})$")
+
+
 def parse_html_date(date_str: str) -> str | None:
     """Convert HTML export date title to ISO format string.
 
     Input: 'DD.MM.YYYY HH:MM:SS' or 'DD.MM.YYYY HH:MM:SS UTC+HH:MM'
-    Output: ISO 8601 string like '2024-01-01T12:00:00'
+    Output: ISO 8601 string like '2024-01-01T12:00:00' or '2024-01-01T12:00:00+02:00'
+
+    The title is the exporter's local wall-clock time; the UTC+HH:MM suffix is the
+    only record of the offset, so it must survive into the ISO string — parse_date
+    normalises aware strings to naive UTC, matching every capture path.
     """
     if not date_str:
         return None
     parts = date_str.strip().split()
     if len(parts) < 2:
         return None
+    offset = ""
+    if len(parts) >= 3:
+        match = _HTML_DATE_OFFSET.match(parts[2])
+        if match:
+            offset = match.group(1)
     try:
         day, month, year = parts[0].split(".")
-        return f"{year}-{month}-{day}T{parts[1]}"
+        return f"{year}-{month}-{day}T{parts[1]}{offset}"
     except ValueError, IndexError:
         return None
 

--- a/tests/test_telegram_import.py
+++ b/tests/test_telegram_import.py
@@ -128,6 +128,22 @@ class TestParseDate(unittest.TestCase):
     def test_invalid_date(self):
         self.assertIsNone(parse_date({"date": "not-a-date"}))
 
+    def test_aware_iso_converts_to_naive_utc(self):
+        """An offset-bearing string is an instant, not a wall clock: 10:00+02:00 IS 08:00 UTC."""
+        result = parse_date({"date": "2024-01-15T10:00:00+02:00"})
+        self.assertEqual(result, datetime(2024, 1, 15, 8, 0, 0))
+        self.assertIsNone(result.tzinfo)
+
+    def test_aware_iso_negative_offset(self):
+        result = parse_date({"date": "2024-01-15T22:30:00-05:00"})
+        self.assertEqual(result, datetime(2024, 1, 16, 3, 30, 0))
+        self.assertIsNone(result.tzinfo)
+
+    def test_naive_iso_unchanged(self):
+        result = parse_date({"date": "2024-01-15T10:00:00"})
+        self.assertEqual(result, datetime(2024, 1, 15, 10, 0, 0))
+        self.assertIsNone(result.tzinfo)
+
 
 class TestParseEditedDate(unittest.TestCase):
     def test_edited_unixtime(self):
@@ -142,6 +158,11 @@ class TestParseEditedDate(unittest.TestCase):
 
     def test_no_edited(self):
         self.assertIsNone(parse_edited_date({}))
+
+    def test_aware_edited_converts_to_naive_utc(self):
+        result = parse_edited_date({"edited": "2024-01-15T10:05:00+02:00"})
+        self.assertEqual(result, datetime(2024, 1, 15, 8, 5, 0))
+        self.assertIsNone(result.tzinfo)
 
 
 class TestDetectMedia(unittest.TestCase):
@@ -952,7 +973,17 @@ class TestParseHtmlDate(unittest.TestCase):
         self.assertEqual(parse_html_date("15.01.2024 10:30:00"), "2024-01-15T10:30:00")
 
     def test_date_with_timezone(self):
-        self.assertEqual(parse_html_date("15.01.2024 10:30:00 UTC+02:00"), "2024-01-15T10:30:00")
+        """The UTC+HH:MM suffix is the only record of the offset — it must survive."""
+        self.assertEqual(parse_html_date("15.01.2024 10:30:00 UTC+02:00"), "2024-01-15T10:30:00+02:00")
+
+    def test_date_with_negative_offset(self):
+        self.assertEqual(parse_html_date("15.01.2024 10:30:00 UTC-05:00"), "2024-01-15T10:30:00-05:00")
+
+    def test_date_with_half_hour_offset(self):
+        self.assertEqual(parse_html_date("15.01.2024 10:30:00 UTC+05:30"), "2024-01-15T10:30:00+05:30")
+
+    def test_unrecognised_third_token_is_dropped(self):
+        self.assertEqual(parse_html_date("15.01.2024 10:30:00 CEST"), "2024-01-15T10:30:00")
 
     def test_empty_string(self):
         self.assertIsNone(parse_html_date(""))
@@ -1040,7 +1071,7 @@ class TestParseHtmlExport(unittest.TestCase):
         self.assertEqual(messages[0]["id"], 100)
         self.assertEqual(messages[0]["from"], "Alice")
         self.assertEqual(messages[0]["text"], "Hello world!")
-        self.assertEqual(messages[0]["date"], "2024-01-15T10:00:00")
+        self.assertEqual(messages[0]["date"], "2024-01-15T10:00:00+02:00")
         self.assertEqual(messages[0]["type"], "message")
 
     def test_joined_messages(self):
@@ -1248,6 +1279,10 @@ class TestHtmlImportIntegration(unittest.TestCase):
         inserted = db.insert_messages_batch.call_args.args[0][0]
         self.assertEqual(inserted["sender_name"], "Alice")
         self.assertIsNone(inserted["sender_id"])
+        # The fixture title is 10:00 UTC+02:00 — the stored instant is naive UTC,
+        # like every capture path, so the merged timeline interleaves correctly.
+        self.assertEqual(inserted["date"], datetime(2024, 1, 15, 8, 0, 0))
+        self.assertIsNone(inserted["date"].tzinfo)
 
     def test_html_import_dry_run(self):
         self._write_html(SAMPLE_HTML_MESSAGE)

--- a/tests/test_telegram_import.py
+++ b/tests/test_telegram_import.py
@@ -985,6 +985,17 @@ class TestParseHtmlDate(unittest.TestCase):
     def test_unrecognised_third_token_is_dropped(self):
         self.assertEqual(parse_html_date("15.01.2024 10:30:00 CEST"), "2024-01-15T10:30:00")
 
+    def test_invalid_offsets_degrade_to_naive(self):
+        """UTC+24:00 would make fromisoformat raise (date LOST) and UTC+02:60
+        would silently normalize to +03:00 (timestamp changed) — both must
+        degrade to the old behavior: token dropped, wall-clock kept naive."""
+        self.assertEqual(parse_html_date("15.01.2024 10:30:00 UTC+24:00"), "2024-01-15T10:30:00")
+        self.assertEqual(parse_html_date("15.01.2024 10:30:00 UTC+02:60"), "2024-01-15T10:30:00")
+
+    def test_extreme_but_real_offsets_are_kept(self):
+        self.assertEqual(parse_html_date("15.01.2024 10:30:00 UTC+14:00"), "2024-01-15T10:30:00+14:00")
+        self.assertEqual(parse_html_date("15.01.2024 10:30:00 UTC-12:00"), "2024-01-15T10:30:00-12:00")
+
     def test_empty_string(self):
         self.assertIsNone(parse_html_date(""))
 


### PR DESCRIPTION
## Problem

Telegram Desktop's HTML export writes each message date as local wall-clock time plus the offset: `15.01.2024 10:00:00 UTC+02:00`. `parse_html_date` kept only the first two tokens, so the offset was discarded and the local time went into `messages.date` — a column every capture path fills with naive UTC. Every HTML-imported message is shifted by the exporter's UTC offset relative to captured messages in the same chat: the merged timeline interleaves in the wrong order, and late-evening messages land on the wrong calendar day in day counts and jump-to-date. The JSON path is immune only because `date_unixtime` wins first — HTML has no such fallback.

## Fix

- `parse_html_date` keeps a recognised `UTC±HH:MM` suffix in the ISO string (`2024-01-15T10:00:00+02:00`). An unrecognised third token (bare zone names) degrades to the old behaviour.
- `parse_date` and `parse_edited_date` normalise aware ISO strings to naive UTC (`astimezone(UTC)` then strip), matching `date_unixtime` and every capture path. Naive strings are unchanged, so JSON imports behave exactly as before.

## Evidence

- Full suite: 3422 passed, 127 skipped, 861 subtests, exit 0.
- Mutation controls (green first, then red): dropping the offset again fails 4 tests; stripping tzinfo without converting fails 4 tests; restore sha-verified.
- End-to-end regression: the offset-bearing fixture title `10:00 UTC+02:00` now stores `datetime(2024, 1, 15, 8, 0, 0)` naive UTC in the inserted row.

Closes bead Telegram-Archive-9t6.5.20.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Telegram date handling for timezone-aware JSON and edited timestamps.
  * Converted timezone-aware timestamps to consistent, naive UTC values while preserving existing naive dates.
  * Added support for numeric UTC offsets in HTML timestamps, including negative and half-hour offsets.
  * Preserved recognized offsets in parsed date strings and safely handled invalid or unrecognized date formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->