### PR TITLE
fix(db): infinite scroll stops paying 1.7x round trips on media-heavy chats

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -2979,31 +2979,22 @@ class DatabaseAdapter:
         """
         async with self.db_manager.async_session_factory() as session:
             # Build query with joins - v6.0.0: join on composite key
+            # No Media join here: a message can carry SEVERAL media rows (a
+            # JSON import writes import_{chat}_{msg} beside the live
+            # {chat}_{msg}_{type} row), and LIMIT applied to the multiplied
+            # join meant a page of 50 could deliver far fewer distinct
+            # messages — measured 50 rows / 30 messages with 10 three-media
+            # heads. Media is batch-attached below from the page's id set,
+            # the same shape versions and reactions already use. The User
+            # join stays: users.id is unique, so it cannot multiply.
             stmt = (
                 select(
                     Message,
                     User.first_name,
                     User.last_name,
                     User.username,
-                    Media.id.label("media_id"),
-                    Media.type.label("media_type"),
-                    Media.file_path.label("media_file_path"),
-                    Media.file_name.label("media_file_name"),
-                    Media.file_size.label("media_file_size"),
-                    Media.mime_type.label("media_mime_type"),
-                    Media.width.label("media_width"),
-                    Media.height.label("media_height"),
-                    Media.duration.label("media_duration"),
                 )
                 .outerjoin(User, Message.sender_id == User.id)
-                .outerjoin(
-                    Media,
-                    and_(
-                        Media.account_id == Message.account_id,
-                        Media.message_id == Message.id,
-                        Media.chat_id == Message.chat_id,
-                    ),
-                )
                 .where(Message.chat_id == chat_id)
             )
 
@@ -3057,27 +3048,16 @@ class DatabaseAdapter:
             result = await session.execute(stmt)
             messages = []
 
+            # account_id is carried beside each row (not in the API dict — the
+            # response stays ref-addressed) so the media attach below can match
+            # per (account, message) even in unscoped mode.
+            row_accounts: list[int] = []
             for row in result:
                 msg = self._message_to_dict(row.Message)
                 msg["first_name"] = row.first_name
                 msg["last_name"] = row.last_name
                 msg["username"] = row.username
-
-                # v6.0.0: Media as nested object
-                if row.media_type:
-                    msg["media"] = {
-                        "id": row.media_id,
-                        "type": row.media_type,
-                        "file_path": row.media_file_path,
-                        "file_name": row.media_file_name,
-                        "file_size": row.media_file_size,
-                        "mime_type": row.media_mime_type,
-                        "width": row.media_width,
-                        "height": row.media_height,
-                        "duration": row.media_duration,
-                    }
-                else:
-                    msg["media"] = None
+                msg["media"] = None
 
                 # Parse raw_data JSON
                 if msg.get("raw_data"):
@@ -3087,14 +3067,53 @@ class DatabaseAdapter:
                         logger.debug("Malformed raw_data JSON for a message row; substituting empty dict")
                         msg["raw_data"] = {}
 
+                row_accounts.append(row.Message.account_id)
                 messages.append(msg)
 
             if after_id is not None:
                 # Selected oldest-first for the LIMIT; restore the newest-first contract.
                 messages.reverse()
+                row_accounts.reverse()
 
             version_counts = {msg["id"]: 0 for msg in messages}
             page_message_ids = [msg["id"] for msg in messages]
+
+            # v6.0.0 media as a nested object — batched for the page. When a
+            # message carries several media rows, ONE is attached
+            # deterministically: a downloaded row beats a pending one, then
+            # the lowest media id wins (the old join order was arbitrary).
+            if page_message_ids:
+                media_stmt = (
+                    select(Media)
+                    .where(
+                        and_(
+                            Media.chat_id == chat_id,
+                            Media.message_id.in_(page_message_ids),
+                        )
+                    )
+                    .order_by(Media.message_id, Media.downloaded.desc(), Media.id)
+                )
+                if account_id is not None:
+                    media_stmt = media_stmt.where(Media.account_id == account_id)
+                media_result = await session.execute(media_stmt)
+                media_by_key: dict[tuple[int, int], dict[str, Any]] = {}
+                for media_row in media_result.scalars():
+                    key = (media_row.account_id, media_row.message_id)
+                    if key in media_by_key:
+                        continue
+                    media_by_key[key] = {
+                        "id": media_row.id,
+                        "type": media_row.type,
+                        "file_path": media_row.file_path,
+                        "file_name": media_row.file_name,
+                        "file_size": media_row.file_size,
+                        "mime_type": media_row.mime_type,
+                        "width": media_row.width,
+                        "height": media_row.height,
+                        "duration": media_row.duration,
+                    }
+                for account, msg in zip(row_accounts, messages, strict=True):
+                    msg["media"] = media_by_key.get((account, msg["id"]))
             if page_message_ids:
                 count_stmt = (
                     select(MessageVersion.message_id, func.count(MessageVersion.id).label("version_count"))

--- a/tests/test_adapter_query_hardening.py
+++ b/tests/test_adapter_query_hardening.py
@@ -498,10 +498,14 @@ async def _seed_media_chat(adapter: DatabaseAdapter, messages: int, media_per_me
 
 @pytest.mark.asyncio
 async def test_message_page_reads_the_media_table_once(sqlite_adapter):
-    """The page already outer-joins media; the selectin loader read it again.
+    """Exactly ONE purposeful media read per page: the batched attach.
 
-    Nothing in src/ reads Message.media_items, so that second read built a full
-    set of Media ORM objects per page and threw them away.
+    History, both directions guarded: the page once outer-joined media AND
+    selectin-loaded it a second time (a full set of ORM objects thrown away);
+    later the join itself proved wrong — LIMIT counted the multiplied join
+    rows, shrinking the page (TestPageLimitCountsMessagesRealEngine). Media
+    now arrives via one batched query keyed by the page's message ids, and
+    the page statement reads no media at all.
     """
     await _seed_media_chat(sqlite_adapter, messages=6)
 
