### PR TITLE
fix(api): an offset-bearing cursor or expiry now means the instant it names

### DIFF
--- a/src/web/main.py
+++ b/src/web/main.py
@@ -2308,9 +2308,9 @@ async def get_messages(
     if before_date:
         try:
             parsed_before_date = datetime.fromisoformat(before_date.replace("Z", "+00:00"))
-            # Strip timezone for DB compatibility
+            # Message.date is naive UTC — convert the instant, never just relabel it
             if parsed_before_date.tzinfo:
-                parsed_before_date = parsed_before_date.replace(tzinfo=None)
+                parsed_before_date = parsed_before_date.astimezone(UTC).replace(tzinfo=None)
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid before_date format. Use ISO 8601.")
 
@@ -3373,9 +3373,13 @@ async def create_token(request: Request, user: UserContext = Depends(require_mas
     expires_at = None
     if data.get("expires_at"):
         try:
-            expires_at = datetime.fromisoformat(data["expires_at"].replace("Z", "+00:00")).replace(tzinfo=None)
+            expires_at = datetime.fromisoformat(data["expires_at"].replace("Z", "+00:00"))
         except ValueError:
             raise HTTPException(status_code=400, detail="Invalid expires_at format. Use ISO 8601.")
+        # Expiry is compared against naive UTC — convert the instant, never just relabel it
+        if expires_at.tzinfo:
+            expires_at = expires_at.astimezone(UTC)
+        expires_at = expires_at.replace(tzinfo=None)
 
     # A share token is ALWAYS scoped: no refs, no token.
     if not allowed_chat_refs or not isinstance(allowed_chat_refs, list):

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -480,6 +480,27 @@ class TestMessagesEndpoint(_WebTestBase):
         self.assertIsNotNone(call_kwargs["before_date"])
         self.assertEqual(call_kwargs["before_id"], 500)
 
+    async def test_offset_cursor_converts_to_naive_utc(self):
+        """A +02:00 cursor names an instant: 12:00+02:00 IS 10:00 UTC. Relabelling it
+        naive asked the DB for messages before 12:00 UTC — two re-delivered hours."""
+        self.mock_db.get_messages_paginated = AsyncMock(return_value=[])
+        async with self._client() as client:
+            resp = await client.get("/api/chats/1/messages?before_date=2025-06-15T12:00:00%2B02:00&before_id=500")
+        self.assertEqual(resp.status_code, 200)
+        call_kwargs = self.mock_db.get_messages_paginated.call_args.kwargs
+        self.assertEqual(call_kwargs["before_date"], datetime(2025, 6, 15, 10, 0, 0))
+        self.assertIsNone(call_kwargs["before_date"].tzinfo)
+
+    async def test_z_cursor_stays_the_same_instant(self):
+        """Z and naive coincide — the conversion must not move a UTC cursor."""
+        self.mock_db.get_messages_paginated = AsyncMock(return_value=[])
+        async with self._client() as client:
+            resp = await client.get("/api/chats/1/messages?before_date=2025-06-15T12:00:00Z&before_id=500")
+        self.assertEqual(resp.status_code, 200)
+        call_kwargs = self.mock_db.get_messages_paginated.call_args.kwargs
+        self.assertEqual(call_kwargs["before_date"], datetime(2025, 6, 15, 12, 0, 0))
+        self.assertIsNone(call_kwargs["before_date"].tzinfo)
+
     async def test_passes_jump_window_cursor_params(self):
         """get_messages forwards a lone before_id and after_id to db (#213 jump window)."""
         self.mock_db.get_messages_paginated = AsyncMock(return_value=[])
@@ -1503,6 +1524,22 @@ class TestAdminTokensEndpoint(_MasterTestBase):
         self.assertIn("token", data)
         self.assertIsNotNone(data["token"])
         self.assertEqual(data["allowed_chat_refs"], ["tokRefA000000000001A", "tokRefB000000000002A"])
+
+    async def test_create_token_offset_expiry_converts_to_naive_utc(self):
+        """Expiry is enforced against utcnow_naive(); a +02:00 expiry relabelled naive
+        would keep the token alive two hours past what the admin asked for."""
+        async with self._client() as client:
+            resp = await client.post(
+                "/api/admin/tokens",
+                json={
+                    "allowed_chat_refs": ["tokRefA000000000001A"],
+                    "expires_at": "2026-09-01T12:00:00+02:00",
+                },
+            )
+        self.assertEqual(resp.status_code, 200)
+        stored = self.mock_db.create_viewer_token.call_args.kwargs["expires_at"]
+        self.assertEqual(stored, datetime(2026, 9, 1, 10, 0, 0))
+        self.assertIsNone(stored.tzinfo)
 
     async def test_update_token_not_found(self):
         """update_token returns 404 when token not found."""


### PR DESCRIPTION
## Problem

Two API inputs parsed ISO-8601 datetimes and then stripped the timezone without converting — relabelling an instant instead of translating it:

- `GET /api/chats/{id}/messages?before_date=2026-01-15T12:00:00+02:00` compared 12:00 against `Message.date` (naive UTC), when the caller named 10:00 UTC. Two hours re-delivered at every page boundary; with negative offsets, a silently skipped window. The bundled SPA is unaffected (it echoes back naive strings) — this bites third-party consumers of the documented HTTP API.
- `POST /api/admin/tokens` with `expires_at: 2026-09-01T12:00:00+02:00` stored 12:00 naive; enforcement compares against `utcnow_naive()` (adapter.py), so the share token outlived the admin's intent by two hours.

The same file already does this right in `get_message_by_date` and `get_message_dates` (`astimezone(UTC)` before stripping) — these were the two remaining relabel sites, found by sweeping `main.py` for `replace(tzinfo=None)`.

## Fix

Convert to UTC before dropping tzinfo at both sites. Z-suffixed and naive inputs are byte-for-byte unchanged.

## Evidence

- Full suite: 3418 passed, 127 skipped, 861 subtests, exit 0.
- Mutation controls (green first, then red): re-relabelling the cursor fails the offset test while the Z test rightly stays green (strip and convert coincide at UTC); dropping the expiry conversion fails its test. Restores sha-verified.

Closes bead Telegram-Archive-9t6.5.77.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected timezone conversion for message date cursors.
  - Corrected token expiration handling so timestamps consistently represent the intended UTC instant.

- **Tests**
  - Added coverage for timezone-offset message cursors.
  - Added coverage for token expiration timestamps with timezone offsets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->