### PR TITLE
feat(capture): forward provenance survives — the origin pointer is stored and the header links to it

### DIFF
--- a/src/listener.py
+++ b/src/listener.py
@@ -45,6 +45,7 @@ from .message_utils import (
     compute_file_hash_async,
     describe_exception,
     download_and_shard_media,
+    extract_forward_origin,
     extract_media_attributes,
     extract_reactions,
     extract_topic_id,
@@ -1272,6 +1273,12 @@ class TelegramListener:
                 webpage_preview = extract_webpage_preview(message.media)
                 if webpage_preview is not None:
                     message_data["raw_data"]["webpage"] = webpage_preview
+
+                # Forward origin pointer: pure metadata off the event, no API
+                # cost — the sweep writer captures the same key.
+                forward_origin = extract_forward_origin(message)
+                if forward_origin:
+                    message_data["raw_data"]["forward_origin"] = forward_origin
 
                 # v6.0.0: Detect media type for logging (download happens after message insert)
                 media_type = None

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -937,3 +937,37 @@ def normalize_configured_chat_ids(configured: set[int], existing_ids: set[int]) 
         unresolved += 1
         normalized.add(chat_id)
     return normalized, corrected, unresolved
+
+
+def extract_forward_origin(message: object) -> dict | None:
+    """The forwarded message's ORIGIN pointer — {chat_id (marked), message_id}.
+
+    Official apps make a forward header tappable because ``fwd_from`` carries
+    where the message came from: ``channel_post`` (the origin message id in
+    the source channel, paired with ``from_id``) for channel forwards, or
+    ``saved_from_peer``/``saved_from_msg_id`` for messages saved from
+    elsewhere. The archive kept only the display name, so the provenance
+    chain died here. Ids are stored MARKED (the project-wide convention), via
+    the same get_peer_id mapping every other persisted id uses.
+
+    Strict isinstance checks keep bare-MagicMock messages inert, and any
+    resolution surprise returns None — provenance is best-effort metadata,
+    never worth failing a capture.
+    """
+    from telethon.utils import get_peer_id
+
+    fwd = getattr(message, "fwd_from", None)
+    if fwd is None:
+        return None
+    try:
+        channel_post = getattr(fwd, "channel_post", None)
+        from_id = getattr(fwd, "from_id", None)
+        if isinstance(channel_post, int) and channel_post > 0 and from_id is not None:
+            return {"chat_id": get_peer_id(from_id), "message_id": channel_post}
+        saved_msg_id = getattr(fwd, "saved_from_msg_id", None)
+        saved_peer = getattr(fwd, "saved_from_peer", None)
+        if isinstance(saved_msg_id, int) and saved_msg_id > 0 and saved_peer is not None:
+            return {"chat_id": get_peer_id(saved_peer), "message_id": saved_msg_id}
+    except Exception:
+        return None
+    return None

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -60,6 +60,7 @@ from .message_utils import (
     compute_file_hash_async,
     describe_exception,
     download_and_shard_media,
+    extract_forward_origin,
     extract_media_attributes,
     extract_reactions,
     extract_topic_id,
@@ -3159,6 +3160,12 @@ class TelegramBackup:
                 forward_name = await self._resolve_forward_source_name(fwd.from_id)
                 if forward_name:
                     message_data["raw_data"]["forward_from_name"] = forward_name
+            # Origin pointer (channel_post / saved_from): what makes the
+            # forward header tappable in official apps. Metadata only, no API
+            # cost; the viewer links it when the origin chat is archived.
+            forward_origin = extract_forward_origin(message)
+            if forward_origin:
+                message_data["raw_data"]["forward_origin"] = forward_origin
 
         # Capture channel post author (signature) if available
         if hasattr(message, "post_author") and message.post_author:

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1300,15 +1300,20 @@
 
                                     <!-- Forwarded Message Info: tappable when the origin is archived,
                                          like official apps' forward headers. -->
-                                    <div v-if="msg.forward_from_id || getForwardName(msg)"
+                                    <div v-if="msg.forward_from_id || getForwardName(msg) || msg.raw_data?.forward_origin"
                                         @click="openForwardOrigin(msg)"
+                                        @keydown.enter.prevent="openForwardOrigin(msg)"
+                                        @keydown.space.prevent="openForwardOrigin(msg)"
+                                        :role="getForwardOriginChat(msg) ? 'button' : null"
+                                        :tabindex="getForwardOriginChat(msg) ? 0 : null"
                                         :class="getForwardOriginChat(msg) ? 'cursor-pointer hover:bg-black/30 transition' : ''"
                                         class="border-l-2 border-green-400/50 pl-2 mb-2 text-xs bg-black/20 rounded p-2">
                                         <div class="font-semibold text-green-400 mb-0.5">
                                             Forwarded from
                                             <i v-if="getForwardOriginChat(msg)" class="fa-solid fa-arrow-up-right-from-square ml-1 opacity-70"></i>
                                         </div>
-                                        <div class="truncate opacity-90">{{ getForwardName(msg) }}</div>
+                                        <div class="truncate opacity-90">
+                                            {{ getForwardName(msg) || getForwardOriginChat(msg)?.title || 'Forwarded message' }}</div>
                                     </div>
 
                                     <!-- Polls: v6.0.0 - detected by presence of raw_data.poll -->
@@ -5535,16 +5540,52 @@
                 }
 
                 // The forward header's tap target: the origin chat, when archived.
+                // The sidebar holds only the current page, so unknown origins
+                // resolve through one shared full-list fetch (archived included,
+                // same limit=1000 bound the search box uses), cached per chat id
+                // (false = resolved, not in this archive).
+                const forwardOriginChats = ref({})
+                const _forwardOriginResolves = new Map()
+                let _forwardOriginListPromise = null
+
+                const _fetchAllChatsOnce = () => {
+                    _forwardOriginListPromise ??= fetch('/api/chats?limit=1000', { credentials: 'same-origin' })
+                        .then(resp => resp.ok ? resp.json() : { chats: [] })
+                        .then(data => data.chats || [])
+                        .catch(() => [])
+                    return _forwardOriginListPromise
+                }
+
+                const _resolveForwardOrigin = (chatId) => {
+                    let pending = _forwardOriginResolves.get(chatId)
+                    if (!pending) {
+                        pending = _fetchAllChatsOnce().then(all => {
+                            forwardOriginChats.value[chatId] = all.find(c => c.id === chatId) || false
+                        })
+                        _forwardOriginResolves.set(chatId, pending)
+                    }
+                    return pending
+                }
+
                 const getForwardOriginChat = (msg) => {
                     const origin = msg.raw_data?.forward_origin
                     if (!origin) return null
-                    return chats.value.find(c => c.id === origin.chat_id) || null
+                    const local = chats.value.find(c => c.id === origin.chat_id)
+                    if (local) return local
+                    const cached = forwardOriginChats.value[origin.chat_id]
+                    if (cached === undefined) _resolveForwardOrigin(origin.chat_id)
+                    return cached || null
                 }
 
                 const openForwardOrigin = async (msg) => {
                     const origin = msg.raw_data?.forward_origin
-                    const chat = getForwardOriginChat(msg)
-                    if (!origin || !chat) return
+                    if (!origin) return
+                    let chat = getForwardOriginChat(msg)
+                    if (!chat) {
+                        await _resolveForwardOrigin(origin.chat_id)
+                        chat = forwardOriginChats.value[origin.chat_id] || null
+                    }
+                    if (!chat) return
                     await openNotificationTarget(chat.ref, origin.message_id)
                 }
 

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1298,10 +1298,16 @@
                                         <div class="truncate opacity-70">{{ replyToSnippet(msg) }}</div>
                                     </div>
 
-                                    <!-- Forwarded Message Info -->
+                                    <!-- Forwarded Message Info: tappable when the origin is archived,
+                                         like official apps' forward headers. -->
                                     <div v-if="msg.forward_from_id || getForwardName(msg)"
+                                        @click="openForwardOrigin(msg)"
+                                        :class="getForwardOriginChat(msg) ? 'cursor-pointer hover:bg-black/30 transition' : ''"
                                         class="border-l-2 border-green-400/50 pl-2 mb-2 text-xs bg-black/20 rounded p-2">
-                                        <div class="font-semibold text-green-400 mb-0.5">Forwarded from</div>
+                                        <div class="font-semibold text-green-400 mb-0.5">
+                                            Forwarded from
+                                            <i v-if="getForwardOriginChat(msg)" class="fa-solid fa-arrow-up-right-from-square ml-1 opacity-70"></i>
+                                        </div>
                                         <div class="truncate opacity-90">{{ getForwardName(msg) }}</div>
                                     </div>
 
@@ -5421,6 +5427,20 @@
                     }, event)
                 }
 
