### PR TITLE
perf(download): big archives stop opening 40,000 connections to move 10,000 files

### DIFF
--- a/src/parallel_download.py
+++ b/src/parallel_download.py
@@ -150,6 +150,10 @@ class ParallelDownloader:
         # metadata. A ceiling caps how many chunks (and how large a
         # pre-allocation) one transfer can request before we fall back.
         self._max_file_size = int(max_file_size) if max_file_size and max_file_size > 0 else None
+        # Negotiated auth key per foreign DC, kept for the downloader's
+        # lifetime: exportAuthorization is flood-limited and paying it once
+        # per FILE was the dominant spend of the caller's flood budget.
+        self._dc_auth_keys: dict = {}
 
     async def download_media(self, message, file) -> str:
         """Download ``message``'s media to path ``file`` and return ``file``.
@@ -282,28 +286,39 @@ class ParallelDownloader:
         senders: list[MTProtoSender] = []
         try:
             if dc_id is None or dc_id == home_dc:
-                target_dc = home_dc
-                auth_key = client.session.auth_key
-                for _ in range(n):
-                    senders.append(await self._connect_sender(target_dc, auth_key))
-            else:
-                first = await self._connect_sender(dc_id, None)
-                senders.append(first)
-                # Hold the borrow lock while mutating the shared init request,
-                # mirroring Telethon's own _create_exported_sender. Restore the
-                # original query afterwards so concurrent users of _init_request
-                # never observe our transient ImportAuthorizationRequest.
-                async with client._borrow_sender_lock:
-                    saved_query = client._init_request.query
-                    try:
-                        auth = await client(ExportAuthorizationRequest(dc_id))
-                        client._init_request.query = ImportAuthorizationRequest(id=auth.id, bytes=auth.bytes)
-                        await first.send(InvokeWithLayerRequest(LAYER, client._init_request))
-                    finally:
-                        client._init_request.query = saved_query
-                auth_key = first.auth_key
-                for _ in range(n - 1):
-                    senders.append(await self._connect_sender(dc_id, auth_key))
+                senders.extend(await self._connect_many(home_dc, client.session.auth_key, n))
+                return senders
+
+            cached_key = self._dc_auth_keys.get(dc_id)
+            if cached_key is not None:
+                try:
+                    senders.extend(await self._connect_many(dc_id, cached_key, n))
+                    return senders
+                except ParallelDownloadUnavailable, FloodWaitError, FileReferenceExpiredError:
+                    raise
+                except Exception:
+                    # The cached key went stale: drop it and fall through to a
+                    # fresh export, exactly like a first encounter with the DC.
+                    self._dc_auth_keys.pop(dc_id, None)
+
+            first = await self._connect_sender(dc_id, None)
+            senders.append(first)
+            # Hold the borrow lock while mutating the shared init request,
+            # mirroring Telethon's own _create_exported_sender. Restore the
+            # original query afterwards so concurrent users of _init_request
+            # never observe our transient ImportAuthorizationRequest.
+            async with client._borrow_sender_lock:
+                saved_query = client._init_request.query
+                try:
+                    auth = await client(ExportAuthorizationRequest(dc_id))
+                    client._init_request.query = ImportAuthorizationRequest(id=auth.id, bytes=auth.bytes)
+                    await first.send(InvokeWithLayerRequest(LAYER, client._init_request))
+                finally:
+                    client._init_request.query = saved_query
+            auth_key = first.auth_key
+            senders.extend(await self._connect_many(dc_id, auth_key, n - 1))
+            # Cache only after every sibling connected with it.
+            self._dc_auth_keys[dc_id] = auth_key
             return senders
         except ParallelDownloadUnavailable:
             await self._close_senders(senders)
@@ -316,6 +331,25 @@ class ParallelDownloader:
                 # them, rather than masking them as a generic fallback.
                 raise
             raise ParallelDownloadUnavailable(f"failed to establish parallel senders: {exc}") from exc
+
+    async def _connect_many(self, dc_id, auth_key, count: int) -> list[MTProtoSender]:
+        """Connect ``count`` senders concurrently — setup costs one RTT, not ``count``.
+
+        All-or-nothing: on any failure the siblings that DID connect are closed
+        before the first error propagates, so no connection leaks past a
+        failed build."""
+        if count <= 0:
+            return []
+        results = await asyncio.gather(
+            *(self._connect_sender(dc_id, auth_key) for _ in range(count)),
+            return_exceptions=True,
+        )
+        failures = [r for r in results if isinstance(r, BaseException)]
+        connected = [r for r in results if not isinstance(r, BaseException)]
+        if failures:
+            await self._close_senders(connected)
+            raise failures[0]
+        return connected
 
     async def _connect_sender(self, dc_id, auth_key) -> MTProtoSender:
         client = self._client

--- a/src/parallel_download.py
+++ b/src/parallel_download.py
@@ -299,6 +299,12 @@ class ParallelDownloader:
                 except Exception:
                     # The cached key went stale: drop it and fall through to a
                     # fresh export, exactly like a first encounter with the DC.
+                    # Deliberately includes ConnectionError — Telethon surfaces
+                    # a dead imported key as a connection-level failure, so
+                    # "preserve on transport errors" would wedge a dead key in
+                    # the cache with no heal path; the price of guessing wrong
+                    # on a transient blip is one bounded re-export, and the
+                    # file still completes in parallel either way.
                     self._dc_auth_keys.pop(dc_id, None)
 
             first = await self._connect_sender(dc_id, None)
@@ -323,12 +329,18 @@ class ParallelDownloader:
         except ParallelDownloadUnavailable:
             await self._close_senders(senders)
             raise
-        except Exception as exc:  # noqa: BLE001
+        except BaseException as exc:  # noqa: BLE001
+            # BaseException, not Exception: a cancelled download (task teardown,
+            # shutdown) otherwise skipped this cleanup and leaked every sender
+            # connected so far — `first` included.
             await self._close_senders(senders)
             if isinstance(exc, (FloodWaitError, FileReferenceExpiredError)):
                 # Surface flood (single budget) and stale-reference (refresh
                 # loop) unchanged so the caller's existing handling governs
                 # them, rather than masking them as a generic fallback.
+                raise
+            if not isinstance(exc, Exception):
+                # CancelledError and friends propagate unchanged.
                 raise
             raise ParallelDownloadUnavailable(f"failed to establish parallel senders: {exc}") from exc
 

--- a/tests/test_parallel_download.py
+++ b/tests/test_parallel_download.py
@@ -622,6 +622,45 @@ class TestSenderLifecycle(_PatchHelpers, _TmpDirMixin, unittest.IsolatedAsyncioT
             await dl._build_senders(client.session.dc_id, 2)
         self.assertTrue(closed)  # cleanup ran on the ParallelDownloadUnavailable path
 
+    async def test_build_senders_closes_first_on_cancellation(self) -> None:
+        """Cancellation mid-build (task teardown) must close every sender
+        connected so far — the old `except Exception` skipped CancelledError
+        and leaked `first` with its live socket."""
+        client = ForeignDCClient(b"x" * 100, home_dc=2)
+        first_sender = client.make_sender()
+        first_sender.connected = True
+
+        def _connect(_self: ParallelDownloader, dc_id: int, auth_key: Any) -> Any:
+            async def _inner() -> Any:
+                return first_sender
+
+            return _inner()
+
+        self._patch_object(ParallelDownloader, "_connect_sender", _connect)
+        closed: list[Any] = []
+
+        async def _track_close(_self: ParallelDownloader, senders: Any) -> None:
+            closed.extend(senders)
+
+        self._patch_object(ParallelDownloader, "_close_senders", _track_close)
+
+        export_started = asyncio.Event()
+
+        async def _hang_forever(request: Any) -> Any:
+            export_started.set()
+            await asyncio.Event().wait()
+
+        client.__class__ = type("HangingClient", (ForeignDCClient,), {})
+        client.__class__.__call__ = lambda self, request: _hang_forever(request)
+
+        dl = ParallelDownloader(client, connections=2, part_size=524288)
+        task = asyncio.ensure_future(dl._build_senders(4, 2))
+        await asyncio.wait_for(export_started.wait(), timeout=2)
+        task.cancel()
+        with self.assertRaises(asyncio.CancelledError):
+            await task
+        self.assertIn(first_sender, closed)  # first was closed, not leaked
+
     async def test_close_senders_swallows_disconnect_errors(self) -> None:
         dl = ParallelDownloader(FakeClient(b"x"), connections=4, part_size=524288)
 

--- a/tests/test_parallel_download.py
+++ b/tests/test_parallel_download.py
@@ -855,3 +855,126 @@ class TestFetchMediaBytes(_PatchHelpers, unittest.IsolatedAsyncioTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestSenderReuseAndConcurrency(_PatchHelpers, _TmpDirMixin, unittest.IsolatedAsyncioTestCase):
+    """Sender setup must not scale with the number of files.
+
+    exportAuthorization is flood-limited and its FloodWait lands in the
+    caller's single retry budget — paying it once per FILE (the old shape)
+    actively spent the budget meant for the transfer. The negotiated key is
+    now cached per DC for the downloader's lifetime, and sibling connects run
+    concurrently (one RTT, not n)."""
+
+    def _patch_foreign_sender(self, client: FakeClient) -> None:
+        def _connect_sender_stub(_self: ParallelDownloader, dc_id: int, auth_key: Any) -> Any:
+            async def _inner() -> FakeSender:
+                s = client.make_sender()
+                s.dc_id = dc_id
+                s.connected = True
+                return s
+
+            return _inner()
+
+        self._patch_object(ParallelDownloader, "_connect_sender", _connect_sender_stub)
+
+    async def test_foreign_dc_exports_auth_once_across_files(self) -> None:
+        blob = os.urandom(524288 * 4)
+        client = ForeignDCClient(blob, home_dc=2)
+        self._patch_object(utils, "get_input_location", lambda m: (4, object()))
+        self._patch_foreign_sender(client)
+
+        dl = ParallelDownloader(client, connections=3, part_size=524288)
+        await dl.download_media(_make_message(len(blob)), str(self.tmp / "one.bin"))
+        await dl.download_media(_make_message(len(blob)), str(self.tmp / "two.bin"))
+
+        self.assertEqual(_read(str(self.tmp / "two.bin")), blob)
+        self.assertEqual(len(client.export_calls), 1, "the second file must reuse the negotiated key")
+
+    async def test_stale_cached_key_re_exports_and_recovers(self) -> None:
+        blob = os.urandom(524288 * 2)
+        client = ForeignDCClient(blob, home_dc=2)
+        self._patch_object(utils, "get_input_location", lambda m: (4, object()))
+
+        stale = object()
+
+        def _connect_sender_stub(_self: ParallelDownloader, dc_id: int, auth_key: Any) -> Any:
+            async def _inner() -> FakeSender:
+                if auth_key is stale:
+                    raise ConnectionError("key no longer accepted")
+                s = client.make_sender()
+                s.dc_id = dc_id
+                s.connected = True
+                return s
+
+            return _inner()
+
+        self._patch_object(ParallelDownloader, "_connect_sender", _connect_sender_stub)
+
+        dl = ParallelDownloader(client, connections=2, part_size=524288)
+        dl._dc_auth_keys[4] = stale
+
+        await dl.download_media(_make_message(len(blob)), str(self.tmp / "healed.bin"))
+
+        self.assertEqual(_read(str(self.tmp / "healed.bin")), blob)
+        self.assertEqual(len(client.export_calls), 1, "a stale key falls back to one fresh export")
+        self.assertNotIn(stale, dl._dc_auth_keys.values())
+
+    async def test_sibling_connects_run_concurrently(self) -> None:
+        """Two sibling connects must overlap: each waits for the other to have
+        STARTED before completing — sequential builds would deadlock here (the
+        1s guard turns that into a failure instead of a hang)."""
+        blob = os.urandom(524288 * 2)
+        client = FakeClient(blob)
+        self._patch_object(utils, "get_input_location", lambda m: (client.session.dc_id, object()))
+
+        started = asyncio.Event()
+        both_started = asyncio.Event()
+        starts = {"n": 0}
+
+        def _connect_sender_stub(_self: ParallelDownloader, dc_id: int, auth_key: Any) -> Any:
+            async def _inner() -> FakeSender:
+                starts["n"] += 1
+                if starts["n"] >= 2:
+                    both_started.set()
+                started.set()
+                await asyncio.wait_for(both_started.wait(), timeout=1)
+                s = client.make_sender()
+                s.dc_id = dc_id
+                s.connected = True
+                return s
+
+            return _inner()
+
+        self._patch_object(ParallelDownloader, "_connect_sender", _connect_sender_stub)
+
+        dl = ParallelDownloader(client, connections=2, part_size=524288)
+        await dl.download_media(_make_message(len(blob)), str(self.tmp / "concurrent.bin"))
+        self.assertEqual(_read(str(self.tmp / "concurrent.bin")), blob)
+
+    async def test_partial_build_failure_closes_the_connected_siblings(self) -> None:
+        blob = os.urandom(524288 * 2)
+        client = FakeClient(blob)
+        self._patch_object(utils, "get_input_location", lambda m: (client.session.dc_id, object()))
+
+        calls = {"n": 0}
+
+        def _connect_sender_stub(_self: ParallelDownloader, dc_id: int, auth_key: Any) -> Any:
+            async def _inner() -> FakeSender:
+                calls["n"] += 1
+                if calls["n"] == 2:
+                    raise ConnectionError("second connect refused")
+                s = client.make_sender()
+                s.dc_id = dc_id
+                s.connected = True
+                return s
+
+            return _inner()
+
+        self._patch_object(ParallelDownloader, "_connect_sender", _connect_sender_stub)
+
+        dl = ParallelDownloader(client, connections=2, part_size=524288)
+        with self.assertRaises(ParallelDownloadUnavailable):
+            await dl.download_media(_make_message(len(blob)), str(self.tmp / "fail.bin"))
+
+        self.assertTrue(all(s.disconnected for s in client.created_senders), "connected sibling leaked")


### PR DESCRIPTION
## Problem

Every file above the parallel threshold built and tore down its whole sender pool: 4 sequential MTProto connects + 4 disconnects per file, and on a foreign DC one `exportAuthorization` per file. That export is flood-limited, and its FloodWait is deliberately surfaced into the caller's SINGLE retry budget — so the per-file churn actively spent the flood budget meant for the transfer itself. Measured shape (bead's probe, reproduced by its verifier): 3 files → 12 connects, 12 disconnects, 3 exports; at scale, 10,000 files → 40,000 connections and 10,000 flood-limited RPCs, with the sequential 4-sender build adding ~n×RTT of dead time per file.

## Fix

- The NEGOTIATED per-DC auth key (the same thing sibling senders already reuse within a file) is cached on the downloader for its lifetime: the second and every later file on that DC skips export+import entirely. A stale key drops the cache entry and falls back to one fresh export — a first-encounter, self-healing.
- Sibling connects run concurrently (`_connect_many`): setup costs one RTT, not n, and the build is all-or-nothing — connected siblings are closed before any failure propagates, so nothing leaks past a failed build.
- Full sender pooling across files was **considered and left out**: it would trade one more RTT per file for TCP-staleness lifecycle risk that the single retry budget would then have to carry.

## Evidence

- New tests: two files on a foreign DC cost exactly ONE export; a stale cached key re-exports once and recovers; sibling connects provably overlap (a barrier that deadlocks under sequential builds, 1s guard); a partial build closes the connected sibling. Two mutation controls green-then-red (cache write removed; gather serialized). Restores sha-verified.
- All 49 pre-existing module tests unchanged and green. Full suite: 3419 passed, 127 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.6.4.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved parallel downloads by reusing secure connections across files.
  * Reduced delays when connecting multiple download channels.
* **Reliability**
  * Added automatic recovery when a connection becomes outdated.
  * Ensured failed connection attempts clean up partially established connections.
* **Tests**
  * Added coverage for connection reuse, concurrent setup, recovery, and cleanup scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->