### PR TITLE
fix(realtime): viewer shutdown no longer hangs into SIGKILL on a dead database socket

### DIFF
--- a/src/realtime.py
+++ b/src/realtime.py
@@ -21,6 +21,10 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
+# Teardown bound for the LISTEN connection: close() on a dead TCP socket waits
+# for the server's ack until the OS timeout, and stop() awaits the listen task.
+_TEARDOWN_TIMEOUT_SECONDS = 5.0
+
 
 def _json_serializer(obj):
     """Custom JSON serializer for datetime objects."""
@@ -287,19 +291,30 @@ class RealtimeListener:
                     await asyncio.sleep(1)
 
             except asyncio.CancelledError:
-                break
+                # Re-raise so the task actually ends CANCELLED: swallowing it
+                # made stop()'s await return as a normal exit and would leave
+                # a future asyncio.timeout/TaskGroup wrapper blind to its own
+                # cancellation.
+                raise
             except Exception as e:
                 logger.error(f"PostgreSQL LISTEN error: {e}")
                 await asyncio.sleep(5)  # Retry after 5 seconds
             finally:
                 # Always tear down the connection, even when CancelledError or
                 # another exception interrupts the "keep connection alive" loop --
-                # otherwise a flapping DB leaks one connection per retry.
+                # otherwise a flapping DB leaks one connection per retry. The
+                # teardown is BOUNDED: on a wedged connection — the very case
+                # the retry loop exists for — an unbounded close() blocks until
+                # the OS gives up the socket, and stop() awaits this task, so
+                # viewer shutdown would hang past its grace period into SIGKILL.
                 if conn is not None:
                     with contextlib.suppress(Exception):
-                        await conn.remove_listener("telegram_updates", self._pg_callback)
+                        await asyncio.wait_for(
+                            conn.remove_listener("telegram_updates", self._pg_callback),
+                            timeout=_TEARDOWN_TIMEOUT_SECONDS,
+                        )
                     with contextlib.suppress(Exception):
