### PR TITLE
fix(config): filter ids missing the -100 prefix auto-correct instead of silently matching nothing

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -9,7 +9,7 @@ import os
 import re
 import sys
 import urllib.parse
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from dotenv import load_dotenv
@@ -190,6 +190,41 @@ class AccountConfig:
     session_path: str
 
 
+# The eleven id-carrying filter fields (chat_types is a vocabulary, not ids).
+# Shared by Config and AccountScopedConfig normalization below.
+_FILTER_ID_SET_FIELDS = (
+    "chat_ids",
+    "global_include_ids",
+    "global_exclude_ids",
+    "private_include_ids",
+    "private_exclude_ids",
+    "groups_include_ids",
+    "groups_exclude_ids",
+    "channels_include_ids",
+    "channels_exclude_ids",
+    "priority_chat_ids",
+    "skip_media_chat_ids",
+)
+
+
+def _normalize_id_set_attrs(config_like, existing_ids: set) -> tuple[int, int]:
+    """Auto-correct every id-set filter attribute on config_like; counts only."""
+    from .message_utils import normalize_configured_chat_ids
+
+    corrected_total = 0
+    unresolved_total = 0
+    for name in _FILTER_ID_SET_FIELDS:
+        current = getattr(config_like, name)
+        if not current:
+            continue
+        normalized, corrected, unresolved = normalize_configured_chat_ids(set(current), existing_ids)
+        if corrected:
+            setattr(config_like, name, set(normalized))
+        corrected_total += corrected
+        unresolved_total += unresolved
+    return corrected_total, unresolved_total
+
+
 @dataclass(frozen=True)
 class AccountFilters:
     """The effective capture-filter set one account sweeps and listens with (8.1, #313).
@@ -319,6 +354,28 @@ class AccountScopedConfig:
         if not self._base.download_media:
             return False
         return chat_id not in self.filters.skip_media_chat_ids
+
+    def normalize_filter_ids(self, existing_ids: set) -> tuple[int, int]:
+        """Auto-correct this account's filter ids against its archived chats.
+
+        The viewer's _normalize_display_chat_ids twin for the capture side: a
+        bare id copied without the -100 marked prefix otherwise silently
+        matches nothing — for exclude/skip lists that is the dangerous
+        direction, capture continuing while startup logs confirm the intent.
+        Rewrites both surfaces workers read — the mutable set attributes AND
+        the frozen per-account decision filters — plus the shared
+        SKIP_TOPIC_IDS keys on the base config. Returns (corrected,
+        unresolved) counts; ids are never logged.
+        """
+        corrected, unresolved = _normalize_id_set_attrs(self, existing_ids)
+        if corrected:
+            self.whitelist_mode = len(self.chat_ids) > 0
+            self.filters = replace(
+                self.filters,
+                **{name: frozenset(getattr(self, name)) for name in _FILTER_ID_SET_FIELDS},
+            )
+        topic_corrected, topic_unresolved = self._base._normalize_skip_topic_keys(existing_ids)
+        return corrected + topic_corrected, unresolved + topic_unresolved
 
 
 class Config:
@@ -1115,6 +1172,35 @@ class Config:
     def for_account(self, index: int) -> AccountScopedConfig:
         """The config view the capture workers of account ``index`` receive."""
         return AccountScopedConfig(self, index, self.filters_for(index))
+
+    def normalize_filter_ids(self, existing_ids: set) -> tuple[int, int]:
+        """Legacy single-account twin of AccountScopedConfig.normalize_filter_ids."""
+        corrected, unresolved = _normalize_id_set_attrs(self, existing_ids)
+        if corrected:
+            self.whitelist_mode = len(self.chat_ids) > 0
+        topic_corrected, topic_unresolved = self._normalize_skip_topic_keys(existing_ids)
+        return corrected + topic_corrected, unresolved + topic_unresolved
+
+    def _normalize_skip_topic_keys(self, existing_ids: set) -> tuple[int, int]:
+        """Auto-correct SKIP_TOPIC_IDS chat keys (shared across accounts)."""
+        if not self.skip_topic_ids:
+            return 0, 0
+        rebuilt: dict[int, set[int]] = {}
+        corrected = 0
+        unresolved = 0
+        for old_key, topics in self.skip_topic_ids.items():
+            new_key = old_key
+            if old_key not in existing_ids:
+                marked_key = -1000000000000 - old_key
+                if old_key > 0 and marked_key in existing_ids:
+                    new_key = marked_key
+                    corrected += 1
+                else:
+                    unresolved += 1
+            rebuilt.setdefault(new_key, set()).update(topics)
+        if corrected:
+            self.skip_topic_ids = rebuilt
+        return corrected, unresolved
 
     def should_skip_topic(self, chat_id: int, topic_id: int | None) -> bool:
         """Check if a specific topic in a chat should be skipped.

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -898,3 +898,33 @@ def extract_reactions(message_reactions: object) -> list[dict[str, object]] | No
         logger.debug("Reaction extraction failed, skipping reconcile: %s", type(e).__name__)
         return None
     return out
