### PR TITLE
fix(capture): excluding the General topic finally excludes its messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Follow these conventions:
 
 ### Forum Topic Filtering
 
-Topic IDs are extracted from `message.reply_to.reply_to_top_id` (primary) with fallback to `reply_to_msg_id`. The General topic (id=1) service messages may not carry `reply_to` metadata and can bypass filtering. The `SKIP_TOPIC_IDS` env var uses format `chat_id:topic_id,...` parsed into `dict[int, set[int]]`.
+Topic IDs are extracted from `message.reply_to.reply_to_top_id` (primary) with fallback to `reply_to_msg_id`. General-topic messages carry NO `reply_to` (Telegram omits `top_msg_id` for General), so `extract_topic_id` returns None for them — `should_skip_topic` maps None to topic 1 when the chat's skip set contains 1, mirroring the archive's `coalesce(reply_to_top_id, 1)` General bucket. The `SKIP_TOPIC_IDS` env var uses format `chat_id:topic_id,...` parsed into `dict[int, set[int]]`.
 
 ### Logging Rules
 

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ Find a chat's ID by forwarding a message to [@userinfobot](https://t.me/userinfo
 SKIP_TOPIC_IDS=-1001234567890:42,-1001234567890:1337,-1009876543210:7
 ```
 
-> Note: The topic-creating service message (1 per topic) may still be backed up since it lacks `reply_to` metadata. This does not affect user-generated content.
+> Note: Excluding topic `1` (General) works by catching messages with no topic metadata — Telegram omits `reply_to` on General-topic messages, and the archive files exactly those under General. The topic-creating service message (1 per topic) of OTHER topics may still be backed up since it also lacks `reply_to` metadata.
 
 ### Real-time Listener
 

--- a/src/config.py
+++ b/src/config.py
@@ -1126,11 +1126,21 @@ class Config:
         Returns:
             True if this topic should be skipped, False otherwise
         """
-        if topic_id is None or not self.skip_topic_ids:
+        if not self.skip_topic_ids:
             return False
         skip_set = self.skip_topic_ids.get(chat_id)
         if skip_set is None:
             return False
+        if topic_id is None:
+            # General-topic messages carry NO reply_to metadata (Telegram sets
+            # top_msg_id "except for the 'General' topic"), so the natural
+            # exclusion spelling chat:1 could never fire — while the topic
+            # SIDEBAR honored it, signalling an exclusion that wasn't
+            # happening. The archive's own General bucket is
+            # coalesce(reply_to_top_id, 1); the filter mirrors it: excluding
+            # topic 1 excludes exactly the messages the viewer files under
+            # General.
+            return 1 in skip_set
         return topic_id in skip_set
 
     def _get_required_env(self, key: str, value_type: type):

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -731,7 +731,16 @@ def extract_topic_id(message: object) -> int | None:
     reply_to.reply_to_msg_id is used as a fallback.
 
     Returns None for non-forum messages or messages without reply_to.
+
+    A topic-creation service message carries NO reply_to either, but it is
+    not General: in Telegram forums a topic's id IS the id of its creation
+    service message, so it identifies itself. Without this, excluding General
+    (which is caught via the None bucket) would also drop every topic's
+    creation record.
     """
+    action = getattr(message, "action", None)
+    if action is not None and type(action).__name__ == "MessageActionTopicCreate":
+        return message.id
     if not message.reply_to or not getattr(message.reply_to, "forum_topic", False):
         return None
     topic_id = getattr(message.reply_to, "reply_to_top_id", None)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -681,7 +681,9 @@ class TestSkipTopicIds(unittest.TestCase):
             self.assertTrue(config.should_skip_topic(-1001234567890, 1))
             # Other chats' General is untouched.
             self.assertFalse(config.should_skip_topic(-1009999999999, None))
-            # And a skip set WITHOUT 1 keeps None messages (existing contract).
+            # An unrelated topic in the same chat stays included. (None with
+            # a skip set NOT containing 1 is pinned by
+            # test_should_skip_topic_none_topic above.)
             self.assertFalse(config.should_skip_topic(-1001234567890, 2))
 
     def test_should_skip_topic_empty_config(self):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -661,6 +661,29 @@ class TestSkipTopicIds(unittest.TestCase):
             config = Config()
             self.assertFalse(config.should_skip_topic(-1001234567890, None))
 
+    def test_excluding_general_catches_messages_without_topic_metadata(self):
+        """chat:1 must actually fire: General-topic messages carry NO reply_to
+        (Telegram omits top_msg_id for General), so extract_topic_id yields
+        None for every one of them — and the old None short-circuit meant the
+        natural General exclusion never skipped a single message while the
+        topic sidebar claimed it did. The filter now mirrors the archive's own
+        General bucket, coalesce(reply_to_top_id, 1)."""
+        env_vars = {
+            "CHAT_TYPES": "private",
+            "SKIP_TOPIC_IDS": "-1001234567890:1",
+            "BACKUP_PATH": self.temp_dir,
+        }
+        with patch.dict(os.environ, env_vars, clear=True):
+            config = Config()
+            # None (no reply_to) = the General bucket -> skipped for this chat.
+            self.assertTrue(config.should_skip_topic(-1001234567890, None))
+            # Explicit topic 1 (a reply within General) skips too.
+            self.assertTrue(config.should_skip_topic(-1001234567890, 1))
+            # Other chats' General is untouched.
+            self.assertFalse(config.should_skip_topic(-1009999999999, None))
+            # And a skip set WITHOUT 1 keeps None messages (existing contract).
+            self.assertFalse(config.should_skip_topic(-1001234567890, 2))
+
     def test_should_skip_topic_empty_config(self):
         """should_skip_topic returns False when SKIP_TOPIC_IDS is not set."""
         env_vars = {"CHAT_TYPES": "private", "BACKUP_PATH": self.temp_dir}

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -1119,6 +1119,21 @@ class TestExtractTopicId(unittest.TestCase):
         msg.reply_to.reply_to_msg_id = 99
         self.assertEqual(extract_topic_id(msg), 99)
 
+    def test_topic_creation_service_message_identifies_itself(self):
+        """A topic's id IS its creation message's id (no reply_to on these):
+        without this branch, excluding General via the None bucket would also
+        drop every topic's creation record. Matched by class NAME — the
+        service_action_type idiom — so bare MagicMock actions stay inert."""
+
+        class MessageActionTopicCreate:
+            pass
+
+        msg = MagicMock()
+        msg.reply_to = None
+        msg.id = 4242
+        msg.action = MessageActionTopicCreate()
+        self.assertEqual(extract_topic_id(msg), 4242)
+
     def test_returns_none_when_both_ids_none(self):
         msg = MagicMock()
         msg.reply_to = MagicMock()


### PR DESCRIPTION
`SKIP_TOPIC_IDS=chat:1` — the natural spelling for excluding a forum's General topic, since the viewer numbers General as 1 — never skipped a single message: Telegram omits `reply_to` on General-topic messages (`top_msg_id` is set \"except for the 'General' topic\" per core.telegram.org/api/forum), so `extract_topic_id` returns None and the filter short-circuited on None. Worse, the topic SIDEBAR did honor the exclusion (the topics API returns General as row 1), so the UI actively signalled an exclusion that wasn't happening, and the README claimed only service messages leak. For a tool whose selling point is controlling what personal data is retained, a silently inert privacy control is a real defect.

The fix mirrors the archive's own definition of the General bucket — `coalesce(reply_to_top_id, 1)`, the exact expression the viewer files these messages under: when a chat's skip set contains `1`, a None topic is treated as General and skipped. A skip set without `1` keeps the existing None-passes contract (pinned by the untouched `test_should_skip_topic_none_topic`), other chats are unaffected, and replies within General that DO carry `reply_to_top_id=1` filtered before and still do.

Both fire paths (listener and sweep) go through this one filter, so one change covers both. README note and CLAUDE.md architecture note corrected. Verified by mutation: restoring the None short-circuit fails the new test while the rest of the class stays green.

Bead `9t6.5.25`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * General-topic messages without topic metadata are now correctly treated as topic 1 and filtered when General is excluded.
  * Topic-creation service messages without reply metadata are correctly associated with their own topic.
  * Existing behavior for explicit topics, other chats, and configurations that include General remains unchanged.

* **Documentation**
  * Clarified General-topic filtering and topic-creation message handling.

* **Tests**
  * Added regression coverage for missing topic metadata and topic-creation messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->