### PR TITLE
fix(media): a failed sharding relocate no longer makes archived media unopenable

### DIFF
--- a/src/migrate_shared_media.py
+++ b/src/migrate_shared_media.py
@@ -8,6 +8,7 @@ pointed at the old flat location.
 Idempotent: files already in shard buckets are skipped.
 """
 
+import contextlib
 import hashlib
 import logging
 import os
@@ -111,18 +112,11 @@ def migrate_shared_media(media_path: str) -> int:
             # created bucket entry — and every failure state is retried or
             # healed by the duplicate branch above on the next start.
             _create_bucket_entry(shared_dir, src_path, dest_path, entry.is_symlink())
-            try:
-                _relink_chat_symlinks(media_path, shared_dir, entry.name, dest_path, chat_dirs)
-            except OSError:
-                # The relink rolled its own changes back; drop the bucket
-                # entry so the retry starts from the original state. If even
-                # that fails, the links that stayed repointed still resolve
-                # (the entry exists) and the next start heals the rest.
-                try:
-                    os.unlink(dest_path)
-                except OSError:
-                    pass
-                raise
+            # On a mid-sweep failure the relink rolls its repoints back and —
+            # only when every rollback landed — removes the bucket entry, so
+            # the retry starts from the original state. A link whose rollback
+            # failed stays aimed at the entry, which therefore must survive.
+            _relink_chat_symlinks(media_path, shared_dir, entry.name, dest_path, chat_dirs, unwind_path=dest_path)
             os.unlink(src_path)
             migrated += 1
         except OSError:
@@ -174,14 +168,20 @@ def _create_bucket_entry(shared_dir: str, src_path: str, dest_path: str, is_syml
 
 
 def _relink_chat_symlinks(
-    media_path: str, shared_dir: str, file_name: str, new_target: str, chat_dirs: list[str]
+    media_path: str,
+    shared_dir: str,
+    file_name: str,
+    new_target: str,
+    chat_dirs: list[str],
+    unwind_path: str | None = None,
 ) -> None:
     """Find and update chat-dir symlinks that pointed at the old flat shared path.
 
     All-or-nothing: on a mid-sweep failure every already-repointed link is put
     back before the error propagates, so the caller can retry from the exact
