### PR TITLE
feat(capture): link-preview photos download like any photo

### DIFF
--- a/src/listener.py
+++ b/src/listener.py
@@ -898,10 +898,13 @@ class TelegramListener:
             # Get Telegram's file unique ID for deduplication. Webpage previews
             # keep their photo/document one level down — unwrap once.
             payload = downloadable_media_payload(media)
+            # Truthy guards, not hasattr: a WebPage carries BOTH .photo and
+            # .document (one None), so hasattr would pick the empty photo
+            # branch for document-backed previews and lose the file id.
             telegram_file_id = None
-            if hasattr(payload, "photo"):
+            if getattr(payload, "photo", None):
                 telegram_file_id = str(getattr(payload.photo, "id", None))
-            elif hasattr(payload, "document"):
+            elif getattr(payload, "document", None):
                 telegram_file_id = str(getattr(payload.document, "id", None))
 
             # Guard against inaccessible media producing "None" string IDs

--- a/src/listener.py
+++ b/src/listener.py
@@ -47,6 +47,7 @@ from .message_utils import (
     compute_file_hash_async,
     describe_exception,
     download_and_shard_media,
+    downloadable_media_payload,
     extract_extended_media_details,
     extract_forward_origin,
     extract_media_attributes,
@@ -844,6 +845,13 @@ class TelegramListener:
         # The nine kinds this ladder used to flatten to None (venue, dice,
         # invoice, story, giveaways, live location, game, unsupported):
         # metadata-only types with a typed viewer chip, never downloaded.
+        if type(media).__name__ == "MessageMediaWebPage":
+            webpage = getattr(media, "webpage", None)
+            if type(webpage).__name__ == "WebPage" and (
+                getattr(webpage, "photo", None) is not None or getattr(webpage, "document", None) is not None
+            ):
+                return "webpage"
+            return None  # card-only preview (raw_data.webpage): nothing to download
         return classify_extended_media(media)
 
     def _get_media_filename(self, message, media_type: str, telegram_file_id: str | None = None) -> str:
@@ -852,8 +860,9 @@ class TelegramListener:
         original_name = None
         mime_type = None
 
-        if hasattr(message.media, "document") and message.media.document:
-            doc = message.media.document
+        media_payload = downloadable_media_payload(message.media)
+        if hasattr(media_payload, "document") and media_payload.document:
+            doc = media_payload.document
             mime_type = getattr(doc, "mime_type", None)
             for attr in getattr(doc, "attributes", None) or ():
                 if hasattr(attr, "file_name") and attr.file_name:
@@ -884,12 +893,14 @@ class TelegramListener:
             return None  # These don't have downloadable files
 
         try:
-            # Get Telegram's file unique ID for deduplication
+            # Get Telegram's file unique ID for deduplication. Webpage previews
+            # keep their photo/document one level down — unwrap once.
+            payload = downloadable_media_payload(media)
             telegram_file_id = None
-            if hasattr(media, "photo"):
-                telegram_file_id = str(getattr(media.photo, "id", None))
-            elif hasattr(media, "document"):
-                telegram_file_id = str(getattr(media.document, "id", None))
+            if hasattr(payload, "photo"):
+                telegram_file_id = str(getattr(payload.photo, "id", None))
+            elif hasattr(payload, "document"):
+                telegram_file_id = str(getattr(payload.document, "id", None))
 
             # Guard against inaccessible media producing "None" string IDs
             if telegram_file_id == "None":
@@ -897,15 +908,15 @@ class TelegramListener:
 
             # Check file size
             file_size = 0
-            if hasattr(media, "document") and media.document:
-                file_size = getattr(media.document, "size", 0)
-            elif hasattr(media, "photo") and media.photo:
-                if hasattr(media.photo, "sizes") and media.photo.sizes:
+            if hasattr(payload, "document") and payload.document:
+                file_size = getattr(payload.document, "size", 0)
+            elif hasattr(payload, "photo") and payload.photo:
+                if hasattr(payload.photo, "sizes") and payload.photo.sizes:
                     # PhotoSizeProgressive (the full rendition) has no scalar
                     # .size, so max-by-getattr scored it 0 and a thumbnail won
                     # — the size gate then measured kilobytes for a photo of
                     # megabytes. _photo_size_bytes reads both shapes.
-                    file_size = max(_photo_size_bytes(s) for s in media.photo.sizes)
+                    file_size = max(_photo_size_bytes(s) for s in payload.photo.sizes)
 
             max_size = self.config.get_max_media_size_bytes()
             if file_size > max_size:
@@ -1324,7 +1335,7 @@ class TelegramListener:
                                 # Same metadata the scheduled sweep records (#263) — without it
                                 # live-captured voice notes had a NULL duration and rendered
                                 # without it while sweep-captured ones showed it.
-                                media_attributes = extract_media_attributes(message.media)
+                                media_attributes = extract_media_attributes(downloadable_media_payload(message.media))
                                 try:
                                     media_attributes["file_size"] = os.path.getsize(media_path)
                                 except OSError:

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -199,6 +199,7 @@ _FALLBACK_MEDIA_EXTENSIONS = {
     "audio": "mp3",
     "sticker": "webp",
     "document": "bin",
+    "webpage": "jpg",
 }
 
 
@@ -1095,3 +1096,18 @@ def extract_forward_origin(message: object) -> dict | None:
     except Exception:
         return None
     return None
+
+
+def downloadable_media_payload(media: object) -> object:
+    """The object whose ``.photo``/``.document`` is the downloadable file.
+
+    ``MessageMediaWebPage`` keeps its preview photo/document on ``.webpage``
+    (Telethon's ``download_media`` unwraps the same way) — one unwrap here
+    lets every size/id/filename sniffer work unchanged. Everything else
+    passes through. Name-based, so mocks stay inert.
+    """
+    if type(media).__name__ == "MessageMediaWebPage":
+        webpage = getattr(media, "webpage", None)
+        if type(webpage).__name__ == "WebPage":
+            return webpage
+    return media

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -62,6 +62,7 @@ from .message_utils import (
     compute_file_hash_async,
     describe_exception,
     download_and_shard_media,
+    downloadable_media_payload,
     extract_extended_media_details,
     extract_forward_origin,
     extract_media_attributes,
@@ -3553,19 +3554,22 @@ class TelegramBackup:
                 "downloaded": False,
             }
 
-        # Get Telegram's file unique ID for deduplication
+        # Get Telegram's file unique ID for deduplication. Webpage previews
+        # keep their photo/document one level down — unwrap once so every
+        # sniffer below sees the real payload.
+        payload = downloadable_media_payload(media)
         telegram_file_id = None
-        if hasattr(media, "photo"):
-            telegram_file_id = str(getattr(media.photo, "id", None))
-        elif hasattr(media, "document"):
-            telegram_file_id = str(getattr(media.document, "id", None))
+        if hasattr(payload, "photo"):
+            telegram_file_id = str(getattr(payload.photo, "id", None))
+        elif hasattr(payload, "document"):
+            telegram_file_id = str(getattr(payload.document, "id", None))
 
         # Guard against inaccessible media producing "None" string IDs
         if telegram_file_id == "None":
             telegram_file_id = None
 
         # Check file size (estimated)
-        file_size = self._get_media_size(media)
+        file_size = self._get_media_size(payload)
         max_size = self.config.get_max_media_size_bytes()
 
         if file_size > max_size:
@@ -3671,7 +3675,7 @@ class TelegramBackup:
                 "content_hash": content_hash,
                 "downloaded": True,
                 "download_date": utcnow_naive(),
-                **extract_media_attributes(media),
+                **extract_media_attributes(payload),
                 "file_size": file_size,
             }
 
