### PR TITLE
fix(backup): an attachment whose download yields no file is finally retried

### DIFF
--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -613,6 +613,20 @@ async def iter_messages_with_flood_retry(client, entity, *, min_id=0, **kwargs):
             await _reconnect_before_retry(client, "iter_messages")
 
 
+def _failed_media_row(media_id: str, media_type: str, message_id: int, chat_id: int) -> dict:
+    """The value-less media row a failed download leaves behind.
+
+    downloaded=0 is what makes the failure retryable: the pending-media drain
+    only sees rows, so a failure that leaves none is permanently silent."""
+    return {
+        "id": media_id,
+        "type": media_type,
+        "message_id": message_id,
+        "chat_id": chat_id,
+        "downloaded": False,
+    }
+
+
 class TelegramBackup:
     """Main class for managing Telegram backups."""
 
@@ -3425,7 +3439,12 @@ class TelegramBackup:
                     account_id=self.account_id,
                 )
                 if not shared_file_path and not os.path.lexists(file_path):
-                    return None
+                    # A download that yields no file must still leave a row:
+                    # the retry drain only sees downloaded=0 rows, so returning
+                    # None here made this failure shape permanently silent
+                    # while the sibling exception path was retried every cycle.
+                    logger.warning("Media download did not produce a file; recorded for retry")
+                    return _failed_media_row(media_id, media_type, message.id, chat_id)
 
                 # Backup-specific post-processing: update file_size from disk
                 if not shared_file_path:
@@ -3449,8 +3468,9 @@ class TelegramBackup:
                         file_path,
                     )
                     if not file_path or not os.path.exists(file_path):
-                        logger.warning("Media download did not produce a file")
-                        return None
+                        # Same retryable row as the dedup branch above.
+                        logger.warning("Media download did not produce a file; recorded for retry")
+                        return _failed_media_row(media_id, media_type, message.id, chat_id)
                     logger.debug(f"Downloaded media: {file_name}")
 
                 # Update file_size and compute hash from disk
@@ -3491,13 +3511,7 @@ class TelegramBackup:
 
         except Exception as e:
             logger.error(f"Error downloading media: {describe_exception(e)}")
-            return {
-                "id": media_id,
-                "type": media_type,
-                "message_id": message.id,
-                "chat_id": chat_id,
-                "downloaded": False,
-            }
+            return _failed_media_row(media_id, media_type, message.id, chat_id)
 
     def _should_parallelize(self, message, file_size: int) -> bool:
         """Decide whether this file should use the parallel chunked path.

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -2124,6 +2124,36 @@ class TestProcessMedia(unittest.TestCase):
         self.backup._get_media_size = MagicMock(return_value=100)
         self.backup._get_media_filename = MagicMock(return_value="test.jpg")
 
+    def test_no_file_download_leaves_a_retryable_row(self):
+        """A download that yields no file must leave a downloaded=0 row —
+        the pending-media drain only sees rows, so the old return None made
+        this failure shape permanently silent while the sibling exception
+        path was retried every cycle."""
+        msg = self._make_photo_message(21)
+        self._setup_photo_download()
+        # download_media returns None and writes nothing: no file appears.
+        self.backup.client.download_media = AsyncMock(return_value=None)
+
+        result = _run(self.backup._process_media(msg, 100))
+
+        self.assertIsNotNone(result, "the failure must leave a row behind")
+        self.assertFalse(result["downloaded"])
+        self.assertEqual(result["id"], "100_21_photo")
+        self.assertEqual(result["message_id"], 21)
+        self.assertEqual(result["chat_id"], 100)
+
+    def test_no_file_download_leaves_a_retryable_row_with_dedup(self):
+        """Same guarantee on the deduplicated path."""
+        msg = self._make_photo_message(22)
+        self._setup_photo_download()
+        self.backup.config.deduplicate_media = True
+        with patch("src.telegram_backup.download_and_shard_media", AsyncMock(return_value=(None, None))):
+            result = _run(self.backup._process_media(msg, 100))
+
+        self.assertIsNotNone(result)
+        self.assertFalse(result["downloaded"])
+        self.assertEqual(result["id"], "100_22_photo")
+
     def test_document_with_dimensions_and_duration(self):
         """Document with width, height, and duration stores metadata."""
         msg = _make_message(1)


### PR DESCRIPTION
## Problem

Whether a failed media download was recoverable depended on **how** it failed. An exception inside `_process_media` persisted a `downloaded=0` row — retried by the pending drain every cycle. But a no-file outcome (`download_media` returned nothing, or `finalize_atomic_download` found no file) returned `None`: no media row at all, so the message was archived as though it never had an attachment. `_retry_pending_media_downloads` only drains rows, the capped-downloads counter never saw it, and once the sweep cursor passed the message, no path ever revisited it. The only signal was one generic warning.

## Fix

Both no-file branches (dedup and direct) return the same value-less `downloaded=0` row the exception path always has, via one shared `_failed_media_row` helper, with the warning now saying the failure was recorded for retry.

The listener's identical-looking shape is deliberately left alone: its messages sit ABOVE the backup cursor (`get_last_message_id` reads sync_status, which only backup runs advance), so the next scheduled sweep re-attempts their media — verified against the cursor source before scoping.

## Evidence

- Regressions on both branches: a no-file download leaves `{id, type, message_id, chat_id, downloaded: False}`; mutation control restoring the silent `return None` fails both. Restore sha-verified.
- Full suite: 3417 passed, 127 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.5.40.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Failed media downloads now remain visible as pending items for retry, including downloads that produce no file or encounter an error.
  - Improved consistency for media download failure handling across standard and deduplicated downloads.

- **Tests**
  - Added coverage confirming failed downloads remain retryable in both download paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->