### PR TITLE
feat(viewer): an archive status panel that answers 'is it healthy right now'

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -705,6 +705,53 @@ class DatabaseAdapter:
             await session.commit()
 
     @retry_on_locked()
+    async def get_operator_status_counts(self, *, max_attempts: int) -> dict[str, Any]:
+        """Aggregate media-pipeline counts for the operator status panel.
+
+        Counts only (PII rule). ``pending`` rows are still retried by the
+        scheduled pass; ``exhausted`` rows hit the retry cap and stay pending
+        until the operator intervenes (the honesty split #212/#360 built).
+        """
+        async with self.db_manager.async_session_factory() as session:
+            downloaded = (
+                await session.execute(select(func.count()).select_from(Media).where(Media.downloaded == 1))
+            ).scalar() or 0
+            pending = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(Media)
+                    .where(Media.downloaded == 0, Media.download_attempts < max_attempts)
+                )
+            ).scalar() or 0
+            exhausted = (
+                await session.execute(
+                    select(func.count())
+                    .select_from(Media)
+                    .where(Media.downloaded == 0, Media.download_attempts >= max_attempts)
+                )
+            ).scalar() or 0
+        return {"downloaded": downloaded, "pending": pending, "exhausted": exhausted}
+
+    async def get_database_size_bytes(self) -> int | None:
+        """Best-effort on-disk size of the archive database.
+
+        SQLite: the database file's size. PostgreSQL: pg_database_size().
+        None when it cannot be determined — the status panel shows "unknown"
+        rather than failing.
+        """
+        try:
+            if self.db_manager._is_sqlite:
+                url = self.db_manager.database_url
+                _, sep, path = url.partition(":///")
+                if not sep or not path:
+                    return None
+                return os.path.getsize(path)
+            async with self.db_manager.async_session_factory() as session:
+                result = await session.execute(text("SELECT pg_database_size(current_database())"))
+                return int(result.scalar())
+        except Exception:
+            return None
+
     async def get_account_ids(self) -> list[int]:
         """All accounts.id values, ascending (viewer status aggregation, 8.1)."""
         async with self.db_manager.async_session_factory() as session:

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -2647,6 +2647,45 @@ async def get_stats(user: UserContext = Depends(require_auth)):
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+@app.get("/api/status")
+async def get_operator_status(user: UserContext = Depends(require_master)):
+    """One page's worth of "is my archive healthy right now" (master-only).
+
+    Aggregates signals the system already writes: last backup run and
+    in-progress flag, per-account listener liveness, the media pipeline's
+    pending/exhausted split, stats freshness and database size. Counts and
+    timestamps only — never ids, titles or content.
+    """
+    try:
+        payload: dict = {
+            "backup": {
+                "last_run": await db.get_metadata("last_backup_time"),
+                "in_progress": (await db.get_metadata("backup_in_progress")) == "1",
+            },
+            "stats_calculated_at": await db.get_metadata("stats_calculated_at"),
+        }
+        try:
+            account_ids = list(await db.get_account_ids())
+        except Exception:
+            account_ids = [DEFAULT_ACCOUNT_ID]
+        listeners = []
+        for account_id in account_ids:
+            since = await db.get_metadata(account_metadata_key("listener_active_since", account_id))
+            listeners.append({"account_id": account_id, "active": bool(since), "active_since": since})
+        payload["listeners"] = listeners
+        payload["media"] = await db.get_operator_status_counts(max_attempts=config.max_media_download_attempts)
+        payload["database"] = {
+            "backend": "sqlite" if db.db_manager._is_sqlite else "postgresql",
+            "size_bytes": await db.get_database_size_bytes(),
+        }
+        return JSONResponse(payload, headers={"Cache-Control": "private, no-store"})
+    except Exception as e:
+        logger.error(f"Error building operator status: {type(e).__name__}")
+        if _is_db_connection_error(e):
+            raise HTTPException(status_code=503, detail="Database temporarily unavailable")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
 @app.post("/api/stats/refresh")
 async def refresh_stats(user: UserContext = Depends(require_master)):
     """Manually trigger stats recalculation (expensive, use sparingly)."""

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -529,6 +529,9 @@
                 <!-- User bar -->
                 <div v-if="authRequired && isAuthenticated" class="flex items-center gap-2 px-3 py-1 border-b border-gray-700">
                     <span class="text-xs text-gray-400 truncate flex-1">{{ currentUsername }}</span>