+
+
+def normalize_configured_chat_ids(configured: set[int], existing_ids: set[int]) -> tuple[set[int], int, int]:
+    """Auto-correct filter ids missing the -100 supergroup/channel prefix.
+
+    The viewer's ``_normalize_display_chat_ids`` established the contract for
+    this exact user mistake (a chat id copied from Telegram Web or the viewer
+    without the marked prefix): an entry present in ``existing_ids`` is kept;
+    a positive entry absent as-is whose ``-100…`` marked form IS archived is
+    rewritten to the marked form; everything else is kept untouched (the chat
+    may simply not be archived yet). Returns
+    ``(normalized, corrected_count, unresolved_count)``. Callers log counts
+    only — never the ids (PII rule).
+    """
+    normalized: set[int] = set()
+    corrected = 0
+    unresolved = 0
+    for chat_id in configured:
+        if chat_id in existing_ids:
+            normalized.add(chat_id)
+            continue
+        if chat_id > 0:
+            marked_id = -1000000000000 - chat_id
+            if marked_id in existing_ids:
+                corrected += 1
+                normalized.add(marked_id)
+                continue
+        unresolved += 1
+        normalized.add(chat_id)
+    return normalized, corrected, unresolved

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -1070,6 +1070,27 @@ class TelegramBackup:
             # ever persisted and this stays empty (warning-only behaviour).
             await self._load_followed_migrations()
 
+            # Auto-correct filter ids missing the -100 marked prefix, against
+            # this account's archived chats — the capture-side twin of the
+            # viewer's DISPLAY_CHAT_IDS normalization. Runs before any
+            # filtering below so a corrected exclude applies THIS run; an id
+            # whose chat is not archived yet corrects on the next run (same
+            # convergence the viewer accepted). Counts only, never ids (PII).
+            try:
+                archived_ids = {c["id"] for c in await self.db.get_all_chats(account_id=self.account_id)}
+                corrected, unresolved = self.config.normalize_filter_ids(archived_ids)
+                if corrected:
+                    logger.warning(
+                        f"Capture filters: auto-corrected {corrected} id entr{'y' if corrected == 1 else 'ies'} "
+                        "to marked (channel/supergroup) format"
+                    )
+                if unresolved:
+                    logger.info(f"Capture filters: {unresolved} configured id entr(y/ies) not in the archive yet")
+            except Exception as e:
+                # MagicMock configs in tests land here too; normalization is
+                # strictly best-effort and must never block a backup.
+                logger.debug("Filter id normalization skipped: %s", type(e).__name__)
+
             # Whitelist mode: skip expensive get_dialogs() and fetch only the
             # specified chats directly.  For accounts with many dialogs the full
             # dialog fetch can hang indefinitely (see #95).

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -1085,7 +1085,10 @@ class TelegramBackup:
                         "to marked (channel/supergroup) format"
                     )
                 if unresolved:
-                    logger.info(f"Capture filters: {unresolved} configured id entr(y/ies) not in the archive yet")
+                    logger.info(
+                        f"Capture filters: {unresolved} configured id entr{'y' if unresolved == 1 else 'ies'} "
+                        "not in the archive yet"
+                    )
             except Exception as e:
                 # MagicMock configs in tests land here too; normalization is
                 # strictly best-effort and must never block a backup.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2055,3 +2055,72 @@ class TestEventWebhookConfig(unittest.TestCase):
         self.assertNotIn(self.URL, joined)
         self.assertNotIn("secret-token-path", joined)
         self.assertIn("EVENT_WEBHOOK enabled", joined)
