### PR TITLE
feat(capture): nine media kinds stop vanishing as empty bubbles

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -39,7 +39,12 @@ from sqlalchemy import (
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 
-from ..message_utils import compute_directory_size, resolve_sender_display_name, utcnow_naive
+from ..message_utils import (
+    METADATA_ONLY_MEDIA_TYPES,
+    compute_directory_size,
+    resolve_sender_display_name,
+    utcnow_naive,
+)
 from .base import DatabaseManager
 from .models import (
     DEFAULT_ACCOUNT_ID,
@@ -716,18 +721,22 @@ class DatabaseAdapter:
             downloaded = (
                 await session.execute(select(func.count()).select_from(Media).where(Media.downloaded == 1))
             ).scalar() or 0
+            # Metadata-only rows (polls, dice, venues, ...) sit at
+            # downloaded=0 by design — counting them as pending would show a
+            # permanently-red pipeline for archives full of polls.
+            not_metadata = Media.type.notin_(sorted(METADATA_ONLY_MEDIA_TYPES))
             pending = (
                 await session.execute(
                     select(func.count())
                     .select_from(Media)
-                    .where(Media.downloaded == 0, Media.download_attempts < max_attempts)
+                    .where(Media.downloaded == 0, Media.download_attempts < max_attempts, not_metadata)
                 )
             ).scalar() or 0
             exhausted = (
                 await session.execute(
                     select(func.count())
                     .select_from(Media)
-                    .where(Media.downloaded == 0, Media.download_attempts >= max_attempts)
+                    .where(Media.downloaded == 0, Media.download_attempts >= max_attempts, not_metadata)
                 )
             ).scalar() or 0
         return {"downloaded": downloaded, "pending": pending, "exhausted": exhausted}
@@ -2349,7 +2358,7 @@ class DatabaseAdapter:
                 # account's client, and only its session can fetch them.
                 Media.account_id == account_id,
                 Media.downloaded == 0,
-                Media.type.notin_(["contact", "geo", "poll"]),
+                Media.type.notin_(sorted(METADATA_ONLY_MEDIA_TYPES)),
             ]
             if max_media_size_bytes is not None:
                 conditions.append(or_(Media.file_size.is_(None), Media.file_size <= max_media_size_bytes))
@@ -2425,7 +2434,7 @@ class DatabaseAdapter:
                 and_(
                     Media.account_id == account_id,
                     Media.downloaded == 0,
-                    Media.type.notin_(["contact", "geo", "poll"]),
+                    Media.type.notin_(sorted(METADATA_ONLY_MEDIA_TYPES)),
                     Media.download_attempts >= max_attempts,
                 )
             )

