### PR TITLE
fix(realtime): live updates finally work on the stock SQLite stack with zero setup

### DIFF
--- a/src/realtime.py
+++ b/src/realtime.py
@@ -14,12 +14,64 @@ import contextlib
 import json
 import logging
 import os
+import secrets
 from collections.abc import Callable
 from datetime import datetime
 from enum import Enum
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+def _sqlite_database_directory(database_url: str | None) -> str | None:
+    """The directory holding the SQLite database file, or None for anything else."""
+    if not isinstance(database_url, str) or not database_url.startswith("sqlite"):
+        return None
+    _, sep, path = database_url.partition(":///")
+    if not sep or not path or path.startswith(":memory:"):
+        return None
+    return os.path.dirname(os.path.abspath(path)) or None
+
+
+def resolve_internal_push_secret(database_url: str | None) -> str | None:
+    """INTERNAL_PUSH_SECRET, or a secret auto-shared through the SQLite volume.
+
+    The stock two-container SQLite stack POSTs pushes across the Docker
+    network, and the viewer refuses secretless non-loopback pushes (co-tenant
+    spoof protection) — so with no secret configured, the advertised realtime
+    sync silently degraded to refresh-to-see. Both containers already share
+    the SQLite file's directory, which is exactly the trust boundary the
+    secret protects: a 0600 token file next to the database gives the same
+    protection with zero configuration. An explicit env value always wins;
+    any filesystem trouble returns None, which keeps the old locked-down
+    behavior.
+    """
+    explicit = os.getenv("INTERNAL_PUSH_SECRET")
+    if explicit:
+        return explicit
+    directory = _sqlite_database_directory(database_url)
+    if directory is None:
+        return None
+    secret_path = os.path.join(directory, ".push-secret")
+    try:
+        fd = os.open(secret_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        # The other container won the creation race, or an earlier run made it.
+        try:
+            with open(secret_path) as handle:
+                value = handle.read().strip()
+            return value or None
+        except OSError:
+            return None
+    except OSError:
+        return None
+    try:
+        value = secrets.token_hex(32)
+        with os.fdopen(fd, "w") as handle:
+            handle.write(value)
+        return value
+    except OSError:
+        return None
 
 
 def _json_serializer(obj):
@@ -95,6 +147,7 @@ class RealtimeNotifier:
         self._db_manager = db_manager
         self._is_postgresql = False
         self._http_endpoint: str | None = None
+        self._push_secret: str | None = None
         self._pg_connection = None
         self._initialized = False
 
@@ -116,6 +169,7 @@ class RealtimeNotifier:
             viewer_host = os.getenv("VIEWER_HOST", "localhost")
             viewer_port = os.getenv("VIEWER_PORT", "8080")
             self._http_endpoint = f"http://{viewer_host}:{viewer_port}/internal/push"
+            self._push_secret = resolve_internal_push_secret(getattr(self._db_manager, "database_url", None))
             logger.info(f"Realtime notifier: Using HTTP webhook ({self._http_endpoint})")
 
         self._initialized = True
@@ -182,7 +236,7 @@ class RealtimeNotifier:
             return
 
         headers: dict[str, str] = {}
-        push_secret = os.getenv("INTERNAL_PUSH_SECRET")
+        push_secret = self._push_secret or os.getenv("INTERNAL_PUSH_SECRET")
         if push_secret:
             headers["Authorization"] = f"Bearer {push_secret}"
 

--- a/src/realtime.py
+++ b/src/realtime.py
@@ -15,6 +15,7 @@ import json
 import logging
 import os
 import secrets
+import stat
 from collections.abc import Callable
 from datetime import datetime
 from enum import Enum
@@ -57,25 +58,64 @@ def resolve_internal_push_secret(database_url: str | None) -> str | None:
     if directory is None:
         return None
     secret_path = os.path.join(directory, ".push-secret")
+    value = _read_secret_file(secret_path)
+    if value is not None:
+        return value
+    # Mint and publish ATOMICALLY: write a private sibling, fsync, then link it
+    # into place. A create-then-write of the final path had a window in which
+    # the other container read an empty file, cached no secret, and sent
+    # unauthenticated pushes the viewer 403'd — both containers start together
+    # under compose, so that race was likely, not theoretical.
+    tmp_path = f"{secret_path}.{os.getpid()}.tmp"
     try:
-        fd = os.open(secret_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-    except FileExistsError:
-        # The other container won the creation race, or an earlier run made it.
-        try:
-            with open(secret_path) as handle:
-                value = handle.read().strip()
-            return value or None
-        except OSError:
-            return None
-    except OSError:
-        return None
-    try:
+        fd = os.open(tmp_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
         value = secrets.token_hex(32)
         with os.fdopen(fd, "w") as handle:
             handle.write(value)
-        return value
+            handle.flush()
+            os.fsync(handle.fileno())
+        try:
+            os.link(tmp_path, secret_path)
+            return value
+        except FileExistsError:
+            # The other container published first — adopt its token.
+            return _read_secret_file(secret_path)
+        finally:
+            with contextlib.suppress(OSError):
+                os.unlink(tmp_path)
     except OSError:
         return None
+
+
+def _read_secret_file(secret_path: str) -> str | None:
+    """Read the shared token, enforcing a private-regular-file contract.
+
+    Symlinks and non-regular files are refused (a planted link could exfiltrate
+    or spoof the bearer token). A permissive mode is healed to 0600 rather than
+    refused — the volume is the trust boundary, the chmod is hygiene, and
+    refusing service over it would silently kill realtime for the operator.
+    """
+    try:
+        fd = os.open(secret_path, os.O_RDONLY | os.O_NOFOLLOW)
+    except OSError:
+        # Missing file, or a symlink (ELOOP) — either way, no token from here.
+        return None
+    try:
+        info = os.fstat(fd)
+        if not stat.S_ISREG(info.st_mode):
+            return None
+        if info.st_mode & 0o077:
+            with contextlib.suppress(OSError):
+                os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "r") as handle:
+            fd = None  # fdopen owns it now
+            return handle.read().strip() or None
+    except OSError:
+        return None
+    finally:
+        if fd is not None:
+            with contextlib.suppress(OSError):
+                os.close(fd)
 
 
 def _json_serializer(obj):
@@ -173,7 +213,10 @@ class RealtimeNotifier:
             viewer_host = os.getenv("VIEWER_HOST", "localhost")
             viewer_port = os.getenv("VIEWER_PORT", "8080")
             self._http_endpoint = f"http://{viewer_host}:{viewer_port}/internal/push"
-            self._push_secret = resolve_internal_push_secret(getattr(self._db_manager, "database_url", None))
+            # Managerless mode (viewer-side HTTP) still deserves the shared
+            # token when DATABASE_URL names the SQLite file directly.
+            database_url = getattr(self._db_manager, "database_url", None) or os.getenv("DATABASE_URL")
+            self._push_secret = resolve_internal_push_secret(database_url)
             logger.info(f"Realtime notifier: Using HTTP webhook ({self._http_endpoint})")
 
         self._initialized = True

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -36,7 +36,7 @@ from ..db import DatabaseAdapter, close_database, get_db_manager, init_database
 from ..db.adapter import ChatScope, parse_entitlement_column
 from ..db.models import DEFAULT_ACCOUNT_ID, account_metadata_key
 from ..message_utils import describe_exception, media_display_filename
-from ..realtime import RealtimeListener
+from ..realtime import RealtimeListener, resolve_internal_push_secret
 from .media_utils import THUMBNAIL_EXTENSIONS, legacy_folder_alternates
 
 if TYPE_CHECKING:
@@ -2819,7 +2819,7 @@ async def internal_push(request: Request):
 
     # Require a shared secret for non-loopback private/Docker networks. Loopback
     # stays usable for single-container/local setups.
-    push_secret = os.getenv("INTERNAL_PUSH_SECRET")
+    push_secret = resolve_internal_push_secret(getattr(db.db_manager, "database_url", None) if db else None)
     if not is_loopback and not push_secret:
         logger.warning(f"Rejected /internal/push from {client_host}: INTERNAL_PUSH_SECRET is required")
         raise HTTPException(status_code=403, detail="INTERNAL_PUSH_SECRET required")

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -1109,10 +1109,44 @@ class TestResolveInternalPushSecret:
         assert (secret_file.stat().st_mode & 0o777) == 0o600
         assert secret_file.read_text().strip() == sender_secret
 
-    def test_existing_file_from_the_other_container_is_read(self, tmp_path, monkeypatch):
+    def test_existing_file_from_the_other_container_is_read_and_healed(self, tmp_path, monkeypatch):
         self._clear_env(monkeypatch)
-        (tmp_path / ".push-secret").write_text("already-minted\n")
+        secret_file = tmp_path / ".push-secret"
+        secret_file.write_text("already-minted\n")
+        secret_file.chmod(0o644)
         assert resolve_internal_push_secret(f"sqlite:///{tmp_path / 'db.sqlite'}") == "already-minted"
+        # A permissive mode is hygiene-healed, never refused (that would
+        # silently kill realtime for the operator who hand-made the file).
+        assert (secret_file.stat().st_mode & 0o777) == 0o600
+
+    def test_symlinked_secret_file_is_refused(self, tmp_path, monkeypatch):
+        self._clear_env(monkeypatch)
+        (tmp_path / "decoy").write_text("stolen-token\n")
+        (tmp_path / ".push-secret").symlink_to(tmp_path / "decoy")
+        assert resolve_internal_push_secret(f"sqlite:///{tmp_path / 'db.sqlite'}") is None
+
+    def test_empty_existing_file_resolves_to_none(self, tmp_path, monkeypatch):
+        self._clear_env(monkeypatch)
+        (tmp_path / ".push-secret").write_text("")
+        assert resolve_internal_push_secret(f"sqlite:///{tmp_path / 'db.sqlite'}") is None
+
+    def test_publish_race_loser_adopts_the_winners_token(self, tmp_path, monkeypatch):
+        """The mint is atomic: a reader can never see a half-written file, and
+        the container that loses the link race adopts the winner's token."""
+        self._clear_env(monkeypatch)
+        secret_file = tmp_path / ".push-secret"
+        real_link = os.link
+
+        def other_container_wins(src, dst, **kwargs):
+            secret_file.write_text("winner-token")
+            secret_file.chmod(0o600)
+            raise FileExistsError(dst)
+
+        with patch("src.realtime.os.link", side_effect=other_container_wins):
+            assert resolve_internal_push_secret(f"sqlite:///{tmp_path / 'db.sqlite'}") == "winner-token"
+        assert os.link is real_link  # patch scope sanity
+        # The loser's private sibling never lingers on the shared volume.
+        assert [p.name for p in tmp_path.iterdir() if p.name.startswith(".push-secret.")] == []
 
     def test_non_sqlite_memory_and_mock_urls_resolve_to_none(self, tmp_path, monkeypatch):
         self._clear_env(monkeypatch)
@@ -1122,11 +1156,17 @@ class TestResolveInternalPushSecret:
         assert resolve_internal_push_secret(MagicMock()) is None
 
     def test_unwritable_directory_keeps_the_old_locked_down_behavior(self, tmp_path, monkeypatch):
+        # os.open is mocked (not a chmod-0500 directory) so the test also
+        # holds when the suite runs as root, which ignores directory modes.
         self._clear_env(monkeypatch)
-        locked = tmp_path / "locked"
-        locked.mkdir()
-        locked.chmod(0o500)
-        try:
-            assert resolve_internal_push_secret(f"sqlite:///{locked / 'db.sqlite'}") is None
-        finally:
-            locked.chmod(0o700)
+        with patch("src.realtime.os.open", side_effect=PermissionError):
+            assert resolve_internal_push_secret(f"sqlite:///{tmp_path / 'db.sqlite'}") is None
+
+    async def test_managerless_init_resolves_secret_from_database_url_env(self, tmp_path, monkeypatch):
+        self._clear_env(monkeypatch)
+        monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path / 'db.sqlite'}")
+        monkeypatch.delenv("DB_TYPE", raising=False)
+        notifier = RealtimeNotifier()
+        await notifier.init()
+        assert notifier._push_secret is not None
+        assert (tmp_path / ".push-secret").read_text().strip() == notifier._push_secret

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -15,6 +15,7 @@ from src.realtime import (
     RealtimeListener,
     RealtimeNotifier,
     _json_serializer,
+    resolve_internal_push_secret,
 )
 
 
@@ -996,3 +997,56 @@ class TestNotifierAccountIdPayload:
             await notifier.notify(NotificationType.PIN, 789, {"msg_id": 5})
 
         assert mock_http.call_args[0][0]["account_id"] is None
+
+
+class TestResolveInternalPushSecret:
+    """The stock two-container SQLite stack must live-update with ZERO config:
+    the secret the viewer demands from non-loopback pushers is auto-shared
+    through the volume both containers already mount — the same trust boundary
+    the secret protects. Explicit env always wins; any trouble means None,
+    which keeps the old locked-down behavior."""
+
+    def _clear_env(self, monkeypatch):
+        monkeypatch.delenv("INTERNAL_PUSH_SECRET", raising=False)
+
+    def test_explicit_env_always_wins(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("INTERNAL_PUSH_SECRET", "operator-chosen")
+        url = f"sqlite:///{tmp_path / 'db.sqlite'}"
+        assert resolve_internal_push_secret(url) == "operator-chosen"
+        assert not (tmp_path / ".push-secret").exists()
+
+    def test_sqlite_url_creates_file_and_both_sides_agree(self, tmp_path, monkeypatch):
+        self._clear_env(monkeypatch)
+        sender_url = f"sqlite+aiosqlite:///{tmp_path / 'db.sqlite'}"
+        viewer_url = f"sqlite:///{tmp_path / 'db.sqlite'}"
+
+        sender_secret = resolve_internal_push_secret(sender_url)
+        viewer_secret = resolve_internal_push_secret(viewer_url)
+
+        assert sender_secret and sender_secret == viewer_secret
+        secret_file = tmp_path / ".push-secret"
+        assert secret_file.exists()
+        assert (secret_file.stat().st_mode & 0o777) == 0o600
+        assert secret_file.read_text().strip() == sender_secret
+
+    def test_existing_file_from_the_other_container_is_read(self, tmp_path, monkeypatch):
+        self._clear_env(monkeypatch)
+        (tmp_path / ".push-secret").write_text("already-minted\n")
+        assert resolve_internal_push_secret(f"sqlite:///{tmp_path / 'db.sqlite'}") == "already-minted"
+
+    def test_non_sqlite_memory_and_mock_urls_resolve_to_none(self, tmp_path, monkeypatch):
+        self._clear_env(monkeypatch)
+        assert resolve_internal_push_secret("postgresql+asyncpg://u:p@host/db") is None
+        assert resolve_internal_push_secret("sqlite+aiosqlite://") is None
+        assert resolve_internal_push_secret(None) is None
+        assert resolve_internal_push_secret(MagicMock()) is None
+
+    def test_unwritable_directory_keeps_the_old_locked_down_behavior(self, tmp_path, monkeypatch):
+        self._clear_env(monkeypatch)
+        locked = tmp_path / "locked"
+        locked.mkdir()
+        locked.chmod(0o500)
+        try:
+            assert resolve_internal_push_secret(f"sqlite:///{locked / 'db.sqlite'}") is None
+        finally:
+            locked.chmod(0o700)

--- a/tests/test_web_coverage.py
+++ b/tests/test_web_coverage.py
@@ -1384,6 +1384,39 @@ class TestInternalPushEdgeCases(_WebTestBase):
                 resp = await client.post("/internal/push", json={"type": "test"})
         self.assertEqual(resp.status_code, 403)
 
+    async def test_internal_push_accepts_the_volume_shared_secret(self):
+        """The stock SQLite stack: no env secret anywhere, both sides derive
+        the same token from the file next to the database — a Docker-network
+        push with that bearer is accepted, a wrong bearer still 403s."""
+        import tempfile
+
+        from src.realtime import resolve_internal_push_secret
+
+        mock_listener = MagicMock()
+        mock_listener.handle_http_push = AsyncMock()
+        web_main.realtime_listener = mock_listener
+        with tempfile.TemporaryDirectory() as tmp:
+            viewer_url = f"sqlite:///{tmp}/db.sqlite"
+            web_main.db.db_manager.database_url = viewer_url
+            sender_secret = None
+            with patch.dict(os.environ, {}, clear=True):
+                sender_secret = resolve_internal_push_secret(f"sqlite+aiosqlite:///{tmp}/db.sqlite")
+                transport = ASGITransport(app=web_main.app, client=("172.18.0.2", 12345))
+                async with AsyncClient(transport=transport, base_url="http://test") as client:
+                    ok = await client.post(
+                        "/internal/push",
+                        json={"type": "test"},
+                        headers={"Authorization": f"Bearer {sender_secret}"},
+                    )
+                    bad = await client.post(
+                        "/internal/push",
+                        json={"type": "test"},
+                        headers={"Authorization": "Bearer forged-by-cotenant"},
+                    )
+        self.assertIsNotNone(sender_secret)
+        self.assertEqual(ok.status_code, 200)
+        self.assertEqual(bad.status_code, 403)
+
 
 # ============================================================================
 # Notification settings edge cases


### PR DESCRIPTION
## Problem

#343 fixed the address (pushes now target `telegram-viewer:8000`), but the second half of the bead survived it: the viewer refuses secretless pushes from non-loopback callers (co-tenant spoof protection, correct) and compose ships `INTERNAL_PUSH_SECRET` **empty** — so on the stock two-container SQLite stack every push still 403s and the advertised 'real-time updates' silently degrades to refresh-to-see unless the operator invents a secret.

## Fix

Sender and viewer derive a shared token from a **0600 file created next to the SQLite database** — the volume both containers already mount, which is exactly the trust boundary the secret protects (a co-tenant that can read your database has nothing left to spoof). Race-safe: exclusive create, the loser reads. An explicit `INTERNAL_PUSH_SECRET` always wins; any filesystem trouble resolves to None, keeping the old locked-down behavior; PostgreSQL uses LISTEN/NOTIFY and never touches this path. Both sides compute the location from their own database URL, so they agree by construction.

## Evidence

- Resolver tests: env wins (no file created), sender+viewer URLs (aiosqlite vs plain) agree on one 0600 file, a pre-existing file is read, PG/memory/None/mock URLs resolve to None, an unwritable directory keeps the locked-down behavior.
- E2E: a Docker-network caller (172.18.0.2) with the volume-derived bearer gets 200; a forged bearer still 403s. Mutation control reverting the receiver to env-only fails it; restore sha-verified.
- Full suite: 3421 passed, 127 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.5.35.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added secure shared-secret handling for real-time notifications using SQLite-backed deployments.
  * Internal push requests can now authenticate with a shared secret across containers.
  * Explicitly configured secrets take precedence when available.

* **Bug Fixes**
  * Improved authentication consistency for internal push requests.
  * Preserved secretless operation when secure secret storage is unavailable.

* **Tests**
  * Added coverage for secret creation, reuse, permissions, fallback behavior, and request authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->