-    original state. A link whose restore also fails stays pointed at the new
-    target — which the caller created before this sweep, so it still resolves.
+    original state. ``unwind_path`` (the just-created bucket entry) is removed
+    only when EVERY rollback landed — a link whose rollback failed stays aimed
+    at that entry, so removing it would dangle the link for good.
     """
     old_rel_suffix = os.path.join("_shared", file_name)
     repointed: list[tuple[str, str]] = []
@@ -200,11 +200,15 @@ def _relink_chat_symlinks(
                 _swap_symlink(link_path, os.path.relpath(new_target, chat_dir))
                 repointed.append((link_path, target))
     except OSError:
+        rollback_complete = True
         for link_path, original_target in repointed:
             try:
                 _swap_symlink(link_path, original_target)
             except OSError:
-                continue
+                rollback_complete = False
+        if unwind_path is not None and rollback_complete:
+            with contextlib.suppress(OSError):
+                os.unlink(unwind_path)
         raise
 
 

--- a/src/migrate_shared_media.py
+++ b/src/migrate_shared_media.py
@@ -11,6 +11,8 @@ Idempotent: files already in shard buckets are skipped.
 import hashlib
 import logging
 import os
+import shutil
+import uuid
 
 logger = logging.getLogger(__name__)
 
@@ -89,8 +91,12 @@ def migrate_shared_media(media_path: str) -> int:
             dest_path = os.path.join(dest_dir, entry.name)
 
             if os.path.lexists(dest_path):
-                # Already exists in shard — remove flat duplicate
                 if os.path.isfile(dest_path):
+                    # Already exists in shard. Repoint any chat symlink still
+                    # aimed at the flat copy BEFORE removing it — this also
+                    # heals a previous run that created the bucket entry but
+                    # failed between the relink and the flat removal.
+                    _relink_chat_symlinks(media_path, shared_dir, entry.name, dest_path, chat_dirs)
                     os.remove(src_path)
                 else:
                     # Destination is not usable content (e.g. a dangling link);
@@ -98,11 +104,26 @@ def migrate_shared_media(media_path: str) -> int:
                     deferred += 1
                 continue
 
-            # Relink symlinks BEFORE moving: if crash occurs between relink and move,
-            # symlinks are dangling but file is still in flat_files on restart → full retry.
-            _relink_chat_symlinks(media_path, shared_dir, entry.name, dest_path, chat_dirs)
-
-            _relocate_into_bucket(shared_dir, src_path, dest_path, entry.is_symlink())
+            # Transactional relocate: create the bucket entry FIRST (the flat
+            # source stays valid), repoint the chat symlinks second, remove
+            # the flat source LAST. At every instant every chat symlink
+            # resolves — to the still-present flat entry or the already-
+            # created bucket entry — and every failure state is retried or
+            # healed by the duplicate branch above on the next start.
+            _create_bucket_entry(shared_dir, src_path, dest_path, entry.is_symlink())
+            try:
+                _relink_chat_symlinks(media_path, shared_dir, entry.name, dest_path, chat_dirs)
+            except OSError:
+                # The relink rolled its own changes back; drop the bucket
+                # entry so the retry starts from the original state. If even
+                # that fails, the links that stayed repointed still resolve
+                # (the entry exists) and the next start heals the rest.
+                try:
+                    os.unlink(dest_path)
+                except OSError:
+                    pass
+                raise
+            os.unlink(src_path)
             migrated += 1
         except OSError:
             # One bad file must not abort the migration, and must not propagate:
@@ -119,44 +140,88 @@ def migrate_shared_media(media_path: str) -> int:
     return migrated
 
 
-def _relocate_into_bucket(shared_dir: str, src_path: str, dest_path: str, is_symlink: bool) -> None:
-    """Move one flat _shared/ entry into its shard bucket.
+def _create_bucket_entry(shared_dir: str, src_path: str, dest_path: str, is_symlink: bool) -> None:
+    """Create the shard-bucket entry while the flat source stays valid.
 
-    A symlink cannot be moved verbatim: a RELATIVE target is resolved against the
-    link's own directory, so relocating the link one level deeper re-points it one
-    directory too high and it dangles for good. Recreate it with the target
-    rewritten against the bucket directory instead. Absolute targets move as-is.
+    A symlink cannot be copied verbatim: a RELATIVE target is resolved against
+    the link's own directory, so recreating the link one level deeper would
+    point it one directory too high and it dangles for good. Recreate it with
+    the target rewritten against the bucket directory; absolute targets carry
+    over as-is. A regular file is hardlinked (both names stay valid for free);
+    filesystems without hardlink support fall back to a temp-file copy that is
+    atomically renamed into place.
     """
     if is_symlink:
         target = os.readlink(src_path)
         if not os.path.isabs(target):
             target = os.path.relpath(os.path.join(shared_dir, target), os.path.dirname(dest_path))
         os.symlink(target, dest_path)
-        os.unlink(src_path)
         return
 
-    os.replace(src_path, dest_path)
+    try:
+        os.link(src_path, dest_path)
+    except OSError:
+        tmp_path = f"{dest_path}.{uuid.uuid4().hex}.part"
+        try:
+            shutil.copy2(src_path, tmp_path)
+            os.replace(tmp_path, dest_path)
+        except OSError:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
 
 
 def _relink_chat_symlinks(
     media_path: str, shared_dir: str, file_name: str, new_target: str, chat_dirs: list[str]
 ) -> None:
-    """Find and update chat-dir symlinks that pointed at the old flat shared path."""
+    """Find and update chat-dir symlinks that pointed at the old flat shared path.
+
+    All-or-nothing: on a mid-sweep failure every already-repointed link is put
+    back before the error propagates, so the caller can retry from the exact
+    original state. A link whose restore also fails stays pointed at the new
+    target — which the caller created before this sweep, so it still resolves.
+    """
     old_rel_suffix = os.path.join("_shared", file_name)
+    repointed: list[tuple[str, str]] = []
 
-    for chat_dir in chat_dirs:
-        link_path = os.path.join(chat_dir, file_name)
-        if not os.path.islink(link_path):
-            continue
+    try:
+        for chat_dir in chat_dirs:
+            link_path = os.path.join(chat_dir, file_name)
+            if not os.path.islink(link_path):
+                continue
 
