### PR TITLE
test(db): the version-dedup ON CONFLICT clause can no longer be deleted with the suite green

### DIFF
--- a/tests/test_db_adapter_soft_delete_upsert.py
+++ b/tests/test_db_adapter_soft_delete_upsert.py
@@ -908,3 +908,36 @@ async def test_deletion_snapshot_media_type_is_deterministic_across_rows(sqlite_
 
     # Lexicographic Media.id order: "300_62_photo" < "300_62_video".
     assert snapshot["media_type"] == "photo"
+
+
+@pytest.mark.asyncio
+async def test_recording_the_same_version_twice_is_a_silent_noop(sqlite_adapter, caplog):
+    """The uq (account_id, change_hash) dedup rides ON CONFLICT DO NOTHING.
+
+    Dropping the on_conflict clause kept the whole suite green: nothing ever
+    re-inserted the same version, so the duplicate path ran dark — and without
+    it every re-scan of an edited message would IntegrityError inside the
+    SAVEPOINT and flood a WARNING per message per cycle through the blanket
+    except. This pins the contract: second identical record -> False, ONE row,
+    and not a word in the log."""
+    import logging as _logging
+
+    when = datetime(2026, 6, 27, 10, 0)
+    async with sqlite_adapter.db_manager.async_session_factory() as session:
+        first = await sqlite_adapter._record_message_version(
+            session, account_id=1, chat_id=300, message_id=70, text="superseded", date=when
+        )
+        with caplog.at_level(_logging.WARNING, logger="src.db.adapter"):
+            again = await sqlite_adapter._record_message_version(
+                session, account_id=1, chat_id=300, message_id=70, text="superseded", date=when
+            )
+        await session.commit()
+
+    assert first is True
+    assert again is False  # deduped, not failed
+    assert "Could not record" not in caplog.text  # DO NOTHING, not except-swallowed
+    async with sqlite_adapter.db_manager.async_session_factory() as session:
+        rows = await session.execute(
+            select(MessageVersion).where(MessageVersion.chat_id == 300, MessageVersion.message_id == 70)
+        )
+        assert len(list(rows.scalars())) == 1


### PR DESCRIPTION
`_record_message_version` dedupes re-captured versions via `ON CONFLICT DO NOTHING` on `(account_id, change_hash)` — the docstring states it, and no test entered the conflict path: dropping the clause kept the whole suite green. Without it, every re-scan of an edited message raises IntegrityError inside the SAVEPOINT, gets swallowed by the blanket `except`, and floods one WARNING per message per cycle on a large archive — with the caller told False-as-failure instead of False-as-duplicate.

New real-engine test records the identical version twice and pins the contract: second call returns False, exactly one row exists, and nothing reaches the log (the caplog assertion is what separates DO-NOTHING from except-swallowed, since both return False). Verified by mutation: dropping the SQLite branch's `on_conflict_do_nothing` fails exactly this test.

Bead `9t6.8.27`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added regression coverage to ensure identical message versions are silently deduplicated.
  * Verified duplicate recordings return the expected result, create only one stored version, and produce no warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->