### PR TITLE
fix(listener): renaming a supergroup no longer files it as a broadcast channel

### DIFF
--- a/src/listener.py
+++ b/src/listener.py
@@ -1435,7 +1435,12 @@ class TelegramListener:
                         if entity:
                             chat_data = {
                                 "id": chat_id,
-                                "type": "channel" if hasattr(entity, "broadcast") else "group",
+                                # _get_chat_type, not hasattr(entity, "broadcast"):
+                                # Telethon's Channel always CARRIES broadcast (False
+                                # on a megagroup), so the hasattr test relabelled
+                                # every supergroup as a broadcast channel and folder
+                                # sync then filed it under the wrong folder flag.
+                                "type": self._get_chat_type(entity),
                                 "title": getattr(entity, "title", None),
                                 "username": getattr(entity, "username", None),
                             }

--- a/tests/test_listener_chat_actions.py
+++ b/tests/test_listener_chat_actions.py
@@ -470,3 +470,43 @@ class TestServiceMessageText:
             pass
 
         assert service_message_text(MessageActionSomethingExotic(), actor_name="Zed") is None
+
+
+class TestMetadataRefreshChatType:
+    """The metadata refresh must classify like the scheduled sweep does.
+
+    Telethon's Channel type always CARRIES a ``broadcast`` attribute — it is
+    False on a megagroup, not absent — so the old ``hasattr(entity,
+    'broadcast')`` test relabelled every supergroup as a broadcast channel on
+    any title or photo change, and folder sync then filed it under the wrong
+    folder flag until (unless) the next full sweep visited the dialog.
+    """
+
+    def _title_event(self):
+        return _event(
+            _service_msg(MessageActionChatEditTitle(title="Renamed")),
+            new_title="Renamed",
+            user_id=ACTOR_ID,
+        )
+
+    async def test_supergroup_stays_group_on_metadata_refresh(self):
+        from telethon.tl.types import Channel as TelethonChannel
+
+        listener, handler, db = _build()
+        supergroup = TelethonChannel(id=123, title="SG", photo=None, date=None, megagroup=True, broadcast=False)
+        listener.client.get_entity = AsyncMock(return_value=supergroup)
+
+        await handler(self._title_event())
+
+        assert db.upsert_chat.call_args[0][0]["type"] == "group"
+
+    async def test_broadcast_channel_stays_channel_on_metadata_refresh(self):
+        from telethon.tl.types import Channel as TelethonChannel
+
+        listener, handler, db = _build()
+        broadcast = TelethonChannel(id=124, title="BC", photo=None, date=None, megagroup=False, broadcast=True)
+        listener.client.get_entity = AsyncMock(return_value=broadcast)
+
+        await handler(self._title_event())
+
+        assert db.upsert_chat.call_args[0][0]["type"] == "channel"


### PR DESCRIPTION
## Problem

Any title or photo change makes the listener refresh the chat's metadata — and it classified the entity with `hasattr(entity, 'broadcast')`. Telethon's `Channel` type always CARRIES that attribute (it is `False` on a megagroup, not absent), so every supergroup was written back as `type='channel'`. Folder membership resolves from the stored type, so on the next folder sync the supergroup matched the folder's `broadcasts` flag instead of `groups` and moved into the wrong folders in the viewer. The next full sweep of the dialog repairs the row — but the damage is permanent for any chat the sweep no longer visits (left group, narrowed CHAT_IDS).

## Fix

The refresh calls the class's own `_get_chat_type` — the same vocabulary the scheduled sweep enforces (`'channel' if not entity.megagroup else 'group'`, Users → private, small chats → group).

## Evidence

- Regressions drive the real handler with REAL Telethon `Channel` entities: a megagroup title change stores `group`, a broadcast channel stores `channel`. Under the reverted `hasattr` classifier the supergroup test goes red (and the broadcast one rightly stays green). Restore sha-verified.
- Full suite: 3417 passed, 127 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.5.49.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Chat metadata now correctly distinguishes Telegram supergroups from broadcast channels.
  - Supergroups are classified as “group,” while broadcast channels are classified as “channel” after chat updates.

- **Tests**
  - Added coverage for metadata refreshes triggered by title changes.
  - Documented and verified the distinction between megagroup and broadcast chat types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->