-        target = os.readlink(link_path)
-        # Check if this symlink points to the old flat location
-        if target.endswith(old_rel_suffix) or (
-            os.path.basename(os.path.dirname(target)) == "_shared" and os.path.basename(target) == file_name
-        ):
-            new_rel = os.path.relpath(new_target, chat_dir)
-            os.unlink(link_path)
-            os.symlink(new_rel, link_path)
+            target = os.readlink(link_path)
+            # Check if this symlink points to the old flat location
+            if target.endswith(old_rel_suffix) or (
+                os.path.basename(os.path.dirname(target)) == "_shared" and os.path.basename(target) == file_name
+            ):
+                _swap_symlink(link_path, os.path.relpath(new_target, chat_dir))
+                repointed.append((link_path, target))
+    except OSError:
+        for link_path, original_target in repointed:
+            try:
+                _swap_symlink(link_path, original_target)
+            except OSError:
+                continue
+        raise
+
+
+def _swap_symlink(link_path: str, target: str) -> None:
+    """Repoint a symlink atomically: the link is never absent, not even
+    mid-swap — an unlink-then-create window would make a failure VANISH the
+    link instead of leaving it aimed somewhere real."""
+    tmp_link = f"{link_path}.{uuid.uuid4().hex}.relink"
+    os.symlink(target, tmp_link)
+    try:
+        os.replace(tmp_link, link_path)
+    except OSError:
+        try:
+            os.unlink(tmp_link)
+        except OSError:
+            pass
+        raise
 
 
 def _write_marker(marker_path: str) -> None:

--- a/src/migrate_shared_media.py
+++ b/src/migrate_shared_media.py
@@ -67,11 +67,22 @@ def migrate_shared_media(media_path: str) -> int:
 
     logger.info(f"Migrating {len(flat_files)} files from flat _shared/ to sharded layout...")
 
-    # Compute chat directories once (not per file)
+    # Compute chat directories once (not per file), sweeping any .relink
+    # temp left by a process kill mid-swap — at migration start no swap is in
+    # flight, so every such name is an orphan sitting in a user-visible
+    # folder.
     try:
         chat_dirs = [e.path for e in os.scandir(media_path) if e.is_dir() and not e.name.startswith("_")]
     except OSError:
         chat_dirs = []
+    for chat_dir in chat_dirs:
+        try:
+            for stale in os.scandir(chat_dir):
+                if stale.name.endswith(".relink"):
+                    with contextlib.suppress(OSError):
+                        os.unlink(stale.path)
+        except OSError:
+            continue
 
     migrated = 0
     deferred = 0
@@ -92,15 +103,19 @@ def migrate_shared_media(media_path: str) -> int:
             dest_path = os.path.join(dest_dir, entry.name)
 
             if os.path.lexists(dest_path):
-                if os.path.isfile(dest_path):
-                    # Already exists in shard. Repoint any chat symlink still
-                    # aimed at the flat copy BEFORE removing it — this also
-                    # heals a previous run that created the bucket entry but
-                    # failed between the relink and the flat removal.
+                if os.path.isfile(dest_path) and _compute_hash(dest_path) == content_hash:
+                    # Same content already in the shard. Repoint any chat
+                    # symlink still aimed at the flat copy BEFORE removing it —
+                    # this also heals a previous run that created the bucket
+                    # entry but failed between the relink and the flat removal.
+                    # The hash comparison is what makes the removal safe: a
+                    # DIFFERENT file can share the bucket and name (the bucket
+                    # is only two hash characters), and relinking to it would
+                    # silently swap the media's content.
                     _relink_chat_symlinks(media_path, shared_dir, entry.name, dest_path, chat_dirs)
                     os.remove(src_path)
                 else:
-                    # Destination is not usable content (e.g. a dangling link);
+                    # Dangling link, or a different file occupying the name —
                     # the flat copy stays, so this entry is still outstanding.
                     deferred += 1
                 continue

