### PR TITLE
feat(viewer): a what-changed feed for the deletions and edits the archive kept

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1605,6 +1605,121 @@ class DatabaseAdapter:
             MessageVersion.id.asc(),
         )
 
+    async def get_recent_changes(
+        self,
+        *,
+        since: datetime | None = None,
+        before: datetime | None = None,
+        limit: int = 50,
+        scope: ChatScope | None = None,
+    ) -> list[dict[str, Any]]:
+        """The what-changed feed: deletions and edits the archive captured.
+
+        The archive's differentiator is that it KEEPS what disappeared; this
+        is the query that finally lists it. Two streams share one shape:
+
+        * ``deleted`` — soft-deleted messages (``is_deleted=1``), dated by
+          ``deleted_at``, carrying the text the archive kept.
+        * ``edited`` — ``message_versions`` rows, dated by ``captured_at``
+          (when the archive observed the supersession), carrying the old text
+          plus the message's CURRENT text.
+
+        Newest first. ``before`` is an exclusive keyset cursor over the
+        per-row date: pass the last row's ``date`` back to page. Rows sharing
+        that exact microsecond with the cursor are skipped — this is a review
+        feed, not an export, and the export path is the lossless one.
+        Entitlements ride ``scope.sql_predicates()`` against the joined chat
+        row, the same compiled rules as the chat list — a restricted viewer's
+        feed touches only their rows. Hard deletions cannot appear: their
+        content no longer exists (DELETION_MODE=soft is what feeds this).
+        """
+        per_stream = max(1, min(int(limit), 200))
+
+        def _chat_fields(row) -> dict[str, Any]:
+            name = row.title or " ".join(p for p in (row.first_name, row.last_name) if p) or row.username or ""
+            return {"ref": row.ref, "title": name, "type": row.chat_type}
+
+        async with self.db_manager.async_session_factory() as session:
+            deleted_stmt = (
+                select(
+                    Message.id.label("message_id"),
+                    Message.deleted_at.label("date"),
+                    Message.text,
+                    Message.sender_name,
+                    Chat.ref,
+                    Chat.title,
+                    Chat.first_name,
+                    Chat.last_name,
+                    Chat.username,
+                    Chat.type.label("chat_type"),
+                )
+                .join(Chat, and_(Chat.account_id == Message.account_id, Chat.id == Message.chat_id))
+                .where(Message.is_deleted == 1, Message.deleted_at.isnot(None))
+            )
+            edited_stmt = (
+                select(
+                    MessageVersion.message_id,
+                    MessageVersion.captured_at.label("date"),
+                    MessageVersion.text.label("old_text"),
+                    Message.text.label("new_text"),
+                    Message.sender_name,
+                    Chat.ref,
+                    Chat.title,
+                    Chat.first_name,
+                    Chat.last_name,
+                    Chat.username,
+                    Chat.type.label("chat_type"),
+                )
+                .join(
+                    Message,
+                    and_(
+                        Message.account_id == MessageVersion.account_id,
+                        Message.chat_id == MessageVersion.chat_id,
+                        Message.id == MessageVersion.message_id,
+                    ),
+                )
+                .join(Chat, and_(Chat.account_id == MessageVersion.account_id, Chat.id == MessageVersion.chat_id))
+            )
+            if since is not None:
+                deleted_stmt = deleted_stmt.where(Message.deleted_at >= since)
+                edited_stmt = edited_stmt.where(MessageVersion.captured_at >= since)
+            if before is not None:
+                deleted_stmt = deleted_stmt.where(Message.deleted_at < before)
+                edited_stmt = edited_stmt.where(MessageVersion.captured_at < before)
+            if scope is not None:
+                for predicate in scope.sql_predicates():
+                    deleted_stmt = deleted_stmt.where(predicate)
+                    edited_stmt = edited_stmt.where(predicate)
+            deleted_stmt = deleted_stmt.order_by(Message.deleted_at.desc()).limit(per_stream)
+            edited_stmt = edited_stmt.order_by(MessageVersion.captured_at.desc()).limit(per_stream)
+
+            changes: list[dict[str, Any]] = []
+            for row in (await session.execute(deleted_stmt)).all():
+                changes.append(
+                    {
+                        "kind": "deleted",
+                        "date": row.date.isoformat() if row.date else None,
+                        "chat": _chat_fields(row),
+                        "message_id": row.message_id,
+                        "sender_name": row.sender_name,
+                        "text": row.text,
+                    }
+                )
+            for row in (await session.execute(edited_stmt)).all():
+                changes.append(
+                    {
+                        "kind": "edited",
+                        "date": row.date.isoformat() if row.date else None,
+                        "chat": _chat_fields(row),
+                        "message_id": row.message_id,
+                        "sender_name": row.sender_name,
+                        "old_text": row.old_text,
+                        "new_text": row.new_text,
+                    }
+                )
+            changes.sort(key=lambda c: c["date"] or "", reverse=True)
+            return changes[:per_stream]
+
     async def get_message_versions_by_date_range(
         self,
         chat_id: int | None = None,

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -2395,6 +2395,52 @@ async def search_tag(
     return payload
 
 
+def _parse_changes_bound(value: str, param: str) -> datetime:
+    """ISO bound to naive UTC — the #365 conversion contract (convert, never relabel)."""
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        raise HTTPException(status_code=400, detail=f"Invalid {param} date. Use ISO 8601.") from None
+    if parsed.tzinfo:
+        parsed = parsed.astimezone(UTC).replace(tzinfo=None)
+    return parsed
+
+
+@app.get("/api/changes")
+async def get_recent_changes(
+    user: UserContext = Depends(require_auth),
+    since: str | None = Query(None),
+    before: str | None = Query(None),
+    limit: int = Query(50, ge=1, le=200),
+):
+    """What changed: deletions and edits the archive captured, newest first.
+
+    ``since`` bounds the window's start (inclusive); ``before`` is the keyset
+    cursor — pass the last row's ``date`` to page older. Entitlements are the
+    chat list's own compiled scope, so a restricted viewer sees only their
+    chats' changes.
+    """
+    parsed_since = _parse_changes_bound(since, "since") if since else None
+    parsed_before = _parse_changes_bound(before, "before") if before else None
+    try:
+        changes = await db.get_recent_changes(
+            since=parsed_since, before=parsed_before, limit=limit, scope=_chat_scope(user)
+        )
+        next_cursor = changes[-1]["date"] if len(changes) == limit else None
+        return JSONResponse(
+            {"changes": changes, "next_before": next_cursor},
+            headers={"Cache-Control": "private, no-store"},
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        # Counts/types only — feed rows carry chat titles and message text.
+        logger.error(f"Error building the changes feed: {type(e).__name__}")
+        if _is_db_connection_error(e):
+            raise HTTPException(status_code=503, detail="Database temporarily unavailable")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
 @app.get("/api/chats/{chat_ref}/messages/{message_id}/versions")
 async def get_message_versions(
     message_id: int,

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -3028,9 +3028,14 @@
                         else changesFeed.value = data.changes
                         changesNextBefore.value = data.next_before
                     } catch (e) {
-                        // Feed is best-effort UI; show the empty state rather than crash.
-                        if (!before) changesFeed.value = []
-                        changesNextBefore.value = null
+                        // Best-effort UI, but a load-more failure must not eat
+                        // the cursor: keeping it leaves the "Load older"
+                        // button in place as the retry affordance. Only an
+                        // INITIAL failure clears to the empty state.
+                        if (!before) {
+                            changesFeed.value = []
+                            changesNextBefore.value = null
+                        }
                     } finally {
                         changesLoading.value = false
                     }

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -541,6 +541,10 @@
                     <div class="flex items-center justify-between mb-3">
                         <div class="flex items-center gap-3">
                             <h1 class="text-xl font-bold">Telegram Archive</h1>
+                            <button @click="openChangesFeed" class="text-gray-400 hover:text-white p-1"
+                                title="What changed (deletions & edits)">
+                                <i class="fas fa-clock-rotate-left"></i>
+                            </button>
                             <!-- Stats Dropdown Button (hidden if SHOW_STATS=false) -->
                             <div class="relative" v-if="showStatsUI && statsData.stats_calculated_at">
                                 <button @click="statsPopupOpen = !statsPopupOpen"
@@ -1680,6 +1684,65 @@
                     <button @click="jumpToDate"
                         class="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition">
                         Jump
+                    </button>
+                </div>
+            </section>
+        </div>
+
+        <!-- What Changed Feed Modal -->
+        <div v-if="showChangesFeed"
+            class="fixed inset-0 bg-black/70 backdrop-blur-sm z-50 flex items-center justify-center overflow-y-auto p-4"
+            @click.self="showChangesFeed = false">
+            <section role="dialog" aria-modal="true" aria-labelledby="changes-feed-title"
+                class="my-auto bg-tg-sidebar rounded-2xl shadow-2xl p-6 w-full max-w-2xl border border-gray-700 max-h-[85vh] flex flex-col">
+                <div class="flex items-center justify-between mb-3">
+                    <h3 id="changes-feed-title" class="text-xl font-bold text-white">What changed</h3>
+                    <div class="flex items-center gap-2">
+                        <select v-model="changesSince" @change="reloadChangesFeed"
+                            class="bg-gray-900 text-white text-sm rounded-lg px-2 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                            <option value="1">Last 24 hours</option>
+                            <option value="7">Last 7 days</option>
+                            <option value="30">Last 30 days</option>
+                            <option value="">All time</option>
+                        </select>
+                        <button type="button" @click="showChangesFeed = false" aria-label="Close changes feed"
+                            class="text-gray-400 hover:text-white transition p-1 focus:outline-none focus:ring-2 focus:ring-blue-400 rounded">
+                            <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+                <p class="mb-3 text-xs text-tg-muted">
+                    Deletions and edits the archive kept. Deletions appear here when DELETION_MODE=soft.
+                </p>
+                <div class="flex-1 overflow-y-auto space-y-2 pr-1">
+                    <div v-if="changesLoading && !changesFeed.length" class="text-sm text-tg-muted py-6 text-center">Loading…</div>
+                    <div v-else-if="!changesFeed.length" class="text-sm text-tg-muted py-6 text-center">
+                        Nothing changed in this window.
+                    </div>
+                    <article v-for="change in changesFeed" :key="change.kind + change.chat.ref + change.message_id + change.date"
+                        class="rounded-xl border border-gray-700 bg-gray-900/60 p-3">
+                        <header class="flex items-center gap-2 text-xs mb-1.5">
+                            <span :class="change.kind === 'deleted' ? 'bg-red-500/20 text-red-300' : 'bg-amber-500/20 text-amber-300'"
+                                class="px-2 py-0.5 rounded-full font-semibold uppercase tracking-wide">
+                                {{ change.kind }}
+                            </span>
+                            <span class="text-white font-medium truncate">{{ change.chat.title || 'Unnamed chat' }}</span>
+                            <span v-if="change.sender_name" class="text-tg-muted truncate">· {{ change.sender_name }}</span>
+                            <span class="text-tg-muted ml-auto whitespace-nowrap">{{ formatChangeDate(change.date) }}</span>
+                        </header>
+                        <div v-if="change.kind === 'deleted'" class="text-sm text-gray-200 whitespace-pre-wrap break-words">
+                            {{ change.text || '(no text — media or service message)' }}
+                        </div>
+                        <div v-else class="text-sm space-y-1">
+                            <div class="text-gray-400 line-through whitespace-pre-wrap break-words">{{ change.old_text || '(empty)' }}</div>
+                            <div class="text-gray-200 whitespace-pre-wrap break-words">{{ change.new_text || '(empty)' }}</div>
+                        </div>
+                    </article>
+                    <button v-if="changesNextBefore" @click="loadMoreChanges" :disabled="changesLoading"
+                        class="w-full py-2 text-sm bg-gray-700 hover:bg-gray-600 disabled:opacity-50 text-white rounded-lg transition">
+                        {{ changesLoading ? 'Loading…' : 'Load older' }}
                     </button>
                 </div>
             </section>
@@ -2900,6 +2963,54 @@
 
                 const selectFolder = (folderId) => {
                     navigateTo({ type: 'chatList', filter: { folderId } })
+                }
+
+                const showChangesFeed = ref(false)
+                const changesFeed = ref([])
+                const changesNextBefore = ref(null)
+                const changesLoading = ref(false)
+                const changesSince = ref('7')
+
+                const changesSinceIso = () => {
+                    if (!changesSince.value) return null
+                    const days = parseInt(changesSince.value, 10)
+                    return new Date(Date.now() - days * 24 * 3600 * 1000).toISOString()
+                }
+
+                const fetchChanges = async (before) => {
+                    changesLoading.value = true
+                    try {
+                        const params = new URLSearchParams({ limit: '50' })
+                        const since = changesSinceIso()
+                        if (since) params.set('since', since)
+                        if (before) params.set('before', before)
+                        const resp = await fetch(`/api/changes?${params}`, { credentials: 'same-origin' })
+                        if (!resp.ok) throw new Error(`HTTP ${resp.status}`)
+                        const data = await resp.json()
+                        if (before) changesFeed.value.push(...data.changes)
+                        else changesFeed.value = data.changes
+                        changesNextBefore.value = data.next_before
+                    } catch (e) {
+                        // Feed is best-effort UI; show the empty state rather than crash.
+                        if (!before) changesFeed.value = []
+                        changesNextBefore.value = null
+                    } finally {
+                        changesLoading.value = false
+                    }
+                }
+
+                const openChangesFeed = () => {
+                    showChangesFeed.value = true
+                    fetchChanges(null)
+                }
+                const reloadChangesFeed = () => fetchChanges(null)
+                const loadMoreChanges = () => {
+                    if (changesNextBefore.value) fetchChanges(changesNextBefore.value)
+                }
+                const formatChangeDate = (iso) => {
+                    if (!iso) return ''
+                    const d = new Date(iso + (iso.endsWith('Z') ? '' : 'Z'))
+                    return d.toLocaleString()
                 }
 
                 const showArchived = () => {
@@ -7528,6 +7639,15 @@
                     retryLoadTopics,
                     selectFolder,
                     showArchived,
+                    showChangesFeed,
+                    changesFeed,
+                    changesNextBefore,
+                    changesLoading,
+                    changesSince,
+                    openChangesFeed,
+                    reloadChangesFeed,
+                    loadMoreChanges,
+                    formatChangeDate,
                     showAllChats,
                     openForumTopics,
                     selectTopic,

--- a/tests/test_db_adapter_soft_delete_upsert.py
+++ b/tests/test_db_adapter_soft_delete_upsert.py
@@ -975,6 +975,7 @@ async def test_version_export_window_uses_the_export_contract(sqlite_adapter):
     ]
     assert [v["text"] for v in windowed] == ["v1", "v2"]
 
+
 # ---------------------------------------------------------------------------
 # What-changed feed (#9t6.11.2)
 # ---------------------------------------------------------------------------

--- a/tests/test_db_adapter_soft_delete_upsert.py
+++ b/tests/test_db_adapter_soft_delete_upsert.py
@@ -941,3 +941,66 @@ async def test_recording_the_same_version_twice_is_a_silent_noop(sqlite_adapter,
             select(MessageVersion).where(MessageVersion.chat_id == 300, MessageVersion.message_id == 70)
         )
         assert len(list(rows.scalars())) == 1
+
+
+# ---------------------------------------------------------------------------
+# What-changed feed (#9t6.11.2)
+# ---------------------------------------------------------------------------
+
+
+async def _seed_feed_chat(adapter, chat_id, title):
+    await adapter.upsert_chat({"id": chat_id, "type": "group", "title": title}, account_id=1)
+
+
+@pytest.mark.asyncio
+async def test_recent_changes_merges_deletions_and_edits_newest_first(sqlite_adapter):
+
+    await _seed_feed_chat(sqlite_adapter, 400, "Feed Group")
+    await sqlite_adapter.insert_message(
+        {"id": 1, "chat_id": 400, "date": datetime(2026, 7, 1, 9, 0), "text": "will be deleted"}, account_id=1
+    )
+    await sqlite_adapter.insert_message(
+        {"id": 2, "chat_id": 400, "date": datetime(2026, 7, 1, 9, 5), "text": "v1"}, account_id=1
+    )
+    await sqlite_adapter.mark_message_deleted(400, 1, datetime(2026, 7, 1, 10, 0), account_id=1)
+    await sqlite_adapter.update_message_text(400, 2, "v2", datetime(2026, 7, 1, 11, 0), account_id=1)
+
+    changes = await sqlite_adapter.get_recent_changes(limit=10)
+
+    assert [c["kind"] for c in changes] == ["edited", "deleted"]  # version captured after the delete
+    edited, deleted = changes
+    assert edited["old_text"] == "v1" and edited["new_text"] == "v2"
+    assert edited["chat"]["title"] == "Feed Group"
+    assert edited["chat"]["ref"]
+    assert deleted["text"] == "will be deleted"
+    assert deleted["date"] == "2026-07-01T10:00:00"
+
+    # since after the deletion excludes it...
+    windowed = await sqlite_adapter.get_recent_changes(since=datetime(2026, 7, 1, 10, 30), limit=10)
+    assert [c["kind"] for c in windowed] == ["edited"]
+
+    # ...and the exclusive before-cursor pages past the newest row.
+    older = await sqlite_adapter.get_recent_changes(before=datetime.fromisoformat(changes[0]["date"]), limit=10)
+    assert [c["kind"] for c in older] == ["deleted"]
+
+
+@pytest.mark.asyncio
+async def test_recent_changes_respects_the_compiled_scope(sqlite_adapter):
+    from src.db.adapter import ChatScope
+
+    await _seed_feed_chat(sqlite_adapter, 401, "Mine")
+    await _seed_feed_chat(sqlite_adapter, 402, "Not mine")
+    for chat_id, msg_id in ((401, 11), (402, 12)):
+        await sqlite_adapter.insert_message(
+            {"id": msg_id, "chat_id": chat_id, "date": datetime(2026, 7, 2, 9, 0), "text": "gone"}, account_id=1
+        )
+        await sqlite_adapter.mark_message_deleted(chat_id, msg_id, datetime(2026, 7, 2, 10, 0), account_id=1)
+
+    mine = await sqlite_adapter.get_chat_by_id(401, account_id=1)
+    scoped = await sqlite_adapter.get_recent_changes(scope=ChatScope(refs={mine["ref"]}), limit=10)
+    assert [c["chat"]["title"] for c in scoped] == ["Mine"]
+
+    # The classic falsy-empty bug must not resurface: an EMPTY grant is
+    # "entitled to nothing", never "no filter".
+    nothing = await sqlite_adapter.get_recent_changes(scope=ChatScope(refs=set()), limit=10)
+    assert nothing == []

--- a/tests/test_viewer_on_8_0_schema.py
+++ b/tests/test_viewer_on_8_0_schema.py
@@ -41,7 +41,7 @@ if not os.environ.get("BACKUP_PATH"):
 
 from src.db.adapter import DatabaseAdapter
 from src.db.base import DatabaseManager
-from src.db.models import Chat, Media, Message, Reaction, ViewerAccount
+from src.db.models import Chat, Media, Message, MessageVersion, Reaction, ViewerAccount
 from src.web import main as web_main
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -467,3 +467,71 @@ class TestViewerOn80Schema(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(export["chat"]["ref"], self.ref_a)
             self.assertEqual(len(export["messages"]), 30)
             self.assertEqual(export["message_versions"], [])
+
+    async def test_changes_feed(self):
+        """/api/changes lists captured deletions and edits, newest first,
+        under the viewer's compiled scope."""
+        from sqlalchemy import delete as sa_delete
+        from sqlalchemy import update as sa_update
+
+        async with self.manager.async_session_factory() as session:
+            await session.execute(
+                sa_update(Message)
+                .where(Message.account_id == 1, Message.chat_id == CHAT_A, Message.id == 1)
+                .values(is_deleted=1, deleted_at=BASE_DATE + timedelta(days=1))
+            )
+            session.add(
+                MessageVersion(
+                    account_id=1,
+                    chat_id=CHAT_A,
+                    message_id=2,
+                    text="the old text",
+                    date=BASE_DATE,
+                    change_hash="feedtesthash0001",
+                    captured_at=BASE_DATE + timedelta(days=1, hours=1),
+                )
+            )
+            await session.commit()
+
+        # The seed is class-scoped: undo these mutations whatever happens, or
+        # alphabetically-later tests inherit a tombstoned message 1.
+        async def _restore():
+            async with self.manager.async_session_factory() as session:
+                await session.execute(
+                    sa_update(Message)
+                    .where(Message.account_id == 1, Message.chat_id == CHAT_A, Message.id == 1)
+                    .values(is_deleted=0, deleted_at=None)
+                )
+                await session.execute(sa_delete(MessageVersion).where(MessageVersion.change_hash == "feedtesthash0001"))
+                await session.commit()
+
+        try:
+            await self._run_changes_feed_assertions()
+        finally:
+            await _restore()
+
+    async def _run_changes_feed_assertions(self):
+        async with self._client() as client:
+            await self._login(client)
+
+            resp = await client.get("/api/changes")
+            self.assertEqual(resp.status_code, 200, resp.text)
+            payload = resp.json()
+            kinds = [c["kind"] for c in payload["changes"]]
+            self.assertEqual(kinds, ["edited", "deleted"])  # captured_at is newer
+            edited, deleted = payload["changes"]
+            self.assertEqual(edited["old_text"], "the old text")
+            self.assertEqual(edited["chat"]["ref"], self.ref_a)
+            self.assertEqual(deleted["message_id"], 1)
+            self.assertIsNone(payload["next_before"])  # short page, no cursor
+
+            # since after both excludes everything.
+            resp = await client.get("/api/changes", params={"since": "2026-03-03T00:00:00Z"})
+            self.assertEqual(resp.json()["changes"], [])
+
+            # Cursor pages strictly older than the given instant.
+            resp = await client.get("/api/changes", params={"before": edited["date"]})
+            self.assertEqual([c["kind"] for c in resp.json()["changes"]], ["deleted"])
+
+            resp = await client.get("/api/changes", params={"since": "not-a-date"})
+            self.assertEqual(resp.status_code, 400)

--- a/tests/test_viewer_on_8_0_schema.py
+++ b/tests/test_viewer_on_8_0_schema.py
@@ -511,7 +511,6 @@ class TestViewerOn80Schema(unittest.IsolatedAsyncioTestCase):
                 f"/api/chats/{self.ref_a}/export", params={"from": "2026-03-02", "to": "2026-03-01"}
             )
 
-
     async def test_changes_feed(self):
         """/api/changes lists captured deletions and edits, newest first,
         under the viewer's compiled scope."""


### PR DESCRIPTION
The archive's differentiator over Telegram itself is that it KEEPS what disappeared — soft-deleted rows and the `message_versions` edit history exist today, but no surface lists them: the operator cannot answer \"what changed since yesterday\". Official apps cannot show this at all.

**`GET /api/changes`** merges two streams into one newest-first feed:
- `deleted` — soft-deleted messages, dated by `deleted_at`, carrying the text the archive kept (hard deletions cannot appear: their content no longer exists — `DELETION_MODE=soft` is what feeds this, and the panel says so).
- `edited` — `message_versions` rows dated by `captured_at`, carrying old text plus the message's current text.

`since` bounds the window; `before` is an exclusive keyset cursor over the row date (documented as a review feed, not an export — the export path stays the lossless one). Entitlements ride `scope.sql_predicates()` against the joined chat row — the chat list's own compiled rules, so a restricted viewer's feed touches only their rows, and the empty-grant-means-nothing contract is pinned by test. Bounds parse under the #365 conversion contract; errors are 400s naming the parameter; logging is counts/types only.

**Viewer**: a sidebar clock-rotate button opens the \"What changed\" panel — window presets (24h/7d/30d/all), kind chips, chat title + sender + local time, deleted text or old→new strikethrough diff, and Load-older keyset paging. Modeled on the Jump-to-Date modal.

Tests: real-engine merge/order/since/cursor + the compiled-scope test including the falsy-empty-grant bypass guard (mutation-verified: removing the scope application fails it), and a route test on the real-schema suite (shape, ordering, window, cursor, 400) that restores the class seed it mutates. Full suite: 3642 passed.

Bead `9t6.11.2`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “What changed” history view showing edited and deleted messages.
  * Added time-range filtering, pagination, reload, and loading/empty states.
  * Changes are displayed newest first with message text, timestamps, and chat details.
* **Bug Fixes**
  * Excludes permanently deleted messages from the history.
  * Added validation and graceful handling for invalid dates and service errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->