+                    <button v-if="userRole === 'master'" @click="openStatusPanel" class="text-gray-400 hover:text-white p-1" title="Archive Status">
+                        <i class="fas fa-heart-pulse"></i>
+                    </button>
                     <button v-if="userRole === 'master'" @click="openAdminPanel" class="text-gray-400 hover:text-white p-1" title="Admin Settings">
                         <i class="fas fa-cog"></i>
                     </button>
@@ -1682,6 +1685,65 @@
                         Jump
                     </button>
                 </div>
+            </section>
+        </div>
+
+        <!-- Operator Status Modal (master only) -->
+        <div v-if="showStatusPanel"
+            class="fixed inset-0 bg-black/70 backdrop-blur-sm z-50 flex items-center justify-center overflow-y-auto p-4"
+            @click.self="showStatusPanel = false">
+            <section role="dialog" aria-modal="true" aria-labelledby="status-panel-title"
+                class="my-auto bg-tg-sidebar rounded-2xl shadow-2xl p-6 w-full max-w-md border border-gray-700">
+                <div class="flex items-center justify-between mb-4">
+                    <h3 id="status-panel-title" class="text-xl font-bold text-white">Archive Status</h3>
+                    <button type="button" @click="showStatusPanel = false" aria-label="Close status panel"
+                        class="text-gray-400 hover:text-white transition p-1 focus:outline-none focus:ring-2 focus:ring-blue-400 rounded">
+                        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                        </svg>
+                    </button>
+                </div>
+                <div v-if="statusLoading" class="text-sm text-tg-muted py-4 text-center">Loading…</div>
+                <div v-else-if="!statusData" class="text-sm text-amber-300 py-4 text-center">Could not load status.</div>
+                <dl v-else class="space-y-3 text-sm">
+                    <div class="flex items-center justify-between gap-3">
+                        <dt class="text-tg-muted">Backup</dt>
+                        <dd class="text-white text-right">
+                            <span v-if="statusData.backup.in_progress" class="text-blue-300">running now</span>
+                            <span v-else-if="statusData.backup.last_run">last run {{ formatStatusDate(statusData.backup.last_run) }}</span>
+                            <span v-else class="text-amber-300">never ran</span>
+                        </dd>
+                    </div>
+                    <div v-for="l in statusData.listeners" :key="l.account_id" class="flex items-center justify-between gap-3">
+                        <dt class="text-tg-muted">Listener (account {{ l.account_id }})</dt>
+                        <dd class="text-right">
+                            <span :class="l.active ? 'text-green-400' : 'text-gray-400'">
+                                {{ l.active ? 'active since ' + formatStatusDate(l.active_since) : 'not running' }}
+                            </span>
+                        </dd>
+                    </div>
+                    <div class="flex items-center justify-between gap-3">
+                        <dt class="text-tg-muted">Media pipeline</dt>
+                        <dd class="text-white text-right">
+                            {{ statusData.media.downloaded.toLocaleString() }} downloaded
+                            <span v-if="statusData.media.pending" class="text-blue-300">· {{ statusData.media.pending.toLocaleString() }} pending</span>
+                            <span v-if="statusData.media.exhausted" class="text-amber-300">· {{ statusData.media.exhausted.toLocaleString() }} gave up</span>
+                        </dd>
+                    </div>
+                    <div class="flex items-center justify-between gap-3">
+                        <dt class="text-tg-muted">Stats freshness</dt>
+                        <dd class="text-white text-right">
+                            {{ statusData.stats_calculated_at ? formatStatusDate(statusData.stats_calculated_at) : 'never calculated' }}
+                        </dd>
+                    </div>
+                    <div class="flex items-center justify-between gap-3">
+                        <dt class="text-tg-muted">Database</dt>
+                        <dd class="text-white text-right">
+                            {{ statusData.database.backend }}
+                            <span v-if="statusData.database.size_bytes != null">· {{ formatStatusSize(statusData.database.size_bytes) }}</span>
+                        </dd>
+                    </div>
+                </dl>
             </section>
         </div>
 