--- a/tests/test_media_symlink_integrity.py
+++ b/tests/test_media_symlink_integrity.py
@@ -246,14 +246,22 @@ class TestMigrationContainsFilesystemErrors(unittest.TestCase):
     def test_oserror_on_one_file_does_not_abort_the_others(self):
         good = self._create_file("good.jpg", "good data")
         bad = self._create_file("bad.jpg", "bad data")
-        real_replace = os.replace
+        real_link = os.link
 
-        def _replace(src, dst):
+        # The transactional relocate hardlinks first and falls back to a copy —
+        # fail BOTH for the bad file so the whole entry defers.
+        def _link(src, dst, **kwargs):
             if os.path.basename(src) == "bad.jpg":
                 raise PermissionError(13, "Permission denied")
-            return real_replace(src, dst)
+            return real_link(src, dst, **kwargs)
 
-        with patch("src.migrate_shared_media.os.replace", side_effect=_replace):
+        def _copy2(src, dst, **kwargs):
+            raise PermissionError(13, "Permission denied")
+
+        with (
+            patch("src.migrate_shared_media.os.link", side_effect=_link),
+            patch("shutil.copy2", side_effect=_copy2),
+        ):
             count = migrate_shared_media(self.media_path)
 
         assert count == 1
@@ -277,3 +285,143 @@ class TestMigrationContainsFilesystemErrors(unittest.TestCase):
         assert count == 0
         assert os.path.islink(link_path)
         assert not os.path.exists(self.marker), "unreadable entry was abandoned instead of retried"
