### PR TITLE
fix(backup): a forward from a channel finally stores an id the user can look up

### DIFF
--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -2798,15 +2798,15 @@ class TelegramBackup:
 
         peer = message.fwd_from.from_id
 
-        # Handle different Peer types
-        if hasattr(peer, "user_id"):
-            return peer.user_id
-        if hasattr(peer, "channel_id"):
-            return peer.channel_id
-        if hasattr(peer, "chat_id"):
-            return peer.chat_id
-
-        return None
+        # Store the MARKED id (user_id, -chat_id, -100<channel_id>) — the
+        # convention every other persisted id in this project follows and the
+        # id the user can actually look up. Returning the raw channel/chat id
+        # dropped it into the user-id numeric space, indistinguishable from a
+        # user forward and matching nothing the user knows.
+        try:
+            return get_peer_id(peer)
+        except TypeError:
+            return None
 
     def _text_with_entities_to_string(self, text_obj) -> str:
         """

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -1177,31 +1177,33 @@ class TestExtractForwardFromId(unittest.TestCase):
         self.assertIsNone(self.backup._extract_forward_from_id(msg))
 
     def test_returns_user_id_from_peer_user(self):
-        """Returns user_id when forward peer is a PeerUser."""
+        """A user forward stores the user id — already the marked form."""
+        from telethon.tl.types import PeerUser
+
         msg = MagicMock()
         msg.fwd_from = MagicMock()
-        peer = MagicMock(spec=["user_id"])
-        peer.user_id = 12345
-        msg.fwd_from.from_id = peer
+        msg.fwd_from.from_id = PeerUser(user_id=12345)
         self.assertEqual(self.backup._extract_forward_from_id(msg), 12345)
 
-    def test_returns_channel_id_from_peer_channel(self):
-        """Returns channel_id when forward peer is a PeerChannel."""
-        msg = MagicMock()
-        msg.fwd_from = MagicMock()
-        peer = MagicMock(spec=["channel_id"])
-        peer.channel_id = 99999
-        msg.fwd_from.from_id = peer
-        self.assertEqual(self.backup._extract_forward_from_id(msg), 99999)
+    def test_returns_marked_id_from_peer_channel(self):
+        """A channel forward stores the MARKED -100... id, the convention
+        every other persisted id follows — the raw channel_id landed in the
+        user-id numeric space and matched nothing the user can look up."""
+        from telethon.tl.types import PeerChannel
 
-    def test_returns_chat_id_from_peer_chat(self):
-        """Returns chat_id when forward peer is a PeerChat."""
         msg = MagicMock()
         msg.fwd_from = MagicMock()
-        peer = MagicMock(spec=["chat_id"])
-        peer.chat_id = 77777
-        msg.fwd_from.from_id = peer
-        self.assertEqual(self.backup._extract_forward_from_id(msg), 77777)
+        msg.fwd_from.from_id = PeerChannel(channel_id=99999)
+        self.assertEqual(self.backup._extract_forward_from_id(msg), -1000000099999)
+
+    def test_returns_marked_id_from_peer_chat(self):
+        """A basic-group forward stores the marked negative chat id."""
+        from telethon.tl.types import PeerChat
+
+        msg = MagicMock()
+        msg.fwd_from = MagicMock()
+        msg.fwd_from.from_id = PeerChat(chat_id=77777)
+        self.assertEqual(self.backup._extract_forward_from_id(msg), -77777)
 
     def test_returns_none_for_unknown_peer_type(self):
         """Returns None when peer has no recognized ID attribute."""


### PR DESCRIPTION
## Problem

`_extract_forward_from_id` returned raw `channel_id`/`chat_id` values, while every other persisted id in this project is the MARKED form (`user_id`, `-chat_id`, `-100<channel_id>`) — the convention this same file's migration pointers already follow via `get_peer_id`. A raw channel id lands in the user-id numeric space: the archive cannot tell 'forwarded from channel X' apart from 'forwarded from user Y' when ids collide, no query using the id the user actually knows ever matches, and the viewer renders the meaningless number verbatim. One row even mixed both conventions (`sender_id` is marked per Telethon's own docstring).

## Fix

The helper returns `get_peer_id(peer)` (TypeError → None for unknown peer shapes). Rows written before this fix keep their raw values — the positive spaces overlap, so no reliable remap exists; new captures are correct and old rows age out with re-sweeps.

## Evidence

- Tests repointed from the bug-pinning raw assertions to real `PeerUser`/`PeerChannel`/`PeerChat` objects asserting 12345 / -1000000099999 / -77777. Mutation control restoring the raw extraction fails both marked tests; restore sha-verified.
- Full suite: 3415 passed, 127 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.5.50.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected forwarded message IDs for channels and group chats.
  * Prevented channel and chat IDs from conflicting with user IDs.
  * Improved handling when a forwarded peer’s ID cannot be determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->