### PR TITLE
fix(realtime): a notification burst can no longer grow the viewer's task set without bound

### DIFF
--- a/src/realtime.py
+++ b/src/realtime.py
@@ -428,13 +428,8 @@ class RealtimeListener:
         if not self._callback:
             return
 
-        try:
-            data = json.loads(payload)
-        except json.JSONDecodeError as e:
-            # Never log the raw payload -- it may contain message content (PII rule).
-            logger.warning(f"Invalid JSON in notification: {type(e).__name__}: {e}")
-            return
-
+        # Capacity first: this runs synchronously on the event loop, so at
+        # overload the drop must not pay json.loads per discarded payload.
         if len(self._callback_tasks) >= self._MAX_CALLBACK_TASKS:
             self._callbacks_dropped += 1
             # Payload never logged (PII rule); counts only.
@@ -443,6 +438,13 @@ class RealtimeListener:
                 len(self._callback_tasks),
                 self._callbacks_dropped,
             )
+            return
+
+        try:
+            data = json.loads(payload)
+        except json.JSONDecodeError as e:
+            # Never log the raw payload -- it may contain message content (PII rule).
+            logger.warning(f"Invalid JSON in notification: {type(e).__name__}: {e}")
             return
 
         # Keep a reference so the task isn't GC'd mid-flight, and retrieve its

--- a/src/realtime.py
+++ b/src/realtime.py
@@ -334,6 +334,7 @@ class RealtimeListener:
         # garbage-collected mid-run and so their exceptions are retrieved
         # (an un-referenced task's exception is otherwise silently dropped).
         self._callback_tasks: set[asyncio.Task] = set()
+        self._callbacks_dropped = 0
 
     async def init(self):
         """Initialize and detect database type."""
@@ -413,6 +414,15 @@ class RealtimeListener:
                     with contextlib.suppress(Exception):
                         await asyncio.wait_for(conn.close(), timeout=_TEARDOWN_TIMEOUT_SECONDS)
 
+    # In-flight ceiling for notification callbacks: asyncpg invokes
+    # _pg_callback synchronously for every NOTIFY, so without a bound the
+    # producer's rate becomes the viewer's memory growth rate (each retained
+    # task holds its payload alive). Beyond the cap the notification is
+    # dropped and counted — the broadcast layer is best-effort by design, a
+    # page refresh re-reads the archive, and dropping the NEWEST under a
+    # sustained burst keeps the already-queued work draining in order.
+    _MAX_CALLBACK_TASKS = 200
+
     def _pg_callback(self, connection, pid, channel, payload):
         """Handle PostgreSQL notification."""
         if not self._callback:
@@ -423,6 +433,16 @@ class RealtimeListener:
         except json.JSONDecodeError as e:
             # Never log the raw payload -- it may contain message content (PII rule).
             logger.warning(f"Invalid JSON in notification: {type(e).__name__}: {e}")
+            return
+
+        if len(self._callback_tasks) >= self._MAX_CALLBACK_TASKS:
+            self._callbacks_dropped += 1
+            # Payload never logged (PII rule); counts only.
+            logger.debug(
+                "Realtime notification dropped: %d callbacks already in flight (%d dropped total)",
+                len(self._callback_tasks),
+                self._callbacks_dropped,
+            )
             return
 
         # Keep a reference so the task isn't GC'd mid-flight, and retrieve its

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -723,6 +723,32 @@ class TestRealtimeListenerPgCallback(unittest.TestCase):
         # Should not raise
         listener._pg_callback(None, 0, "telegram_updates", '{"type": "test"}')
 
+    def test_pg_callback_drops_beyond_the_in_flight_cap(self):
+        """asyncpg invokes this synchronously per NOTIFY — without a bound the
+        producer's rate is the viewer's memory growth rate. At the cap the
+        notification is dropped and counted, never queued unbounded."""
+        mock_cb = AsyncMock()
+        listener = RealtimeListener(callback=mock_cb)
+        listener._callback_tasks = {MagicMock() for _ in range(listener._MAX_CALLBACK_TASKS)}
+
+        with patch("src.realtime.asyncio.create_task") as mock_task:
+            listener._pg_callback(None, 0, "telegram_updates", '{"type": "new_message"}')
+
+        mock_task.assert_not_called()
+        assert listener._callbacks_dropped == 1
+        assert len(listener._callback_tasks) == listener._MAX_CALLBACK_TASKS
+
+    def test_pg_callback_below_cap_still_schedules(self):
+        mock_cb = AsyncMock()
+        listener = RealtimeListener(callback=mock_cb)
+        listener._callback_tasks = {MagicMock() for _ in range(listener._MAX_CALLBACK_TASKS - 1)}
+
+        with patch("src.realtime.asyncio.create_task") as mock_task:
+            listener._pg_callback(None, 0, "telegram_updates", '{"type": "new_message"}')
+
+        mock_task.assert_called_once()
+        assert listener._callbacks_dropped == 0
+
 
 class TestRealtimeListenerHttpPush:
     """Tests for RealtimeListener.handle_http_push."""

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -729,6 +729,9 @@ class TestRealtimeListenerPgCallback(unittest.TestCase):
         notification is dropped and counted, never queued unbounded."""
         mock_cb = AsyncMock()
         listener = RealtimeListener(callback=mock_cb)
+        # The ceiling itself is pinned so a tuning change is deliberate, not
+        # an accident these self-sizing fixtures would silently absorb.
+        assert listener._MAX_CALLBACK_TASKS == 200
         listener._callback_tasks = {MagicMock() for _ in range(listener._MAX_CALLBACK_TASKS)}
 
         with patch("src.realtime.asyncio.create_task") as mock_task:
@@ -743,7 +746,11 @@ class TestRealtimeListenerPgCallback(unittest.TestCase):
         listener = RealtimeListener(callback=mock_cb)
         listener._callback_tasks = {MagicMock() for _ in range(listener._MAX_CALLBACK_TASKS - 1)}
 
-        with patch("src.realtime.asyncio.create_task") as mock_task:
+        def close_coro(coro):
+            coro.close()  # never-awaited otherwise: the patch swallows it
+            return MagicMock()
+
+        with patch("src.realtime.asyncio.create_task", side_effect=close_coro) as mock_task:
             listener._pg_callback(None, 0, "telegram_updates", '{"type": "new_message"}')
 
         mock_task.assert_called_once()


### PR DESCRIPTION
asyncpg invokes `_pg_callback` synchronously for every NOTIFY and the callback spawned a retained task per notification with no limit — so the producer's rate (one notification per live message, edit, pin batch and reaction flush; none rate-limited for new messages) was the viewer's memory growth rate, each task holding its payload alive.

The fix is the same cheap bound the event webhook ships: at 200 in-flight callbacks the notification is dropped and counted (`_callbacks_dropped`), with a count-only debug line. Dropping is safe by design — the broadcast layer is best-effort, a page refresh re-reads the archive, and dropping the newest under a sustained burst keeps the queued work draining in order. Queue-and-worker machinery was considered and rejected as YAGNI for a bound whose practical ceiling is the account's real message rate (bead `9t6.5.31`'s own rating).

Two tests (at-cap drops + counts, below-cap schedules); mutation-verified — removing the guard fails the cap test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved realtime notification handling by limiting concurrent callback processing.
  * Excess notifications are safely dropped and tracked when processing capacity is reached.
  * Added logging for dropped notifications without exposing their payload data.

* **Tests**
  * Added coverage for notification handling at and below the processing limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->