### PR TITLE
fix(db): setting DATABASE_TIMEOUT now actually does something

### DIFF
--- a/src/db/base.py
+++ b/src/db/base.py
@@ -19,6 +19,18 @@ from .models import Base
 logger = logging.getLogger(__name__)
 
 
+def _busy_timeout_ms() -> int:
+    """DATABASE_TIMEOUT (seconds) as PRAGMA busy_timeout milliseconds."""
+    raw = os.getenv("DATABASE_TIMEOUT", "60.0")
+    try:
+        seconds = float(raw)
+    except ValueError:
+        return 60000
+    if seconds <= 0:
+        return 60000
+    return int(seconds * 1000)
+
+
 class DatabaseManager:
     """
     Manages async database connections for SQLite and PostgreSQL.
@@ -219,6 +231,15 @@ class DatabaseManager:
         if that fails the database still works in the default journal mode.
         """
 
+        # DATABASE_TIMEOUT is documented (README, .env.example) as THE knob for
+        # "database is locked", but it never reached this pragma — the 60s
+        # default happening to equal the old hardcoded 60000ms kept that
+        # invisible. Seconds in, milliseconds out; invalid or non-positive
+        # values keep the old default. Read from the environment like every
+        # other configuration value (the manager is URL-driven, not
+        # Config-driven, so importing Config here would invert the layers).
+        busy_timeout_ms = _busy_timeout_ms()
+
         @event.listens_for(self.engine.sync_engine, "connect")
         def set_sqlite_pragma(dbapi_connection, connection_record):
             cursor = dbapi_connection.cursor()
@@ -233,8 +254,7 @@ class DatabaseManager:
                     "This is expected for viewer containers with read-only mounts."
                 )
             try:
-                # 60 second busy timeout
-                cursor.execute("PRAGMA busy_timeout=60000")
+                cursor.execute(f"PRAGMA busy_timeout={busy_timeout_ms}")
                 # 64MB cache for better performance
                 cursor.execute("PRAGMA cache_size=-64000")
             except Exception:

