### PR TITLE
fix(backup): a premium flood no longer makes the re-sweep hammer a rate-limited account

### DIFF
--- a/src/connection.py
+++ b/src/connection.py
@@ -21,7 +21,7 @@ import shutil
 import sqlite3
 
 from telethon import TelegramClient
-from telethon.errors import FloodWaitError
+from telethon.errors import FloodPremiumWaitError, FloodWaitError
 
 from .config import AccountConfig, Config
 
@@ -62,7 +62,7 @@ async def _call_with_flood_retry(coro_fn, *args, **kwargs):
     while True:
         try:
             return await coro_fn(*args, **kwargs)
-        except FloodWaitError as e:
+        except (FloodWaitError, FloodPremiumWaitError) as e:
             retries += 1
             if retries > MAX_FLOOD_RETRIES:
                 logger.error(

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -2679,7 +2679,7 @@ class TelegramBackup:
             try:
                 result = await self.client(GetMessagesReactionsRequest(peer=entity, id=chunk))
                 updates = getattr(result, "updates", []) or []
-            except FloodWaitError as e:
+            except (FloodWaitError, FloodPremiumWaitError) as e:
                 self._register_resweep_flood(e.seconds, chat_id, skip_n + i, "getMessagesReactions")
                 return
             except Exception as e:
@@ -2719,7 +2719,7 @@ class TelegramBackup:
             await self._resweep_pace()
             try:
                 msgs = await self.client.get_messages(entity, ids=chunk)
-            except FloodWaitError as e:
+            except (FloodWaitError, FloodPremiumWaitError) as e:
                 self._register_resweep_flood(e.seconds, chat_id, skip_n + i, "get_messages")
                 return
             except Exception as e:

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -8,7 +8,7 @@ import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from telethon.errors import FloodWaitError
+from telethon.errors import FloodPremiumWaitError, FloodWaitError
 
 from src import connection
 from src.connection import TelegramConnection
@@ -737,3 +737,30 @@ async def test_async_context_manager_exit():
 
 if __name__ == "__main__":
     unittest.main()
+
+
+@pytest.mark.asyncio
+async def test_connection_flood_retry_covers_premium_flood_too():
+    """FloodPremiumWaitError is NOT a FloodWaitError subclass — the lone catch
+    turned a premium flood on get_me into a hard connect() failure with no
+    retry, while every other flood-aware site in the codebase treats the pair
+    as one class of error."""
+    calls = {"n": 0}
+
+    async def flaky_api():
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise FloodPremiumWaitError(request=None, capture=1)
+        return "ok"
+
+    async def no_sleep(seconds):
+        return None
+
+    with (
+        patch.object(connection.asyncio, "sleep", no_sleep),
+        patch("src.connection.random.uniform", return_value=1.0),
+    ):
+        result = await connection._call_with_flood_retry(flaky_api)
+
+    assert result == "ok"
+    assert calls["n"] == 2

--- a/tests/test_reaction_resweep.py
+++ b/tests/test_reaction_resweep.py
@@ -23,7 +23,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
-from telethon.errors import FloodWaitError
+from telethon.errors import FloodPremiumWaitError, FloodWaitError
 from telethon.tl.types import PeerChannel, UpdateMessageReactions
 
 from src.config import Config
@@ -403,6 +403,21 @@ class TestResweepPacing:
         b.db.get_message_ids_since.assert_not_awaited()
         assert b._resweep_dialogs_deferred == 2
         assert b._resweep_deferred_any is True
+
+    async def test_premium_flood_on_raw_also_pauses_without_fallback(self):
+        # FloodPremiumWaitError is NOT a FloodWaitError subclass in Telethon;
+        # the old lone catch dropped it into the generic handler, which fell
+        # back to get_messages — a second rate bucket hammered under the same
+        # pressure, the exact regression #224 was fixed to prevent.
+        b = _backup()
+        b.db.get_message_ids_since = AsyncMock(return_value=[1, 2])
+        b.client.side_effect = FloodPremiumWaitError(request=None, capture=60)
+
+        await b._resweep_reactions(MagicMock(), CHAT)
+
+        assert b._resweep_flood_until is not None
+        b.client.get_messages.assert_not_awaited()
+        assert CHAT not in b._resweep_cycle_done
 
     async def test_flood_on_fallback_also_pauses(self):
         b = _backup()

--- a/tests/test_reaction_resweep.py
+++ b/tests/test_reaction_resweep.py
@@ -430,6 +430,22 @@ class TestResweepPacing:
         assert b._resweep_flood_until is not None
         assert CHAT not in b._resweep_cycle_done
 
+    async def test_premium_flood_on_fallback_also_pauses(self):
+        # The paired catch must cover the fallback branch too: get_messages
+        # answering FloodPremiumWaitError registers the cooldown exactly like
+        # a FloodWaitError there — reverting the fallback's premium half must
+        # fail this test even while the raw-path test above stays green.
+        b = _backup()
+        b.db.get_message_ids_since = AsyncMock(return_value=[1])
+        b.client.side_effect = RuntimeError("peer unsupported")  # raw path → genuine non-flood error
+        b.client.get_messages = AsyncMock(side_effect=FloodPremiumWaitError(request=None, capture=60))
+
+        await b._resweep_reactions(MagicMock(), CHAT)
+
+        b.client.get_messages.assert_awaited_once()  # the fallback WAS taken
+        assert b._resweep_flood_until is not None
+        assert CHAT not in b._resweep_cycle_done
+
     async def test_resweep_resumes_within_run_after_cooldown(self, monkeypatch):
         # #224 follow-up: a FloodWait pauses the re-sweep, and once wall-clock
         # passes the server-requested window the SAME run resumes — full


### PR DESCRIPTION
## Problem

Telethon's `FloodPremiumWaitError` derives from `FloodError`, NOT `FloodWaitError` — and while the codebase treats the pair as one class of error at every flood-aware call site, three stragglers caught only `FloodWaitError`:

- both reaction re-sweep catches: a premium flood fell into the generic handler, which did exactly what the adjacent comment forbids — fell back to `get_messages`, a DIFFERENT rate bucket under the same pressure, with `_register_resweep_flood` never called: nothing paused, nothing deferred, cursor not persisted. The account kept being hammered while already rate-limited — the exact regression #224 was fixed to prevent.
- `connection.py`'s `_call_with_flood_retry`: a premium flood on `get_me` became a hard `connect()` failure with no retry.

## Fix

All three sites catch `(FloodWaitError, FloodPremiumWaitError)`; `.seconds` carries over identically.

## Evidence

- Verified in the venv: `issubclass(FloodPremiumWaitError, FloodWaitError)` is False, and `.seconds` is populated from capture.
- New tests: a premium flood on the raw re-sweep request registers the cooldown and never touches the fallback bucket; the connection retry survives one premium flood. Mutation control restoring the lone catches fails both; restores sha-verified.
- Full suite: 3417 passed, 127 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.5.52.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of premium flood-wait responses during connection retries.
  * Reaction processing now safely defers when premium limits are reached and resumes during a later resweep.
  * Prevented unnecessary fallback message requests while a premium flood wait is active.

* **Tests**
  * Added coverage for retry behavior and reaction resweep cooldown handling under premium flood limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->