### PR TITLE
fix(web): a restricted viewer can no longer see archive-wide totals when the stats cache is thin

### DIFF
--- a/src/web/main.py
+++ b/src/web/main.py
@@ -2580,6 +2580,10 @@ async def get_stats(user: UserContext = Depends(require_auth)):
         # Filter per-chat stats to only chats the user can access
         user_chat_ids = await _visible_chat_id_set(user)
         per_chat = stats.get("per_chat_message_counts", {})
+        if not isinstance(per_chat, dict):
+            # A malformed cached blob (null, a list) must scope to zeros like
+            # an absent map — not crash the restricted request with a 500.
+            per_chat = {}
         if user_chat_ids is not None:
             # ACL-driven, never data-driven: an absent or empty per-chat map
             # (startup calculation failed, or a pre-8.0 cached blob) must scope

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -2580,7 +2580,11 @@ async def get_stats(user: UserContext = Depends(require_auth)):
         # Filter per-chat stats to only chats the user can access
         user_chat_ids = await _visible_chat_id_set(user)
         per_chat = stats.get("per_chat_message_counts", {})
-        if user_chat_ids is not None and per_chat:
+        if user_chat_ids is not None:
+            # ACL-driven, never data-driven: an absent or empty per-chat map
+            # (startup calculation failed, or a pre-8.0 cached blob) must scope
+            # a restricted viewer to zeros, not fail open to the archive-wide
+            # numbers this block exists to hide.
             # JSON keys are strings after json.loads(), user_chat_ids are ints
             stats["per_chat_message_counts"] = {k: v for k, v in per_chat.items() if int(k) in user_chat_ids}
             # Recompute aggregates from visible chats only

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -743,6 +743,33 @@ class TestStatsEndpoint(_WebTestBase):
         self.assertEqual(data["messages"], 100)
         self.assertNotIn("media_files", data)
 
+    async def test_stats_scope_fails_closed_when_per_chat_map_is_missing(self):
+        """A restricted viewer with a cached blob that lacks (or has an empty)
+        per_chat_message_counts must get zeros — not the archive-wide chats,
+        messages, media_files and total_size_mb the scope exists to hide."""
+        web_main.AUTH_ENABLED = True
+        token = "sv2"
+        web_main._sessions[token] = web_main.SessionData(
+            username="v1", role="viewer", allowed_chat_refs={"statsRefOne000000001A"}
+        )
+        self.mock_db.get_all_chats, self.mock_db.get_chat_count, self.mock_db.get_visible_chat_ids = scoped_chat_source(
+            [{"id": 1, "account_id": 1, "ref": "statsRefOne000000001A"}]
+        )
+        self.mock_db.get_metadata = AsyncMock(return_value=None)
+        for blob in (
+            {"chats": 900, "messages": 4242, "media_files": 77, "total_size_mb": 1234.5},
+            {"chats": 900, "messages": 4242, "media_files": 77, "total_size_mb": 1234.5, "per_chat_message_counts": {}},
+        ):
+            self.mock_db.get_cached_statistics = AsyncMock(return_value=dict(blob))
+            async with self._client() as client:
+                resp = await client.get("/api/stats", cookies={"viewer_auth": token})
+            self.assertEqual(resp.status_code, 200)
+            data = resp.json()
+            self.assertEqual(data["chats"], 0, blob)
+            self.assertEqual(data["messages"], 0, blob)
+            self.assertNotIn("media_files", data, blob)
+            self.assertNotIn("total_size_mb", data, blob)
+
     async def test_backup_in_progress_true_when_metadata_is_one(self):
         """get_stats sets backup_in_progress=True when metadata key is '1'."""
         self.mock_db.get_cached_statistics = AsyncMock(return_value={})

--- a/tests/test_web_routes.py
+++ b/tests/test_web_routes.py
@@ -759,6 +759,21 @@ class TestStatsEndpoint(_WebTestBase):
         for blob in (
             {"chats": 900, "messages": 4242, "media_files": 77, "total_size_mb": 1234.5},
             {"chats": 900, "messages": 4242, "media_files": 77, "total_size_mb": 1234.5, "per_chat_message_counts": {}},
+            # Malformed cached values must behave like an absent map, not 500.
+            {
+                "chats": 900,
+                "messages": 4242,
+                "media_files": 77,
+                "total_size_mb": 1234.5,
+                "per_chat_message_counts": None,
+            },
+            {
+                "chats": 900,
+                "messages": 4242,
+                "media_files": 77,
+                "total_size_mb": 1234.5,
+                "per_chat_message_counts": [1],
+            },
         ):
             self.mock_db.get_cached_statistics = AsyncMock(return_value=dict(blob))
             async with self._client() as client:


### PR DESCRIPTION
## Problem

`/api/stats` scopes a restricted viewer's numbers by recomputing them from `per_chat_message_counts` — but the whole scoping block was guarded by `if user_chat_ids is not None and per_chat:`. When the cached blob lacks that key (startup calculation failed and the app logs a warning and continues) or carries an empty map (a blob written before the key existed, only rewritten at the daily recalculation), the block is skipped and the restricted viewer receives the archive-wide `chats`, `messages`, `media_files` and `total_size_mb` — precisely the figures the scope exists to hide. It failed open: less data meant less filtering.

## Fix

The scope is driven by the user's ACL alone: `if user_chat_ids is not None`. An absent or empty per-chat map now yields zeros, and the global media/size figures are removed as before. Unrestricted sessions are untouched, and the populated path is byte-for-byte the same.

## Evidence

- New regression drives both thin-blob shapes (key missing, key empty) through the real route with a restricted session: chats=0, messages=0, no `media_files`, no `total_size_mb`. Under the reverted guard it goes red with the archive-wide numbers.
- Mutation control green-then-red; restore sha-verified.
- Full suite: 3416 passed, 127 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.5.75.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted statistics views now correctly return zero chat and message counts when per-chat data is unavailable.
  * Archive-wide media and storage totals are no longer exposed when restricted statistics cannot be calculated safely.

* **Tests**
  * Added coverage for missing and empty per-chat statistics scenarios to prevent future data exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->