+
+
+@unittest.skipIf(os.name == "nt", "Symlinks require administrator privileges on Windows")
+class TestTransactionalRelocate(unittest.TestCase):
+    """The relocate order is destination -> relink -> source removal.
+
+    The old order repointed the chat symlinks BEFORE creating the destination:
+    a relocation failure then left every link aimed at a path that was never
+    created — media silently inaccessible while the migration carried on and
+    the listener started. These tests inject failures between each step and
+    assert the one invariant that matters: every chat symlink resolves at
+    every observable moment, and the next start converges.
+    """
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.media_path = self.tmpdir
+        self.shared_dir = os.path.join(self.media_path, "_shared")
+        os.makedirs(self.shared_dir)
+        self.marker = os.path.join(self.shared_dir, SHARD_MARKER)
+
+    def tearDown(self):
+        shutil.rmtree(self.tmpdir)
+
+    def _flat_file(self, name, content):
+        path = os.path.join(self.shared_dir, name)
+        with open(path, "w") as f:
+            f.write(content)
+        return path
+
+    def _chat_link(self, chat, name, flat_path):
+        chat_dir = os.path.join(self.media_path, chat)
+        os.makedirs(chat_dir, exist_ok=True)
+        link_path = os.path.join(chat_dir, name)
+        os.symlink(os.path.relpath(flat_path, chat_dir), link_path)
+        return link_path
+
+    def _bucket_path(self, name, content):
+        return os.path.join(self.shared_dir, hashlib.sha256(content.encode()).hexdigest()[:2], name)
+
+    def test_relink_failure_rolls_back_and_every_link_still_resolves(self):
+        content = "txn data"
+        flat = self._flat_file("clip.mp4", content)
+        link_one = self._chat_link("-1001", "clip.mp4", flat)
+        link_two = self._chat_link("-1002", "clip.mp4", flat)
+
+        real_symlink = os.symlink
+        calls = {"n": 0}
+
+        # Fail exactly one repoint (the second chat's), then behave — so the
+        # rollback's own symlink calls succeed.
+        def _symlink(target, link, **kwargs):
+            if os.path.dirname(link) != self.shared_dir and not link.startswith(self.shared_dir):
+                calls["n"] += 1
+                if calls["n"] == 2:
+                    raise PermissionError(13, "Permission denied")
+            return real_symlink(target, link, **kwargs)
+
+        with patch("src.migrate_shared_media.os.symlink", side_effect=_symlink):
+            count = migrate_shared_media(self.media_path)
+
+        assert count == 0
+        # The invariant: both links resolve, at the original flat location.
+        assert os.path.exists(link_one) and os.path.exists(link_two)
+        assert os.path.isfile(flat), "the flat source must survive a failed relocate"
+        assert not os.path.lexists(self._bucket_path("clip.mp4", content)), "the bucket entry must be unwound"
+        assert not os.path.exists(self.marker)
+
+        # Next start, failure gone: converges fully.
+        count2 = migrate_shared_media(self.media_path)
+        assert count2 == 1
+        assert os.path.exists(link_one) and os.path.exists(link_two)
+        assert os.path.realpath(link_one) == os.path.realpath(self._bucket_path("clip.mp4", content))
+        assert os.path.exists(self.marker)
+
+    def test_source_removal_failure_leaves_links_on_the_live_bucket_entry(self):
+        content = "late failure"
+        flat = self._flat_file("voice.ogg", content)
+        link = self._chat_link("-1003", "voice.ogg", flat)
+
+        real_unlink = os.unlink
+
+        def _unlink(path, **kwargs):
+            if path == flat:
+                raise PermissionError(13, "Permission denied")
+            return real_unlink(path, **kwargs)
+
+        with patch("src.migrate_shared_media.os.unlink", side_effect=_unlink):
+            count = migrate_shared_media(self.media_path)
+
+        # The entry deferred, but the link already resolves on the bucket copy.
+        assert count == 0
+        assert os.path.exists(link)
+        assert os.path.realpath(link) == os.path.realpath(self._bucket_path("voice.ogg", content))
+        assert os.path.isfile(flat)
+        assert not os.path.exists(self.marker)
+
+        # Next start: the duplicate branch sweeps the flat leftover and seals.
+        count2 = migrate_shared_media(self.media_path)
+        assert count2 == 0
+        assert not os.path.lexists(flat)
+        assert os.path.exists(link)
+        assert os.path.exists(self.marker)
+
+    def test_duplicate_branch_heals_links_left_on_the_flat_copy(self):
+        """The poison state a crashed or partially-failed run can leave: the
+        bucket entry exists, the flat copy exists, and a chat link still aims
+        at the flat copy. Removing the flat copy without repointing first
+        (the old behaviour) dangled that link for good."""
+        content = "poison state"
+        flat = self._flat_file("doc.pdf", content)
+        link = self._chat_link("-1004", "doc.pdf", flat)
+        bucket = self._bucket_path("doc.pdf", content)
+        os.makedirs(os.path.dirname(bucket), exist_ok=True)
+        shutil.copy2(flat, bucket)
+
+        count = migrate_shared_media(self.media_path)
+
+        assert count == 0
+        assert not os.path.lexists(flat)
+        assert os.path.exists(link), "the healed link must resolve"
+        assert os.path.realpath(link) == os.path.realpath(bucket)
+        assert os.path.exists(self.marker)
+
+    def test_hardlink_unsupported_falls_back_to_copy(self):
+        content = "no hardlinks here"
+        flat = self._flat_file("photo.jpg", content)
+        link = self._chat_link("-1005", "photo.jpg", flat)
+
+        def _link(src, dst, **kwargs):
+            raise OSError(1, "Operation not permitted")
+
+        with patch("src.migrate_shared_media.os.link", side_effect=_link):
+            count = migrate_shared_media(self.media_path)
+
+        assert count == 1
+        assert os.path.exists(link)
+        assert os.path.realpath(link) == os.path.realpath(self._bucket_path("photo.jpg", content))
+        assert not os.path.lexists(flat)
+        assert os.path.exists(self.marker)

--- a/tests/test_media_symlink_integrity.py
+++ b/tests/test_media_symlink_integrity.py
@@ -455,8 +455,10 @@ class TestTransactionalRelocate(unittest.TestCase):
         assert os.path.isfile(flat)
         assert not os.path.exists(self.marker)
 
-        # Next start converges completely.
+        # Next start converges completely — via the duplicate/heal branch,
+        # which must never double-count as a migration.
         count2 = migrate_shared_media(self.media_path)
+        assert count2 == 0, "the duplicate branch heals; it does not re-migrate"
         bucket = self._bucket_path("song.mp3", content)
         assert os.path.exists(link_one) and os.path.exists(link_two)
         assert os.path.realpath(link_one) == os.path.realpath(bucket)
@@ -519,3 +521,36 @@ class TestTransactionalRelocate(unittest.TestCase):
         assert os.path.exists(link)
         assert os.path.isfile(flat), "the flat copy must survive an unusable destination"
         assert not os.path.exists(self.marker)