@@ -2941,6 +3003,35 @@
 
                 const selectFolder = (folderId) => {
                     navigateTo({ type: 'chatList', filter: { folderId } })
+                }
+
+                const showStatusPanel = ref(false)
+                const statusData = ref(null)
+                const statusLoading = ref(false)
+
+                const openStatusPanel = async () => {
+                    showStatusPanel.value = true
+                    statusLoading.value = true
+                    try {
+                        const resp = await fetch('/api/status', { credentials: 'same-origin' })
+                        statusData.value = resp.ok ? await resp.json() : null
+                    } catch (e) {
+                        statusData.value = null
+                    } finally {
+                        statusLoading.value = false
+                    }
+                }
+                const formatStatusDate = (iso) => {
+                    if (!iso) return ''
+                    const d = new Date(iso.endsWith('Z') ? iso : iso + 'Z')
+                    return d.toLocaleString()
+                }
+                const formatStatusSize = (bytes) => {
+                    if (bytes == null) return ''
+                    const units = ['B', 'KB', 'MB', 'GB', 'TB']
+                    let v = bytes, u = 0
+                    while (v >= 1024 && u < units.length - 1) { v /= 1024; u++ }
+                    return `${v.toFixed(u ? 1 : 0)} ${units[u]}`
                 }
 
                 const showArchived = () => {
@@ -7588,6 +7679,12 @@
                     retryLoadTopics,
                     selectFolder,
                     showArchived,
+                    showStatusPanel,
+                    statusData,
+                    statusLoading,
+                    openStatusPanel,
+                    formatStatusDate,
+                    formatStatusSize,
                     showAllChats,
                     openForumTopics,
                     selectTopic,

--- a/tests/test_db_adapter.py
+++ b/tests/test_db_adapter.py
@@ -3746,3 +3746,31 @@ class TestDeleteChatPushSubscriptionPurge:
             assert "FOR UPDATE" in str(locked.compile(dialect=postgresql.dialect()))
         finally:
             await db_manager.engine.dispose()
+
+
+class TestDatabaseSizeBytes:
+    """get_database_size_bytes: PG branch and the never-raise contract."""
+
+    @pytest.mark.asyncio
+    async def test_postgres_branch_returns_pg_database_size(self):
+        db_manager, mock_session = _make_mock_db_manager(is_sqlite=False)
+        adapter = DatabaseAdapter(db_manager)
+        mock_session.execute.return_value = MagicMock(scalar=MagicMock(return_value=123456))
+
+        assert await adapter.get_database_size_bytes() == 123456
+
+    @pytest.mark.asyncio
+    async def test_query_failure_degrades_to_none(self):
+        db_manager, mock_session = _make_mock_db_manager(is_sqlite=False)
+        adapter = DatabaseAdapter(db_manager)
+        mock_session.execute.side_effect = RuntimeError("connection lost")
+
+        assert await adapter.get_database_size_bytes() is None
+
+    @pytest.mark.asyncio
+    async def test_memory_sqlite_url_has_no_file_to_size(self):
+        db_manager, _ = _make_mock_db_manager(is_sqlite=True)
+        db_manager.database_url = "sqlite+aiosqlite://"
+        adapter = DatabaseAdapter(db_manager)
+
+        assert await adapter.get_database_size_bytes() is None

--- a/tests/test_db_adapter_soft_delete_upsert.py
+++ b/tests/test_db_adapter_soft_delete_upsert.py
@@ -974,3 +974,35 @@ async def test_version_export_window_uses_the_export_contract(sqlite_adapter):
         )
     ]
     assert [v["text"] for v in windowed] == ["v1", "v2"]
