### PR TITLE
feat(viewer): every message gets a shareable link, and pasted t.me links jump to the archived copy

### DIFF
--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1891,7 +1891,7 @@
                         <dd class="mt-1 font-mono text-white">{{ senderInfoMessage.sender_id ?? 'Unknown' }}</dd>
                     </div>
                 </dl>
-                <div class="mt-4 flex justify-end">
+                <div v-if="senderInfoMessage.id" class="mt-4 flex justify-end">
                     <button @click="copyMessageLink(senderInfoMessage)"
                         class="px-3 py-1.5 text-sm bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition">
                         <i class="fa-solid fa-link mr-1"></i> Copy message link
@@ -3493,14 +3493,41 @@
                         return false
                     }
                     await selectChat(targetChat)
-                    if (messageId) {
-                        await nextTick()
-                        // The #367-hardened jump: windows around the id even when the
-                        // message is far outside the loaded page. scrollToMessage only
-                        // worked for already-rendered rows — fine for a fresh push
-                        // notification, silently a no-op for a shared link to history.
-                        await loadMessagesAroundId(messageId)
+                    if (!messageId) return true
+                    if (targetChat.is_forum) {
+                        // selectChat short-circuits a forum into its topics list
+                        // without setting the pane — the jump needs the message's
+                        // topic first (the playbar's own continuation pattern).
+                        try {
+                            const resp = await fetch(
+                                `/api/chats/${encodeURIComponent(targetChat.ref)}/messages?after_id=${messageId - 1}&limit=1`,
+                                { credentials: 'same-origin' }
+                            )
+                            const rows = resp.ok ? await resp.json() : []
+                            const target = Array.isArray(rows) ? rows.find(m => m.id === messageId) || rows[0] : null
+                            const topicId = target?.reply_to_top_id ?? GENERAL_TOPIC_ID
+                            let topic = topics.value.find(t => Number(t.id) === Number(topicId))
+                            if (!topic && Number(topicId) === Number(GENERAL_TOPIC_ID)) {
+                                // Old captures may lack a General row — General always
+                                // exists conceptually (the playbar synthesizes it too).
+                                topic = { id: GENERAL_TOPIC_ID, title: 'General' }
+                            }
+                            if (!topic) {
+                                showToast('Could not locate that topic')
+                                return false
+                            }
+                            await selectTopic(targetChat, topic)
+                        } catch (e) {
+                            showToast('Could not locate that topic')
+                            return false
+                        }
                     }
+                    await nextTick()
+                    // The #367-hardened jump: windows around the id even when the
+                    // message is far outside the loaded page. scrollToMessage only
+                    // worked for already-rendered rows — fine for a fresh push
+                    // notification, silently a no-op for a shared link to history.
+                    await loadMessagesAroundId(messageId)
                     return true
                 }
 
@@ -3523,10 +3550,29 @@
                     return null
                 }
 
