### PR TITLE
fix(backup): sync can no longer overwrite one message's text with another's

### DIFF
--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -2395,9 +2395,36 @@ class TelegramBackup:
                 # Fetch current state from Telegram
                 remote_messages = await call_with_flood_retry(self.client.get_messages, entity, ids=batch_ids)
 
-                for msg_id, remote_msg in zip(batch_ids, remote_messages):
+                # Telethon buffers one entry per RETURNED message, and its own
+                # comment warns Telegram "may decide to not send" invalid ids at
+                # all on the non-channel path — one omission shifts every later
+                # position, and a positional zip would overwrite message A's
+                # text with message B's or hard-delete a live message. Trust
+                # positions only when the response provably lines up; otherwise
+                # key by id and treat unmatched ids as unknown — a destructive
+                # write never rides an ambiguous signal.
+                aligned = len(remote_messages) == len(batch_ids) and all(
+                    remote_msg is None or remote_msg.id == msg_id
+                    for msg_id, remote_msg in zip(batch_ids, remote_messages)
+                )
+                if aligned:
+                    pairs = list(zip(batch_ids, remote_messages))
+                else:
+                    remote_by_id = {m.id: m for m in remote_messages if m is not None}
+                    pairs = [(msg_id, remote_by_id.get(msg_id)) for msg_id in batch_ids]
+                    unmatched = len(batch_ids) - sum(1 for _, m in pairs if m is not None)
+                    logger.warning(
+                        f"  → Sync response misaligned for a batch ({unmatched} of {len(batch_ids)} ids "
+                        "unmatched) — treating the unmatched ids as unknown this run, no deletions for them"
+                    )
+
+                for msg_id, remote_msg in pairs:
                     # Check for deletion
                     if remote_msg is None:
+                        if not aligned:
+                            # Ambiguous: the id was omitted from a misaligned
+                            # response, not confirmed deleted. Retry next run.
+                            continue
                         if getattr(self.config, "deletion_mode", "hard") == "soft":
                             # mark_message_deleted defaults deleted_at to now(UTC); this path
                             # doesn't broadcast, so no need to pass an explicit timestamp.

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -1053,6 +1053,7 @@ class TestSyncDeletionsAndEdits(unittest.TestCase):
         """Remote message with different edit_date triggers update."""
         self.backup.db.get_messages_sync_data = AsyncMock(return_value={1: datetime(2024, 1, 1)})
         remote_msg = MagicMock()
+        remote_msg.id = 1
         remote_msg.edit_date = datetime(2024, 6, 15)
         remote_msg.message = "updated text"
         self.backup.client.get_messages = AsyncMock(return_value=[remote_msg])