@@ -3809,6 +3813,13 @@ class TelegramBackup:
         # The nine kinds this ladder used to flatten to None (venue, dice,
         # invoice, story, giveaways, live location, game, unsupported):
         # metadata-only types with a typed viewer chip, never downloaded.
+        if type(media).__name__ == "MessageMediaWebPage":
+            webpage = getattr(media, "webpage", None)
+            if type(webpage).__name__ == "WebPage" and (
+                getattr(webpage, "photo", None) is not None or getattr(webpage, "document", None) is not None
+            ):
+                return "webpage"
+            return None  # card-only preview (raw_data.webpage): nothing to download
         return classify_extended_media(media)
 
     def _get_media_filename(self, message: Message, media_type: str, telegram_file_id: str = None) -> str:
@@ -3820,8 +3831,9 @@ class TelegramBackup:
         original_name = None
         mime_type = None
 
-        if hasattr(message.media, "document") and message.media.document:
-            doc = message.media.document
+        media_payload = downloadable_media_payload(message.media)
+        if hasattr(media_payload, "document") and media_payload.document:
+            doc = media_payload.document
             mime_type = getattr(doc, "mime_type", None)
 
             for attr in getattr(doc, "attributes", None) or ():

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -3573,10 +3573,13 @@ class TelegramBackup:
         # keep their photo/document one level down — unwrap once so every
         # sniffer below sees the real payload.
         payload = downloadable_media_payload(media)