+
+    def test_different_content_at_the_bucket_name_is_never_adopted(self):
+        """Two different files CAN share the bucket and filename (the bucket is
+        only two hash characters) — relinking to the impostor and deleting the
+        flat original would silently swap the media's content."""
+        content = "the real bytes"
+        flat = self._flat_file("track.mp3", content)
+        link = self._chat_link("-2006", "track.mp3", flat)
+        bucket = self._bucket_path("track.mp3", content)
+        os.makedirs(os.path.dirname(bucket), exist_ok=True)
+        with open(bucket, "w") as handle:
+            handle.write("an impostor with the same name")
+
+        count = migrate_shared_media(self.media_path)
+
+        assert count == 0
+        assert os.path.isfile(flat), "the original must survive"
+        assert os.path.exists(link)
+        assert os.path.realpath(link) == os.path.realpath(flat), "the link must NOT be swapped to the impostor"
+        assert not os.path.exists(self.marker)
+
+    def test_orphaned_relink_temp_is_swept_at_start(self):
+        content = "sweep me"
+        flat = self._flat_file("note.ogg", content)
+        link = self._chat_link("-2007", "note.ogg", flat)
+        chat_dir = os.path.dirname(link)
+        orphan = os.path.join(chat_dir, "note.ogg.deadbeef.relink")
+        os.symlink("nowhere", orphan)
+
+        migrate_shared_media(self.media_path)
+
+        assert not os.path.lexists(orphan), "the kill-window orphan must be swept"
+        assert os.path.exists(link)

--- a/tests/test_media_symlink_integrity.py
+++ b/tests/test_media_symlink_integrity.py
@@ -425,3 +425,97 @@ class TestTransactionalRelocate(unittest.TestCase):
         assert os.path.realpath(link) == os.path.realpath(self._bucket_path("photo.jpg", content))
         assert not os.path.lexists(flat)
         assert os.path.exists(self.marker)
+
+    def test_partial_rollback_keeps_the_bucket_entry_alive(self):
+        """If a rollback swap ALSO fails, the repointed link stays aimed at the
+        bucket entry — so the entry must survive the unwind, or that link
+        dangles for good. Convergence still happens next start via the
+        duplicate branch."""
+        content = "partial rollback"
+        flat = self._flat_file("song.mp3", content)
+        link_one = self._chat_link("-2001", "song.mp3", flat)
+        link_two = self._chat_link("-2002", "song.mp3", flat)
+
+        real_symlink = os.symlink
+        calls = {"n": 0}
+
+        def _symlink(target, link, **kwargs):
+            if not link.startswith(self.shared_dir):
+                calls["n"] += 1
+                if calls["n"] >= 2:
+                    raise PermissionError(13, "Permission denied")
+            return real_symlink(target, link, **kwargs)
+
+        with patch("src.migrate_shared_media.os.symlink", side_effect=_symlink):
+            count = migrate_shared_media(self.media_path)
+
+        assert count == 0
+        # Every link resolves, whatever it points at.
+        assert os.path.exists(link_one) and os.path.exists(link_two)
+        assert os.path.isfile(flat)
+        assert not os.path.exists(self.marker)
+
+        # Next start converges completely.
+        count2 = migrate_shared_media(self.media_path)
+        bucket = self._bucket_path("song.mp3", content)
+        assert os.path.exists(link_one) and os.path.exists(link_two)
+        assert os.path.realpath(link_one) == os.path.realpath(bucket)
+        assert os.path.realpath(link_two) == os.path.realpath(bucket)
+        assert not os.path.lexists(flat)
+        assert os.path.exists(self.marker)
+
+    def test_swap_failure_cleans_its_temp_link(self):
+        content = "swap cleanup"
+        flat = self._flat_file("pic.png", content)
+        link = self._chat_link("-2003", "pic.png", flat)
+        chat_dir = os.path.dirname(link)
+
+        real_replace = os.replace
+
+        def _replace(src, dst, **kwargs):
+            if ".relink" in src:
+                raise PermissionError(13, "Permission denied")
+            return real_replace(src, dst, **kwargs)
+
+        with patch("src.migrate_shared_media.os.replace", side_effect=_replace):
+            count = migrate_shared_media(self.media_path)
+
+        assert count == 0
+        assert os.path.exists(link), "the original link must be untouched"
+        assert os.path.realpath(link) == os.path.realpath(flat)
+        assert not [name for name in os.listdir(chat_dir) if ".relink" in name], "temp link left behind"
+        assert not os.path.exists(self.marker)
+
+    def test_copy_fallback_failure_defers_cleanly(self):
+        content = "no copy either"
+        flat = self._flat_file("doc2.pdf", content)
+        link = self._chat_link("-2004", "doc2.pdf", flat)
+
+        with (
+            patch("src.migrate_shared_media.os.link", side_effect=OSError(1, "no hardlinks")),
+            patch("src.migrate_shared_media.shutil.copy2", side_effect=OSError(28, "disk full")),
+        ):
+            count = migrate_shared_media(self.media_path)
+
+        assert count == 0
+        assert os.path.exists(link)
+        assert os.path.isfile(flat)
+        bucket_dir = os.path.dirname(self._bucket_path("doc2.pdf", content))
+        leftovers = [name for name in os.listdir(bucket_dir)] if os.path.isdir(bucket_dir) else []
+        assert not [name for name in leftovers if name.endswith(".part")], "temp copy left behind"
+        assert not os.path.exists(self.marker)
+
+    def test_dangling_bucket_destination_defers(self):
+        content = "dest is a dead link"
+        flat = self._flat_file("clip2.mp4", content)
+        link = self._chat_link("-2005", "clip2.mp4", flat)
+        bucket = self._bucket_path("clip2.mp4", content)
+        os.makedirs(os.path.dirname(bucket), exist_ok=True)
+        os.symlink(os.path.join(os.path.dirname(bucket), "nowhere"), bucket)  # lexists, not usable
+
+        count = migrate_shared_media(self.media_path)
+
+        assert count == 0
+        assert os.path.exists(link)
+        assert os.path.isfile(flat), "the flat copy must survive an unusable destination"
+        assert not os.path.exists(self.marker)