@@ -1070,6 +1071,7 @@ class TestSyncDeletionsAndEdits(unittest.TestCase):
         """
         self.backup.db.get_messages_sync_data = AsyncMock(return_value={1: datetime(2024, 6, 15, 12, 0)})
         remote_msg = MagicMock()
+        remote_msg.id = 1
         remote_msg.edit_date = datetime(2024, 6, 15, 12, 0, tzinfo=UTC)
         remote_msg.message = "same text"
         self.backup.client.get_messages = AsyncMock(return_value=[remote_msg])
@@ -1083,6 +1085,7 @@ class TestSyncDeletionsAndEdits(unittest.TestCase):
         """Message with no edit_date does not trigger update."""
         self.backup.db.get_messages_sync_data = AsyncMock(return_value={1: None})
         remote_msg = MagicMock()
+        remote_msg.id = 1
         remote_msg.edit_date = None
         self.backup.client.get_messages = AsyncMock(return_value=[remote_msg])
         entity = MagicMock()
@@ -1098,6 +1101,57 @@ class TestSyncDeletionsAndEdits(unittest.TestCase):
         entity = MagicMock()
 
         _run(self.backup._sync_deletions_and_edits(100, entity))
+
+    def _remote(self, message_id, edit_date=None, text=""):
+        msg = MagicMock()
+        msg.id = message_id
+        msg.edit_date = edit_date
+        msg.message = text
+        msg.reactions = None
+        return msg
+
+    def test_omitted_id_never_shifts_pairs_or_deletes(self):
+        """Telethon buffers one entry per RETURNED message and Telegram may
+        omit invalid ids entirely (non-channel path) — the old positional zip
+        then overwrote message 2's archived text with message 3's and treated
+        the tail as untouched. An omission must delete NOTHING and every
+        surviving pair must be keyed by id."""
+        self.backup.db.get_messages_sync_data = AsyncMock(
+            return_value={1: datetime(2024, 1, 1), 2: datetime(2024, 1, 1), 3: datetime(2024, 1, 1)}
+        )
+        # id 2 omitted from the response entirely; 3 arrives edited.
+        response = [self._remote(1), self._remote(3, edit_date=datetime(2024, 6, 15), text="three edited")]
+        self.backup.client.get_messages = AsyncMock(return_value=response)
+        entity = MagicMock()
+
+        with self.assertLogs("src.telegram_backup", level="WARNING") as captured:
+            _run(self.backup._sync_deletions_and_edits(100, entity))
+
+        self.backup.db.delete_message.assert_not_awaited()
+        self.backup.db.mark_message_deleted.assert_not_awaited()
+        self.backup.db.update_message_text.assert_awaited_once_with(
+            100, 3, "three edited", datetime(2024, 6, 15), account_id=1
+        )
+        assert any("misaligned" in line for line in captured.output)
+
+    def test_scrambled_full_length_response_pairs_by_id(self):
+        """Same length, order not preserved: the id check must reject the
+        positional pairing and every edit must land on its own id."""
+        self.backup.db.get_messages_sync_data = AsyncMock(
+            return_value={1: datetime(2024, 1, 1), 2: datetime(2024, 1, 1)}
+        )
+        response = [
+            self._remote(2, edit_date=datetime(2024, 6, 1), text="two edited"),
+            self._remote(1, edit_date=datetime(2024, 6, 2), text="one edited"),
+        ]
+        self.backup.client.get_messages = AsyncMock(return_value=response)
+        entity = MagicMock()
+
+        _run(self.backup._sync_deletions_and_edits(100, entity))
+
+        self.backup.db.delete_message.assert_not_awaited()
+        calls = {call.args[1]: call.args[2] for call in self.backup.db.update_message_text.await_args_list}
+        assert calls == {1: "one edited", 2: "two edited"}
 
 
 # ===========================================================================


### PR DESCRIPTION
## Problem

`_sync_deletions_and_edits` paired its `get_messages(ids=batch)` response with `zip(batch_ids, remote_messages)`. Telethon's `_IDsIter` buffers **one entry per RETURNED message**, and its own source comments that Telegram "may decide to not send" invalid ids at all on the non-channel path (users and basic groups; channels pad with `MessageEmpty`). One omission shifts every later position: message A's archived text gets overwritten with message B's, and a `None` landing on a shifted slot hard-deletes a message that still exists on Telegram (DELETION_MODE defaults to hard — row, media and reactions). Entirely silent: the run reports ordinary sync counts, and B905 (zip-without-strict) is explicitly ignored for this file.

## Fix

Positions are trusted only when the response **provably lines up** — same length AND every non-None entry's id matches its slot (the length check alone would still trust a reordered response). Otherwise the batch is keyed by id: matched messages process edits and reactions normally, and unmatched ids are treated as unknown for this run — logged as a count-only warning and retried next pass. A destructive write never rides an ambiguous signal.

## Evidence

- Verified against the installed Telethon's `_IDsIter._load_next_chunk` — the per-returned-message buffering and the omission warning are exactly as described.
- New regressions: an omitted mid-batch id deletes NOTHING and the surviving edit lands on its own id (the old zip overwrote the wrong row); a full-length but reordered response pairs by id. Mutation control forcing the old positional zip fails both; restore sha-verified.
- Existing mocks now carry real ids (a MagicMock id would silently divert them down the id-keyed path).
- Full suite: 3417 passed, 127 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.5.41.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization when Telegram returns messages in a different order than requested.
  * Prevented incorrectly deleting or overwriting messages when remote responses omit or reorder items.
  * Ensured unknown or missing message IDs are excluded from deletion processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->