+        # Truthy guards, not hasattr: a WebPage carries BOTH .photo and
+        # .document (one None), so hasattr would pick the empty photo branch
+        # for document-backed previews and lose the file id.
         telegram_file_id = None
-        if hasattr(payload, "photo"):
+        if getattr(payload, "photo", None):
             telegram_file_id = str(getattr(payload.photo, "id", None))
-        elif hasattr(payload, "document"):
+        elif getattr(payload, "document", None):
             telegram_file_id = str(getattr(payload.document, "id", None))
 
         # Guard against inaccessible media producing "None" string IDs

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1369,7 +1369,7 @@
                                     <!-- Media (show if media exists, even if not yet downloaded).
                                          Extended kinds are metadata-only: the chip above is the whole
                                          rendering, so the pending-download placeholder must not show. -->
-                                    <div v-if="(msg.media?.file_path || msg.media?.type) && !getExtendedMediaChip(msg)"
+                                    <div v-if="(msg.media?.file_path || msg.media?.type) && msg.media?.type !== 'webpage' && !getExtendedMediaChip(msg)"
                                         class="mb-2 space-y-1">
                                         <!-- Placeholder for media not yet downloaded -->
                                         <div v-if="!msg.media?.file_path && msg.media?.type"
@@ -1580,6 +1580,10 @@
                                             class="text-sm font-medium hover:underline break-words block">{{ msg.raw_data.webpage.title || msg.raw_data.webpage.display_url || msg.raw_data.webpage.url }}</a>
                                         <div v-else-if="msg.raw_data.webpage.title" class="text-sm font-medium break-words">{{ msg.raw_data.webpage.title }}</div>
                                         <div v-if="msg.raw_data.webpage.description" class="text-xs opacity-70 line-clamp-3 break-words whitespace-pre-wrap">{{ msg.raw_data.webpage.description }}</div>
+                                        <img v-if="msg.media?.type === 'webpage' && msg.media?.file_path"
+                                            :src="getMediaUrl(msg)" loading="lazy" alt=""
+                                            class="mt-1 rounded max-h-48 max-w-full object-cover"
+                                            @error="handleImageError($event, msg)">
                                     </div>
 
                                     <!-- Reactions -->

--- a/tests/test_webpage_preview_photo.py
+++ b/tests/test_webpage_preview_photo.py
@@ -16,6 +16,7 @@ import shutil
 import sys
 import tempfile
 import unittest
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -185,6 +186,7 @@ class TestFilenameFallback(unittest.TestCase):
 
 class TestViewerTemplate(unittest.TestCase):
     def test_card_shows_downloaded_image_and_generic_block_excludes_webpage(self):
-        html = open(os.path.join(os.path.dirname(__file__), "..", "src", "web", "templates", "index.html")).read()
+        template = Path(__file__).resolve().parents[1] / "src" / "web" / "templates" / "index.html"
+        html = template.read_text(encoding="utf-8")
         self.assertIn("msg.media?.type === 'webpage' && msg.media?.file_path", html)
         self.assertIn("msg.media?.type !== 'webpage' && !getExtendedMediaChip(msg)", html)