-                        await conn.close()
+                        await asyncio.wait_for(conn.close(), timeout=_TEARDOWN_TIMEOUT_SECONDS)
 
     def _pg_callback(self, connection, pid, channel, payload):
         """Handle PostgreSQL notification."""

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -10,6 +10,8 @@ import unittest
 from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from src.realtime import (
     NotificationType,
     RealtimeListener,
@@ -955,8 +957,10 @@ class TestListenPostgres:
         mock_conn.remove_listener.assert_awaited_once()
         mock_conn.close.assert_awaited_once()
 
-    async def test_listen_postgres_handles_cancelled_error(self):
-        """_listen_postgres breaks on CancelledError (lines 238-239)."""
+    async def test_listen_postgres_propagates_cancelled_error(self):
+        """CancelledError must escape, never turn into a normal exit — a task
+        that swallows it reads as cleanly finished to stop() and to any future
+        asyncio.timeout/TaskGroup wrapper (see TestListenPostgresShutdownDiscipline)."""
         mock_db = MagicMock()
         mock_db._is_sqlite = False
         mock_db.database_url = "postgresql+asyncpg://user:pass@localhost/db"
@@ -968,7 +972,7 @@ class TestListenPostgres:
         mock_asyncpg = MagicMock()
         mock_asyncpg.connect = AsyncMock(side_effect=asyncio.CancelledError)
 
-        with patch.dict("sys.modules", {"asyncpg": mock_asyncpg}):
+        with patch.dict("sys.modules", {"asyncpg": mock_asyncpg}), pytest.raises(asyncio.CancelledError):
             await listener._listen_postgres()
 
 
@@ -996,3 +1000,74 @@ class TestNotifierAccountIdPayload:
             await notifier.notify(NotificationType.PIN, 789, {"msg_id": 5})
 
         assert mock_http.call_args[0][0]["account_id"] is None
+
+
+class TestListenPostgresShutdownDiscipline:
+    """stop() must terminate promptly and honestly even on a wedged connection.
+
+    The old loop caught CancelledError and ``break``-ed — the task finished
+    NORMALLY instead of cancelled — and its finally awaited remove_listener()
+    and close() unbounded, so a dead TCP socket hung viewer shutdown past its
+    grace period into SIGKILL.
+    """
+
+    def _listener(self):
+        mock_db = MagicMock()
+        mock_db._is_sqlite = False
+        mock_db.database_url = "postgresql+asyncpg://user:pass@localhost/db"
+        listener = RealtimeListener(db_manager=mock_db, callback=AsyncMock())
+        listener._is_postgresql = True
+        listener._running = True
+        return listener
+
+    async def test_cancellation_is_reraised_not_swallowed(self):
+        listener = self._listener()
+        mock_conn = AsyncMock()
+        mock_asyncpg = MagicMock()
+        mock_asyncpg.connect = AsyncMock(return_value=mock_conn)
+
+        with patch.dict("sys.modules", {"asyncpg": mock_asyncpg}):
+            task = asyncio.create_task(listener._listen_postgres())
+            # Let it connect and enter the keepalive sleep.
+            for _ in range(10):
+                await asyncio.sleep(0)
+                if mock_conn.add_listener.await_count:
+                    break
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert task.cancelled(), "the listen task must end CANCELLED, not as a normal exit"
+        mock_conn.close.assert_awaited_once()
+
+    async def test_stop_completes_when_close_hangs(self):
+        listener = self._listener()
+
+        async def hang(*args, **kwargs):
+            await asyncio.Event().wait()
+
+        mock_conn = AsyncMock()
+        mock_conn.remove_listener = AsyncMock(side_effect=hang)
+        mock_conn.close = AsyncMock(side_effect=hang)
+        mock_asyncpg = MagicMock()
+        mock_asyncpg.connect = AsyncMock(return_value=mock_conn)
+
+        with (
+            patch.dict("sys.modules", {"asyncpg": mock_asyncpg}),
+            patch("src.realtime._TEARDOWN_TIMEOUT_SECONDS", 0.05),
+        ):
+            listener._task = asyncio.create_task(listener._listen_postgres())
+            for _ in range(10):
+                await asyncio.sleep(0)
+                if mock_conn.add_listener.await_count:
+                    break
+            # A wedged socket must not hang shutdown: 2s is the tripwire, the
+            # bounded teardown finishes in ~0.1s. asyncio.wait — NOT wait_for —
+            # because wait_for cancels stop() on timeout, stop()'s own
+            # CancelledError guard swallows that cancel, and wait_for then
+            # returns "success": a tripwire that cannot fire.
+            stop_task = asyncio.ensure_future(listener.stop())
+            done, pending = await asyncio.wait([stop_task], timeout=2)
+            assert stop_task in done, "stop() hung on the wedged connection"
+            for task in pending:
+                task.cancel()

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -1069,5 +1069,10 @@ class TestListenPostgresShutdownDiscipline:
             stop_task = asyncio.ensure_future(listener.stop())
             done, pending = await asyncio.wait([stop_task], timeout=2)
             assert stop_task in done, "stop() hung on the wedged connection"
+            # Retrieve stop()'s outcome and pin the teardown contract: both
+            # calls must have been attempted (bounded), not skipped outright.
+            await stop_task
+            mock_conn.remove_listener.assert_awaited_once()
+            mock_conn.close.assert_awaited_once()
             for task in pending:
                 task.cancel()


### PR DESCRIPTION
## Problem

`_listen_postgres` caught `CancelledError` and `break`-ed — the listen task ended as a NORMAL exit, invisible as a cancellation to `stop()` and to any future `asyncio.timeout`/`TaskGroup` wrapper. Its `finally` then awaited `remove_listener()` and `close()` with no bound: on a dead TCP socket asyncpg's `close()` waits for the server's termination ack until the OS gives up — exactly the wedged-connection case the retry loop exists for — so `stop()`'s `await self._task` blocked, viewer shutdown overran its grace period, and the container got SIGKILLed.

## Fix

- `CancelledError` re-raises, so the task genuinely ends cancelled.
- Both teardown awaits are bounded by `asyncio.wait_for` (5s module constant), errors still suppressed — a flapping database costs at most ten bounded seconds, never a hang.

## Evidence

- New tests: cancellation propagates (`task.cancelled()` is True, teardown still ran) and `stop()` completes under a 2s tripwire while both teardown calls hang forever. The tripwire uses `asyncio.wait`, NOT `wait_for` — `wait_for` cancels `stop()` on timeout, `stop()`'s own CancelledError guard swallows that cancel, and `wait_for` then reports success: a tripwire that cannot fire (caught while proving the mutant red).
- The old test that PINNED the swallow is repointed to expect propagation.
- Mutation controls green-then-red: restoring the swallow fails two tests; unbounding `close()` fails the hang test. Restores sha-verified.
- Full suite: 3417 passed, 127 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.5.30.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostgreSQL listener shutdown reliability.
  * Cancellations now propagate correctly instead of being silently ignored.
  * Listener cleanup and connection closing no longer hang indefinitely.
  * Added a five-second timeout to ensure shutdown completes even when cleanup operations stall.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->