+
+
+@pytest.mark.asyncio
+async def test_operator_status_counts_split_pending_from_exhausted(sqlite_adapter):
+    """The status panel's honesty split: rows still in the retry loop vs rows
+    that hit the cap and wait for the operator."""
+    rows = [
+        ("m1", 1, 0, 0),  # pending, never tried
+        ("m2", 2, 0, 3),  # pending, some attempts left (cap 5)
+        ("m3", 3, 0, 5),  # exhausted at the cap
+        ("m4", 4, 1, 2),  # downloaded
+    ]
+    for media_id, msg_id, downloaded, attempts in rows:
+        await sqlite_adapter.insert_message(
+            {"id": msg_id, "chat_id": 500, "date": datetime(2026, 7, 3, 9, msg_id), "text": "m"}, account_id=1
+        )
+        await sqlite_adapter.insert_media(
+            {"id": media_id, "message_id": msg_id, "chat_id": 500, "type": "photo", "downloaded": bool(downloaded)},
+            account_id=1,
+        )
+        for _ in range(attempts):
+            await sqlite_adapter.increment_media_download_attempts(media_id, account_id=1)
+
+    counts = await sqlite_adapter.get_operator_status_counts(max_attempts=5)
+
+    assert counts == {"downloaded": 1, "pending": 2, "exhausted": 1}
+
+
+@pytest.mark.asyncio
+async def test_database_size_is_reported_for_sqlite(sqlite_adapter):
+    size = await sqlite_adapter.get_database_size_bytes()
+    assert isinstance(size, int) and size > 0

--- a/tests/test_viewer_on_8_0_schema.py
+++ b/tests/test_viewer_on_8_0_schema.py
@@ -471,6 +471,14 @@ class TestViewerOn80Schema(unittest.IsolatedAsyncioTestCase):
             # full history and must not suggest otherwise.
             self.assertNotIn("filters", export)
 