-                const openTelegramLink = async (parsed) => {
-                    const chat = chats.value.find(c => parsed.markedId != null
+                const resolveChatForLink = async (parsed) => {
+                    const matches = (c) => parsed.markedId != null
                         ? c.id === parsed.markedId
-                        : (c.username || '').toLowerCase() === parsed.username.toLowerCase())
+                        : (c.username || '').toLowerCase() === parsed.username.toLowerCase()
+                    const local = chats.value.find(matches)
+                    if (local) return local
+                    // The sidebar holds only the current page — ask the server
+                    // for the rest before declaring the chat unarchived (the
+                    // same limit=1000 bound the search box already uses;
+                    // archived chats included by default).
+                    try {
+                        const query = parsed.username ? `search=${encodeURIComponent(parsed.username)}&` : ''
+                        const resp = await fetch(`/api/chats?${query}limit=1000`, { credentials: 'same-origin' })
+                        if (!resp.ok) return null
+                        const data = await resp.json()
+                        return (data.chats || []).find(matches) || null
+                    } catch (e) {
+                        return null
+                    }
+                }
+
+                const openTelegramLink = async (parsed) => {
+                    const chat = await resolveChatForLink(parsed)
                     if (!chat) {
                         showToast('That link points at a chat this archive does not hold')
                         return false

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1829,6 +1829,12 @@
                         <dd class="mt-1 font-mono text-white">{{ senderInfoMessage.sender_id ?? 'Unknown' }}</dd>
                     </div>
                 </dl>
+                <div class="mt-4 flex justify-end">
+                    <button @click="copyMessageLink(senderInfoMessage)"
+                        class="px-3 py-1.5 text-sm bg-gray-700 hover:bg-gray-600 text-white rounded-lg transition">
+                        <i class="fa-solid fa-link mr-1"></i> Copy message link
+                    </button>
+                </div>
             </section>
         </div>
 
@@ -2862,6 +2868,16 @@
                         return
                     }
 
+                    // A pasted t.me link is a navigation, not a search.
+                    const telegramLink = parseTelegramLink(query)
+                    if (telegramLink) {
+                        searchQuery.value = ''
+                        searchResults.value = []
+                        searchLoading.value = false
+                        openTelegramLink(telegramLink)
+                        return
+                    }
+
                     searchLoading.value = true
                     searchDebounceTimer = setTimeout(async () => {
                         try {
@@ -3388,9 +3404,54 @@
                     await selectChat(targetChat)
                     if (messageId) {
                         await nextTick()
-                        scrollToMessage(messageId)
+                        // The #367-hardened jump: windows around the id even when the
+                        // message is far outside the loaded page. scrollToMessage only
+                        // worked for already-rendered rows — fine for a fresh push
+                        // notification, silently a no-op for a shared link to history.
+                        await loadMessagesAroundId(messageId)
                     }
                     return true
+                }
+
+                // ---- Deep links: stable per-message URLs + t.me recognition ----
+                // The shareable form is the push-notification contract the app
+                // already honors on load: /?chat=<ref>&msg=<id> (opaque ref, so
+                // chat ids stay out of URLs and browser history).
+                const parseTelegramLink = (text) => {
+                    const value = (text || '').trim()
+                    const c = /^(?:https?:\/\/)?t\.me\/c\/(\d+)\/(\d+)(?:[?#].*)?$/.exec(value)
+                    if (c) {
+                        // t.me/c/<internal>/<msg>: the internal id is the marked id
+                        // without its -100 prefix.
+                        return { markedId: -1000000000000 - parseInt(c[1], 10), username: null, messageId: parseInt(c[2], 10) }
+                    }
+                    const u = /^(?:https?:\/\/)?t\.me\/([A-Za-z][A-Za-z0-9_]{3,31})\/(\d+)(?:[?#].*)?$/.exec(value)
+                    if (u) {
+                        return { markedId: null, username: u[1], messageId: parseInt(u[2], 10) }
+                    }
+                    return null
+                }
+
+                const openTelegramLink = async (parsed) => {
+                    const chat = chats.value.find(c => parsed.markedId != null
+                        ? c.id === parsed.markedId
+                        : (c.username || '').toLowerCase() === parsed.username.toLowerCase())
+                    if (!chat) {
+                        showToast('That link points at a chat this archive does not hold')
+                        return false
+                    }
+                    return openNotificationTarget(chat.ref, parsed.messageId)
+                }
+
+                const copyMessageLink = async (msg) => {
+                    if (!selectedChat.value || !msg?.id) return
+                    const url = `${window.location.origin}/?chat=${encodeURIComponent(selectedChat.value.ref)}&msg=${msg.id}`
+                    try {
+                        await navigator.clipboard.writeText(url)
+                        showToast('Message link copied')
+                    } catch (e) {
+                        showToast(url)  // clipboard unavailable (http origin): show it instead
+                    }
                 }
 
                 // A notification click can arrive before initialization has loaded the
@@ -7700,6 +7761,7 @@
                     retryLoadTopics,
                     selectFolder,
                     showArchived,
+                    copyMessageLink,
                     showChangesFeed,
                     changesFeed,
                     changesNextBefore,

--- a/tests/test_frontend_audit_fixes.py
+++ b/tests/test_frontend_audit_fixes.py
@@ -328,7 +328,13 @@ const opened = [];
 const scrolled = [];
 const toasts = [];
 const selectChat = async chat => { opened.push(chat.id); };
-const scrollToMessage = id => { scrolled.push(id); };
+// The shared opener rides the #367-hardened jump now (scrollToMessage was a
+// silent no-op outside the rendered window); the non-forum path never touches
+// the topic helpers, but the identifiers must exist for the forum branch.
+const loadMessagesAroundId = async id => { scrolled.push(id); };
+const GENERAL_TOPIC_ID = 1;
+const topics = { value: [] };
+const selectTopic = async () => {};
 const nextTick = async () => {};
 const showToast = message => { toasts.push(message); };
 const console = { error: () => {}, log: () => {} };

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -4541,3 +4541,31 @@ const messageIdKey = (msg) => (msg && msg.id != null ? String(msg.id) : null)
         epilogue,
     )
     assert out == [1, 1, 1, 2], out
+
+
+def test_parse_telegram_link_recognizes_both_forms_and_rejects_noise():
+    """t.me/c/<internal>/<msg> maps to the marked id (-100 prefix); public
+    t.me/<username>/<msg> maps by username; anything else is a plain search."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+
+    cases = """
+(() => {
+    const results = [
+        parseTelegramLink('https://t.me/c/1234567890/42'),
+        parseTelegramLink('t.me/c/1234567890/42?single'),
+        parseTelegramLink('https://t.me/durov/100'),
+        parseTelegramLink('t.me/Some_Channel/7#comment'),
+        parseTelegramLink('hello world'),
+        parseTelegramLink('t.me/c/notanumber/42'),
+        parseTelegramLink(''),
+        parseTelegramLink(null),
+    ]
+    console.log(JSON.stringify(results))
+})();
+"""
+    out = _run_setup_program(html, ("const parseTelegramLink = ",), "", cases)
+    assert out[0] == {"markedId": -1001234567890, "username": None, "messageId": 42}
+    assert out[1] == {"markedId": -1001234567890, "username": None, "messageId": 42}
+    assert out[2] == {"markedId": None, "username": "durov", "messageId": 100}
+    assert out[3] == {"markedId": None, "username": "Some_Channel", "messageId": 7}
+    assert out[4] is None and out[5] is None and out[6] is None and out[7] is None


### PR DESCRIPTION
Official clients let any message be linked (`t.me/c/…`); the viewer had no addressable message URL — sharing a finding meant screenshots. The building blocks already existed and just weren't joined: the push-notification path has honored `/?chat=<ref>&msg=<id>` entry URLs since #240-era work (opaque ref, so chat ids stay out of URLs and history), and #367 hardened `loadMessagesAroundId` to window around any id.

Three additions join them:

- **Copy message link** — a button in the per-message Sender-details dialog copies `/?chat=<ref>&msg=<id>` (clipboard-unavailable origins get the URL shown in the toast instead).
- **Pasted t.me links navigate** — the sidebar search recognizes `t.me/c/<internal>/<msg>` (internal id → `-100…` marked mapping) and public `t.me/<username>/<msg>`, and jumps straight to the archived copy; a link whose chat is not archived says so. Anything else stays a plain search. ACL is inherent: the lookup runs over the chat list the viewer was served.
- **The shared opener now uses the hardened jump** — `openNotificationTarget` called `scrollToMessage`, a silent no-op for anything outside the rendered window. Fine for a fresh push notification, broken for a shared link into history; it now rides `loadMessagesAroundId`.

Tests: the link parser runs for real under the node harness (both forms, query/fragment suffixes, noise rejection); mutation-verified — breaking the marked-id mapping fails it. Full frontend-bootstrap suite: 146 passed.

Bead `9t6.11.3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Message details now show copyable links when a message ID is available.
  * Telegram deep links can open chats beyond the currently loaded sidebar entries.
  * Forum links open the relevant topic and center the target message, including messages in the General topic.
  * Telegram links from sidebar search open the relevant chat and message location.

* **Bug Fixes**
  * Improved handling of links with query strings and fragments.
  * Invalid or unsupported links display a notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->