### PR TITLE
fix(viewer): clicking the playing track no longer shows someone else's conversation

### DIFF
--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -6697,7 +6697,10 @@
                         && activeTopicId() != null && Number(activeTopicId()) !== trackTopicId
                     if (wrongChat || wrongTopic) {
                         const chat = chats.value.find(c => c.id === track.chatId)
-                        if (!chat) return
+                        if (!chat) {
+                            audioError.value = "This track's chat is not in the archive view"
+                            return
+                        }
                         await selectChat(chat)
                         // A forum chat short-circuits selectChat into its topics list
                         // without touching selectedChat (that is what selectTopic is
@@ -6706,8 +6709,18 @@
                         // stale list. A vanished topic bails on the topics list
                         // rather than windowing whatever pane was left behind.
                         if (chat.is_forum) {
-                            const topic = topics.value.find(t => Number(t.id) === trackTopicId)
-                            if (!topic) return
+                            let topic = topics.value.find(t => Number(t.id) === trackTopicId)
+                            if (!topic && trackTopicId === Number(GENERAL_TOPIC_ID)) {
+                                // get_forum_topics returns captured rows only, and old
+                                // captures may lack a General row — but General always
+                                // exists conceptually, so synthesize it rather than
+                                // stranding the jump on the topics list.
+                                topic = { id: GENERAL_TOPIC_ID, title: 'General' }
+                            }
+                            if (!topic) {
+                                audioError.value = "The track's topic is no longer in the archive"
+                                return
+                            }
                             await selectTopic(chat, topic)
                         }
                     }

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -5922,6 +5922,9 @@
                 const audioTrackFromMessage = (msg) => ({
                     id: msg.id,
                     chatId: audioMessageChatId(msg),
+                    // Forum messages live in a topic; the jump needs it to land the
+                    // pane on the right one (null means the General topic).
+                    topicId: msg.reply_to_top_id ?? null,
                     // The ref addresses every queue-page request; chatId stays as the
                     // in-memory identity the queue compares tracks by.
                     chatRef: selectedChat.value?.ref ?? null,
@@ -6684,11 +6687,32 @@
                 const focusAudioTrackMessage = async () => {
                     const track = audioTrack.value
                     if (!track) return
-                    if (track.chatId != null && track.chatId !== (selectedChat.value?.id ?? null)) {
+                    const trackTopicId = Number(track.topicId ?? GENERAL_TOPIC_ID)
+                    // Re-navigate when the pane is another chat, or the same forum
+                    // chat's pane is scoped to a different topic — the window fetch
+                    // below is scoped to the active topic, so a mismatched pane
+                    // would show an unrelated slice positioned by a meaningless id.
+                    const wrongChat = track.chatId != null && track.chatId !== (selectedChat.value?.id ?? null)
+                    const wrongTopic = !wrongChat && track.chatId != null && !!selectedChat.value?.is_forum
+                        && activeTopicId() != null && Number(activeTopicId()) !== trackTopicId
+                    if (wrongChat || wrongTopic) {
                         const chat = chats.value.find(c => c.id === track.chatId)
                         if (!chat) return
                         await selectChat(chat)
+                        // A forum chat short-circuits selectChat into its topics list
+                        // without touching selectedChat (that is what selectTopic is
+                        // for) — continue into the track's own topic. selectChat just
+                        // reloaded this chat's topics, so the lookup cannot hit a
+                        // stale list. A vanished topic bails on the topics list
+                        // rather than windowing whatever pane was left behind.
+                        if (chat.is_forum) {
+                            const topic = topics.value.find(t => Number(t.id) === trackTopicId)
+                            if (!topic) return
+                            await selectTopic(chat, topic)
+                        }
                     }
+                    // The pane must be the track's chat before loading a window by id.
+                    if (track.chatId != null && (selectedChat.value?.id ?? null) !== track.chatId) return
                     await nextTick()
                     // #257: the queue reaches far past the loaded message window, so the
                     // track's row is usually NOT in the DOM — scrollToMessage alone just

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -1873,6 +1873,145 @@ const scenario = async (pages) => {
             body.index("scrollToMessage(track.id)"),
         )
 
+    def test_playbar_jump_lands_in_the_forum_tracks_own_topic(self) -> None:
+        """selectChat short-circuits a forum chat into its topics list without
+        touching selectedChat, so the old jump windowed WHATEVER pane was left
+        behind — an unrelated slice of another chat positioned by a message id
+        that means nothing there. The real navigation chain is executed here:
+        the window load must only ever fire with the pane on the track's chat
+        and topic, and a vanished topic must bail instead of windowing."""
+        prelude = """
+const selectedChat = { value: null }
+const selectedPaneTopic = { value: null }
+const messages = { value: [] }
+const messageSearchQuery = { value: '' }
+const chatStats = { value: null }
+const pinnedMessages = { value: [] }
+const currentPinnedIndex = { value: 0 }
+const showPinnedOnly = { value: false }
+const showMediaGallery = { value: false }
+const loading = { value: false }
+const navStack = { value: [] }
+const chats = { value: [] }
+const topics = { value: [] }
+const audioTrack = { value: null }
+let chatVersion = 0
+let galleryReturnState = null
+let TOPICS_BY_REF = {}
+const WINDOW_LOADS = []
+const SCROLLS = []
+const stopMessageRefresh = () => {}
+const startMessageRefresh = () => {}
+const resetMessagePagination = () => {}
+const setupMessagesScrollObserver = () => {}
+const scrollToBottom = () => {}
+const nextTick = async () => {}
+const loadMessages = async () => {}
+const loadChatStats = async () => {}
+const loadPinnedMessages = async () => {}
+const getChatName = (chat) => chat.title || ''
+const navigateTo = (entry) => { navStack.value.push(entry) }
+const loadTopics = async (ref) => { topics.value = TOPICS_BY_REF[ref] || [] }
+const findMessageElement = () => null
+const scrollToMessage = (id) => { SCROLLS.push(id) }
+const loadMessagesAroundId = async (messageId) => {
+    WINDOW_LOADS.push({
+        messageId,
+        chatId: selectedChat.value?.id ?? null,
+        topicId: activeTopicId(),
+    })
+}
+"""
+        epilogue = """
+(async () => {
+    const forumChat = { id: -1001111, ref: 'refA', title: 'Forum A', is_forum: true }
+    const plainChat = { id: -1002222, ref: 'refB', title: 'Plain B' }
+    const otherChat = { id: -1003333, ref: 'refC', title: 'Plain C' }
+    chats.value = [forumChat, plainChat, otherChat]
+
+    const reset = () => {
+        WINDOW_LOADS.length = 0
+        navStack.value = []
+        topics.value = []
+        selectedPaneTopic.value = null
+    }
+
+    // 1. The bead's trigger: track from a forum topic, pane on another chat.
+    reset()
+    TOPICS_BY_REF = { refA: [{ id: 1, title: 'General' }, { id: 7, title: 'Topic 7' }] }
+    selectedChat.value = plainChat
+    audioTrack.value = { id: 4242, chatId: -1001111, topicId: 7 }
+    await focusAudioTrackMessage()
+    const forumJump = { loads: [...WINDOW_LOADS], paneTopic: selectedPaneTopic.value?.id ?? null }
+
+    // 2. The track's topic no longer exists: bail on the topics list.
+    reset()
+    TOPICS_BY_REF = { refA: [{ id: 1, title: 'General' }] }
+    selectedChat.value = plainChat
+    audioTrack.value = { id: 4242, chatId: -1001111, topicId: 7 }
+    await focusAudioTrackMessage()
+    const vanishedTopic = { loads: [...WINDOW_LOADS] }
+
+    // 3. Same forum chat, pane scoped to a different topic.
+    reset()
+    TOPICS_BY_REF = { refA: [{ id: 1, title: 'General' }, { id: 7, title: 'Topic 7' }] }
+    selectedChat.value = forumChat
+    selectedPaneTopic.value = { id: 1, title: 'General' }
+    audioTrack.value = { id: 4242, chatId: -1001111, topicId: 7 }
+    await focusAudioTrackMessage()
+    const topicSwitch = { loads: [...WINDOW_LOADS], paneTopic: selectedPaneTopic.value?.id ?? null }
+
+    // 4. A plain chat switch keeps working exactly as before.
+    reset()
+    selectedChat.value = plainChat
+    audioTrack.value = { id: 99, chatId: -1003333, topicId: null }
+    await focusAudioTrackMessage()
+    const plainSwitch = { loads: [...WINDOW_LOADS] }
+
+    console.log(JSON.stringify({ forumJump, vanishedTopic, topicSwitch, plainSwitch }))
+})();
+"""
+        out = _run_setup_program(
+            self.html,
+            (
+                "const GENERAL_TOPIC_ID = ",
+                "const activeTopicId = () => {",
+                "const openForumTopics = async (chat) =>",
+                "const selectTopic = async (chat, topic) =>",
+                "const selectChat = async (chat) =>",
+            ),
+            prelude,
+            # focusAudioTrackMessage is followed by audioEngine listener wiring,
+            # not a 16-space const, so _setup_slice would swallow it — lift the
+            # function by exact brace match and define it just before the driver.
+            _setup_function(self.html, "const focusAudioTrackMessage = async () =>") + "\n" + epilogue,
+        )
+
+        # The window load fired exactly once, with the pane on the track's chat
+        # AND topic — never on the chat the user happened to be reading.
+        self.assertEqual(
+            out["forumJump"]["loads"],
+            [{"messageId": 4242, "chatId": -1001111, "topicId": 7}],
+        )
+        self.assertEqual(out["forumJump"]["paneTopic"], 7)
+
+        # Vanished topic: no window load at all — the user is left on the
+        # topics list, not on an unrelated pane.
+        self.assertEqual(out["vanishedTopic"]["loads"], [])
+
+        # Same chat, wrong topic pane: re-navigates into the track's topic.
+        self.assertEqual(
+            out["topicSwitch"]["loads"],
+            [{"messageId": 4242, "chatId": -1001111, "topicId": 7}],
+        )
+        self.assertEqual(out["topicSwitch"]["paneTopic"], 7)
+
+        # A non-forum switch is untouched by all of this.
+        self.assertEqual(
+            out["plainSwitch"]["loads"],
+            [{"messageId": 99, "chatId": -1003333, "topicId": None}],
+        )
+
 
 # --- Directional, on-demand audio queue (#266) ---------------------------------
 

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -1873,6 +1873,7 @@ const scenario = async (pages) => {
             body.index("scrollToMessage(track.id)"),
         )
 
+    @unittest.skipUnless(NODE, "node is required to execute the navigation chain")
     def test_playbar_jump_lands_in_the_forum_tracks_own_topic(self) -> None:
         """selectChat short-circuits a forum chat into its topics list without
         touching selectedChat, so the old jump windowed WHATEVER pane was left
@@ -1895,6 +1896,7 @@ const navStack = { value: [] }
 const chats = { value: [] }
 const topics = { value: [] }
 const audioTrack = { value: null }
+const audioError = { value: '' }
 let chatVersion = 0
 let galleryReturnState = null
 let TOPICS_BY_REF = {}
@@ -1944,13 +1946,24 @@ const loadMessagesAroundId = async (messageId) => {
     await focusAudioTrackMessage()
     const forumJump = { loads: [...WINDOW_LOADS], paneTopic: selectedPaneTopic.value?.id ?? null }
 
-    // 2. The track's topic no longer exists: bail on the topics list.
+    // 2. The track's topic no longer exists: bail on the topics list, and SAY so.
     reset()
+    audioError.value = ''
     TOPICS_BY_REF = { refA: [{ id: 1, title: 'General' }] }
     selectedChat.value = plainChat
     audioTrack.value = { id: 4242, chatId: -1001111, topicId: 7 }
     await focusAudioTrackMessage()
-    const vanishedTopic = { loads: [...WINDOW_LOADS] }
+    const vanishedTopic = { loads: [...WINDOW_LOADS], error: audioError.value }
+
+    // 2b. A General-topic track whose captured topics lack a General row:
+    // General always exists conceptually — the jump synthesizes it.
+    reset()
+    audioError.value = ''
+    TOPICS_BY_REF = { refA: [{ id: 7, title: 'Topic 7' }] }
+    selectedChat.value = plainChat
+    audioTrack.value = { id: 4243, chatId: -1001111, topicId: null }
+    await focusAudioTrackMessage()
+    const generalSynthesized = { loads: [...WINDOW_LOADS], paneTopic: selectedPaneTopic.value?.id ?? null }
 
     // 3. Same forum chat, pane scoped to a different topic.
     reset()
@@ -1968,7 +1981,7 @@ const loadMessagesAroundId = async (messageId) => {
     await focusAudioTrackMessage()
     const plainSwitch = { loads: [...WINDOW_LOADS] }
 
-    console.log(JSON.stringify({ forumJump, vanishedTopic, topicSwitch, plainSwitch }))
+    console.log(JSON.stringify({ forumJump, vanishedTopic, generalSynthesized, topicSwitch, plainSwitch }))
 })();
 """
         out = _run_setup_program(
@@ -1996,8 +2009,16 @@ const loadMessagesAroundId = async (messageId) => {
         self.assertEqual(out["forumJump"]["paneTopic"], 7)
 
         # Vanished topic: no window load at all — the user is left on the
-        # topics list, not on an unrelated pane.
+        # topics list with an error surfaced, not on an unrelated pane.
         self.assertEqual(out["vanishedTopic"]["loads"], [])
+        self.assertTrue(out["vanishedTopic"]["error"], "the bail must be surfaced, not silent")
+
+        # Missing General row: synthesized, jump lands in topic 1.
+        self.assertEqual(
+            out["generalSynthesized"]["loads"],
+            [{"messageId": 4243, "chatId": -1001111, "topicId": 1}],
+        )
+        self.assertEqual(out["generalSynthesized"]["paneTopic"], 1)
 
         # Same chat, wrong topic pane: re-navigates into the track's topic.
         self.assertEqual(


### PR DESCRIPTION
## Problem

Play a voice note from inside a forum chat's topic, switch to a different chat, then click the track label in the audio playbar. `focusAudioTrackMessage` calls `selectChat` for the forum chat — but `selectChat` short-circuits into `openForumTopics` and returns without ever assigning `selectedChat`. The following `loadMessagesAroundId(track.id)` then windows the chat the user was reading: an unrelated slice of the wrong chat's history, positioned by a message id that means nothing there, silently, because the request succeeds. (Executed verification on the bead lifted the real functions under node and reproduced exactly this request.) Official clients always land the jump on the message in its own topic.

## Fix

- The track records its topic at play time (`reply_to_top_id`, null = General).
- The jump re-navigates when the pane is another chat OR the same forum chat scoped to a different topic (the window fetch is topic-scoped, so that pane would also miss the message), continuing through `selectTopic` into the track's topic. `selectChat` just reloaded that chat's topics, so the lookup cannot hit a stale list.
- A vanished topic bails on the topics list — one tap from the goal — instead of windowing whatever pane was left behind, and a final guard refuses to window any pane that is not the track's chat.

## Evidence

- New EXECUTED regression test lifts the real `selectChat`/`openForumTopics`/`selectTopic`/`focusAudioTrackMessage` chain verbatim under node and drives four scenarios: forum jump lands chat+topic correct; vanished topic loads nothing; same-chat-wrong-topic re-navigates; plain chat switch unchanged.
- Mutation controls (green first, then red): deadening the forum branch fails the test; deadening the vanished-topic bail fails it. Restores sha-verified.
- Full suite: 3416 passed, 127 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.5.60.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio track navigation for forum topics.
  * Selecting an audio track now switches to the correct chat and topic before loading or scrolling to the message.
  * Navigation stops safely when the track’s forum topic is unavailable.
  * Preserved existing behavior for regular chats.

* **Tests**
  * Added regression coverage for forum-topic navigation, missing topics, mismatched topics, and regular chat switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->