+
+
+class TestFilterIdNormalization(unittest.TestCase):
+    """Capture-side twin of the viewer's DISPLAY_CHAT_IDS auto-correction: a
+    filter id copied without the -100 marked prefix silently matched nothing —
+    for exclude/skip lists the dangerous direction, since capture continued
+    while the startup log confirmed the configured intent by count."""
+
+    MARKED = -1000000000123
+    BARE = 123
+
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp()
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=True)
+
+    def _config(self, **extra):
+        env = _get_base_env(self.temp_dir) | extra
+        with patch.dict(os.environ, env, clear=True):
+            return Config()
+
+    def test_bare_exclude_id_is_corrected_and_the_decision_flips(self):
+        config = self._config(CHAT_TYPES="channels", GLOBAL_EXCLUDE_CHAT_IDS=str(self.BARE))
+        # Before: the bare id matches nothing — the excluded channel captures.
+        self.assertTrue(config.should_backup_chat(self.MARKED, False, False, True))
+
+        corrected, unresolved = config.normalize_filter_ids({self.MARKED})
+
+        self.assertEqual((corrected, unresolved), (1, 0))
+        self.assertEqual(config.global_exclude_ids, {self.MARKED})
+        self.assertFalse(config.should_backup_chat(self.MARKED, False, False, True))
+
+    def test_skip_topic_keys_are_corrected_with_topics_preserved(self):
+        config = self._config(SKIP_TOPIC_IDS=f"{self.BARE}:7,{self.BARE}:9")
+        self.assertFalse(config.should_skip_topic(self.MARKED, 7))
+
+        corrected, unresolved = config.normalize_filter_ids({self.MARKED})
+
+        self.assertEqual(corrected, 1)
+        self.assertEqual(config.skip_topic_ids, {self.MARKED: {7, 9}})
+        self.assertTrue(config.should_skip_topic(self.MARKED, 7))
+
+    def test_unarchived_ids_are_kept_untouched(self):
+        config = self._config(CHAT_TYPES="channels", SKIP_MEDIA_CHAT_IDS="456")
+        corrected, unresolved = config.normalize_filter_ids({self.MARKED})
+        self.assertEqual((corrected, unresolved), (0, 1))
+        self.assertEqual(config.skip_media_chat_ids, {456})
+
+    def test_whitelist_membership_and_mode_survive_correction(self):
+        config = self._config(CHAT_IDS=str(self.BARE))
+        self.assertTrue(config.whitelist_mode)
+        corrected, _ = config.normalize_filter_ids({self.MARKED})
+        self.assertEqual(corrected, 1)
+        self.assertTrue(config.whitelist_mode)
+        self.assertEqual(config.chat_ids, {self.MARKED})
+
+    def test_account_scoped_view_corrects_both_surfaces(self):
+        """Workers read the mutable sets AND the frozen decision filters —
+        normalization must rewrite both or they'd disagree."""
+        config = self._config(CHAT_TYPES="channels", SKIP_MEDIA_CHAT_IDS=str(self.BARE), DOWNLOAD_MEDIA="true")
+        scoped = config.for_account(1)
+        self.assertTrue(scoped.should_download_media_for_chat(self.MARKED))
+
+        corrected, _ = scoped.normalize_filter_ids({self.MARKED})
+
+        self.assertEqual(corrected, 1)
+        self.assertEqual(scoped.skip_media_chat_ids, {self.MARKED})  # mutable surface
+        self.assertFalse(scoped.should_download_media_for_chat(self.MARKED))  # frozen surface


### PR DESCRIPTION
A chat id copied from Telegram Web or the viewer without the `-100` supergroup/channel prefix parses cleanly into any filter list — and then matches nothing: every consumer does exact set membership against marked ids. For exclude/skip lists that failure direction is the dangerous one: the archive keeps downloading media and keeps capturing a forum topic the user explicitly excluded, while the startup log confirms the intent by counting configured (not matched) entries. The viewer has corrected this exact mistake for `DISPLAY_CHAT_IDS` since `_normalize_display_chat_ids`; the capture side had no twin.

The fix mirrors the viewer's contract at backup start, per account, against that account's archived chats: an entry present as-is is kept; a positive entry whose `-100…` form is archived is rewritten; anything else is kept untouched (the chat may simply not be archived yet — same convergence the viewer accepted, corrected on the next run). All eleven id-carrying filter sets are covered plus the shared `SKIP_TOPIC_IDS` keys (topics merged on key collision), and on the 8.1 per-account view BOTH surfaces are rewritten — the mutable set attributes workers read directly AND the frozen `AccountFilters` behind the decision methods — so they cannot disagree. Logs are counts only (PII rule); normalization is strictly best-effort and can never block a backup.

Five tests: the exclude decision flips after correction, topic keys correct with topics preserved, unarchived ids stay untouched, whitelist mode survives, and the two per-account surfaces stay in agreement. Mutation-verified: dropping the frozen-filters rebuild fails the both-surfaces test. Full suite: 3626 passed.

Bead `9t6.5.37`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic normalization of configured Telegram chat IDs during backups.
  * Supports global filters, topic exclusions, whitelists, media, and account-specific filters.
  * Preserves unresolved or unrelated IDs while reporting correction results.

* **Bug Fixes**
  * Backups now recognize valid chats when IDs use an alternate format.
  * General-topic exclusions now apply when topic metadata is unavailable.
  * Invalid numeric settings provide clearer validation errors and safe defaults.
  * Normalization errors no longer prevent backups from proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->