--- a/src/db/base.py
+++ b/src/db/base.py
@@ -5,6 +5,7 @@ Supports both SQLite and PostgreSQL with proper configuration for each.
 """
 
 import logging
+import math
 import os
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
@@ -20,15 +21,22 @@ logger = logging.getLogger(__name__)
 
 
 def _busy_timeout_ms() -> int:
-    """DATABASE_TIMEOUT (seconds) as PRAGMA busy_timeout milliseconds."""
+    """DATABASE_TIMEOUT (seconds) as PRAGMA busy_timeout milliseconds.
+
+    A knob must never abort startup: garbage, non-finite ("nan"/"inf" parse as
+    real floats and would raise in int()) and non-positive values fall back to
+    the 60s default, and a positive sub-millisecond value clamps to 1ms —
+    busy_timeout=0 would silently disable the wait, the opposite of what a
+    tiny-but-positive timeout asks for.
+    """
     raw = os.getenv("DATABASE_TIMEOUT", "60.0")
     try:
         seconds = float(raw)
     except ValueError:
         return 60000
-    if seconds <= 0:
+    if not math.isfinite(seconds) or seconds <= 0:
         return 60000
-    return int(seconds * 1000)
+    return max(1, int(seconds * 1000))
 
 
 class DatabaseManager:

--- a/tests/test_db_base.py
+++ b/tests/test_db_base.py
@@ -627,6 +627,21 @@ class TestDatabaseTimeoutWiring:
         with patch.dict(os.environ, {"DATABASE_TIMEOUT": "-5"}):
             assert _busy_timeout_ms() == 60000
 
+    def test_busy_timeout_survives_nonfinite_and_subms_values(self):
+        """ "nan"/"inf" parse as real floats — the old int() conversion raised
+        (ValueError/OverflowError) and aborted init(); a positive value under
+        1ms became busy_timeout=0, silently disabling the wait entirely."""
+        from src.db.base import _busy_timeout_ms
+
+        with patch.dict(os.environ, {"DATABASE_TIMEOUT": "nan"}):
+            assert _busy_timeout_ms() == 60000
+        with patch.dict(os.environ, {"DATABASE_TIMEOUT": "inf"}):
+            assert _busy_timeout_ms() == 60000
+        with patch.dict(os.environ, {"DATABASE_TIMEOUT": "-inf"}):
+            assert _busy_timeout_ms() == 60000
+        with patch.dict(os.environ, {"DATABASE_TIMEOUT": "0.0001"}):
+            assert _busy_timeout_ms() == 1  # clamped, never 0 (= wait disabled)
+
     @pytest.mark.asyncio
     async def test_configured_timeout_reaches_the_live_connection(self, tmp_path):
         from sqlalchemy import text as sa_text

--- a/tests/test_db_base.py
+++ b/tests/test_db_base.py
@@ -599,3 +599,44 @@ class TestGetSessionRollback:
 
         mock_session.rollback.assert_awaited_once()
         mock_session.commit.assert_not_awaited()
+
+
+class TestDatabaseTimeoutWiring:
+    """DATABASE_TIMEOUT is documented as THE knob for 'database is locked' —
+    it must actually reach PRAGMA busy_timeout. The old hardcoded 60000ms
+    equalled the knob's default, which is what kept the dead wire invisible."""
+
+    def test_busy_timeout_parses_seconds_to_milliseconds(self):
+        from src.db.base import _busy_timeout_ms
+
+        with patch.dict(os.environ, {"DATABASE_TIMEOUT": "300"}):
+            assert _busy_timeout_ms() == 300000
+        with patch.dict(os.environ, {"DATABASE_TIMEOUT": "2.5"}):
+            assert _busy_timeout_ms() == 2500
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("DATABASE_TIMEOUT", None)
+            assert _busy_timeout_ms() == 60000
+
+    def test_busy_timeout_rejects_garbage_and_nonpositive(self):
+        from src.db.base import _busy_timeout_ms
+
+        with patch.dict(os.environ, {"DATABASE_TIMEOUT": "forever"}):
+            assert _busy_timeout_ms() == 60000
+        with patch.dict(os.environ, {"DATABASE_TIMEOUT": "0"}):
+            assert _busy_timeout_ms() == 60000
+        with patch.dict(os.environ, {"DATABASE_TIMEOUT": "-5"}):
+            assert _busy_timeout_ms() == 60000
+
+    @pytest.mark.asyncio
+    async def test_configured_timeout_reaches_the_live_connection(self, tmp_path):
+        from sqlalchemy import text as sa_text
+
+        with patch.dict(os.environ, {"DATABASE_TIMEOUT": "5"}):
+            manager = DatabaseManager(f"sqlite:///{tmp_path / 'timeout.db'}")
+            await manager.init()
+        try:
+            async with manager.get_session() as session:
+                value = (await session.execute(sa_text("PRAGMA busy_timeout"))).scalar()
+            assert value == 5000
+        finally:
+            await manager.close()


### PR DESCRIPTION
## Problem

`DATABASE_TIMEOUT` is documented (README table, .env.example) as THE knob for 'database is locked' — the exact contention an Unraid backup+viewer pair on one SQLite file hits. But `PRAGMA busy_timeout` was hardcoded at 60000ms; `config.database_timeout` was read, parsed, and consumed by nothing. The knob's default of 60.0 seconds equalling the hardcoded value is what kept this invisible: an operator setting `DATABASE_TIMEOUT=300` changed nothing and reasonably concluded the tool cannot be tuned.

## Fix

The SQLite connect listener derives `busy_timeout` from the environment (seconds in, milliseconds out; garbage or non-positive values keep the old 60s default). Read via env like every other configuration value — the manager is URL-driven, so importing Config here would invert the layers.

## Evidence

- Unit tests for the parse (300→300000, 2.5→2500, default, garbage, 0, negative) and a live-connection test: `DATABASE_TIMEOUT=5` → `PRAGMA busy_timeout` reads back 5000 on a real engine. Mutation control re-hardcoding the pragma fails the live test; restore sha-verified.
- Full suite: 3418 passed, 127 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.5.42.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Database operations now honor the configured `DATABASE_TIMEOUT` value.
  - Invalid or non-positive timeout settings safely fall back to 60 seconds.

- **Tests**
  - Added coverage for timeout parsing, fallback behavior, and verification of the active SQLite timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->