### PR TITLE
refactor(web): push notifications stop hand-rolling the sender-name rule

### DIFF
--- a/src/web/main.py
+++ b/src/web/main.py
@@ -35,7 +35,7 @@ from ..config import Config
 from ..db import DatabaseAdapter, close_database, get_db_manager, init_database
 from ..db.adapter import ChatScope, parse_entitlement_column
 from ..db.models import DEFAULT_ACCOUNT_ID, account_metadata_key
-from ..message_utils import describe_exception, media_display_filename
+from ..message_utils import describe_exception, media_display_filename, resolve_sender_display_name
 from ..realtime import RealtimeListener
 from .media_utils import THUMBNAIL_EXTENSIONS, legacy_folder_alternates
 
@@ -384,15 +384,24 @@ async def handle_realtime_notification(payload: dict):
             message = data.get("message", {})
             chat_title = chat.get("title") or "Telegram"
 
-            snapshot_name = message.get("sender_name")
-            sender_name = snapshot_name.strip() if isinstance(snapshot_name, str) else ""
-            if not sender_name and message.get("sender_id"):
-                sender = await db.get_user_by_id(message.get("sender_id")) if db else None
+            # One precedence rule for "who sent this row" — the shared helper,
+            # fed from the payload the listener already enriches with the API
+            # row shape (first/last/username), so the common path costs no DB
+            # query. The lookup below remains only for payloads that carry no
+            # user fields at all.
+            sender_name = resolve_sender_display_name(
+                message.get("sender_name"),
+                message.get("first_name"),
+                message.get("last_name"),
+                message.get("username"),
+            )
+            if sender_name is None and message.get("sender_id") and db:
+                sender = await db.get_user_by_id(message.get("sender_id"))
                 if sender:
-                    sender_name = (
-                        f"{sender.get('first_name') or ''} {sender.get('last_name') or ''}".strip()
-                        or sender.get("username", "")
+                    sender_name = resolve_sender_display_name(
+                        None, sender.get("first_name"), sender.get("last_name"), sender.get("username")
                     )
+            sender_name = sender_name or ""
 
             await push_manager.notify_new_message(
                 chat_id=chat_id,

--- a/tests/test_web_main.py
+++ b/tests/test_web_main.py
@@ -1186,3 +1186,60 @@ class TestSharedChatRealtimeResolution(unittest.IsolatedAsyncioTestCase):
                     {"type": "new_message", "chat_id": 42, "account_id": garbage, "data": {"message": {"id": 1}}}
                 )
             mock_bc.assert_not_awaited()
+
+
+@_skip_unless_web_main
+class TestPushSenderNamePrecedence(unittest.IsolatedAsyncioTestCase):
+    """The push path rides resolve_sender_display_name, fed from the payload
+    the listener already enriches with the API row shape — no per-notification
+    DB query on the common path, and no fourth hand-synced copy of the
+    precedence chain to drift from the app."""
+
+    def setUp(self):
+        self._saved_display = web_main.config.display_chat_ids
+        self._saved_push = web_main.push_manager
+        self._saved_db = web_main.db
+        web_main.config.display_chat_ids = set()
+        self.push = MagicMock()
+        self.push.is_enabled = True
+        self.push.notify_new_message = AsyncMock()
+        web_main.push_manager = self.push
+        web_main.db = AsyncMock()
+        web_main.db.get_chat_by_id = AsyncMock(
+            side_effect=lambda chat_id, **kwargs: _chat_row(chat_id, f"refPushName{chat_id:011d}")
+        )
+        web_main._broadcast_chat_cache.clear()
+
+    def tearDown(self):
+        web_main.config.display_chat_ids = self._saved_display
+        web_main.push_manager = self._saved_push
+        web_main.db = self._saved_db
+        web_main._broadcast_chat_cache.clear()
+
+    def _payload(self, message):
+        return {"type": "new_message", "chat_id": 100, "data": {"message": message}}
+
+    async def test_enriched_payload_needs_no_db_lookup(self):
+        await web_main.handle_realtime_notification(
+            self._payload(
+                {"id": 1, "sender_id": 42, "sender_name": "", "first_name": "Ada", "last_name": "L", "text": "hi"}
+            )
+        )
+
+        web_main.db.get_user_by_id.assert_not_awaited()
+        assert self.push.notify_new_message.await_args.kwargs["sender_name"] == "Ada L"
+
+    async def test_capture_time_snapshot_still_wins(self):
+        await web_main.handle_realtime_notification(
+            self._payload({"id": 1, "sender_id": 42, "sender_name": "Snapshot", "first_name": "Ada", "text": "hi"})
+        )
+
+        assert self.push.notify_new_message.await_args.kwargs["sender_name"] == "Snapshot"
+
+    async def test_bare_payload_falls_back_to_one_db_lookup(self):
+        web_main.db.get_user_by_id = AsyncMock(return_value={"first_name": "Grace", "last_name": "", "username": "gh"})
+
+        await web_main.handle_realtime_notification(self._payload({"id": 1, "sender_id": 42, "text": "hi"}))
+
+        web_main.db.get_user_by_id.assert_awaited_once_with(42)
+        assert self.push.notify_new_message.await_args.kwargs["sender_name"] == "Grace"


### PR DESCRIPTION
## Problem

`resolve_sender_display_name` is documented as the single source of truth for 'who sent this row' — so the message list, gallery, export and quote block can never drift apart — and the adapter uses it at three call sites. The Web Push path hand-rolled a FOURTH copy of the precedence chain, and paid a `get_user_by_id` DB round trip per notification for fields the listener already enriches into the WS payload (`first_name`/`last_name`/`username`, mirroring the API row shape). A future precedence change would silently miss the push path, and users would see a different sender in the notification than in the app.

## Fix

The push path feeds the shared helper from the payload first — the common path costs no DB query — with the lookup retained only for payloads that carry no user fields at all (and even that fallback now routes through the helper).

## Evidence

- Three regressions: an enriched payload resolves with ZERO db lookups; the capture-time snapshot still wins; a bare payload falls back to exactly one lookup. Mutation control blinding the helper to the payload fields fails the first; restore sha-verified.
- Full suite: 3418 passed, 127 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.5.46.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Push notifications now display the sender’s name from available message details when provided.
  * Sender information captured with a message takes precedence, while database lookup is used only when necessary.
  * Notifications without sender details now handle the sender name gracefully.

* **Tests**
  * Added coverage for sender-name precedence and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->