@@ -509,14 +513,18 @@ async def test_message_page_reads_the_media_table_once(sqlite_adapter):
         messages = await sqlite_adapter.get_messages_paginated(CHAT_ID, limit=5)
 
     assert messages, "the page must still carry its messages"
-    assert any(message.get("media") for message in messages), "media must still be joined in"
+    assert any(message.get("media") for message in messages), "media must still be attached"
 
-    eager_reads = [
-        statement
-        for statement in recorder.statements
-        if statement.startswith("SELECT media.") and "JOIN" not in statement and "messages" not in statement
+    media_reads = [statement for statement in recorder.statements if "FROM media" in statement]
+    assert len(media_reads) == 1, f"exactly one media read expected: {media_reads}"
+    assert "message_id IN" in media_reads[0], "the media read must be keyed by the page ids"
+
+    page_reads = [
+        statement for statement in recorder.statements if "FROM messages" in statement and "LIMIT" in statement
     ]
-    assert eager_reads == [], f"the media table is still being read a second time: {eager_reads}"
+    assert page_reads and all("media" not in statement for statement in page_reads), (
+        "the page statement must not touch media — LIMIT would count join rows again"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -2065,11 +2065,33 @@ class TestGetMessagesPaginated:
         adapter = DatabaseAdapter(db_manager)
 
         row = self._make_message_row(msg_id=20, media_type="photo")
+        row.Message.account_id = 1
         mock_result = MagicMock()
         mock_result.__iter__ = MagicMock(return_value=iter([row]))
-        mock_session.execute.return_value = mock_result
 
-        adapter.get_reactions = AsyncMock(return_value=[])
+        # Media is batch-attached from the page's id set (second query) since
+        # the join-multiplication fix — one deterministic row per message.
+        media_row = MagicMock()
+        media_row.account_id = 1
+        media_row.message_id = 20
+        media_row.id = "100_20_photo"
+        media_row.type = "photo"
+        media_row.file_path = "/path/photo.jpg"
+        media_row.file_name = "photo.jpg"
+        media_row.file_size = 1000
+        media_row.mime_type = "image/jpeg"
+        media_row.width = 100
+        media_row.height = 100
+        media_row.duration = None
+        media_result = MagicMock()
+        media_result.scalars.return_value = [media_row]
+
+        versions_result = MagicMock()
+        versions_result.__iter__ = MagicMock(return_value=iter([]))
+        reactions_result = MagicMock()
+        reactions_result.scalars.return_value = []
+
+        mock_session.execute.side_effect = [mock_result, media_result, versions_result, reactions_result]
 
         result = await adapter.get_messages_paginated(chat_id=100)
         assert result[0]["media"] is not None
@@ -2231,6 +2253,11 @@ class TestGetMessagesPaginated:
         mock_result = MagicMock()
         mock_result.__iter__ = MagicMock(return_value=iter([row]))
 
+        # Second execute since the join-multiplication fix: the batched media
+        # attach for the page (none here).
+        media_result = MagicMock()
+        media_result.scalars.return_value = []
+
         version_count_result = MagicMock()
         version_count_result.__iter__ = MagicMock(return_value=iter([]))
 
@@ -2245,7 +2272,13 @@ class TestGetMessagesPaginated:
         reactions_result = MagicMock()
         reactions_result.scalars.return_value = []
 
-        mock_session.execute.side_effect = [mock_result, version_count_result, reply_result, reactions_result]
+        mock_session.execute.side_effect = [
+            mock_result,
+            media_result,
+            version_count_result,
+            reply_result,
+            reactions_result,
+        ]
 
         result = await adapter.get_messages_paginated(chat_id=100)
         assert result[0]["reply_to_text"] == "Original message text"[:100]

--- a/tests/test_db_adapter_real_engine.py
+++ b/tests/test_db_adapter_real_engine.py
@@ -222,3 +222,64 @@ class TestPaginationRealEngine:
         async with real_adapter.db_manager.engine.connect() as conn:
             names = await conn.run_sync(lambda c: {ix["name"] for ix in sa.inspect(c).get_indexes("messages")})
         assert "idx_messages_text_trgm" not in names
+
+
+class TestPageLimitCountsMessagesRealEngine:
+    """LIMIT must deliver LIMIT distinct messages.
+
+    A message can carry several media rows (a JSON import writes
+    import_{chat}_{msg} beside the live {chat}_{msg}_{type} row), and the old
+    join-then-LIMIT shape returned 50 JOIN rows holding far fewer distinct
+    messages — the measured case: 10 three-media heads turned a page of 50
+    into 30 messages."""
+
+    async def _seed(self, real_adapter, chat_id):
+        await _seed_chat(real_adapter, chat_id)
+        for n in range(1, 61):
+            await real_adapter.insert_message(_message(chat_id, n, offset_minutes=n), account_id=1)
+        for n in range(51, 61):
+            for media_id, downloaded in (
+                # msg 60 isolates the downloaded-preference: both live rows
+                # pending, only the import row downloaded.
+                (f"{chat_id}_{n}_photo", 0 if n == 60 else 1),
+                (f"import_{chat_id}_{n}", 1),
+                (f"{chat_id}_{n}_video", 0 if n == 60 else 1),
+            ):
+                await real_adapter.insert_media(
+                    {
+                        "id": media_id,
+                        "message_id": n,
+                        "chat_id": chat_id,
+                        "type": "photo",
+                        "file_path": f"{chat_id}/{media_id}.jpg",
+                        "file_name": f"{media_id}.jpg",
+                        "file_size": 1,
+                        "mime_type": "image/jpeg",
+                        "downloaded": downloaded,
+                    },
+                    account_id=1,
+                )
+
+    async def test_page_of_50_returns_50_distinct_messages(self, real_adapter):
+        await self._seed(real_adapter, 900100)
+
+        page = await real_adapter.get_messages_paginated(900100, limit=50)
+
+        ids = [m["id"] for m in page]
+        assert len(ids) == 50, f"page shortfall: {len(ids)}"
+        assert len(set(ids)) == 50
+        assert ids == list(range(60, 10, -1)), "newest-first contract broken"
+
+    async def test_multi_row_media_attaches_one_deterministic_row(self, real_adapter):
+        await self._seed(real_adapter, 900101)
+
+        page = await real_adapter.get_messages_paginated(900101, limit=50)
+        by_id = {m["id"]: m for m in page}
+
+        # msg 60: its plain photo row is NOT downloaded — the downloaded
+        # import row must win.
+        assert by_id[60]["media"]["id"] == "import_900101_60"
+        # msg 59: all three downloaded — lowest media id wins (digits < letters).
+        assert by_id[59]["media"]["id"] == "900101_59_photo"
+        # A message without media stays None.
+        assert by_id[20]["media"] is None


### PR DESCRIPTION
## Problem

`get_messages_paginated` applied `LIMIT` to the message×media outer join. A message can legitimately carry SEVERAL media rows — a JSON import writes `import_{chat}_{msg}` beside the live `{chat}_{msg}_{type}` row — so a page of 50 could deliver far fewer distinct messages: the bead's measured case, 10 three-media heads → 50 rows / 30 messages. The frontend dedupes by id, so nothing rendered twice; the cost was throughput (~1.7× the round trips to cover the same history, each re-running the whole page pipeline) and duplicated `raw_data` bytes serialized per extra row.

## Fix

Media leaves the page query entirely and arrives via ONE batched query keyed by the page's message ids — the exact shape the function already uses for version counts and reactions. One deterministic row attaches per message: downloaded beats pending, then lowest media id (the old join order was arbitrary). The User join stays (users.id is unique — it cannot multiply), account matching is carried out-of-band so the API row shape is unchanged, and `get_pinned_messages` was checked: it joins media the same way but its LIMIT applies to pinned flags (bounded, no measured shortfall) — left alone.

## Evidence

- Real-engine regression seeds the measured shape: limit=50 returns 50 DISTINCT messages newest-first (the join-restored mutant returns fewer — red); a second test pins the deterministic media pick (downloaded-preference and id tiebreak) and None for media-less messages.
- The query-hardening guard is repointed to pin BOTH directions: exactly one media read keyed by page ids, and a page statement that never touches media.
- Mutation control green-then-red; restore sha-verified. Full suite: 3417 passed, 129 skipped, 861 subtests, exit 0.

Closes bead Telegram-Archive-9t6.6.14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed message pagination so pages consistently contain the requested number of distinct messages, even when messages have multiple media attachments.
  * Improved media selection by prioritizing downloaded media and applying deterministic fallback ordering.
  * Preserved account ordering when reversing forward-pagination results.
  * Ensured messages without media continue to display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->