### PR TITLE
feat(capture): formatting survives — entities stored and rendered instead of flattened

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1475,7 +1475,15 @@ class DatabaseAdapter:
 
     @retry_on_locked()
     async def update_message_text(
-        self, chat_id: int, message_id: int, new_text: str, edit_date: datetime | None, *, account_id: int
+        self,
+        chat_id: int,
+        message_id: int,
+        new_text: str,
+        edit_date: datetime | None,
+        *,
+        account_id: int,
+        entities: list | None = None,
+        update_entities: bool = False,
     ) -> tuple[str, dict | None]:
         """Update a message's text and edit_date.
 
@@ -1495,7 +1503,26 @@ class DatabaseAdapter:
                 return "not_found", None
 
             if not self._should_apply_edit_text(message, new_text, edit_date):
-                logger.debug("Edit no-op: message already current")
+                # Formatting-only edits arrive with UNCHANGED text but different
+                # entities. Merge them silently — no edit_date bump, no version,
+                # no webhook — so formatting stays current without the phantom
+                # "edited" marker #219 removed.
+                if update_entities and self._merge_raw_data_entities(message, entities):
+                    await session.execute(
+                        update(Message)
+                        .where(
+                            and_(
+                                Message.account_id == account_id,
+                                Message.chat_id == chat_id,
+                                Message.id == message_id,
+                            )
+                        )
+                        .values(raw_data=message.raw_data)
+                    )
+                    await session.commit()
+                    logger.debug("Edit no-op text, entities refreshed")
+                else:
+                    logger.debug("Edit no-op: message already current")
                 return "noop", None
 
             prior = {"text": message.text, "sender_id": message.sender_id, "sender_name": message.sender_name}
@@ -1513,9 +1540,45 @@ class DatabaseAdapter:
                 .where(and_(Message.account_id == account_id, Message.chat_id == chat_id, Message.id == message_id))
                 .values(text=new_text, edit_date=edit_date)
             )
+            if update_entities and self._merge_raw_data_entities(message, entities):
+                await session.execute(
+                    update(Message)
+                    .where(
+                        and_(
+                            Message.account_id == account_id,
+                            Message.chat_id == chat_id,
+                            Message.id == message_id,
+                        )
+                    )
+                    .values(raw_data=message.raw_data)
+                )
             await session.commit()
             logger.debug("Updated archived message text")
             return "applied", prior
+
+    def _merge_raw_data_entities(self, message: Message, entities: list | None) -> bool:
+        """Set or drop raw_data["entities"] on the loaded row; True if it changed.
+
+        raw_data is a JSON string column, so the merge round-trips through
+        json; a row whose raw_data is unparseable is left untouched (never
+        destroy unrelated capture payloads for a formatting refresh).
+        """
+        try:
+            raw = json.loads(message.raw_data) if message.raw_data else {}
+        except ValueError, TypeError:
+            return False
+        if not isinstance(raw, dict):
+            return False
+        if raw.get("entities") == entities and (entities is not None or "entities" not in raw):
+            return False
+        if entities is None:
+            if "entities" not in raw:
+                return False
+            raw.pop("entities")
+        else:
+            raw["entities"] = entities
+        message.raw_data = json.dumps(raw)
+        return True
 
     async def sender_has_message_in_chats(
         self, sender_id: int, chat_ids: Iterable[int], *, account_id: int | None = None

--- a/src/listener.py
+++ b/src/listener.py
@@ -52,8 +52,10 @@ from .message_utils import (
     extract_webpage_preview,
     fallback_media_filename,
     finalize_atomic_download,
+    message_plain_text,
     sanitize_media_filename,
     sender_display_name,
+    serialize_message_entities,
     service_action_type,
     service_message_text,
     utcnow_naive,
@@ -1043,7 +1045,7 @@ class TelegramListener:
                 self._buffer_reaction_snapshot(chat_id, message)
 
                 self.stats["edits_received"] += 1
-                new_text = message.text or ""
+                new_text = message_plain_text(message)
                 edit_date = message.edit_date
 
                 # Check rate limit before applying
@@ -1062,6 +1064,8 @@ class TelegramListener:
                     new_text=new_text,
                     edit_date=edit_date,
                     account_id=self.account_id,
+                    entities=serialize_message_entities(getattr(message, "entities", None)),
+                    update_entities=True,
                 )
                 if outcome != "applied":
                     self.stats["edits_skipped"] += 1
@@ -1255,7 +1259,7 @@ class TelegramListener:
                     "sender_id": message.sender_id,
                     "sender_name": sender_display_name(sender),
                     "date": message.date,
-                    "text": message.text or "",
+                    "text": message_plain_text(message),
                     "reply_to_msg_id": message.reply_to_msg_id if hasattr(message, "reply_to_msg_id") else None,
                     "reply_to_top_id": reply_to_top_id,
                     "reply_to_text": None,
@@ -1279,6 +1283,11 @@ class TelegramListener:
                 forward_origin = extract_forward_origin(message)
                 if forward_origin:
                     message_data["raw_data"]["forward_origin"] = forward_origin
+
+                # Formatting entities — same contract as the sweep writer.
+                message_entities = serialize_message_entities(getattr(message, "entities", None))
+                if message_entities:
+                    message_data["raw_data"]["entities"] = message_entities
 
                 # v6.0.0: Detect media type for logging (download happens after message insert)
                 media_type = None

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -971,3 +971,67 @@ def extract_forward_origin(message: object) -> dict | None:
     except Exception:
         return None
     return None
+
+
+def message_plain_text(message: object) -> str:
+    """The message's RAW text — what entity offsets index into.
+
+    Telethon's ``.text`` runs the client's default parse mode (markdown) and
+    re-inserts ``**``/``__``/backtick markers, silently DROPPING spoilers —
+    and entity offsets never align with that serialization. ``.raw_text`` is
+    the wire text. isinstance guards keep MagicMock fixtures inert (a mock's
+    ``.raw_text`` is not a str, so tests that set ``.text`` keep working).
+    """
+    raw = getattr(message, "raw_text", None)
+    if isinstance(raw, str):
+        return raw
+    text = getattr(message, "text", None)
+    return text if isinstance(text, str) else ""
+
+
+_ENTITY_CLASS_PREFIX = "MessageEntity"
+_ENTITY_SNAKE_RE = re.compile(r"(?<!^)(?=[A-Z])")
+
+
+def serialize_message_entities(entities: object) -> list[dict] | None:
+    """JSON-safe ``[{type, offset, length, ...extras}]`` off ``message.entities``.
+
+    Offsets/lengths are Telegram's native UTF-16 code units and are stored
+    untouched — JavaScript strings index the same units, so the viewer
+    applies them directly. Name-based type mapping (``MessageEntityTextUrl``
+    -> ``text_url``) with isinstance guards, so a bare MagicMock serializes
+    to nothing. None when no usable entity remains.
+    """
+    if not isinstance(entities, (list, tuple)) or not entities:
+        return None
+    serialized: list[dict] = []
+    for entity in entities:
+        name = type(entity).__name__
+        if not name.startswith(_ENTITY_CLASS_PREFIX):
+            continue
+        offset = getattr(entity, "offset", None)
+        length = getattr(entity, "length", None)
+        if not isinstance(offset, int) or not isinstance(length, int) or offset < 0 or length <= 0:
+            continue
+        record: dict = {
+            "type": _ENTITY_SNAKE_RE.sub("_", name[len(_ENTITY_CLASS_PREFIX) :]).lower(),
+            "offset": offset,
+            "length": length,
+        }
+        url = getattr(entity, "url", None)
+        if isinstance(url, str) and url:
+            record["url"] = url
+        user_id = getattr(entity, "user_id", None)
+        if isinstance(user_id, int):
+            record["user_id"] = user_id
+        language = getattr(entity, "language", None)
+        if isinstance(language, str) and language:
+            record["language"] = language
+        document_id = getattr(entity, "document_id", None)
+        if isinstance(document_id, int):
+            record["document_id"] = document_id
+        collapsed = getattr(entity, "collapsed", None)
+        if isinstance(collapsed, bool) and collapsed:
+            record["collapsed"] = True
+        serialized.append(record)
+    return serialized or None

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -67,8 +67,10 @@ from .message_utils import (
     extract_webpage_preview,
     fallback_media_filename,
     finalize_atomic_download,
+    message_plain_text,
     resolve_shared_file_path,
     sender_display_name,
+    serialize_message_entities,
     service_action_type,
     service_message_text,
     utcnow_naive,
@@ -2538,7 +2540,13 @@ class TelegramBackup:
                         # Update text and edit_date; count only edits the archive
                         # actually accepted (the adapter re-checks under lock).
                         outcome, _ = await self.db.update_message_text(
-                            chat_id, msg_id, remote_msg.message, remote_msg.edit_date, account_id=self.account_id
+                            chat_id,
+                            msg_id,
+                            remote_msg.message,
+                            remote_msg.edit_date,
+                            account_id=self.account_id,
+                            entities=serialize_message_entities(getattr(remote_msg, "entities", None)),
+                            update_entities=True,
                         )
                         if outcome == "applied":
                             total_updated += 1
@@ -3062,7 +3070,7 @@ class TelegramBackup:
             "sender_id": message.sender_id,
             "sender_name": sender_display_name(sender),
             "date": message.date,
-            "text": message.text or "",
+            "text": message_plain_text(message),
             "reply_to_msg_id": message.reply_to_msg_id,
             "reply_to_top_id": reply_to_top_id,
             "reply_to_text": None,
@@ -3166,6 +3174,13 @@ class TelegramBackup:
             forward_origin = extract_forward_origin(message)
             if forward_origin:
                 message_data["raw_data"]["forward_origin"] = forward_origin
+
+        # Formatting entities (bold/italic/code/spoiler/blockquote/...): the
+        # raw text above is what their UTF-16 offsets index into. Without them
+        # spoilers arrive pre-revealed and code blocks flatten to body text.
+        message_entities = serialize_message_entities(getattr(message, "entities", None))
+        if message_entities:
+            message_data["raw_data"]["entities"] = message_entities
 
         # Capture channel post author (signature) if available
         if hasattr(message, "post_author") and message.post_author:

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -3730,6 +3730,9 @@
                 document.addEventListener('click', (event) => {
                     const link = event.target.closest ? event.target.closest('a.tag-link') : null
                     if (!link) return
+                    // A tag concealed inside a spoiler must reveal, not open:
+                    // the spoiler handler below owns that first click.
+                    if (link.closest('.tg-spoiler:not(.tg-spoiler-revealed)')) return
                     event.preventDefault()
                     openTagView(link.dataset.tag)
                 })
@@ -3737,8 +3740,11 @@
                 const toggleSpoiler = (event) => {
                     const spoiler = event.target.closest ? event.target.closest('.tg-spoiler') : null
                     if (!spoiler) return
+                    // Once revealed the span stops intercepting (official apps do
+                    // not re-conceal): links and tags inside behave normally.
+                    if (spoiler.classList.contains('tg-spoiler-revealed')) return
                     event.preventDefault()
-                    spoiler.classList.toggle('tg-spoiler-revealed')
+                    spoiler.classList.add('tg-spoiler-revealed')
                 }
                 document.addEventListener('click', toggleSpoiler)
                 document.addEventListener('keydown', (event) => {

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -435,6 +435,48 @@
                 justify-content: center;
             }
         }
+
+        /* Telegram entity formatting (bold/italic handled by native tags) */
+        .tg-code {
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+            background: rgba(0, 0, 0, 0.3);
+            border-radius: 4px;
+            padding: 1px 4px;
+            font-size: 0.9em;
+        }
+        .tg-pre {
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+            background: rgba(0, 0, 0, 0.3);
+            border-radius: 8px;
+            padding: 8px 10px;
+            margin: 4px 0;
+            overflow-x: auto;
+            white-space: pre;
+            font-size: 0.85em;
+        }
+        .tg-blockquote {
+            border-left: 3px solid rgba(96, 165, 250, 0.6);
+            padding: 2px 8px;
+            margin: 4px 0;
+            border-radius: 4px;
+            background: rgba(0, 0, 0, 0.15);
+        }
+        .tg-spoiler {
+            filter: blur(4px);
+            cursor: pointer;
+            border-radius: 3px;
+            transition: filter 0.15s ease;
+            -webkit-user-select: none;
+            user-select: none;
+        }
+        .tg-spoiler-revealed {
+            filter: none;
+            -webkit-user-select: text;
+            user-select: text;
+        }
+        .tg-mention {
+            color: rgb(96, 165, 250);
+        }
     </style>
     <script>
         tailwind.config = {
@@ -1556,7 +1598,7 @@
                                     <!-- Text with clickable links (for albums, use caption from whichever message has it) -->
                                     <div class="whitespace-pre-wrap break-words message-text"
                                         :class="{ 'opacity-50': msg.is_deleted }"
-                                        v-html="linkifyText(getAlbumCaption(msg) || msg.text)"></div>
+                                        v-html="renderMessageHtml(getAlbumCaptionMessage(msg) || msg)"></div>
 
                                     <!-- Capture-time link preview (mf7): Telegram's own webpage card
                                          as it existed when the message was archived -->
@@ -3677,6 +3719,17 @@
                     event.preventDefault()
                     openTagView(link.dataset.tag)
                 })
+                // Spoilers are injected via v-html too — same delegated pattern.
+                const toggleSpoiler = (event) => {
+                    const spoiler = event.target.closest ? event.target.closest('.tg-spoiler') : null
+                    if (!spoiler) return
+                    event.preventDefault()
+                    spoiler.classList.toggle('tg-spoiler-revealed')
+                }
+                document.addEventListener('click', toggleSpoiler)
+                document.addEventListener('keydown', (event) => {
+                    if (event.key === 'Enter' || event.key === ' ') toggleSpoiler(event)
+                })
 
                 let pendingNotificationClick = null
                 let notificationClickReady = false
@@ -4702,13 +4755,19 @@
                 }
 
                 // For album messages, find the caption from any message in the group
-                const getAlbumCaption = (msg) => {
+                // The album member carrying the caption — the renderer needs the
+                // MESSAGE (its entities live beside its text), not just the string.
+                const getAlbumCaptionMessage = (msg) => {
                     const groupedId = getGroupedId(msg)
                     if (!groupedId) return null
                     if (msg.media?.type !== 'photo' && msg.media?.type !== 'video') return null
                     const album = getAlbumForMessage(msg)
                     if (!album) return null
-                    const captionMsg = album.find(m => m.text && m.text.trim() !== '')
+                    return album.find(m => m.text && m.text.trim() !== '') || null
+                }
+
+                const getAlbumCaption = (msg) => {
+                    const captionMsg = getAlbumCaptionMessage(msg)
                     return captionMsg ? captionMsg.text : null
                 }
 
@@ -6235,6 +6294,93 @@
                         .join('')
                 }
 
+                // Telegram formatting entities: escape-first HTML off the RAW text.
+                // Stored offsets/lengths are UTF-16 code units — the units JS
+                // strings index — so they apply directly, no transformation.
+                const safeEntityUrl = (url) => {
+                    if (typeof url !== 'string') return null
+                    return /^(https?|tg):\/\//i.test(url) ? url : null
+                }
+
+                const wrapEntity = (node, inner, text) => {
+                    switch (node.type) {
+                        case null: return inner
+                        case 'bold': return `<strong>${inner}</strong>`
+                        case 'italic': return `<em>${inner}</em>`
+                        case 'underline': return `<u>${inner}</u>`
+                        case 'strikethrough': return `<s>${inner}</s>`
+                        case 'code': return `<code class="tg-code">${inner}</code>`
+                        case 'pre': return `<pre class="tg-pre"><code>${inner}</code></pre>`
+                        case 'blockquote': return `<blockquote class="tg-blockquote">${inner}</blockquote>`
+                        case 'spoiler': return `<span class="tg-spoiler" role="button" tabindex="0" aria-label="Spoiler, activate to reveal">${inner}</span>`
+                        case 'text_url': {
+                            const url = safeEntityUrl(node.url)
+                            return url ? `<a href="${escapeUrlForAttr(url)}" target="_blank" rel="noopener noreferrer">${inner}</a>` : inner
+                        }
+                        case 'url': {
+                            const raw = text.slice(node.offset, node.end)
+                            return isHttpUrl(raw) ? `<a href="${escapeUrlForAttr(raw)}" target="_blank" rel="noopener noreferrer">${inner}</a>` : inner
+                        }
+                        case 'email': {
+                            const raw = text.slice(node.offset, node.end)
+                            return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(raw) ? `<a href="mailto:${escapeUrlForAttr(raw)}">${inner}</a>` : inner
+                        }
+                        case 'mention':
+                        case 'mention_name': return `<span class="tg-mention">${inner}</span>`
+                        default: return inner
+                    }
+                }
+
+                // These render their inner text escaped-only: code keeps its
+                // characters literal, and link entities must not linkify again.
+                const ESCAPE_ONLY_ENTITY_TYPES = new Set(['code', 'pre', 'url', 'text_url', 'email'])
+
+                const renderEntityHtml = (text, entityList) => {
+                    const len = text.length
+                    const valid = entityList
+                        .filter(e => e && Number.isInteger(e.offset) && Number.isInteger(e.length)
+                            && e.offset >= 0 && e.length > 0 && e.offset < len)
+                        .map(e => ({ type: e.type, url: e.url, offset: e.offset, end: Math.min(e.offset + e.length, len), children: [] }))
+                        .sort((a, b) => a.offset - b.offset || b.end - a.end)
+                    // Proper forest: children fully inside their parent; the rare
+                    // partially-overlapping entity is clipped to the open parent.
+                    const root = { type: null, offset: 0, end: len, children: [] }
+                    const stack = [root]
+                    for (const node of valid) {
+                        while (node.offset >= stack[stack.length - 1].end && stack.length > 1) stack.pop()
+                        const parent = stack[stack.length - 1]
+                        if (node.end > parent.end) node.end = parent.end
+                        if (node.end <= node.offset) continue
+                        parent.children.push(node)
+                        stack.push(node)
+                    }
+                    const renderLeaf = (raw, escapeOnly) => escapeOnly ? escapeHtml(raw) : linkifyText(raw)
+                    const renderNode = (node, escapeOnly) => {
+                        const escapeHere = escapeOnly || ESCAPE_ONLY_ENTITY_TYPES.has(node.type)
+                        let inner = ''
+                        let cursor = node.offset
+                        for (const child of node.children) {
+                            if (child.offset > cursor) inner += renderLeaf(text.slice(cursor, child.offset), escapeHere)
+                            inner += renderNode(child, escapeHere)
+                            cursor = child.end
+                        }
+                        if (cursor < node.end) inner += renderLeaf(text.slice(cursor, node.end), escapeHere)
+                        return wrapEntity(node, inner, text)
+                    }
+                    return renderNode(root, false)
+                }
+
+                const renderMessageHtml = (msg) => {
+                    const text = String((msg && msg.text) || '')
+                    const entities = Array.isArray(msg?.raw_data?.entities) ? msg.raw_data.entities : null
+                    if (!entities || !entities.length) return linkifyText(text)
+                    try {
+                        return renderEntityHtml(text, entities)
+                    } catch (e) {
+                        return linkifyText(text)  // malformed payload: degrade to today's output
+                    }
+                }
+
                 // Resolve the rendered row for a message id via its data-msg-id attribute.
                 // Hidden album members (only the first photo/video of a group renders a row)
                 // resolve to their visible first-in-album sibling so album targets still get
@@ -7759,6 +7905,7 @@
                     isHiddenAlbumMessage,
                     getAlbumGridClass,
                     getAlbumCaption,
+                    getAlbumCaptionMessage,
                     getChatName,
                     getInitials,
                     formatDate,
@@ -7797,6 +7944,7 @@
                     isLightboxImage,
                     isLightboxVideo,
                     linkifyText,
+                    renderMessageHtml,
                     // Tag view
                     tagView,
                     tagTabs,

--- a/tests/test_entity_formatting.py
+++ b/tests/test_entity_formatting.py
@@ -1,0 +1,269 @@
+"""Message entities: capture and store formatting instead of flattening (9t6.10.1).
+
+The archive stored ``message.text`` — Telethon's markdown re-serialization —
+so ``**bold**`` markers leaked into archived text, spoilers arrived silently
+PRE-REVEALED (markdown.unparse drops them), and entity offsets never aligned
+with what was stored. Now both writers store ``message.raw_text`` (the wire
+text entity offsets actually index) plus ``raw_data["entities"]`` as JSON,
+and both edit paths refresh entities — including formatting-only edits, which
+merge silently without the phantom "edited" marker #219 removed.
+"""
+
+import asyncio
+import json
+import os
+import sys
+import unittest
+from datetime import datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Base, Chat, Message
+from src.message_utils import message_plain_text, serialize_message_entities
+from src.telegram_backup import TelegramBackup
+
+CHAT_ID = -1001
+
+
+class TestSerializeMessageEntities(unittest.TestCase):
+    def test_real_telethon_entities_serialize_with_extras(self):
+        from telethon.tl.types import (
+            MessageEntityBlockquote,
+            MessageEntityBold,
+            MessageEntityCustomEmoji,
+            MessageEntityMentionName,
+            MessageEntityPre,
+            MessageEntitySpoiler,
+            MessageEntityTextUrl,
+        )
+
+        serialized = serialize_message_entities(
+            [
+                MessageEntityBold(offset=0, length=4),
+                MessageEntityTextUrl(offset=5, length=3, url="https://x.example"),
+                MessageEntitySpoiler(offset=9, length=2),
+                MessageEntityPre(offset=12, length=5, language="py"),
+                MessageEntityBlockquote(offset=18, length=4, collapsed=True),
+                MessageEntityMentionName(offset=23, length=2, user_id=42),
+                MessageEntityCustomEmoji(offset=26, length=2, document_id=999),
+            ]
+        )
+        self.assertEqual(
+            serialized,
+            [
+                {"type": "bold", "offset": 0, "length": 4},
+                {"type": "text_url", "offset": 5, "length": 3, "url": "https://x.example"},
+                {"type": "spoiler", "offset": 9, "length": 2},
+                {"type": "pre", "offset": 12, "length": 5, "language": "py"},
+                {"type": "blockquote", "offset": 18, "length": 4, "collapsed": True},
+                {"type": "mention_name", "offset": 23, "length": 2, "user_id": 42},
+                {"type": "custom_emoji", "offset": 26, "length": 2, "document_id": 999},
+            ],
+        )
+
+    def test_payload_is_json_safe(self):
+        from telethon.tl.types import MessageEntityItalic
+
+        serialized = serialize_message_entities([MessageEntityItalic(offset=0, length=3)])
+        json.dumps(serialized)  # raises if anything non-serializable leaked
+
+    def test_magicmock_and_garbage_are_inert(self):
+        self.assertIsNone(serialize_message_entities([MagicMock()]))
+        self.assertIsNone(serialize_message_entities(None))
+        self.assertIsNone(serialize_message_entities([]))
+        self.assertIsNone(serialize_message_entities("not a list"))
+
+    def test_invalid_offsets_are_skipped(self):
+        from telethon.tl.types import MessageEntityBold
+
+        bad = MessageEntityBold(offset=0, length=4)
+        bad.offset = -1
+        zero = MessageEntityBold(offset=0, length=4)
+        zero.length = 0
+        good = MessageEntityBold(offset=2, length=3)
+        self.assertEqual(
+            serialize_message_entities([bad, zero, good]),
+            [{"type": "bold", "offset": 2, "length": 3}],
+        )
+
+
+class TestMessagePlainText(unittest.TestCase):
+    def test_raw_text_wins_over_markdown_serialization(self):
+        class Msg:
+            raw_text = "hola mundo"
+            text = "**hola** mundo"
+
+        self.assertEqual(message_plain_text(Msg()), "hola mundo")
+
+    def test_mock_fixture_falls_back_to_text(self):
+        mock = MagicMock()
+        mock.text = "plain"
+        self.assertEqual(message_plain_text(mock), "plain")
+
+    def test_service_message_is_empty(self):
+        svc = MagicMock()
+        svc.raw_text = None
+        svc.text = None
+        self.assertEqual(message_plain_text(svc), "")
+
+
+class TestSweepCapturesEntities(unittest.TestCase):
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.backup.account_id = 1
+        self.backup.db = AsyncMock()
+        self.backup.config = MagicMock()
+        self.backup.config.should_download_media_for_chat = MagicMock(return_value=False)
+        self.backup.client = AsyncMock()
+
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def _make_message(self, msg_id):
+        msg = MagicMock()
+        msg.id = msg_id
+        msg.sender = None
+        msg.sender_id = 42
+        msg.date = datetime(2026, 1, 1)
+        msg.text = "hello"
+        msg.reply_to_msg_id = None
+        msg.reply_to = None
+        msg.edit_date = None
+        msg.out = False
+        msg.pinned = False
+        msg.grouped_id = None
+        msg.fwd_from = None
+        msg.media = None
+        msg.reactions = None
+        msg.post_author = None
+        msg.action = None
+        return msg
+
+    def test_raw_text_and_entities_are_stored(self):
+        from telethon.tl.types import MessageEntityBold
+
+        msg = self._make_message(1)
+        msg.raw_text = "hola mundo"
+        msg.text = "**hola** mundo"  # what Telethon's markdown parse mode serves
+        msg.entities = [MessageEntityBold(offset=0, length=4)]
+
+        result = self._run(self.backup._process_message(msg, CHAT_ID))
+        self.assertEqual(result["text"], "hola mundo")
+        self.assertEqual(
+            result["raw_data"]["entities"],
+            [{"type": "bold", "offset": 0, "length": 4}],
+        )
+
+    def test_plain_message_stores_no_entities_key(self):
+        msg = self._make_message(2)
+        result = self._run(self.backup._process_message(msg, CHAT_ID))
+        self.assertNotIn("entities", result["raw_data"])
+
+
+# ---------------------------------------------------------------------------
+# Adapter: entity merge on the edit paths (real in-memory SQLite)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def adapter():
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db_manager = DatabaseManager.__new__(DatabaseManager)
+    db_manager.engine = engine
+    db_manager.database_url = "sqlite+aiosqlite://"
+    db_manager._is_sqlite = True
+    db_manager.async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with db_manager.async_session_factory() as session:
+        session.add(Chat(id=CHAT_ID, type="channel", title="Chat A"))
+        session.add(
+            Message(
+                id=1,
+                chat_id=CHAT_ID,
+                sender_id=None,
+                date=datetime(2026, 1, 1),
+                text="original",
+                raw_data=json.dumps({"webpage": {"url": "https://keep.example"}}),
+                account_id=1,
+            )
+        )
+        await session.commit()
+
+    return DatabaseAdapter(db_manager)
+
+
+async def _row(adapter_):
+    async with adapter_.db_manager.async_session_factory() as session:
+        result = await session.execute(select(Message).where(Message.id == 1))
+        return result.scalar_one()
+
+
+BOLD = [{"type": "bold", "offset": 0, "length": 3}]
+ITALIC = [{"type": "italic", "offset": 0, "length": 3}]
+
+
+@pytest.mark.asyncio
+async def test_text_edit_stores_entities_and_preserves_raw_data(adapter):
+    outcome, _ = await adapter.update_message_text(
+        CHAT_ID, 1, "new text", datetime(2026, 1, 2), account_id=1, entities=BOLD, update_entities=True
+    )
+    assert outcome == "applied"
+    row = await _row(adapter)
+    raw = json.loads(row.raw_data)
+    assert raw["entities"] == BOLD
+    assert raw["webpage"] == {"url": "https://keep.example"}  # merge, not overwrite
+    assert row.text == "new text"
+
+
+@pytest.mark.asyncio
+async def test_formatting_only_edit_merges_silently(adapter):
+    """Same text + different entities: entities refresh, but NO edit_date bump
+    (that would resurrect the phantom 'edited' marker #219 removed)."""
+    outcome, _ = await adapter.update_message_text(
+        CHAT_ID, 1, "original", datetime(2026, 1, 2), account_id=1, entities=ITALIC, update_entities=True
+    )
+    assert outcome == "noop"
+    row = await _row(adapter)
+    assert json.loads(row.raw_data)["entities"] == ITALIC
+    assert row.edit_date is None
+
+
+@pytest.mark.asyncio
+async def test_edit_that_dropped_formatting_removes_the_key(adapter):
+    await adapter.update_message_text(CHAT_ID, 1, "original", None, account_id=1, entities=BOLD, update_entities=True)
+    outcome, _ = await adapter.update_message_text(
+        CHAT_ID, 1, "original", None, account_id=1, entities=None, update_entities=True
+    )
+    assert outcome == "noop"
+    raw = json.loads((await _row(adapter)).raw_data)
+    assert "entities" not in raw
+    assert raw["webpage"] == {"url": "https://keep.example"}
+
+
+@pytest.mark.asyncio
+async def test_legacy_caller_without_flag_leaves_raw_data_alone(adapter):
+    outcome, _ = await adapter.update_message_text(CHAT_ID, 1, "newer", datetime(2026, 1, 3), account_id=1)
+    assert outcome == "applied"
+    raw = json.loads((await _row(adapter)).raw_data)
+    assert "entities" not in raw
+    assert raw["webpage"] == {"url": "https://keep.example"}

--- a/tests/test_entity_rendering_frontend.py
+++ b/tests/test_entity_rendering_frontend.py
@@ -1,0 +1,186 @@
+"""Executable regressions for the viewer's entity-formatting renderer (9t6.10.1)."""
+
+import re
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+INDEX_HTML = Path(__file__).resolve().parents[1] / "src" / "web" / "templates" / "index.html"
+
+
+def _extract_between(html: str, start: str, end: str) -> str:
+    i = html.index(start)
+    j = html.index(end, i)
+    return html[i:j]
+
+
+def _renderer_bundle(html: str) -> str:
+    """The renderer plus every template helper it calls, escapeHtml stubbed.
+
+    The shipped escapeHtml is DOM-based (document.createElement), so the node
+    harness substitutes a pure equivalent; everything else runs verbatim.
+    """
+    parts = [
+        _extract_between(html, "const isHttpUrl", "const TAG_TOKEN_RE"),
+        _extract_between(html, "const TAG_TOKEN_RE", "const safeEntityUrl"),
+        _extract_between(html, "const safeEntityUrl", "const renderMessageHtml"),
+        _extract_between(html, "const renderMessageHtml", "// Resolve the rendered row"),
+    ]
+    code = "\n".join(parts)
+    names = (
+        "isHttpUrl|escapeUrlForAttr|TAG_TOKEN_RE|isTagToken|tagifyText|linkifyText|"
+        "safeEntityUrl|wrapEntity|ESCAPE_ONLY_ENTITY_TYPES|renderEntityHtml|renderMessageHtml"
+    )
+    code = re.sub(rf"\bconst ({names})", r"globalThis.\1", code)
+    stub = (
+        "globalThis.escapeHtml = (t) => String(t)"
+        ".replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')"
+        ".replace(/\"/g, '&quot;').replace(/'/g, '&#39;');\n"
+    )
+    return stub + code
+
+
+def _run_node(script: str) -> None:
+    node = shutil.which("node")
+    if node is None:
+        pytest.skip("node executable is not installed")
+
+    # SECURITY-REVIEW: The executable path is resolved locally and untrusted input is never passed to a shell.
+    result = subprocess.run(
+        [node, "-e", script],
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"Node behavior test failed with exit code {result.returncode}\n"
+        f"stdout:\n{result.stdout}\n"
+        f"stderr:\n{result.stderr}"
+    )
+
+
+def _run_renderer_asserts(assert_body: str) -> None:
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    script = "\n".join(
+        [
+            '"use strict";',
+            "const assert = require('node:assert/strict');",
+            _renderer_bundle(html),
+            "const R = (text, ents) => renderMessageHtml({ text, raw_data: { entities: ents } });",
+            assert_body,
+        ]
+    )
+    _run_node(script)
+
+
+def test_entity_text_is_escaped_before_markup() -> None:
+    """Hostile text inside a formatted span must never become live HTML."""
+    _run_renderer_asserts(
+        """
+const html = R('<img src=x onerror=alert(1)> hi', [{type: 'bold', offset: 0, length: 27}])
+assert.ok(!html.includes('<img'), html)
+assert.ok(html.includes('&lt;img'), html)
+assert.ok(html.startsWith('<strong>'), html)
+"""
+    )
+
+
+def test_nested_entities_render_as_nested_tags() -> None:
+    _run_renderer_asserts(
+        """
+assert.equal(
+    R('hola mundo', [{type: 'bold', offset: 0, length: 10}, {type: 'italic', offset: 5, length: 5}]),
+    '<strong>hola <em>mundo</em></strong>')
+"""
+    )
+
+
+def test_spoiler_is_one_span_and_blurred_by_default() -> None:
+    """One spoiler entity produces ONE reveal target, not per-segment shards."""
+    _run_renderer_asserts(
+        """
+const html = R('el secreto grande', [{type: 'spoiler', offset: 3, length: 14}])
+assert.equal((html.match(/tg-spoiler/g) || []).length, 1, html)
+assert.ok(html.includes('role="button"'), html)
+assert.ok(!html.includes('tg-spoiler-revealed'), html)
+"""
+    )
+
+
+def test_code_keeps_characters_literal_and_untagged() -> None:
+    """No linkify/tagify inside code — #test must stay text, < must escape."""
+    _run_renderer_asserts(
+        """
+const html = R('run #test <now>', [{type: 'code', offset: 4, length: 11}])
+assert.ok(html.includes('<code class="tg-code">#test &lt;now&gt;</code>'), html)
+assert.ok(!html.includes('tag-link'), html)
+"""
+    )
+
+
+def test_text_url_rejects_javascript_scheme() -> None:
+    _run_renderer_asserts(
+        """
+assert.equal(R('click', [{type: 'text_url', offset: 0, length: 5, url: 'javascript:alert(1)'}]), 'click')
+const ok = R('click', [{type: 'text_url', offset: 0, length: 5, url: 'https://ok.example'}])
+assert.ok(ok.includes('href="https://ok.example"'), ok)
+assert.ok(ok.includes('rel="noopener noreferrer"'), ok)
+"""
+    )
+
+
+def test_url_entity_anchors_once_without_double_linkify() -> None:
+    _run_renderer_asserts(
+        """
+const html = R('see https://x.example/a now', [{type: 'url', offset: 4, length: 19}])
+assert.equal((html.match(/<a /g) || []).length, 1, html)
+assert.ok(html.includes('href="https://x.example/a"'), html)
+"""
+    )
+
+
+def test_no_entities_falls_back_to_linkify() -> None:
+    """Old rows (and malformed payloads) render exactly as before this change."""
+    _run_renderer_asserts(
+        """
+const plain = R('plain https://y.example #tag', null)
+assert.ok(plain.includes('href="https://y.example"'), plain)
+assert.ok(plain.includes('tag-link'), plain)
+assert.equal(R('x', []), 'x')
+assert.equal(R('short', [{type: 'bold', offset: 99, length: 4}]), 'short')
+"""
+    )
+
+
+def test_utf16_offsets_apply_natively() -> None:
+    """Telegram offsets are UTF-16 units; an emoji (surrogate pair) before the
+    entity must not shift the formatted range."""
+    _run_renderer_asserts(
+        """
+assert.equal(
+    R('X \\u{1F3B2} bold', [{type: 'bold', offset: 5, length: 4}]),
+    'X \\u{1F3B2} <strong>bold</strong>')
+"""
+    )
+
+
+def test_blockquote_and_pre_wrap_as_blocks() -> None:
+    _run_renderer_asserts(
+        """
+assert.equal(
+    R('quoted', [{type: 'blockquote', offset: 0, length: 6}]),
+    '<blockquote class="tg-blockquote">quoted</blockquote>')
+const pre = R('x = 1', [{type: 'pre', offset: 0, length: 5, language: 'py'}])
+assert.equal(pre, '<pre class="tg-pre"><code>x = 1</code></pre>')
+"""
+    )
+
+
+def test_template_uses_entity_renderer_for_message_text() -> None:
+    """The message bubble must route through renderMessageHtml (album-aware)."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    assert 'v-html="renderMessageHtml(getAlbumCaptionMessage(msg) || msg)"' in html
+    assert 'v-html="linkifyText(getAlbumCaption(msg) || msg.text)"' not in html

--- a/tests/test_entity_rendering_frontend.py
+++ b/tests/test_entity_rendering_frontend.py
@@ -179,6 +179,43 @@ assert.equal(pre, '<pre class="tg-pre"><code>x = 1</code></pre>')
     )
 
 
+def test_spoiler_reveal_does_not_hijack_revealed_links() -> None:
+    """Concealed: first activation reveals and suppresses navigation. Revealed:
+    the span stops intercepting so url/text_url/tag links inside work."""
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    start = html.index("const toggleSpoiler")
+    end = html.index("}", html.index("spoiler.classList.add", start)) + 1
+    script = "\n".join(
+        [
+            '"use strict";',
+            "const assert = require('node:assert/strict');",
+            html[start:end].replace("const toggleSpoiler", "globalThis.toggleSpoiler"),
+            """
+const mkEvent = (revealed) => {
+    const cls = new Set(revealed ? ['tg-spoiler', 'tg-spoiler-revealed'] : ['tg-spoiler'])
+    const spoiler = { classList: { contains: (c) => cls.has(c), add: (c) => cls.add(c) } }
+    let prevented = false
+    return {
+        ev: { target: { closest: (sel) => sel === '.tg-spoiler' ? spoiler : null }, preventDefault: () => { prevented = true } },
+        cls,
+        wasPrevented: () => prevented,
+    }
+}
+const concealed = mkEvent(false)
+toggleSpoiler(concealed.ev)
+assert.ok(concealed.cls.has('tg-spoiler-revealed'))
+assert.ok(concealed.wasPrevented())
+const revealed = mkEvent(true)
+toggleSpoiler(revealed.ev)
+assert.ok(!revealed.wasPrevented())
+""",
+        ]
+    )
+    _run_node(script)
+    # And the tag delegate must leave concealed-spoiler tags to the reveal.
+    assert ".tg-spoiler:not(.tg-spoiler-revealed)" in html
+
+
 def test_template_uses_entity_renderer_for_message_text() -> None:
     """The message bubble must route through renderMessageHtml (album-aware)."""
     html = INDEX_HTML.read_text(encoding="utf-8")

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -451,6 +451,49 @@ class TestEventHandlers:
             "message_id": 777,
         }
 
+    def test_on_new_message_stores_raw_text_and_entities(self, listener_with_handlers, full_config):
+        """Formatted messages store the WIRE text + entities, never markdown markers."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.NewMessage]
+
+        from datetime import datetime
+
+        from telethon.tl.types import MessageEntityBold
+
+        event = MagicMock()
+        event.chat_id = -1001234567890
+
+        msg = MagicMock()
+        msg.reply_to = None
+        msg.id = 44
+        msg.sender_id = 111
+        msg.date = datetime(2025, 1, 1, tzinfo=UTC)
+        msg.raw_text = "hola mundo"
+        msg.text = "**hola** mundo"  # Telethon's markdown parse mode output
+        msg.entities = [MessageEntityBold(offset=0, length=4)]
+        msg.reply_to_msg_id = None
+        msg.edit_date = None
+        msg.out = False
+        msg.grouped_id = None
+        msg.media = None
+        msg.sender = None
+        msg.fwd_from = None
+        event.message = msg
+
+        chat_entity = MagicMock()
+        chat_entity.title = "Test Chat"
+        chat_entity.username = None
+        chat_entity.first_name = None
+        chat_entity.last_name = None
+        event.get_chat = AsyncMock(return_value=chat_entity)
+
+        asyncio.run(handler(event))
+
+        listener.db.insert_message.assert_called_once()
+        saved = listener.db.insert_message.call_args[0][0]
+        assert saved["text"] == "hola mundo"
+        assert saved["raw_data"]["entities"] == [{"type": "bold", "offset": 0, "length": 4}]
+
     def test_on_new_message_adds_untracked_chat_to_tracking(self, listener_with_handlers, full_config):
         """Test new message from untracked-but-included chat gets added to tracking."""
         listener, handlers = listener_with_handlers
@@ -581,6 +624,8 @@ class TestEventHandlers:
             new_text="Updated text",
             edit_date=msg.edit_date,
             account_id=1,
+            entities=None,
+            update_entities=True,
         )
 
     def test_on_message_edited_handles_none_text(self, listener_with_handlers):

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -1163,7 +1163,7 @@ class TestSyncDeletionsAndEdits(unittest.TestCase):
         self.backup.db.delete_message.assert_not_awaited()
         self.backup.db.mark_message_deleted.assert_not_awaited()
         self.backup.db.update_message_text.assert_awaited_once_with(
-            100, 3, "three edited", datetime(2024, 6, 15), account_id=1
+            100, 3, "three edited", datetime(2024, 6, 15), account_id=1, entities=None, update_entities=True
         )
         assert any("misaligned" in line for line in captured.output)
 