+    async def test_operator_status_is_master_only(self):
+        """/api/status is operator surface; this suite's login is a
+        viewer-role account, so the gate must refuse it."""
+        async with self._client() as client:
+            await self._login(client)
+            resp = await client.get("/api/status")
+            self.assertEqual(resp.status_code, 403)
+
     async def test_export_date_window(self):
         """?from/?to reach the export stream (the README advertised this).
 

--- a/tests/test_web_coverage.py
+++ b/tests/test_web_coverage.py
@@ -2184,3 +2184,39 @@ class TestPushInitializeDerKey(unittest.IsolatedAsyncioTestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+@_skip_unless_web
+class TestOperatorStatus(_MasterTestBase):
+    """GET /api/status — the one-page health answer (master-only)."""
+
+    async def test_status_aggregates_the_health_signals(self):
+        async def fake_metadata(key):
+            return {
+                "last_backup_time": "2026-08-22T06:00:00Z",
+                "backup_in_progress": "0",
+                "stats_calculated_at": "2026-08-22T03:00:00",
+                "listener_active_since_account_2": "2026-08-22T05:00:00",
+            }.get(key)
+
+        self.mock_db.get_metadata = AsyncMock(side_effect=fake_metadata)
+        self.mock_db.get_account_ids = AsyncMock(return_value=[1, 2])
+        self.mock_db.get_operator_status_counts = AsyncMock(
+            return_value={"downloaded": 10, "pending": 2, "exhausted": 1}
+        )
+        self.mock_db.get_database_size_bytes = AsyncMock(return_value=4096)
+        self.mock_db.db_manager = MagicMock(_is_sqlite=True)
+
+        async with self._client() as client:
+            resp = await client.get("/api/status")
+
+        assert resp.status_code == 200, resp.text
+        payload = resp.json()
+        assert payload["backup"] == {"last_run": "2026-08-22T06:00:00Z", "in_progress": False}
+        assert payload["listeners"] == [
+            {"account_id": 1, "active": False, "active_since": None},
+            {"account_id": 2, "active": True, "active_since": "2026-08-22T05:00:00"},
+        ]
+        assert payload["media"] == {"downloaded": 10, "pending": 2, "exhausted": 1}
+        assert payload["database"] == {"backend": "sqlite", "size_bytes": 4096}
+        self.mock_db.get_operator_status_counts.assert_awaited_once()

--- a/tests/test_web_coverage.py
+++ b/tests/test_web_coverage.py
@@ -2220,3 +2220,36 @@ class TestOperatorStatus(_MasterTestBase):
         assert payload["media"] == {"downloaded": 10, "pending": 2, "exhausted": 1}
         assert payload["database"] == {"backend": "sqlite", "size_bytes": 4096}
         self.mock_db.get_operator_status_counts.assert_awaited_once()
+
+    async def test_account_list_failure_degrades_to_the_default_account(self):
+        """Advisory status only: a broken get_account_ids falls back to the
+        legacy single-account key instead of failing the whole panel."""
+        self.mock_db.get_metadata = AsyncMock(return_value=None)
+        self.mock_db.get_account_ids = AsyncMock(side_effect=RuntimeError("no accounts table"))
+        self.mock_db.get_operator_status_counts = AsyncMock(
+            return_value={"downloaded": 0, "pending": 0, "exhausted": 0}
+        )
+        self.mock_db.get_database_size_bytes = AsyncMock(return_value=None)
+        self.mock_db.db_manager = MagicMock(_is_sqlite=False)
+
+        async with self._client() as client:
+            resp = await client.get("/api/status")
+
+        assert resp.status_code == 200, resp.text
+        payload = resp.json()
+        assert [entry["account_id"] for entry in payload["listeners"]] == [1]
+        assert payload["database"] == {"backend": "postgresql", "size_bytes": None}
+
+    async def test_status_failure_maps_to_500_and_connection_loss_to_503(self):
+        self.mock_db.get_metadata = AsyncMock(side_effect=RuntimeError("boom"))
+
+        async with self._client() as client:
+            resp = await client.get("/api/status")
+        assert resp.status_code == 500
+
+        from sqlalchemy.exc import OperationalError
+
+        self.mock_db.get_metadata = AsyncMock(side_effect=OperationalError("x", None, Exception("down")))
+        async with self._client() as client:
+            resp = await client.get("/api/status")
+        assert resp.status_code == 503


### PR DESCRIPTION
The operator signal today is scattered across container logs: sync counts, flood pauses, pending-media retries, listener liveness. Answering \"is my archive healthy right now\" means grepping. Official apps have no equivalent — this is pure operator surface.

**`GET /api/status`** (master-only) aggregates signals the system already writes, without new bookkeeping:
- last backup run + the in-progress flag,
- per-account listener liveness (the 8.1 per-account metadata keys, legacy key for account 1),
- the media pipeline's honesty split — downloaded / still-retrying pending / `exhausted` rows that hit the retry cap and wait for the operator (#212/#360's design, now visible),
- stats freshness and the database backend + on-disk size (SQLite file size / `pg_database_size`, best-effort None over failure).

Counts and timestamps only — never ids, titles or content.

**Viewer**: a master-only heart-pulse button beside Admin Settings opens the panel — backup row, one row per account's listener (green when active), media pipeline counts with amber \"gave up\", stats freshness, database size.

Tests: real-engine pending/exhausted split + SQLite size; mocked-web route shape (both listener key forms); and a 403 pin in the real-schema suite whose login is a viewer-role account — mutation-verified: weakening the gate to `require_auth` fails it. Full targeted run: 173 passed.

Bead `9t6.11.4`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an operator-only Archive Status view showing backup health, listener activity, media download progress, statistics freshness, and database information.
  - Added detailed media status counts for completed, retryable, and exhausted downloads.
  - Added database size reporting where supported.
  - Added loading and error states for status information.

- **Bug Fixes**
  - Restricted operational status information to authorized operators.

- **Tests**
  - Added coverage for status reporting, access control, media categories, and database size display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->