### PR TITLE
perf(backup): forward-heavy channels stop hammering Telegram once per forwarded message

### DIFF
--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -2783,6 +2783,64 @@ class TelegramBackup:
             # Don't fail the backup if pinned sync fails
             logger.debug(f"  → Could not sync pinned messages: {e}")
 
+    _FORWARD_NAME_CACHE_LIMIT = 10_000
+
+    async def _resolve_forward_source_name(self, peer) -> str | None:
+        """Resolve a forward source's display name: run cache, local DB, then API.
+
+        The sweep path deliberately avoids per-message entity resolution — one
+        API request per message is the dominant flood risk on forward-heavy
+        channels, and Telethon's get_entity has NO full-entity memory cache,
+        so 10,000 forwards used to cost 10,000 requests per run, again on
+        every later run. Each distinct source now costs at most one lookup per
+        run; negative results are cached too, so one unresolvable source costs
+        one request, not one per message.
+        """
+        try:
+            marked_id = get_peer_id(peer)
+        except TypeError:
+            return None
+        cache = getattr(self, "_forward_name_cache", None)
+        if cache is None:
+            cache = self._forward_name_cache = {}
+        if marked_id in cache:
+            return cache[marked_id]
+
+        name: str | None = None
+        try:
+            if marked_id > 0:
+                row = await self.db.get_user_by_id(marked_id)
+                if row:
+                    name = (
+                        f"{row.get('first_name') or ''} {row.get('last_name') or ''}".strip()
+                        or (row.get("username") or "").strip()
+                        or None
+                    )
+            else:
+                row = await self.db.get_chat_by_id(marked_id, account_id=self.account_id)
+                if row:
+                    name = (row.get("title") or "").strip() or None
+        except Exception:
+            name = None
+
+        if name is None:
+            try:
+                fwd_entity = await call_with_flood_retry(self.client.get_entity, peer)
+                if hasattr(fwd_entity, "title"):
+                    name = (fwd_entity.title or "").strip() or None
+                elif hasattr(fwd_entity, "first_name"):
+                    value = fwd_entity.first_name or ""
+                    if fwd_entity.last_name:
+                        value += " " + fwd_entity.last_name
+                    name = value.strip() or None
+            except Exception:
+                # Can't resolve - will fall back to ID in viewer
+                name = None
+
+        if len(cache) < self._FORWARD_NAME_CACHE_LIMIT:
+            cache[marked_id] = name
+        return name
+
     def _extract_forward_from_id(self, message: Message) -> int | None:
         """
         Extract forward sender ID safely handling different Peer types.
@@ -2977,19 +3035,9 @@ class TelegramBackup:
             if fwd.from_name:
                 message_data["raw_data"]["forward_from_name"] = fwd.from_name
             elif fwd.from_id:
-                # Try to resolve the name from the entity
-                try:
-                    fwd_entity = await call_with_flood_retry(self.client.get_entity, fwd.from_id)
-                    if hasattr(fwd_entity, "title"):
-                        message_data["raw_data"]["forward_from_name"] = fwd_entity.title
-                    elif hasattr(fwd_entity, "first_name"):
-                        name = fwd_entity.first_name or ""
-                        if fwd_entity.last_name:
-                            name += " " + fwd_entity.last_name
-                        message_data["raw_data"]["forward_from_name"] = name.strip()
-                except Exception:
-                    # Can't resolve - will fall back to ID in viewer
-                    pass
+                forward_name = await self._resolve_forward_source_name(fwd.from_id)
+                if forward_name:
+                    message_data["raw_data"]["forward_from_name"] = forward_name
 
         # Capture channel post author (signature) if available
         if hasattr(message, "post_author") and message.post_author:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -2837,8 +2837,13 @@ class TelegramBackup:
                 # Can't resolve - will fall back to ID in viewer
                 name = None
 
-        if len(cache) < self._FORWARD_NAME_CACHE_LIMIT:
-            cache[marked_id] = name
+        if len(cache) >= self._FORWARD_NAME_CACHE_LIMIT and marked_id not in cache:
+            # FIFO eviction at the cap (dicts preserve insertion order): a run
+            # with >10k distinct forward sources keeps best-effort caching
+            # instead of silently reverting to a per-message get_entity
+            # pattern — the FloodWait risk this cache exists to prevent.
+            cache.pop(next(iter(cache)))
+        cache[marked_id] = name
         return name
 
     def _extract_forward_from_id(self, message: Message) -> int | None:

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -1808,12 +1808,14 @@ class TestProcessMessage(unittest.TestCase):
         self.assertEqual(len(result["reply_to_text"]), 100)
 
     def test_forward_from_id_resolves_channel_title(self):
-        """Forward from channel resolves title via get_entity."""
+        """Forward from a channel unknown locally resolves its title via get_entity."""
+        from telethon.tl.types import PeerChannel
+
         msg = self._make_message(12)
         msg.fwd_from = MagicMock()
         msg.fwd_from.from_name = None
-        msg.fwd_from.from_id = MagicMock(spec=["channel_id"])
-        msg.fwd_from.from_id.channel_id = 555
+        msg.fwd_from.from_id = PeerChannel(channel_id=555)
+        self.backup.db.get_chat_by_id = AsyncMock(return_value=None)
 
         fwd_entity = MagicMock()
         fwd_entity.title = "Forwarded Channel"
@@ -1825,12 +1827,14 @@ class TestProcessMessage(unittest.TestCase):
         self.assertEqual(result["raw_data"]["forward_from_name"], "Forwarded Channel")
 
     def test_forward_from_id_resolves_user_name(self):
-        """Forward from user resolves first+last name via get_entity."""
+        """Forward from a user unknown locally resolves first+last via get_entity."""
+        from telethon.tl.types import PeerUser
+
         msg = self._make_message(13)
         msg.fwd_from = MagicMock()
         msg.fwd_from.from_name = None
-        msg.fwd_from.from_id = MagicMock(spec=["user_id"])
-        msg.fwd_from.from_id.user_id = 777
+        msg.fwd_from.from_id = PeerUser(user_id=777)
+        self.backup.db.get_user_by_id = AsyncMock(return_value=None)
 
         fwd_entity = MagicMock(spec=["first_name", "last_name"])
         fwd_entity.first_name = "John"
@@ -2194,3 +2198,112 @@ class TestBackupDialogCursorAdvancesOnSkippedMessages(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestForwardSourceNameResolution(unittest.TestCase):
+    """Forward sources resolve local-first with a per-run cache.
+
+    The sweep path forbids per-message entity resolution (its own comment:
+    one API request per message is avoidable flood risk), yet every forward
+    with a from_id paid a get_entity call — Telethon has no full-entity
+    memory cache, so a 10,000-forward channel cost 10,000 requests per run,
+    every run. Each distinct source now costs at most one lookup per run,
+    negative results included.
+    """
+
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
+        self.backup.db = AsyncMock()
+        self.backup.db.get_user_by_id = AsyncMock(return_value=None)
+        self.backup.db.get_chat_by_id = AsyncMock(return_value=None)
+        self.backup.config = MagicMock()
+        self.backup.config.should_download_media_for_chat = MagicMock(return_value=False)
+        self.backup.client = AsyncMock()
+
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def test_local_users_table_wins_no_api_call(self):
+        from telethon.tl.types import PeerUser
+
+        self.backup.db.get_user_by_id = AsyncMock(return_value={"first_name": "Ada", "last_name": "Lovelace"})
+
+        name = self._run(self.backup._resolve_forward_source_name(PeerUser(user_id=42)))
+
+        self.assertEqual(name, "Ada Lovelace")
+        self.backup.client.get_entity.assert_not_awaited()
+        self.backup.db.get_user_by_id.assert_awaited_once_with(42)
+
+    def test_local_chats_table_wins_for_channels(self):
+        from telethon.tl.types import PeerChannel
+
+        self.backup.db.get_chat_by_id = AsyncMock(return_value={"title": "News Channel"})
+
+        name = self._run(self.backup._resolve_forward_source_name(PeerChannel(channel_id=99999)))
+
+        self.assertEqual(name, "News Channel")
+        self.backup.client.get_entity.assert_not_awaited()
+        self.backup.db.get_chat_by_id.assert_awaited_once_with(-1000000099999, account_id=1)
+
+    def test_one_api_call_per_distinct_source_per_run(self):
+        from telethon.tl.types import PeerChannel
+
+        entity = MagicMock(spec=["title"])
+        entity.title = "Aggregated"
+        self.backup.client.get_entity = AsyncMock(return_value=entity)
+
+        async def scenario():
+            results = []
+            for _ in range(500):
+                results.append(await self.backup._resolve_forward_source_name(PeerChannel(channel_id=777)))
+            return results
+
+        results = self._run(scenario())
+
+        self.assertEqual(results, ["Aggregated"] * 500)
+        self.backup.client.get_entity.assert_awaited_once()
+
+    def test_unresolvable_source_costs_one_request_not_one_per_message(self):
+        from telethon.tl.types import PeerUser
+
+        self.backup.client.get_entity = AsyncMock(side_effect=ValueError("no such user"))
+
+        async def scenario():
+            return [await self.backup._resolve_forward_source_name(PeerUser(user_id=314)) for _ in range(50)]
+
+        results = self._run(scenario())
+
+        self.assertEqual(results, [None] * 50)
+        self.backup.client.get_entity.assert_awaited_once()
+
+    def test_process_message_stores_the_resolved_name(self):
+        from telethon.tl.types import PeerChannel
+
+        self.backup.db.get_chat_by_id = AsyncMock(return_value={"title": "Origin"})
+        msg = MagicMock()
+        msg.id = 7
+        msg.sender = None
+        msg.sender_id = 42
+        msg.date = datetime(2024, 1, 1)
+        msg.text = "fwd"
+        msg.reply_to_msg_id = None
+        msg.reply_to = None
+        msg.edit_date = None
+        msg.out = False
+        msg.media = None
+        msg.grouped_id = None
+        msg.post_author = None
+        msg.action = None
+        msg.fwd_from = MagicMock()
+        msg.fwd_from.from_name = None
+        msg.fwd_from.from_id = PeerChannel(channel_id=555)
+
+        result = self._run(self.backup._process_message(msg, 100))
+
+        self.assertEqual(result["raw_data"]["forward_from_name"], "Origin")
+        self.backup.client.get_entity.assert_not_awaited()

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -2281,6 +2281,37 @@ class TestForwardSourceNameResolution(unittest.TestCase):
         self.assertEqual(results, [None] * 50)
         self.backup.client.get_entity.assert_awaited_once()
 
+    def test_cache_at_capacity_evicts_fifo_instead_of_refusing_new_sources(self):
+        """Beyond the cap the cache must stay best-effort (FIFO eviction), not
+        go read-only: a refuse-at-cap policy made every message from source
+        10,001+ repeat the get_entity call — the per-message API pattern this
+        cache exists to prevent."""
+        from telethon.tl.types import PeerChannel
+
+        entity = MagicMock(spec=["title"])
+        entity.title = "Overflow"
+        self.backup.client.get_entity = AsyncMock(return_value=entity)
+        # The cache is lazily created on first resolve; pre-fill it to the cap
+        # with resolved entries. Id 0 is the oldest.
+        cache = self.backup._forward_name_cache = {
+            marked_id: f"cached-{marked_id}" for marked_id in range(self.backup._FORWARD_NAME_CACHE_LIMIT)
+        }
+
+        async def scenario():
+            return [await self.backup._resolve_forward_source_name(PeerChannel(channel_id=777)) for _ in range(5)]
+
+        results = self._run(scenario())
+
+        self.assertEqual(results, ["Overflow"] * 5)
+        # One lookup, then served from cache — the new source WAS admitted...
+        self.backup.client.get_entity.assert_awaited_once()
+        marked = next(k for k in cache if k not in range(self.backup._FORWARD_NAME_CACHE_LIMIT))
+        self.assertEqual(cache[marked], "Overflow")
+        # ...the oldest entry made room, and the cap still holds.
+        self.assertNotIn(0, cache)
+        self.assertIn(1, cache)
+        self.assertEqual(len(cache), self.backup._FORWARD_NAME_CACHE_LIMIT)
+
     def test_process_message_stores_the_resolved_name(self):
         from telethon.tl.types import PeerChannel
 


### PR DESCRIPTION
## Problem

The sweep path deliberately avoids per-message entity resolution — its own comment, 100 lines above this site, calls it avoidable flood risk. Yet every forwarded message whose `fwd_from` carries a `from_id` (the normal case for public-channel and non-hidden-user forwards) paid a `get_entity` API call. Verified against the installed Telethon: `get_entity` has NO full-entity memory cache — `users.GetUsers`/`channels.GetChannels` go out unconditionally — so a 10,000-forward aggregator channel cost 10,000 extra requests per backfill, and the same again on every later run, with every failure swallowed by a bare `except`.

## Fix

Forward sources resolve exactly like the file's own `_resolve_display_name`: the local users/chats tables first (marked peer id keying, account-scoped for chats), then at most ONE API call per distinct source per run — negative results cached too, so one unresolvable source costs one request rather than one per message. Bounded per-instance dict (10k entries).

## Evidence

- Tests: a locally-known user/channel resolves with ZERO API calls; 500 forwards from one source cost exactly one `get_entity`; 50 forwards from an unresolvable source cost exactly one; `_process_message` end-to-end stores the DB-resolved name. Two mutation controls green-then-red (memoization removed; DB step skipped); restores sha-verified.
- The two legacy tests that drove this branch with mock peers are repointed to real `PeerChannel`/`PeerUser` objects with an explicit local miss.
- Full suite: 3420 passed, 127 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.5.51.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display of names for forwarded messages.
  * Forwarded-source names are now resolved from available local information before contacting Telegram, improving reliability and reducing unnecessary lookups.
  * Added caching for successful and unsuccessful name resolutions, improving performance when processing repeated forwarded sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->