### PR TITLE
fix(db): importing an old export no longer re-fetches the whole chat from Telegram

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -2481,7 +2481,10 @@ class DatabaseAdapter:
                 stmt = stmt.on_conflict_do_update(
                     index_elements=["account_id", "chat_id"],
                     set_={
-                        "last_message_id": stmt.excluded.last_message_id,
+                        # High-water mark: the backup reads this as min_id for the
+                        # next incremental pass, so it must never move backwards
+                        # (an older export import supplies a smaller max id).
+                        "last_message_id": func.max(SyncStatus.last_message_id, stmt.excluded.last_message_id),
                         "last_sync_date": stmt.excluded.last_sync_date,
                         "message_count": SyncStatus.message_count + stmt.excluded.message_count,
                     },
@@ -2491,7 +2494,8 @@ class DatabaseAdapter:
                 stmt = stmt.on_conflict_do_update(
                     index_elements=["account_id", "chat_id"],
                     set_={
-                        "last_message_id": stmt.excluded.last_message_id,
+                        # Same high-water clamp; PostgreSQL spells two-arg max GREATEST.
+                        "last_message_id": func.greatest(SyncStatus.last_message_id, stmt.excluded.last_message_id),
                         "last_sync_date": stmt.excluded.last_sync_date,
                         "message_count": SyncStatus.message_count + stmt.excluded.message_count,
                     },

--- a/tests/test_db_adapter_real_engine.py
+++ b/tests/test_db_adapter_real_engine.py
@@ -75,6 +75,28 @@ class TestUpdateSyncStatusRealEngine:
         await real_adapter.update_sync_status(900002, 1234, 7, account_id=1)
         assert await real_adapter.get_last_message_id(900002, account_id=1) == 1234
 
+    async def test_cursor_never_moves_backwards(self, real_adapter):
+        """last_message_id is a high-water mark: the backup reads it as min_id for
+        the next incremental pass, so importing an older export — which calls
+        update_sync_status with that export's smaller max id — must not drag the
+        checkpoint down and re-fetch everything above it from Telegram."""
+        await _seed_chat(real_adapter, 900009)
+
+        await real_adapter.update_sync_status(900009, 500, 10, account_id=1)
+        await real_adapter.update_sync_status(900009, 400, 5, account_id=1)
+        assert await real_adapter.get_last_message_id(900009, account_id=1) == 500
+
+        # Forward motion still moves the mark, and the count kept accumulating.
+        await real_adapter.update_sync_status(900009, 600, 5, account_id=1)
+        assert await real_adapter.get_last_message_id(900009, account_id=1) == 600
+        async with real_adapter.db_manager.async_session_factory() as session:
+            row = (
+                (await session.execute(SyncStatus.__table__.select().where(SyncStatus.chat_id == 900009)))
+                .mappings()
+                .one()
+            )
+        assert row["message_count"] == 20
+
 
 class TestMessageUpsertConflictRealEngine:
     """insert_message's conflict branch on both dialects."""


### PR DESCRIPTION
## Problem

`sync_status.last_message_id` is a high-water mark: the backup reads it as `min_id` for the next incremental pass. But `update_sync_status`'s ON CONFLICT clause assigned `excluded.last_message_id` unconditionally, so `telegram_import --merge` of an older export (whose max id is below the live checkpoint) dragged the cursor down. The next backup pass then re-fetched everything above it from Telegram — wasted API calls and real FloodWait risk on a large chat. Official clients keep their update checkpoints monotonic for exactly this reason.

## Fix

The conflict clause clamps the cursor: `max(stored, excluded)` on SQLite, `greatest(stored, excluded)` on PostgreSQL (no portable spelling exists — branched alongside the existing `_is_sqlite` split). `last_sync_date` and the `message_count` accumulation are unchanged. The backup's own calls always move forward, so they see no difference.

## Evidence

- Regression test in `test_db_adapter_real_engine.py` runs on BOTH backends (the PG leg executes on CI): 500 → 400 keeps 500; 600 still advances; count still accumulates.
- Mutation control (green first, then red): reverting the SQLite clamp fails the new test; restore sha-verified. The PG spelling is compile-verified to render `greatest(sync_status.last_message_id, excluded.last_message_id)`.
- Full suite: 3416 passed, 128 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.5.67.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sync progress now retains the highest message ID, preventing older imports from moving the sync position backward.
  * Newer messages continue advancing the sync position while message counts accumulate correctly.

* **Tests**
  * Added coverage validating sync behavior with a real database engine.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->