--- a/tests/test_webpage_preview_photo.py
+++ b/tests/test_webpage_preview_photo.py
@@ -124,6 +124,26 @@ class TestSweepDownloadsPreviewPhoto(unittest.TestCase):
         self.assertTrue(result["file_name"].startswith("987"))
         backup._download_media_to_path.assert_awaited()
 
+    def test_document_backed_preview_keeps_its_file_id(self):
+        """A real WebPage has BOTH .photo and .document (one None): a bare
+        hasattr sniff picks the empty photo branch and loses the document id,
+        so the filename degrades to <msg>_webpage.<ext> and dedup identity dies.
+        """
+        media_root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, media_root, ignore_errors=True)
+        backup = self._make_backup(media_root)
+
+        message = MagicMock()
+        message.id = 34
+        doc = SimpleNamespace(id=555, size=3000, mime_type="image/gif", attributes=[])
+        message.media = _webpage_media(photo=None, document=doc)
+
+        result = self._run(backup._process_media(message, CHAT_ID))
+        self.assertEqual(result["type"], "webpage")
+        self.assertTrue(result["downloaded"])
+        self.assertTrue(result["file_name"].startswith("555"))
+        self.assertTrue(result["file_name"].endswith(".gif"))
+
     def test_oversized_preview_is_size_capped(self):
         media_root = tempfile.mkdtemp()
         self.addCleanup(shutil.rmtree, media_root, ignore_errors=True)
@@ -176,6 +196,36 @@ class TestListenerDownloadsPreviewPhoto(unittest.TestCase):
         _path, file_name, _hash = result
         self.assertTrue(file_name.startswith("654"))
         listener.client.download_media.assert_awaited()
+
+    def test_listener_document_backed_preview_keeps_its_file_id(self):
+        listener = TelegramListener.__new__(TelegramListener)
+        listener.db = AsyncMock()
+        listener.account_id = 1
+        listener.config = MagicMock()
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        listener.config.media_path = tmp
+        listener.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
+        listener.config.deduplicate_media = False
+        listener.client = AsyncMock()
+
+        async def fake_download(_message, path):
+            with open(path, "wb") as handle:
+                handle.write(b"previewbytes")
+            return path
+
+        listener.client.download_media = AsyncMock(side_effect=fake_download)
+
+        message = MagicMock()
+        message.id = 35
+        doc = SimpleNamespace(id=777, size=2000, mime_type="image/gif", attributes=[])
+        message.media = _webpage_media(photo=None, document=doc)
+
+        result = self._run(listener._download_media(message, CHAT_ID))
+        self.assertIsNotNone(result)
+        _path, file_name, _hash = result
+        self.assertTrue(file_name.startswith("777"))
+        self.assertTrue(file_name.endswith(".gif"))
 
 
 class TestFilenameFallback(unittest.TestCase):

