### PR TITLE
feat(export): the advertised date range filters finally reach the export stream

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1618,14 +1618,28 @@ class DatabaseAdapter:
             result = await session.execute(self._message_versions_query(chat_id, start_date, end_date, account_id))
             return [self._message_version_to_dict(row) for row in result.scalars()]
 
-    async def iter_message_versions_for_export(self, chat_id: int, *, account_id: int | None = None):
+    async def iter_message_versions_for_export(
+        self,
+        chat_id: int,
+        *,
+        account_id: int | None = None,
+        from_date: datetime | None = None,
+        to_date: datetime | None = None,
+    ):
         """Stream a chat's message versions one by one (async generator).
 
         Mirrors get_messages_for_export so the export endpoint never
-        materializes an entire edit history in memory.
+        materializes an entire edit history in memory. The optional window
+        uses the export contract (>= from, < to) — deliberately NOT the shared
+        query's inclusive end_date, whose contract other callers own.
         """
         async with self.db_manager.async_session_factory() as session:
-            result = await session.stream(self._message_versions_query(chat_id, account_id=account_id))
+            stmt = self._message_versions_query(chat_id, account_id=account_id)
+            if from_date is not None:
+                stmt = stmt.where(MessageVersion.date >= from_date)
+            if to_date is not None:
+                stmt = stmt.where(MessageVersion.date < to_date)
+            result = await session.stream(stmt)
             async for row in result.scalars():
                 yield self._message_version_to_dict(row)
 