### PR DESCRIPTION
## Problem

The flat-to-sharded migration repointed every chat symlink BEFORE creating the destination (`_relink_chat_symlinks` ran before `_relocate_into_bucket`). If the relocation then failed, the flat source still existed but every chat link already aimed at a path that was never created — those media silently unopenable, while the migration carried on and the listener started. (Flagged in the review of #286 and deliberately scoped out there.)

## Fix

The relocate is transactional, ordered so that **every chat symlink resolves at every instant**:

1. The bucket entry is created FIRST — a hardlink, so the flat source stays valid for free (a filesystem that refuses hardlinks, e.g. some FUSE mounts, gets a temp-file copy renamed into place).
2. Chat symlinks are repointed SECOND, each via an atomic temp-name `os.replace` swap — a link is never absent, not even mid-swap (an unlink-then-create window would make a failure VANISH a link; the test suite caught exactly that in an earlier draft of this fix, since scandir order is arbitrary).
3. The flat source is removed LAST; a failure there leaves both copies valid and the duplicate branch sweeps it next start.

A mid-sweep relink failure rolls its own repoints back and unwinds the bucket entry; the duplicate branch now repoints before it sweeps, so the one poison state a crash can leave (bucket entry + links still flat) heals on the next start instead of dangling forever.

## Evidence

- Four failure-injection tests, each asserting the resolve-always invariant: mid-relink failure (rollback, then clean convergence next run), source-removal failure (links live on the bucket entry, swept next run), the poison state (healed), and hardlink-unsupported (copy fallback).
- Three mutation controls green-then-red: no-rollback, no-healer, no-unwind each fail their test. Restores sha-verified.
- The existing one-bad-file containment test re-targeted at the new write path (its old `os.replace` injection no longer fires for regular files).
- Full suite: 3419 passed, 127 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.5.79.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media migration reliability by preventing dangling links and preserving files when relocation fails.
  * Added safe recovery and retry behavior for partial failures, duplicate media, and unavailable destinations.
  * Improved handling of file transfers when hardlinks are unsupported.
  * Ensured temporary files and links are cleaned up after unsuccessful operations.

* **Tests**
  * Expanded coverage for transactional relocation, rollback behavior, duplicate recovery, and transfer fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->