--- a/tests/test_webpage_preview_photo.py
+++ b/tests/test_webpage_preview_photo.py
@@ -1,0 +1,190 @@
+"""Link-preview photos download like any photo (9t6.10.4 remainder).
+
+The mf7 card captured url/title/description at archive time, but the
+preview IMAGE was lost: ``MessageMediaWebPage`` fell out of both
+``_get_media_type`` ladders as None, so no media row existed and nothing
+downloaded. Official apps show the thumbnail; a dead link in an old archive
+kept only text. Now a webpage whose ``WebPage`` carries a photo or document
+classifies as ``webpage``, its payload is unwrapped for every size/id/
+filename sniffer (Telethon's ``download_media`` unwraps the same way), and
+the viewer's card renders the downloaded image.
+"""
+
+import asyncio
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.listener import TelegramListener
+from src.message_utils import downloadable_media_payload, fallback_media_filename
+from src.telegram_backup import TelegramBackup
+
+CHAT_ID = -1001
+
+
+def _named(class_name: str, **attrs):
+    obj = type(class_name, (), {})()
+    for key, value in attrs.items():
+        setattr(obj, key, value)
+    return obj
+
+
+def _webpage_media(photo=None, document=None, page_class="WebPage"):
+    webpage = _named(page_class, photo=photo, document=document)
+    return _named("MessageMediaWebPage", webpage=webpage)
+
+
+def _preview_photo(photo_id=987, size=4000):
+    return SimpleNamespace(id=photo_id, sizes=[SimpleNamespace(type="m", size=size)])
+
+
+class TestDownloadableMediaPayload(unittest.TestCase):
+    def test_webpage_unwraps_to_the_webpage_object(self):
+        media = _webpage_media(photo=_preview_photo())
+        self.assertIs(downloadable_media_payload(media), media.webpage)
+
+    def test_webpage_empty_passes_through(self):
+        media = _webpage_media(page_class="WebPageEmpty")
+        self.assertIs(downloadable_media_payload(media), media)
+
+    def test_other_media_and_mocks_pass_through(self):
+        photo = _named("MessageMediaPhoto", photo=_preview_photo())
+        self.assertIs(downloadable_media_payload(photo), photo)
+        mock = MagicMock()
+        self.assertIs(downloadable_media_payload(mock), mock)
+
+
+class TestWebpageMediaType(unittest.TestCase):
+    def setUp(self):
+        self.backup = TelegramBackup.__new__(TelegramBackup)
+        self.listener = TelegramListener.__new__(TelegramListener)
+
+    def test_webpage_with_photo_classifies_on_both_ladders(self):
+        media = _webpage_media(photo=_preview_photo())
+        self.assertEqual(self.backup._get_media_type(media), "webpage")
+        self.assertEqual(self.listener._get_media_type(media), "webpage")
+
+    def test_webpage_with_document_classifies(self):
+        media = _webpage_media(document=SimpleNamespace(id=5, size=100, mime_type="image/gif", attributes=[]))
+        self.assertEqual(self.backup._get_media_type(media), "webpage")
+
+    def test_card_only_previews_stay_none(self):
+        self.assertIsNone(self.backup._get_media_type(_webpage_media()))
+        self.assertIsNone(self.backup._get_media_type(_webpage_media(page_class="WebPageEmpty")))
+        self.assertIsNone(self.listener._get_media_type(_webpage_media()))
+
+
+class TestSweepDownloadsPreviewPhoto(unittest.TestCase):
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def _make_backup(self, media_root):
+        backup = TelegramBackup.__new__(TelegramBackup)
+        backup.account_id = 1
+        backup.config = MagicMock()
+        backup.config.media_path = media_root
+        backup.config.deduplicate_media = False
+        backup.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
+        backup.db = AsyncMock()
+        backup.client = AsyncMock()
+
+        async def fake_download(_message, path, _size, _chat_id):
+            with open(path, "wb") as handle:
+                handle.write(b"previewbytes")
+            return path
+
+        backup._download_media_to_path = AsyncMock(side_effect=fake_download)
+        return backup
+
+    def test_webpage_photo_flows_through_the_download_path(self):
+        media_root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, media_root, ignore_errors=True)
+        backup = self._make_backup(media_root)
+
+        message = MagicMock()
+        message.id = 31
+        message.media = _webpage_media(photo=_preview_photo(photo_id=987, size=4000))
+
+        result = self._run(backup._process_media(message, CHAT_ID))
+        self.assertEqual(result["type"], "webpage")
+        # The record keeps the ACTUAL on-disk size (#263), not Telegram's estimate.
+        self.assertEqual(result["file_size"], len(b"previewbytes"))
+        self.assertTrue(result["downloaded"])
+        self.assertTrue(result["file_name"].startswith("987"))
+        backup._download_media_to_path.assert_awaited()
+
+    def test_oversized_preview_is_size_capped(self):
+        media_root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, media_root, ignore_errors=True)
+        backup = self._make_backup(media_root)
+        backup.config.get_max_media_size_bytes = MagicMock(return_value=100)
+
+        message = MagicMock()
+        message.id = 32
+        message.media = _webpage_media(photo=_preview_photo(size=5000))
+
+        result = self._run(backup._process_media(message, CHAT_ID))
+        self.assertEqual(result["type"], "webpage")
+        self.assertNotIn("downloaded", result)
+        backup._download_media_to_path.assert_not_awaited()
+
+
+class TestListenerDownloadsPreviewPhoto(unittest.TestCase):
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def test_listener_download_path_handles_webpage(self):
+        listener = TelegramListener.__new__(TelegramListener)
+        listener.db = AsyncMock()
+        listener.account_id = 1
+        listener.config = MagicMock()
+        tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, tmp, ignore_errors=True)
+        listener.config.media_path = tmp
+        listener.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
+        listener.config.deduplicate_media = False
+        listener.client = AsyncMock()
+
+        async def fake_download(_message, path):
+            with open(path, "wb") as handle:
+                handle.write(b"previewbytes")
+            return path
+
+        listener.client.download_media = AsyncMock(side_effect=fake_download)
+
+        message = MagicMock()
+        message.id = 33
+        message.media = _webpage_media(photo=_preview_photo(photo_id=654, size=2000))
+
+        result = self._run(listener._download_media(message, CHAT_ID))
+        self.assertIsNotNone(result)
+        _path, file_name, _hash = result
+        self.assertTrue(file_name.startswith("654"))
+        listener.client.download_media.assert_awaited()
+
+
+class TestFilenameFallback(unittest.TestCase):
+    def test_webpage_defaults_to_jpg(self):
+        self.assertEqual(fallback_media_filename("987", "webpage", None), "987.jpg")
+        self.assertEqual(fallback_media_filename(None, "webpage", None, 55), "55_webpage.jpg")
+
+
+class TestViewerTemplate(unittest.TestCase):
+    def test_card_shows_downloaded_image_and_generic_block_excludes_webpage(self):
+        html = open(os.path.join(os.path.dirname(__file__), "..", "src", "web", "templates", "index.html")).read()
+        self.assertIn("msg.media?.type === 'webpage' && msg.media?.file_path", html)
+        self.assertIn("msg.media?.type !== 'webpage' && !getExtendedMediaChip(msg)", html)


