### PR TITLE
fix(config): a typo'd timezone can no longer freeze the viewer's statistics forever

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass, field
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from dotenv import load_dotenv
 
@@ -642,8 +643,18 @@ class Config:
         self.display_chat_ids = self._parse_id_list(os.getenv("DISPLAY_CHAT_IDS", ""))
 
         # Timezone configuration for viewer display
-        # Defaults to Europe/Madrid if not specified
-        self.viewer_timezone = os.getenv("VIEWER_TIMEZONE", "Europe/Madrid")
+        # Defaults to Europe/Madrid if not specified. Validated HERE: the
+        # stats scheduler builds ZoneInfo(viewer_timezone) inside a retry
+        # loop whose catch-all would otherwise log-and-sleep every hour,
+        # forever, on a misspelled tz name (the request path already falls
+        # back to UTC; the scheduler had no such defence).
+        viewer_timezone = os.getenv("VIEWER_TIMEZONE", "Europe/Madrid")
+        try:
+            ZoneInfo(viewer_timezone)
+        except ZoneInfoNotFoundError, ValueError, KeyError:
+            logger.warning(f"VIEWER_TIMEZONE {viewer_timezone!r} is not a known timezone; falling back to UTC")
+            viewer_timezone = "UTC"
+        self.viewer_timezone = viewer_timezone
 
         # Viewer notifications (internal use, prefer PUSH_NOTIFICATIONS)
         self.enable_notifications = _parse_bool_env("ENABLE_NOTIFICATIONS", False)
@@ -663,8 +674,18 @@ class Config:
 
         # Stats calculation schedule
         # Daily calculation of statistics (chat counts, message counts, etc.)
-        # Default: 03:00 (3am) in the configured viewer timezone
-        self.stats_calculation_hour = int(os.getenv("STATS_CALCULATION_HOUR", "3"))
+        # Default: 03:00 (3am) in the configured viewer timezone. Documented
+        # as 0-23 and validated here for the same reason as the timezone:
+        # now.replace(hour=24) raises inside the scheduler's hourly catch-all.
+        stats_hour_raw = os.getenv("STATS_CALCULATION_HOUR", "3")
+        try:
+            stats_hour = int(stats_hour_raw)
+        except ValueError:
+            stats_hour = -1
+        if not 0 <= stats_hour <= 23:
+            logger.warning(f"STATS_CALCULATION_HOUR {stats_hour_raw!r} is not an hour in 0-23; using 3")
+            stats_hour = 3
+        self.stats_calculation_hour = stats_hour
 
         # Show stats in viewer UI
         # When disabled, hides the stats dropdown next to "Telegram Archive" title

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1812,3 +1812,52 @@ class TestMultiAccountConfig(unittest.TestCase):
         self.assertNotIn("very-private-label", text)
         self.assertNotIn("10001", text)
         self.assertIn("index=1", text)
+
+
+class TestSchedulerConfigValidation(unittest.TestCase):
+    """VIEWER_TIMEZONE and STATS_CALCULATION_HOUR are validated at construction.
+
+    Stored verbatim, a misspelled tz name or an out-of-range hour raised inside
+    the stats scheduler's hourly catch-all — logged, slept, and retried forever
+    while the viewer kept serving first-launch counts.
+    """
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+        self.env_patcher = patch.dict(
+            os.environ, {"BACKUP_PATH": self.temp_dir, "DATABASE_DIR": self.temp_dir}, clear=True
+        )
+        self.env_patcher.start()
+
+    def tearDown(self):
+        self.env_patcher.stop()
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _config(self, **env):
+        with patch.dict(os.environ, env):
+            return Config()
+
+    def test_misspelled_timezone_falls_back_to_utc_with_warning(self):
+        with self.assertLogs("src.config", level="WARNING") as captured:
+            config = self._config(VIEWER_TIMEZONE="Europe/Madird")
+        self.assertEqual(config.viewer_timezone, "UTC")
+        self.assertTrue(any("VIEWER_TIMEZONE" in line for line in captured.output))
+
+    def test_valid_timezone_is_kept(self):
+        config = self._config(VIEWER_TIMEZONE="Europe/Madrid")
+        self.assertEqual(config.viewer_timezone, "Europe/Madrid")
+
+    def test_hour_out_of_range_falls_back_to_default(self):
+        with self.assertLogs("src.config", level="WARNING") as captured:
+            config = self._config(STATS_CALCULATION_HOUR="24")
+        self.assertEqual(config.stats_calculation_hour, 3)
+        self.assertTrue(any("STATS_CALCULATION_HOUR" in line for line in captured.output))
+
+    def test_hour_not_a_number_falls_back_to_default(self):
+        with self.assertLogs("src.config", level="WARNING"):
+            config = self._config(STATS_CALCULATION_HOUR="midnight")
+        self.assertEqual(config.stats_calculation_hour, 3)
+
+    def test_hour_bounds_are_accepted(self):
+        self.assertEqual(self._config(STATS_CALCULATION_HOUR="0").stats_calculation_hour, 0)
+        self.assertEqual(self._config(STATS_CALCULATION_HOUR="23").stats_calculation_hour, 23)


### PR DESCRIPTION
## Problem

`VIEWER_TIMEZONE` and `STATS_CALCULATION_HOUR` were stored verbatim. The stats scheduler builds `ZoneInfo(viewer_timezone)` and `now.replace(hour=target_hour, ...)` inside a `while True` whose handler is `except Exception: log; sleep(3600)` — so `Europe/Madird` or `STATS_CALCULATION_HOUR=24` (a natural spelling of midnight) put the scheduler in a silent hourly error loop forever. Statistics were never recalculated, and the lifespan log still cheerfully announced 'runs daily at 25:00'. The request path already defends itself (falls back to UTC); the scheduler had no such defence.

## Fix

Validated at construction, where the value is read: an unknown tz name warns and falls back to UTC; a non-numeric or out-of-range hour warns (naming the variable and the offending value) and uses the documented default of 3. Valid values are untouched.

## Evidence

- Five tests: misspelled tz → UTC + warning, valid tz kept, hour 24 → 3 + warning, `midnight` → 3, bounds 0 and 23 accepted. Two mutation controls green-then-red (dropping the tz guard, dropping the clamp); restores sha-verified.
- Full suite: 3420 passed, 127 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.5.39.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration handling for invalid time zones and calculation hours.
  * Invalid time zones now fall back to UTC with a warning.
  * Invalid or out-of-range calculation hours now fall back to 3 with a warning.
  * Valid time zones and boundary hours remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->