### PR DESCRIPTION
## Problem

Send a message with bold, a spoiler, a code block or a quote, and the archive mangles it. Telethon's default parse mode is markdown, so `message.text` — what both writers stored — re-serializes formatting: archived text carries literal `**bold**`/`__italic__` markers, **spoilers are dropped entirely and arrive pre-revealed**, and code blocks and blockquotes flatten into body text. Every official client keeps the raw text plus a `MessageEntity` list and applies it at render; the archive threw that list away, and it cannot be recovered later.

## Fix

**Capture** (both the sweep and the live listener):
- Store `message.raw_text` — the wire text whose entity offsets actually index — via `message_plain_text` (isinstance-guarded, MagicMock-inert).
- Serialize `message.entities` into `raw_data.entities` (`serialize_message_entities`): type from the TL class name, offset/length kept in Telegram's native UTF-16 units — exactly the units JavaScript strings index, so the viewer applies them with no transformation.
- Both edit paths refresh entities. A formatting-only edit (same text, different entities) merges silently: entities update, but no `edit_date` bump and no version row, so the phantom "edited" marker #219 removed stays gone.

**Render** (viewer):
- `renderMessageHtml` builds a proper nesting forest from the entities and emits escape-first HTML: `<strong>/<em>/<u>/<s>`, literal-only `code`/`pre`, `blockquote`, spoiler as a **single** blurred span with click *and* keyboard reveal, `text_url` restricted to http(s)/tg schemes, url/email anchored exactly once (no double-linkify).
- Rows without entities — every existing capture — render byte-identically to before: the function falls back to the existing `linkifyText`.

## Tests

13 backend (serializer against real Telethon classes, raw-text-wins, sweep capture, adapter merge semantics on real SQLite incl. the formatting-only and key-removal paths) + 10 node-driven frontend (XSS escape, nesting, single spoiler span, code literality, `javascript:` rejection, UTF-16 emoji offsets, fallback identity) + 2 updated call pins. Seven mutations — each capture line, the raw-text switches, the adapter merge, the URL scheme gate, leaf escaping — were each proven to fail a test before restoring.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Telegram message formatting is now preserved and rendered for code, quotes, spoilers, links, mentions, and email addresses.
  * Spoiler content can be revealed with clicks or keyboard controls.
  * Message edits now update formatting without creating unnecessary edit activity.
  * Captions and album captions support the same rich formatting.

* **Bug Fixes**
  * Improved handling of raw message text and malformed formatting metadata.
  * Prevented stale formatting data from remaining after edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->