### PR DESCRIPTION
## Problem

Send a link and Telegram shows a rich card — title, description, thumbnail. The archive's mf7 card captured the TEXT at archive time, but the preview image was lost forever: `MessageMediaWebPage` fell out of both `_get_media_type` ladders as `None`, so no media row was written and nothing ever downloaded. A dead link in a five-year-old archive keeps only words.

## Fix

- A webpage whose `WebPage` carries a photo or document now classifies as `webpage` (name-based, mock-inert). Card-only previews (no image, `WebPageEmpty`, pending) stay `None` — text card only, exactly as today.
- `downloadable_media_payload` unwraps `.webpage` so every existing sniffer — dedup file id, size estimate, size cap, filename, `extract_media_attributes` — works unchanged. This is the same unwrap Telethon's `download_media` performs internally, so the actual download needs zero changes.
- The pending-media drain refetches and retries webpage rows like any photo; `MAX_MEDIA_SIZE_MB` caps oversized previews with the no-`downloaded`-key contract intact.
- The viewer's preview card renders the downloaded image (`max-h-48`, lazy); the generic media block and its "Will download on next backup" placeholder never render webpage rows — the card owns them.

## Tests

11 new tests: unwrap identity (webpage / WebPageEmpty / mocks), both ladders (photo, document, card-only), the sweep download path end-to-end into a temp dir (real-size override kept), the size-cap path (no download attempted, no `downloaded` key), the listener path, the `.jpg` filename fallback, and template gating. Four mutations (each ladder arm, each unwrap, the size source) proven caught.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedded photos and documents in webpage previews can now be downloaded and archived.
  * Archived webpage previews with images display inline image previews.
  * Downloaded preview media supports filenames, file identification, size checks, and deduplication.
  * Archived messages now preserve rich-text formatting, including emphasis, code, blockquotes, spoilers, mentions, and links.
  * Spoilers can be revealed by clicking or using the keyboard.

* **Bug Fixes**
  * Text-only and card-only webpage previews remain metadata-only.
  * Improved fallback handling for webpage media filenames and extensions.
  * Edited messages now retain updated text formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->