--- a/src/listener.py
+++ b/src/listener.py
@@ -40,11 +40,14 @@ from .db import DatabaseAdapter, create_adapter
 from .db.models import account_metadata_key
 from .event_webhook import EventWebhookSender
 from .message_utils import (
+    METADATA_ONLY_MEDIA_TYPES,
     _photo_size_bytes,
     build_media_filename,
+    classify_extended_media,
     compute_file_hash_async,
     describe_exception,
     download_and_shard_media,
+    extract_extended_media_details,
     extract_media_attributes,
     extract_reactions,
     extract_topic_id,
@@ -837,7 +840,10 @@ class TelegramListener:
             return "geo"
         elif isinstance(media, MessageMediaPoll):
             return "poll"
-        return None
+        # The nine kinds this ladder used to flatten to None (venue, dice,
+        # invoice, story, giveaways, live location, game, unsupported):
+        # metadata-only types with a typed viewer chip, never downloaded.
+        return classify_extended_media(media)
 
     def _get_media_filename(self, message, media_type: str, telegram_file_id: str | None = None) -> str:
         """Generate a filename for media."""
@@ -873,7 +879,7 @@ class TelegramListener:
         media = message.media
         media_type = self._get_media_type(media)
 
-        if not media_type or media_type in ("contact", "geo", "poll"):
+        if not media_type or media_type in METADATA_ONLY_MEDIA_TYPES:
             return None  # These don't have downloadable files
 
         try:
@@ -1272,6 +1278,12 @@ class TelegramListener:
                 webpage_preview = extract_webpage_preview(message.media)
                 if webpage_preview is not None:
                     message_data["raw_data"]["webpage"] = webpage_preview
+
+                # Extended media kinds: same raw_data shape the sweep writes.
+                extended_media = extract_extended_media_details(message.media)
+                if extended_media is not None:
+                    extended_kind, extended_details = extended_media
+                    message_data["raw_data"][extended_kind] = extended_details
 
                 # v6.0.0: Detect media type for logging (download happens after message insert)
                 media_type = None

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -937,3 +937,127 @@ def normalize_configured_chat_ids(configured: set[int], existing_ids: set[int]) 
         unresolved += 1
         normalized.add(chat_id)
     return normalized, corrected, unresolved
+
+
+# Media types that are Telegram message payloads rather than downloadable
+# files. THE single source for that split: the media pipeline stores them as
+# metadata-only rows, the retry drain and the operator-status pending count
+# must never treat them as failed downloads.
+METADATA_ONLY_MEDIA_TYPES = frozenset(
+    {
+        "contact",
+        "geo",
+        "poll",
+        "venue",
+        "dice",
+        "invoice",
+        "story",
+        "giveaway",
+        "giveaway_results",
+        "geo_live",
+        "game",
+        "unsupported",
+    }
+)
+
+# The nine kinds official apps render as typed placeholders and the archive
+# used to flatten to nothing (type=None, no record, no chip). Name-based so a
+# bare MagicMock (type name "MagicMock") stays inert, matching the module's
+# service_action_type idiom. GeoLive must precede Geo checks at call sites —
+# handled here by exact class-name match, which cannot collide.
+_EXTENDED_MEDIA_TYPES = {
+    "MessageMediaVenue": "venue",
+    "MessageMediaDice": "dice",
+    "MessageMediaInvoice": "invoice",
+    "MessageMediaStory": "story",
+    "MessageMediaGiveaway": "giveaway",
+    "MessageMediaGiveawayResults": "giveaway_results",
+    "MessageMediaGeoLive": "geo_live",
+    "MessageMediaGame": "game",
+    "MessageMediaUnsupported": "unsupported",
+}
+
+
+def classify_extended_media(media: object) -> str | None:
+    """The nine metadata-only kinds _get_media_type's isinstance ladder misses."""
+    if media is None:
+        return None
+    return _EXTENDED_MEDIA_TYPES.get(type(media).__name__)
+
+
+def extract_extended_media_details(media: object) -> tuple[str, dict] | None:
+    """(raw_data key, salient fields) for an extended media kind, else None.
+
+    Both writers store the payload under ``raw_data[key]`` so the viewer can
+    render the typed chip official apps show. Field access is defensive
+    (getattr chains) — a Telethon layer change degrades a chip to its bare
+    label, never fails a capture. Nothing here is logged (PII rule).
+    """
+    kind = classify_extended_media(media)
+    if kind is None:
+        return None
+    details: dict = {}
+    try:
+        if kind == "dice":
+            details = {"emoticon": getattr(media, "emoticon", None), "value": getattr(media, "value", None)}
+        elif kind == "venue":
+            geo = getattr(media, "geo", None)
+            details = {
+                "title": getattr(media, "title", None),
+                "address": getattr(media, "address", None),
+                "provider": getattr(media, "provider", None),
+                "lat": getattr(geo, "lat", None),
+                "long": getattr(geo, "long", None),
+            }
+        elif kind == "invoice":
+            details = {
+                "title": getattr(media, "title", None),
+                "description": getattr(media, "description", None),
+                "currency": getattr(media, "currency", None),
+                "total_amount": getattr(media, "total_amount", None),
+                "test": bool(getattr(media, "test", False)),
+            }
+        elif kind == "story":
+            peer = getattr(media, "peer", None)
+            peer_id = None
+            if peer is not None:
+                from telethon.utils import get_peer_id
+
+                try:
+                    peer_id = get_peer_id(peer)
+                except Exception:
+                    peer_id = None
+            details = {"peer_id": peer_id, "story_id": getattr(media, "id", None)}
+        elif kind == "giveaway":
+            channels = getattr(media, "channels", None)
+            until = getattr(media, "until_date", None)
+            details = {
+                "quantity": getattr(media, "quantity", None),
+                "months": getattr(media, "months", None),
+                "until_date": until.isoformat() if hasattr(until, "isoformat") else None,
+                "channel_count": len(channels) if isinstance(channels, (list, tuple)) else None,
+            }
+        elif kind == "giveaway_results":
+            details = {
+                "winners_count": getattr(media, "winners_count", None),
+                "months": getattr(media, "months", None),
+            }
+        elif kind == "geo_live":
+            geo = getattr(media, "geo", None)
+            details = {
+                "lat": getattr(geo, "lat", None),
+                "long": getattr(geo, "long", None),
+                "period": getattr(media, "period", None),
+            }
+        elif kind == "game":
+            game = getattr(media, "game", None)
+            details = {
+                "title": getattr(game, "title", None),
+                "short_name": getattr(game, "short_name", None),
+                "description": getattr(game, "description", None),
+            }
+        # "unsupported": presence alone is the signal; empty payload.
+    except Exception:
+        details = {}
+    clean = {key: value for key, value in details.items() if isinstance(value, (str, int, float, bool))}
+    return kind, clean

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -55,11 +55,14 @@ from .db.models import account_metadata_key
 from .folder_utils import FolderChat, FolderRules, resolve_folder_member_ids
 from .media_errors import is_media_location_error
 from .message_utils import (
+    METADATA_ONLY_MEDIA_TYPES,
     _photo_size_bytes,
     build_media_filename,
+    classify_extended_media,
     compute_file_hash_async,
     describe_exception,
     download_and_shard_media,
+    extract_extended_media_details,
     extract_media_attributes,
     extract_reactions,
     extract_topic_id,
@@ -3078,6 +3081,14 @@ class TelegramBackup:
         if webpage_preview is not None:
             message_data["raw_data"]["webpage"] = webpage_preview
 
+        # Extended media kinds (venue/dice/invoice/story/giveaways/live
+        # location/game/unsupported): salient fields for the viewer's typed
+        # chip — official apps render these, the archive used to show nothing.
+        extended_media = extract_extended_media_details(message.media)
+        if extended_media is not None:
+            extended_kind, extended_details = extended_media
+            message_data["raw_data"][extended_kind] = extended_details
+
         # Preserve service-action metadata (e.g. forum topic creations and
         # renames) so historical backfills carry the same raw_data *shape* AND
         # *vocabulary* as the live listener: since the #222 fix both derive
@@ -3521,10 +3532,11 @@ class TelegramBackup:
         # Generate unique media ID
         media_id = f"{chat_id}_{message.id}_{media_type}"
 
-        # Contacts, locations, and polls are Telegram message payloads rather
-        # than downloadable files. Store them as metadata-only records when the
+        # Metadata-only kinds (contacts, locations, polls, and the nine
+        # extended kinds) are Telegram message payloads rather than
+        # downloadable files. Store them as metadata-only records when the
         # caller asks for media processing.
-        if media_type in {"contact", "geo", "poll"}:
+        if media_type in METADATA_ONLY_MEDIA_TYPES:
             return {
                 "id": media_id,
                 "type": media_type,
@@ -3787,7 +3799,10 @@ class TelegramBackup:
             return "geo"
         elif isinstance(media, MessageMediaPoll):
             return "poll"
-        return None
+        # The nine kinds this ladder used to flatten to None (venue, dice,
+        # invoice, story, giveaways, live location, game, unsupported):
+        # metadata-only types with a typed viewer chip, never downloaded.
+        return classify_extended_media(media)
 
     def _get_media_filename(self, message: Message, media_type: str, telegram_file_id: str = None) -> str:
         """

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1344,6 +1344,17 @@
                                         </div>
                                     </div>
 
+                                    <!-- Extended media chip (dice, venue, invoice, story, giveaway, live location, game, ...) -->
+                                    <div v-if="getExtendedMediaChip(msg)"
+                                        class="mb-2 inline-flex items-start gap-2 bg-black/20 rounded-lg px-3 py-2 text-sm max-w-full">
+                                        <span class="text-lg leading-none">{{ getExtendedMediaChip(msg).icon }}</span>
+                                        <div class="min-w-0">
+                                            <div class="font-semibold truncate">{{ getExtendedMediaChip(msg).label }}</div>
+                                            <div v-if="getExtendedMediaChip(msg).detail" class="text-xs opacity-80 break-words">
+                                                {{ getExtendedMediaChip(msg).detail }}</div>
+                                        </div>
+                                    </div>
+
                                     <!-- Media (show if media exists, even if not yet downloaded) -->
                                     <div v-if="msg.media?.file_path || msg.media?.type" class="mb-2 space-y-1">
                                         <!-- Placeholder for media not yet downloaded -->
@@ -5774,6 +5785,74 @@
                     return Math.round((res.voters / results.total_voters) * 100)
                 }
 
+                const EXTENDED_MEDIA_CHIP_META = {
+                    dice: { icon: '\u{1F3B2}', label: 'Dice' },
+                    venue: { icon: '\u{1F4CD}', label: 'Venue' },
+                    invoice: { icon: '\u{1F9FE}', label: 'Invoice' },
+                    story: { icon: '\u{1F4D6}', label: 'Story' },
+                    giveaway: { icon: '\u{1F381}', label: 'Giveaway' },
+                    giveaway_results: { icon: '\u{1F3C6}', label: 'Giveaway results' },
+                    geo_live: { icon: '\u{1F4E1}', label: 'Live location' },
+                    game: { icon: '\u{1F3AE}', label: 'Game' },
+                    unsupported: { icon: '\u26A0\uFE0F', label: 'Unsupported media' },
+                }
+
+                const formatInvoiceAmount = (amount, currency) => {
+                    // Telegram sends prices in the currency's smallest unit;
+                    // Intl knows each currency's minor-unit count (JPY=0, USD=2).
+                    try {
+                        const fmt = new Intl.NumberFormat(undefined, { style: 'currency', currency })
+                        const digits = fmt.resolvedOptions().maximumFractionDigits
+                        return fmt.format(amount / Math.pow(10, digits))
+                    } catch (e) {
+                        return `${amount} ${currency}`
+                    }
+                }
+
+                const getExtendedMediaChip = (msg) => {
+                    const kind = msg.media?.type
+                    const meta = EXTENDED_MEDIA_CHIP_META[kind]
+                    if (!meta) return null
+                    const data = msg.raw_data?.[kind] || {}
+                    let icon = meta.icon
+                    let label = meta.label
+                    let detail = ''
+                    if (kind === 'dice') {
+                        if (typeof data.emoticon === 'string' && data.emoticon) icon = data.emoticon
+                        if (Number.isFinite(data.value)) detail = `Rolled ${data.value}`
+                    } else if (kind === 'venue') {
+                        if (data.title) label = data.title
+                        detail = data.address || ''
+                    } else if (kind === 'invoice') {
+                        if (data.title) label = data.title
+                        if (Number.isFinite(data.total_amount) && typeof data.currency === 'string' && data.currency) {
+                            detail = formatInvoiceAmount(data.total_amount, data.currency)
+                        } else {
+                            detail = data.description || ''
+                        }
+                    } else if (kind === 'story') {
+                        detail = 'Shared story'
+                    } else if (kind === 'giveaway') {
+                        if (Number.isFinite(data.quantity) && Number.isFinite(data.months)) {
+                            detail = `${data.quantity} \u00D7 ${data.months}-month Premium`
+                        }
+                    } else if (kind === 'giveaway_results') {
+                        if (Number.isFinite(data.winners_count)) {
+                            detail = `${data.winners_count} winner${data.winners_count === 1 ? '' : 's'}`
+                        }
+                    } else if (kind === 'geo_live') {
+                        if (Number.isFinite(data.lat) && Number.isFinite(data.long)) {
+                            detail = `${data.lat.toFixed(5)}, ${data.long.toFixed(5)}`
+                        }
+                    } else if (kind === 'game') {
+                        if (data.title) label = data.title
+                        detail = data.description || ''
+                    } else if (kind === 'unsupported') {
+                        detail = 'Sent with a newer Telegram feature this archive version cannot decode'
+                    }
+                    return { icon, label, detail }
+                }
+
                 const getSenderStyle = (msg) => {
                     return {
                         backgroundColor: getMessageBackground(msg),
@@ -7816,6 +7895,7 @@
                     getSenderInitials,
                     getAvatarFill,
                     getPollPercentage,
+                    getExtendedMediaChip,
                     isDeletedChat,
                     isAudioFile,
                     exportChat,

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1366,8 +1366,11 @@
                                         </div>
                                     </div>
 
-                                    <!-- Media (show if media exists, even if not yet downloaded) -->
-                                    <div v-if="msg.media?.file_path || msg.media?.type" class="mb-2 space-y-1">
+                                    <!-- Media (show if media exists, even if not yet downloaded).
+                                         Extended kinds are metadata-only: the chip above is the whole
+                                         rendering, so the pending-download placeholder must not show. -->
+                                    <div v-if="(msg.media?.file_path || msg.media?.type) && !getExtendedMediaChip(msg)"
+                                        class="mb-2 space-y-1">
                                         <!-- Placeholder for media not yet downloaded -->
                                         <div v-if="!msg.media?.file_path && msg.media?.type"
                                             class="bg-gray-700/50 rounded-lg p-4 flex items-center gap-3 max-w-md">

--- a/tests/test_extended_media_kinds.py
+++ b/tests/test_extended_media_kinds.py
@@ -1,0 +1,402 @@
+"""Nine media kinds stop vanishing (9t6.10.2).
+
+Venue, dice, invoice, story, giveaway, giveaway results, live location, game
+and unsupported media used to flatten to nothing: ``_get_media_type`` returned
+None, no media record was written, and the viewer showed a bare bubble.
+Official apps render each as a typed placeholder. Now:
+
+- ``classify_extended_media`` names the kind (name-based, MagicMock-inert);
+- ``extract_extended_media_details`` captures salient fields into
+  ``raw_data[<kind>]`` for the viewer chip;
+- both writers store a metadata-only media row (downloaded=0, no file);
+- the download drain and the operator status counts exclude metadata-only
+  kinds, so archives full of polls/dice do not show a permanently-red
+  pending pipeline.
+"""
+
+import asyncio
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Base, Chat, Media, Message
+from src.listener import TelegramListener
+from src.message_utils import (
+    _EXTENDED_MEDIA_TYPES,
+    METADATA_ONLY_MEDIA_TYPES,
+    classify_extended_media,
+    extract_extended_media_details,
+)
+from src.telegram_backup import TelegramBackup
+
+CHAT_ID = -1001
+
+
+def _fake_media(class_name: str, **attrs):
+    """An object whose type NAME matches a Telethon MessageMedia class.
+
+    classify_extended_media is name-based (like service_action_type), so a
+    locally defined class with the right name exercises the real contract.
+    """
+    cls = type(class_name, (), {})
+    obj = cls()
+    for key, value in attrs.items():
+        setattr(obj, key, value)
+    return obj
+
+
+class TestClassifyExtendedMedia(unittest.TestCase):
+    def test_real_telethon_classes_map_to_their_kind(self):
+        """Every name in the map is a REAL Telethon class and classifies.
+
+        Guards against a typo'd key: duck-typed tests alone would keep passing
+        while real captures silently missed the kind.
+        """
+        import telethon.tl.types as tl
+
+        for class_name, kind in _EXTENDED_MEDIA_TYPES.items():
+            cls = getattr(tl, class_name)  # AttributeError => stale map
+            instance = object.__new__(cls)
+            self.assertEqual(classify_extended_media(instance), kind)
+
+    def test_covers_all_metadata_only_kinds_beyond_the_original_three(self):
+        self.assertEqual(
+            set(_EXTENDED_MEDIA_TYPES.values()),
+            METADATA_ONLY_MEDIA_TYPES - {"contact", "geo", "poll"},
+        )
+
+    def test_magicmock_is_inert(self):
+        self.assertIsNone(classify_extended_media(MagicMock()))
+
+    def test_none_and_unrelated_types_are_none(self):
+        self.assertIsNone(classify_extended_media(None))
+        self.assertIsNone(classify_extended_media(_fake_media("MessageMediaPhoto")))
+
+
+class TestExtractExtendedMediaDetails(unittest.TestCase):
+    def test_dice(self):
+        media = _fake_media("MessageMediaDice", emoticon="🎯", value=6)
+        self.assertEqual(
+            extract_extended_media_details(media),
+            ("dice", {"emoticon": "🎯", "value": 6}),
+        )
+
+    def test_venue(self):
+        media = _fake_media(
+            "MessageMediaVenue",
+            title="Cafe",
+            address="Calle Mayor 1",
+            provider="foursquare",
+            geo=SimpleNamespace(lat=40.4, long=-3.7),
+        )
+        kind, details = extract_extended_media_details(media)
+        self.assertEqual(kind, "venue")
+        self.assertEqual(details["title"], "Cafe")
+        self.assertEqual(details["address"], "Calle Mayor 1")
+        self.assertEqual(details["lat"], 40.4)
+        self.assertEqual(details["long"], -3.7)
+
+    def test_invoice(self):
+        media = _fake_media(
+            "MessageMediaInvoice",
+            title="Subscription",
+            description="One month",
+            currency="USD",
+            total_amount=14500,
+            test=False,
+        )
+        kind, details = extract_extended_media_details(media)
+        self.assertEqual(kind, "invoice")
+        self.assertEqual(details["total_amount"], 14500)
+        self.assertEqual(details["currency"], "USD")
+        self.assertFalse(details["test"])
+
+    def test_story_uses_real_peer_id(self):
+        from telethon.tl.types import PeerChannel
+
+        media = _fake_media("MessageMediaStory", peer=PeerChannel(channel_id=123), id=77)
+        kind, details = extract_extended_media_details(media)
+        self.assertEqual(kind, "story")
+        self.assertEqual(details["story_id"], 77)
+        self.assertEqual(details["peer_id"], -1000000000123)
+
+    def test_giveaway(self):
+        media = _fake_media(
+            "MessageMediaGiveaway",
+            quantity=5,
+            months=3,
+            until_date=datetime(2026, 9, 1),
+            channels=[1, 2],
+        )
+        kind, details = extract_extended_media_details(media)
+        self.assertEqual(kind, "giveaway")
+        self.assertEqual(details["quantity"], 5)
+        self.assertEqual(details["months"], 3)
+        self.assertEqual(details["until_date"], "2026-09-01T00:00:00")
+        self.assertEqual(details["channel_count"], 2)
+
+    def test_giveaway_results(self):
+        media = _fake_media("MessageMediaGiveawayResults", winners_count=4, months=6)
+        self.assertEqual(
+            extract_extended_media_details(media),
+            ("giveaway_results", {"winners_count": 4, "months": 6}),
+        )
+
+    def test_geo_live(self):
+        media = _fake_media("MessageMediaGeoLive", geo=SimpleNamespace(lat=40.0, long=-3.0), period=900)
+        self.assertEqual(
+            extract_extended_media_details(media),
+            ("geo_live", {"lat": 40.0, "long": -3.0, "period": 900}),
+        )
+
+    def test_game(self):
+        media = _fake_media(
+            "MessageMediaGame",
+            game=SimpleNamespace(title="Chess", short_name="chess", description="Play"),
+        )
+        self.assertEqual(
+            extract_extended_media_details(media),
+            ("game", {"title": "Chess", "short_name": "chess", "description": "Play"}),
+        )
+
+    def test_unsupported_is_kind_with_empty_payload(self):
+        media = _fake_media("MessageMediaUnsupported")
+        self.assertEqual(extract_extended_media_details(media), ("unsupported", {}))
+
+    def test_missing_attributes_degrade_to_bare_kind(self):
+        """A Telethon layer change must degrade the chip, never fail capture."""
+        kind, details = extract_extended_media_details(_fake_media("MessageMediaVenue"))
+        self.assertEqual(kind, "venue")
+        self.assertEqual(details, {})
+
+    def test_non_scalar_values_are_filtered(self):
+        media = _fake_media("MessageMediaDice", emoticon=["not", "a", "string"], value=3)
+        kind, details = extract_extended_media_details(media)
+        self.assertEqual(details, {"value": 3})
+
+    def test_unrelated_media_returns_none(self):
+        self.assertIsNone(extract_extended_media_details(MagicMock()))
+        self.assertIsNone(extract_extended_media_details(None))
+
+
+class TestMediaTypeTail(unittest.TestCase):
+    """Both _get_media_type ladders fall through to the classifier."""
+
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.listener = TelegramListener.__new__(TelegramListener)
+
+    def test_backup_returns_extended_kind(self):
+        media = _fake_media("MessageMediaDice", emoticon="🎲", value=2)
+        self.assertEqual(self.backup._get_media_type(media), "dice")
+
+    def test_listener_returns_extended_kind(self):
+        media = _fake_media("MessageMediaVenue", title="Cafe")
+        self.assertEqual(self.listener._get_media_type(media), "venue")
+
+    def test_magicmock_still_falls_out_as_none_on_both(self):
+        mock_media = MagicMock()
+        mock_media.photo = None
+        mock_media.document = None
+        mock_media.webpage = None
+        self.assertIsNone(self.backup._get_media_type(mock_media))
+        self.assertIsNone(self.listener._get_media_type(mock_media))
+
+
+class TestMetadataOnlyGates(unittest.TestCase):
+    """Extended kinds produce metadata rows, never download attempts."""
+
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def test_backup_process_media_writes_metadata_row_for_dice(self):
+        backup = TelegramBackup.__new__(TelegramBackup)
+        backup.account_id = 1
+        backup.db = AsyncMock()
+        backup.config = MagicMock()
+        backup.client = AsyncMock()
+
+        message = MagicMock()
+        message.id = 11
+        message.media = _fake_media("MessageMediaDice", emoticon="🎲", value=4)
+
+        result = self._run(backup._process_media(message, CHAT_ID))
+        self.assertEqual(result["type"], "dice")
+        self.assertEqual(result["file_size"], 0)
+        backup.client.download_media.assert_not_awaited()
+
+    def test_listener_download_media_skips_extended_kinds(self):
+        # Fully wired (media_path, size cap, dedup off): without the gate this
+        # fixture genuinely reaches the download call, so the assertion cannot
+        # pass vacuously on an AttributeError swallowed by the except.
+        listener = TelegramListener.__new__(TelegramListener)
+        listener.client = AsyncMock()
+        listener.db = AsyncMock()
+        listener.account_id = 1
+        listener.config = MagicMock()
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        listener.config.media_path = tmp
+        listener.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
+        listener.config.deduplicate_media = False
+
+        message = MagicMock()
+        message.id = 12
+        message.media = _fake_media("MessageMediaGiveaway", quantity=1, months=1)
+
+        result = self._run(listener._download_media(message, CHAT_ID))
+        self.assertIsNone(result)
+        listener.client.download_media.assert_not_awaited()
+
+
+class TestProcessMessageCapturesExtendedPayload(unittest.TestCase):
+    """The sweep stores raw_data[<kind>] so the viewer chip has fields."""
+
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
+        self.backup.db = AsyncMock()
+        self.backup.config = MagicMock()
+        self.backup.config.should_download_media_for_chat = MagicMock(return_value=False)
+        self.backup.client = AsyncMock()
+
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def _make_message(self, msg_id, media):
+        msg = MagicMock()
+        msg.id = msg_id
+        msg.sender = None
+        msg.sender_id = 42
+        msg.date = datetime(2026, 1, 1)
+        msg.text = ""
+        msg.reply_to_msg_id = None
+        msg.reply_to = None
+        msg.edit_date = None
+        msg.out = False
+        msg.pinned = False
+        msg.grouped_id = None
+        msg.fwd_from = None
+        msg.media = media
+        msg.reactions = None
+        msg.post_author = None
+        msg.action = None
+        return msg
+
+    def test_dice_payload_lands_in_raw_data(self):
+        msg = self._make_message(21, _fake_media("MessageMediaDice", emoticon="🎯", value=5))
+        result = self._run(self.backup._process_message(msg, CHAT_ID))
+        self.assertEqual(result["raw_data"]["dice"], {"emoticon": "🎯", "value": 5})
+
+    def test_plain_text_message_stores_no_extended_key(self):
+        msg = self._make_message(22, None)
+        result = self._run(self.backup._process_message(msg, CHAT_ID))
+        for kind in _EXTENDED_MEDIA_TYPES.values():
+            self.assertNotIn(kind, result["raw_data"])
+
+
+# ---------------------------------------------------------------------------
+# Drain + status-count exclusion (real in-memory SQLite)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def adapter():
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db_manager = DatabaseManager.__new__(DatabaseManager)
+    db_manager.engine = engine
+    db_manager.database_url = "sqlite+aiosqlite://"
+    db_manager._is_sqlite = True
+    db_manager.async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with db_manager.async_session_factory() as session:
+        session.add(Chat(id=CHAT_ID, type="channel", title="Chat A"))
+        session.add(Message(id=1, chat_id=CHAT_ID, sender_id=None, date=datetime(2026, 1, 1), text=""))
+        session.add(Message(id=2, chat_id=CHAT_ID, sender_id=None, date=datetime(2026, 1, 1), text=""))
+        session.add(Message(id=3, chat_id=CHAT_ID, sender_id=None, date=datetime(2026, 1, 1), text=""))
+        # A real pending download, an undownloaded dice, and an exhausted venue.
+        session.add(
+            Media(
+                id=f"{CHAT_ID}_1_photo",
+                message_id=1,
+                chat_id=CHAT_ID,
+                type="photo",
+                file_size=1000,
+                downloaded=0,
+                download_attempts=0,
+                account_id=1,
+            )
+        )
+        session.add(
+            Media(
+                id=f"{CHAT_ID}_2_dice",
+                message_id=2,
+                chat_id=CHAT_ID,
+                type="dice",
+                file_size=0,
+                downloaded=0,
+                download_attempts=0,
+                account_id=1,
+            )
+        )
+        session.add(
+            Media(
+                id=f"{CHAT_ID}_3_venue",
+                message_id=3,
+                chat_id=CHAT_ID,
+                type="venue",
+                file_size=0,
+                downloaded=0,
+                download_attempts=99,
+                account_id=1,
+            )
+        )
+        await session.commit()
+
+    return DatabaseAdapter(db_manager)
+
+
+@pytest.mark.asyncio
+async def test_drain_excludes_extended_metadata_rows(adapter):
+    """get_pending_media_downloads must never hand a dice/venue row to the
+    downloader — there is no file behind it, so it would retry forever."""
+    pending = await adapter.get_pending_media_downloads(100 * 1024 * 1024, 5, account_id=1)
+    assert [row["id"] for row in pending] == [f"{CHAT_ID}_1_photo"]
+
+
+@pytest.mark.asyncio
+async def test_status_counts_exclude_metadata_only_rows(adapter):
+    """Operator status: dice (attempts=0) is not pending, venue (attempts=99)
+    is not exhausted — both sit at downloaded=0 by design."""
+    counts = await adapter.get_operator_status_counts(max_attempts=5)
+    assert counts["pending"] == 1  # just the photo
+    assert counts["exhausted"] == 0


### PR DESCRIPTION
## Problem

Send a dice, a venue, an invoice, a story share, a giveaway, a live location, a game — or anything from a newer Telegram layer — and the archive captures a message with **nothing in it**. `_get_media_type` recognized only photo/document/webpage/contact/geo/poll, returned `None` for everything else, so no media record was written and the viewer showed a bare empty bubble. Official apps render every one of these as a typed placeholder; the archive silently dropped nine kinds of content.

## Fix

- `classify_extended_media` names the kind from the TL class name (MagicMock-inert, the same idiom as `service_action_type`); both `_get_media_type` ladders fall through to it.
- `extract_extended_media_details` captures the salient fields — dice value, venue title/address, invoice amount+currency, giveaway quantity/months, live-location coords, game title — into `raw_data[<kind>]` in **both** the scheduled sweep and the live listener.
- Both writers store a metadata-only media row (`downloaded=0`, no file), same as contact/geo/poll.
- The download drain and the operator status counts exclude metadata-only kinds — without this, every dice in the archive would sit in the pending queue forever and the status panel would show a permanently red pipeline.
- The viewer renders a typed chip per kind. Invoice amounts go through `Intl.NumberFormat`, which knows each currency's minor-unit count (¥1,000 stays ¥1,000; $145.00 stays $145.00).

## Tests

25 new tests: the classifier against the **real** Telethon classes (a typo'd class name in the map cannot survive), per-kind extractor payloads, both `_get_media_type` tails, both metadata gates, drain + status-count exclusion on a real in-memory SQLite. Six mutations (classifier tail, both gates, drain filter, status filter, raw_data capture) were each proven to fail the new tests before restoring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for displaying Telegram venues, dice, invoices, stories, giveaways, live locations, games, and other previously unsupported media.
  * Extended media now includes relevant details such as labels, icons, amounts, coordinates, and other available metadata.
  * New-message captures preserve extended media information for backup viewers.

* **Bug Fixes**
  * Metadata-only media is no longer treated as downloadable content.
  * Download queues and operator status counts now exclude non-downloadable media, improving accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->