+                // The forward header's tap target: the origin chat, when archived.
+                const getForwardOriginChat = (msg) => {
+                    const origin = msg.raw_data?.forward_origin
+                    if (!origin) return null
+                    return chats.value.find(c => c.id === origin.chat_id) || null
+                }
+
+                const openForwardOrigin = async (msg) => {
+                    const origin = msg.raw_data?.forward_origin
+                    const chat = getForwardOriginChat(msg)
+                    if (!origin || !chat) return
+                    await openNotificationTarget(chat.ref, origin.message_id)
+                }
+
                 // Get name for forwarded message source
                 const getForwardName = (msg) => {
                     // First check raw_data for the resolved name
@@ -7791,6 +7811,8 @@
                     retryLoadTopics,
                     selectFolder,
                     showArchived,
+                    getForwardOriginChat,
+                    openForwardOrigin,
                     showChangesFeed,
                     changesFeed,
                     changesNextBefore,

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -400,6 +400,57 @@ class TestEventHandlers:
         listener.db.insert_message.assert_called_once()
         listener.db.upsert_chat.assert_called_once()
 
+    def test_on_new_message_captures_forward_origin(self, listener_with_handlers, full_config):
+        """A forwarded channel post stores the origin pointer in raw_data."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.NewMessage]
+
+        from datetime import datetime
+        from types import SimpleNamespace
+
+        from telethon.tl.types import PeerChannel
+
+        event = MagicMock()
+        event.chat_id = -1001234567890
+
+        msg = MagicMock()
+        msg.reply_to = None
+        msg.id = 43
+        msg.sender_id = 111
+        msg.date = datetime(2025, 1, 1, tzinfo=UTC)
+        msg.text = "forwarded"
+        msg.reply_to_msg_id = None
+        msg.edit_date = None
+        msg.out = False
+        msg.grouped_id = None
+        msg.media = None
+        msg.sender = None
+        msg.fwd_from = SimpleNamespace(
+            channel_post=777,
+            from_id=PeerChannel(channel_id=123),
+            saved_from_msg_id=None,
+            saved_from_peer=None,
+            date=None,
+            from_name=None,
+        )
+        event.message = msg
+
+        chat_entity = MagicMock()
+        chat_entity.title = "Test Chat"
+        chat_entity.username = None
+        chat_entity.first_name = None
+        chat_entity.last_name = None
+        event.get_chat = AsyncMock(return_value=chat_entity)
+
+        asyncio.run(handler(event))
+
+        listener.db.insert_message.assert_called_once()
+        saved = listener.db.insert_message.call_args[0][0]
+        assert saved["raw_data"]["forward_origin"] == {
+            "chat_id": -1000000000123,
+            "message_id": 777,
+        }
+
     def test_on_new_message_adds_untracked_chat_to_tracking(self, listener_with_handlers, full_config):
         """Test new message from untracked-but-included chat gets added to tracking."""
         listener, handlers = listener_with_handlers

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -2380,3 +2380,59 @@ class TestForwardSourceNameResolution(unittest.TestCase):
 
         self.assertEqual(result["raw_data"]["forward_from_name"], "Origin")
         self.backup.client.get_entity.assert_not_awaited()
+
+
+class TestExtractForwardOrigin(unittest.TestCase):
+    """The origin pointer official apps make tappable (#9t6.10.3)."""
+
+    def test_channel_forward_carries_marked_origin(self):
+        from telethon.tl.types import PeerChannel
+
+        class Fwd:
+            channel_post = 777
+            from_id = PeerChannel(channel_id=123)
+            saved_from_msg_id = None
+            saved_from_peer = None
+
+        class Msg:
+            fwd_from = Fwd()
+
+        from src.message_utils import extract_forward_origin
+
+        self.assertEqual(extract_forward_origin(Msg()), {"chat_id": -1000000000123, "message_id": 777})
+
+    def test_saved_from_fallback(self):
+        from telethon.tl.types import PeerChat
+
+        class Fwd:
+            channel_post = None
+            from_id = None
+            saved_from_msg_id = 55
+            saved_from_peer = PeerChat(chat_id=99)
+
+        class Msg:
+            fwd_from = Fwd()
+
+        from src.message_utils import extract_forward_origin
+
+        self.assertEqual(extract_forward_origin(Msg()), {"chat_id": -99, "message_id": 55})
+
+    def test_plain_forward_and_bare_mock_are_inert(self):
+        from src.message_utils import extract_forward_origin
+
+        class Fwd:
+            channel_post = None
+            from_id = None
+            saved_from_msg_id = None
+            saved_from_peer = None
+
+        class Msg:
+            fwd_from = Fwd()
+
+        self.assertIsNone(extract_forward_origin(Msg()))
+        no_fwd = MagicMock()
+        no_fwd.fwd_from = None
+        self.assertIsNone(extract_forward_origin(no_fwd))
+        # Bare MagicMock: truthy fwd_from with MagicMock fields must not
+        # fabricate a pointer (the isinstance guards are the inertness).
+        self.assertIsNone(extract_forward_origin(MagicMock()))

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -1638,6 +1638,27 @@ class TestProcessMessage(unittest.TestCase):
         result = self._run(self.backup._process_message(msg, 100))
         self.assertEqual(result["is_outgoing"], 1)
 
+    def test_forward_origin_pointer_lands_in_raw_data(self):
+        """The sweep stores the origin pointer the viewer's tappable header reads."""
+        from types import SimpleNamespace
+
+        from telethon.tl.types import PeerChannel
+
+        msg = self._make_message(3)
+        msg.fwd_from = SimpleNamespace(
+            channel_post=777,
+            from_id=PeerChannel(channel_id=123),
+            saved_from_msg_id=None,
+            saved_from_peer=None,
+            date=None,
+            from_name=None,
+        )
+        result = self._run(self.backup._process_message(msg, 100))
+        self.assertEqual(
+            result["raw_data"]["forward_origin"],
+            {"chat_id": -1000000000123, "message_id": 777},
+        )
+
     def test_pinned_message_sets_flag(self):
         """Pinned message sets is_pinned=1."""
         msg = self._make_message(3)
@@ -2436,3 +2457,18 @@ class TestExtractForwardOrigin(unittest.TestCase):
         # Bare MagicMock: truthy fwd_from with MagicMock fields must not
         # fabricate a pointer (the isinstance guards are the inertness).
         self.assertIsNone(extract_forward_origin(MagicMock()))
+
+    def test_peer_resolution_failure_degrades_to_none(self):
+        """A garbage from_id makes get_peer_id raise — capture must not fail."""
+        from src.message_utils import extract_forward_origin
+
+        class Fwd:
+            channel_post = 777
+            from_id = object()  # not a Peer: get_peer_id raises
+            saved_from_msg_id = None
+            saved_from_peer = None
+
+        class Msg:
+            fwd_from = Fwd()
+
+        self.assertIsNone(extract_forward_origin(Msg()))


### PR DESCRIPTION
Official apps make a forward header tappable because `fwd_from` carries where the message came from. The archive kept only a display name (`forward_from_name`) and the marked sender id — the origin MESSAGE pointer (`channel_post` for channel forwards, `saved_from_peer`/`saved_from_msg_id` otherwise) was discarded, so the provenance chain died at capture.

**Capture** (both writers, mirror rule): a new pure `extract_forward_origin(message)` in `message_utils` stores `raw_data.forward_origin = {chat_id (marked, via the same get_peer_id mapping every persisted id uses), message_id}`. The sweep captures it beside the existing name resolution; the listener captures it on live new messages — pure metadata off the event, zero API cost. Strict `isinstance` guards keep bare-MagicMock messages inert, and any resolution surprise degrades to None: provenance is best-effort, never worth failing a capture.

**Viewer**: when the origin chat is archived, the \"Forwarded from\" header becomes tappable (with a small external-link glyph) and jumps to the archived original via the shared opener — which #399 upgrades to the #367-hardened jump, so the two PRs compose without depending on each other. Unarchived origins render exactly as before.

Tests: channel-forward marked mapping, saved_from fallback, plain-forward/bare-mock inertness — mutation-verified (dropping the channel_post branch fails the mapping test). Full suite: 3656 passed.

Bead `9t6.10.3`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preserved the origin details of forwarded messages in archived data.
  * Made forwarded-message headers interactive when the original message is available, enabling direct navigation to the archived source.
  * Added a fallback label when the original source name is unavailable.

* **Bug Fixes**
  * Improved handling of forwarded messages from channels and saved messages.
  * Safely handles forwards with missing, unsupported, or invalid origin information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->