@@ -3621,7 +3635,13 @@ class DatabaseAdapter:
             }
 
     async def get_messages_for_export(
-        self, chat_id: int, include_media: bool = False, *, account_id: int | None = None
+        self,
+        chat_id: int,
+        include_media: bool = False,
+        *,
+        account_id: int | None = None,
+        from_date: datetime | None = None,
+        to_date: datetime | None = None,
     ):
         """
         Get messages for export with user info.
@@ -3633,6 +3653,8 @@ class DatabaseAdapter:
         Args:
             chat_id: Chat ID to export
             include_media: If True, include media info from media table
+            from_date: naive-UTC inclusive lower bound on Message.date
+            to_date: naive-UTC EXCLUSIVE upper bound on Message.date
 
         Yields:
             Message dictionaries with user info
@@ -3685,6 +3707,10 @@ class DatabaseAdapter:
 
             if account_id is not None:
                 stmt = stmt.where(Message.account_id == account_id)
+            if from_date is not None:
+                stmt = stmt.where(Message.date >= from_date)
+            if to_date is not None:
+                stmt = stmt.where(Message.date < to_date)
 
             result = await session.stream(stmt)
             async for row in result:

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -3036,11 +3036,46 @@ async def get_message_dates(
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+def _parse_export_bound(value: str, param: str, *, exclusive_end: bool) -> datetime:
+    """Parse an export date bound to naive UTC (the #365 conversion contract).
+
+    A bare date (``2026-01-31``) as the end bound means "through that whole
+    day", so it becomes the NEXT midnight and the query compares with ``<``.
+    Offset-bearing datetimes are converted to UTC and stripped — Message.date
+    is naive UTC, so relabelling would shift the window by the client offset.
+    """
+    date_only = len(value) == 10
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"Invalid {param} date. Use ISO 8601.") from None
+    if parsed.tzinfo:
+        parsed = parsed.astimezone(UTC).replace(tzinfo=None)
+    if exclusive_end and date_only:
+        parsed += timedelta(days=1)
+    return parsed
+
+
 @app.get("/api/chats/{chat_ref}/export")
-async def export_chat(chat: ChatContext = Depends(require_chat), user: UserContext = Depends(require_auth)):
-    """Export chat history to JSON."""
+async def export_chat(
+    chat: ChatContext = Depends(require_chat),
+    user: UserContext = Depends(require_auth),
+    from_date: str | None = Query(None, alias="from"),
+    to_date: str | None = Query(None, alias="to"),
+):
+    """Export chat history to JSON, optionally windowed by date.
+
+    ``from`` is inclusive; ``to`` is inclusive of the named day when given as
+    a bare date (internally an exclusive next-midnight bound) and exclusive
+    when given as a full timestamp. Both accept ISO 8601, tz-aware or naive.
+    """
     if user.no_download:
         raise HTTPException(status_code=403, detail="Downloads disabled for this account")
+
+    parsed_from = _parse_export_bound(from_date, "from", exclusive_end=False) if from_date else None
+    parsed_to = _parse_export_bound(to_date, "to", exclusive_end=True) if to_date else None
+    if parsed_from and parsed_to and parsed_from >= parsed_to:
+        raise HTTPException(status_code=400, detail="'from' must be before 'to'")
 
     try:
         chat_row = await db.get_chat_by_id(chat.chat_id, account_id=chat.account_id)
@@ -3057,9 +3092,16 @@ async def export_chat(chat: ChatContext = Depends(require_chat), user: UserConte
         async def iter_json():
             yield "{\n"
             yield f'  "chat": {json.dumps(_export_chat_metadata(chat_row), ensure_ascii=False, default=str)},\n'
+            if parsed_from or parsed_to:
+                # Record what this file contains — a windowed export must not
+                # masquerade as the full history.
+                window = {"from": from_date, "to": to_date}
+                yield f'  "filters": {json.dumps(window, ensure_ascii=False)},\n'
             yield '  "messages": [\n'
             first = True
-            async for msg in db.get_messages_for_export(chat.chat_id, account_id=chat.account_id):
+            async for msg in db.get_messages_for_export(
+                chat.chat_id, account_id=chat.account_id, from_date=parsed_from, to_date=parsed_to
+            ):
                 if not first:
                     yield ",\n"
                 first = False
@@ -3070,7 +3112,9 @@ async def export_chat(chat: ChatContext = Depends(require_chat), user: UserConte
             # so it must never be materialized into a single list/dumps here.
             yield '  "message_versions": [\n'
             first_version = True
-            async for version in db.iter_message_versions_for_export(chat.chat_id, account_id=chat.account_id):
+            async for version in db.iter_message_versions_for_export(
+                chat.chat_id, account_id=chat.account_id, from_date=parsed_from, to_date=parsed_to
+            ):
                 if not first_version:
                     yield ",\n"
                 first_version = False

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -3052,7 +3052,12 @@ def _parse_export_bound(value: str, param: str, *, exclusive_end: bool) -> datet
     if parsed.tzinfo:
         parsed = parsed.astimezone(UTC).replace(tzinfo=None)
     if exclusive_end and date_only:
-        parsed += timedelta(days=1)
+        try:
+            parsed += timedelta(days=1)
+        except OverflowError:
+            # to=9999-12-31 means "no upper bound" — clamp instead of 500ing
+            # on a valid ISO date.
+            parsed = datetime.max
     return parsed
 
 

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1685,6 +1685,47 @@
             </section>
         </div>
 
+        <!-- Export Chat Modal (date-windowed JSON export) -->
+        <div v-if="showExportModal"
+            class="fixed inset-0 bg-black/70 backdrop-blur-sm z-50 flex items-center justify-center overflow-y-auto p-4"
+            @click.self="showExportModal = false">
+            <section role="dialog" aria-modal="true" aria-labelledby="export-modal-title"
+                class="my-auto bg-tg-sidebar rounded-2xl shadow-2xl p-6 w-full max-w-md border border-gray-700">
+                <div class="flex items-center justify-between mb-4">
+                    <h3 id="export-modal-title" class="text-xl font-bold text-white">Export Chat to JSON</h3>
+                    <button type="button" @click="showExportModal = false" aria-label="Close export dialog"
+                        class="text-gray-400 hover:text-white transition p-1 focus:outline-none focus:ring-2 focus:ring-blue-400 rounded">
+                        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                        </svg>
+                    </button>
+                </div>
+                <div class="mb-4 grid grid-cols-2 gap-3">
+                    <label class="block">
+                        <span class="text-xs text-tg-muted">From (optional)</span>
+                        <input type="date" v-model="exportFromDate"
+                            class="mt-1 w-full bg-gray-900 text-white rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                    </label>
+                    <label class="block">
+                        <span class="text-xs text-tg-muted">To (optional)</span>
+                        <input type="date" v-model="exportToDate"
+                            class="mt-1 w-full bg-gray-900 text-white rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                    </label>
+                </div>
+                <p class="mb-4 text-xs text-tg-muted">Both days are included. Leave empty to export everything.</p>
+                <div class="flex gap-2 justify-end">
+                    <button @click="showExportModal = false"
+                        class="px-4 py-2 bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition">
+                        Cancel
+                    </button>
+                    <button @click="runExport"
+                        class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition">
+                        Export
+                    </button>
+                </div>
+            </section>
+        </div>
+
         <!-- Sender Details Dialog -->
         <div v-if="senderInfoMessage"
             class="fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-4"
@@ -5239,9 +5280,24 @@
                         filename.endsWith('.opus') || filename.endsWith('.flac')
                 }
 
+                const showExportModal = ref(false)
+                const exportFromDate = ref('')
+                const exportToDate = ref('')
+
                 const exportChat = () => {
                     if (!selectedChat.value) return
-                    const url = `/api/chats/${encodeURIComponent(selectedChat.value.ref)}/export`
+                    showExportModal.value = true
+                }
+
+                const runExport = () => {
+                    if (!selectedChat.value) return
+                    const params = new URLSearchParams()
+                    // Bare dates: the server includes the whole "to" day (#365 tz contract).
+                    if (exportFromDate.value) params.set('from', exportFromDate.value)
+                    if (exportToDate.value) params.set('to', exportToDate.value)
+                    const query = params.toString()
+                    const url = `/api/chats/${encodeURIComponent(selectedChat.value.ref)}/export${query ? '?' + query : ''}`
+                    showExportModal.value = false
                     window.open(url, '_blank')
                 }
 
@@ -7453,6 +7509,10 @@
                     isDeletedChat,
                     isAudioFile,
                     exportChat,
+                    runExport,
+                    showExportModal,
+                    exportFromDate,
+                    exportToDate,
                     // Error states
                     chatsError,
                     loadChats,

--- a/tests/test_db_adapter_soft_delete_upsert.py
+++ b/tests/test_db_adapter_soft_delete_upsert.py
@@ -908,3 +908,36 @@ async def test_deletion_snapshot_media_type_is_deterministic_across_rows(sqlite_
 
     # Lexicographic Media.id order: "300_62_photo" < "300_62_video".
     assert snapshot["media_type"] == "photo"
+
+
+@pytest.mark.asyncio
+async def test_version_export_window_uses_the_export_contract(sqlite_adapter):
+    """iter_message_versions_for_export windows with (>= from, < to) — the
+    export contract — without touching the shared query's inclusive end_date
+    that other callers own."""
+    await sqlite_adapter.insert_message(
+        {"id": 80, "chat_id": 300, "date": datetime(2026, 6, 28, 9, 0), "text": "v1"}, account_id=1
+    )
+    await sqlite_adapter.update_message_text(300, 80, "v2", datetime(2026, 6, 28, 10, 0), account_id=1)
+    await sqlite_adapter.update_message_text(300, 80, "v3", datetime(2026, 6, 28, 11, 0), account_id=1)
+
+    everything = [v async for v in sqlite_adapter.iter_message_versions_for_export(300, account_id=1)]
+    assert len(everything) == 2
+
+    windowed = [
+        v
+        async for v in sqlite_adapter.iter_message_versions_for_export(
+            300, account_id=1, from_date=datetime(2026, 6, 28, 9, 30), to_date=datetime(2026, 6, 28, 10, 0)
+        )
+    ]
+    # v1's version row carries the superseded text's date (9:00) -> below from;
+    # v2's row (10:00) -> excluded by the EXCLUSIVE to bound.
+    assert windowed == []
+
+    windowed = [
+        v
+        async for v in sqlite_adapter.iter_message_versions_for_export(
+            300, account_id=1, from_date=datetime(2026, 6, 28, 9, 0), to_date=datetime(2026, 6, 28, 10, 1)
+        )
+    ]
+    assert [v["text"] for v in windowed] == ["v1", "v2"]

--- a/tests/test_viewer_on_8_0_schema.py
+++ b/tests/test_viewer_on_8_0_schema.py
@@ -499,6 +499,11 @@ class TestViewerOn80Schema(unittest.IsolatedAsyncioTestCase):
             resp = await client.get(f"/api/chats/{self.ref_a}/export", params={"to": "2026-03-01"})
             self.assertEqual(len(json.loads(resp.text)["messages"]), 30)
 
+            # The maximum ISO date means "no upper bound", not a 500.
+            resp = await client.get(f"/api/chats/{self.ref_a}/export", params={"to": "9999-12-31"})
+            self.assertEqual(resp.status_code, 200, resp.text)
+            self.assertEqual(len(json.loads(resp.text)["messages"]), 30)
+
             resp = await client.get(f"/api/chats/{self.ref_a}/export", params={"from": "not-a-date"})
             self.assertEqual(resp.status_code, 400)
 

--- a/tests/test_viewer_on_8_0_schema.py
+++ b/tests/test_viewer_on_8_0_schema.py
@@ -467,3 +467,42 @@ class TestViewerOn80Schema(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(export["chat"]["ref"], self.ref_a)
             self.assertEqual(len(export["messages"]), 30)
             self.assertEqual(export["message_versions"], [])
+            # An unwindowed export carries no filters block: the file IS the
+            # full history and must not suggest otherwise.
+            self.assertNotIn("filters", export)
+
+    async def test_export_date_window(self):
+        """?from/?to reach the export stream (the README advertised this).
+
+        Bounds follow the #365 conversion contract: tz-aware instants convert
+        to naive UTC (never relabel), a bare "to" date includes its whole day,
+        a full "to" timestamp is exclusive.
+        """
+        async with self._client() as client:
+            await self._login(client)
+
+            resp = await client.get(f"/api/chats/{self.ref_a}/export", params={"from": "2026-03-01T12:11:00"})
+            self.assertEqual(resp.status_code, 200, resp.text)
+            export = json.loads(resp.text)
+            self.assertEqual(len(export["messages"]), 20)  # minutes 11..30
+            self.assertEqual(export["filters"], {"from": "2026-03-01T12:11:00", "to": None})
+
+            # +02:00 is the same instant as 12:11 UTC — the window must not shift.
+            resp = await client.get(f"/api/chats/{self.ref_a}/export", params={"from": "2026-03-01T14:11:00+02:00"})
+            self.assertEqual(len(json.loads(resp.text)["messages"]), 20)
+
+            # Full-timestamp "to" is exclusive: < 12:10 keeps minutes 1..9.
+            resp = await client.get(f"/api/chats/{self.ref_a}/export", params={"to": "2026-03-01T12:10:00"})
+            self.assertEqual(len(json.loads(resp.text)["messages"]), 9)
+
+            # A bare "to" date includes the whole named day.
+            resp = await client.get(f"/api/chats/{self.ref_a}/export", params={"to": "2026-03-01"})
+            self.assertEqual(len(json.loads(resp.text)["messages"]), 30)
+
+            resp = await client.get(f"/api/chats/{self.ref_a}/export", params={"from": "not-a-date"})
+            self.assertEqual(resp.status_code, 400)
+
+            resp = await client.get(
+                f"/api/chats/{self.ref_a}/export", params={"from": "2026-03-02", "to": "2026-03-01"}
+            )
+            self.assertEqual(resp.status_code, 400)

--- a/tests/test_web_coverage.py
+++ b/tests/test_web_coverage.py
@@ -937,12 +937,12 @@ class TestExportEndpoint(_WebTestBase):
             }
         )
 
-        async def fake_versions(chat_id, account_id=None):
+        async def fake_versions(chat_id, account_id=None, from_date=None, to_date=None):
             yield {"message_id": 2, "chat_id": 42, "text": "old", "date": "2025-01-01"}
 
         self.mock_db.iter_message_versions_for_export = fake_versions
 
-        async def fake_export(chat_id, account_id=None):
+        async def fake_export(chat_id, account_id=None, from_date=None, to_date=None):
             yield {"id": 1, "text": "hello", "date": "2025-01-01"}
             yield {"id": 2, "text": "world", "date": "2025-01-02"}
 


### PR DESCRIPTION
The README's feature list has said \"JSON export — Download chat history with date range filters\" for a long time, and none of it existed: the endpoint took no date parameters, and the export button opened the bare URL. Every export was all-or-nothing.

Now `GET /api/chats/{ref}/export?from=…&to=…`:

- Bounds follow the #365 conversion contract — tz-aware instants convert to naive UTC (never relabelled), so a `+02:00` timestamp lands on the same instant. A bare `to` date includes its whole named day (internally an exclusive next-midnight bound); a full `to` timestamp is exclusive. `from >= to` and garbage are 400s naming the parameter.
- Both streams window: messages via new `from_date`/`to_date` kwargs on `get_messages_for_export`, and message versions via the same (>= from, < to) contract on `iter_message_versions_for_export` — added as its OWN clauses, deliberately not through the shared versions query whose inclusive `end_date` other callers own.
- A windowed export records a `\"filters\"` block in the JSON header, so a partial file can never masquerade as the full history; unwindowed exports carry no block.
- The export button now opens a small dialog with two optional native date pickers (matching the Jump-to-Date modal's pattern); empty fields keep the one-click full export.

Tests: route-level windows on the real-schema viewer suite (inclusive whole-day `to`, exclusive timestamp `to`, tz conversion, 400s, filters-block presence/absence), a real-engine version-window test, and the coverage-suite stubs migrated to the new signature. Mutation-verified: dropping the message-window clauses fails the route test. Full suite: 3623 passed.

Bead `9t6.11.5`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional date-range filters to chat exports through a selection dialog.
  * Supports ISO 8601 dates and timestamps, including timezone-aware values.
  * Bare end dates include the entire specified day.
  * Export files now include the selected date filters.

* **Bug Fixes**
  * Invalid dates and reversed ranges return clear 400 errors.
  * Date filtering applies consistently to messages and message versions.
  * Maximum supported dates no longer cause export errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->