### PR TITLE
feat(search): indexed full-text search replaces the ILIKE table scan

### DIFF
--- a/alembic/versions/20260823_028_full_text_search.py
+++ b/alembic/versions/20260823_028_full_text_search.py
@@ -1,0 +1,83 @@
+"""Full-text search: FTS5 external-content table (SQLite) / tsvector GIN (PostgreSQL).
+
+Search was ILIKE '%q%' — no index can serve a leading wildcard, so every
+search scanned the chat (or the whole archive on the global path). Official
+apps search indexed and instantly. This migration adds the index layer both
+engines need; the adapter uses it when present and keeps ILIKE where the
+migration has not run (fresh create_all() databases get the tables here on
+their first upgrade pass).
+
+Idempotence: every statement is IF NOT EXISTS, and the one non-DDL step —
+the FTS5 rebuild that indexes pre-existing rows — runs only when this pass
+actually created the table, so a re-run against an already-migrated
+database does nothing. The entrypoint stamping ladder tops out at 018 and
+relies on exactly that (see migration 027's header).
+
+Revision ID: 028
+Revises: 027
+Create Date: 2026-08-23
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+from src.db.fts import (
+    PG_ADD_COLUMN,
+    PG_CREATE_INDEX,
+    PG_TSVECTOR_COLUMN,
+    SQLITE_CREATE_FTS,
+    SQLITE_FTS_TABLE,
+    SQLITE_REBUILD,
+    SQLITE_TRIGGERS,
+)
+
+revision: str = "028"
+down_revision: str | None = "027"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name == "sqlite":
+        fts5_available = (
+            conn.exec_driver_sql("SELECT 1 FROM pragma_compile_options WHERE compile_options='ENABLE_FTS5'").first()
+            is not None
+        )
+        if not fts5_available:
+            # Exotic SQLite builds without FTS5: search stays on ILIKE (the
+            # adapter probes for the table and keeps the old path). Never
+            # fail the upgrade ladder over a search accelerator.
+            return
+        already_present = (
+            conn.exec_driver_sql(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                (SQLITE_FTS_TABLE,),
+            ).first()
+            is not None
+        )
+        conn.exec_driver_sql(SQLITE_CREATE_FTS)
+        for trigger_sql in SQLITE_TRIGGERS:
+            conn.exec_driver_sql(trigger_sql)
+        if not already_present:
+            # Index the rows that existed before this migration; new rows
+            # arrive via the triggers.
+            conn.exec_driver_sql(SQLITE_REBUILD)
+    else:
+        conn.exec_driver_sql(PG_ADD_COLUMN)
+        conn.exec_driver_sql(PG_CREATE_INDEX)
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+    if conn.dialect.name == "sqlite":
+        for trigger_name in ("messages_fts_ai", "messages_fts_ad", "messages_fts_au"):
+            conn.exec_driver_sql(f"DROP TRIGGER IF EXISTS {trigger_name}")
+        conn.exec_driver_sql(f"DROP TABLE IF EXISTS {SQLITE_FTS_TABLE}")
+    else:
+        conn.exec_driver_sql("DROP INDEX IF EXISTS idx_messages_text_search")
+        inspector = sa.inspect(conn)
+        if PG_TSVECTOR_COLUMN in {c["name"] for c in inspector.get_columns("messages")}:
+            op.drop_column("messages", PG_TSVECTOR_COLUMN)

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -46,6 +46,7 @@ from ..message_utils import (
     utcnow_naive,
 )
 from .base import DatabaseManager
+from .fts import PG_TSVECTOR_COLUMN, SQLITE_FTS_TABLE, fts_match_query, pg_tsquery
 from .models import (
     DEFAULT_ACCOUNT_ID,
     Account,
@@ -369,6 +370,8 @@ class DatabaseAdapter:
         """
         self.db_manager = db_manager
         self._is_sqlite = db_manager._is_sqlite
+        # Full-text capability, probed once on first search: None = unknown.
+        self._fts_ready_cache: bool | None = None
 
     def _serialize_raw_data(self, raw_data: Any) -> str:
         """
@@ -3203,6 +3206,50 @@ class DatabaseAdapter:
             "truncated": truncated,
         }
 
+    async def _fts_ready(self, session) -> bool:
+        """Whether migration 028's full-text layer exists in THIS database.
+
+        Probed once per adapter (databases do not gain or lose the index
+        mid-process except during the migration itself, which restarts the
+        app). A create_all() database that has not run migrations yet keeps
+        ILIKE until its first upgrade pass.
+        """
+        if self._fts_ready_cache is None:
+            if self._is_sqlite:
+                row = await session.execute(
+                    text("SELECT name FROM sqlite_master WHERE type='table' AND name=:t").bindparams(t=SQLITE_FTS_TABLE)
+                )
+            else:
+                row = await session.execute(
+                    text(
+                        "SELECT column_name FROM information_schema.columns "
+                        "WHERE table_name='messages' AND column_name=:c"
+                    ).bindparams(c=PG_TSVECTOR_COLUMN)
+                )
+            self._fts_ready_cache = row.first() is not None
+        return self._fts_ready_cache
+
+    async def _text_search_predicate(self, session, search: str):
+        """An indexed word-prefix predicate for ``search``, or None for ILIKE.
+
+        None means: no index in this database, or the search reduced to no
+        words (punctuation-only) — the caller keeps the substring ILIKE that
+        has always answered those.
+        """
+        if not await self._fts_ready(session):
+            return None
+        if self._is_sqlite:
+            match = fts_match_query(search)
+            if match is None:
+                return None
+            return text(
+                "messages.rowid IN (SELECT rowid FROM messages_fts WHERE messages_fts MATCH :fts_match)"
+            ).bindparams(fts_match=match)
+        tsq = pg_tsquery(search)
+        if tsq is None:
+            return None
+        return text("messages.text_search @@ to_tsquery('simple', :fts_tsq)").bindparams(fts_tsq=tsq)
+
     async def get_messages_paginated(
         self,
         chat_id: int,
@@ -3277,8 +3324,12 @@ class DatabaseAdapter:
                 stmt = stmt.where(func.coalesce(Message.reply_to_top_id, 1) == topic_id)
 
             if search:
-                escaped = search.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
-                stmt = stmt.where(Message.text.ilike(f"%{escaped}%", escape="\\"))
+                fts_predicate = await self._text_search_predicate(session, search)
+                if fts_predicate is not None:
+                    stmt = stmt.where(fts_predicate)
+                else:
+                    escaped = search.replace("\\", "\\\\").replace("%", r"\%").replace("_", r"\_")
+                    stmt = stmt.where(Message.text.ilike(f"%{escaped}%", escape="\\"))
 
             # Cursor-based pagination (preferred - O(1) performance)
             # Mirrored by the viewer (src/web/templates/index.html: compareMessagesDesc/messageCursor) — keep in sync.

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -46,7 +46,7 @@ from ..message_utils import (
     utcnow_naive,
 )
 from .base import DatabaseManager
-from .fts import PG_TSVECTOR_COLUMN, SQLITE_FTS_TABLE, fts_match_query, pg_tsquery
+from .fts import PG_TSQUERY_FROM_SEARCH, PG_TSVECTOR_COLUMN, SQLITE_FTS_TABLE, fts_match_query, search_has_words
 from .models import (
     DEFAULT_ACCOUNT_ID,
     Account,
@@ -3313,10 +3313,12 @@ class DatabaseAdapter:
             return text(
                 "messages.rowid IN (SELECT rowid FROM messages_fts WHERE messages_fts MATCH :fts_match)"
             ).bindparams(fts_match=match)
-        tsq = pg_tsquery(search)
-        if tsq is None:
+        if not search_has_words(search):
             return None
-        return text("messages.text_search @@ to_tsquery('simple', :fts_tsq)").bindparams(fts_tsq=tsq)
+        # The tsquery is built inside PostgreSQL from the same parser that
+        # built the index (see PG_TSQUERY_FROM_SEARCH) — the raw search
+        # string only ever travels as a bind parameter.
+        return text(f"messages.text_search @@ {PG_TSQUERY_FROM_SEARCH}").bindparams(fts_search=search)
 
     async def get_messages_paginated(
         self,

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -3283,10 +3283,15 @@ class DatabaseAdapter:
                     text("SELECT name FROM sqlite_master WHERE type='table' AND name=:t").bindparams(t=SQLITE_FTS_TABLE)
                 )
             else:
+                # to_regclass resolves 'messages' through search_path exactly
+                # like the unqualified queries below do, so the probe answers
+                # for the table they will actually hit — a same-named table in
+                # another schema can neither fake the column nor hide it.
                 row = await session.execute(
                     text(
-                        "SELECT column_name FROM information_schema.columns "
-                        "WHERE table_name='messages' AND column_name=:c"
+                        "SELECT 1 FROM pg_attribute "
+                        "WHERE attrelid = to_regclass('messages') "
+                        "AND attname = :c AND NOT attisdropped"
                     ).bindparams(c=PG_TSVECTOR_COLUMN)
                 )
             self._fts_ready_cache = row.first() is not None

--- a/src/db/fts.py
+++ b/src/db/fts.py
@@ -49,30 +49,42 @@ PG_ADD_COLUMN = (
 )
 PG_CREATE_INDEX = "CREATE INDEX IF NOT EXISTS idx_messages_text_search ON messages USING GIN (text_search)"
 
-_WORD_RE = re.compile(r"\w+", re.UNICODE)
+# NOT \w+: unicode61 treats '_' as a separator (\w keeps it), so foo_bar is
+# indexed as foo,bar and the query must split the same way.
+_WORD_RE = re.compile(r"[^\W_]+", re.UNICODE)
 
 
 def fts_match_query(search: str) -> str | None:
     """FTS5 MATCH string: every word as a quoted prefix term (``"tok"*``).
 
-    Word extraction (``\\w+``) mirrors unicode61's own alnum tokenization
-    ("covid-19" becomes the terms covid and 19 in the index, so it must
-    become two query terms too) and leaves nothing that FTS5's parser could
-    read as an operator. None when no word survives — callers fall back to
-    ILIKE for punctuation-only searches.
+    Word extraction mirrors unicode61's own tokenization ("covid-19" and
+    "foo_bar" are both two terms in the index, so each must become two
+    required query terms) and leaves nothing that FTS5's parser could read
+    as an operator. None when no word survives — callers fall back to ILIKE
+    for punctuation-only searches.
     """
     tokens = [f'"{word}"*' for word in _WORD_RE.findall(search or "")]
     return " ".join(tokens) or None
 
 
-def pg_tsquery(search: str) -> str | None:
-    """``to_tsquery('simple', ...)`` input: ``'tok':* & 'tok2':*``.
+def search_has_words(search: str) -> bool:
+    """Gate for the indexed path: does the search carry any word at all?"""
+    return _WORD_RE.search(search or "") is not None
 
-    Same word extraction as the FTS5 side so both engines agree on what a
-    query means; quoting each lexeme keeps tsquery syntax uninjectable.
-    """
-    tokens = [f"'{word}':*" for word in _WORD_RE.findall(search or "")]
-    return " & ".join(tokens) or None
+
+# PostgreSQL builds the query from ITS OWN parser's lexemes: 'simple' keeps
+# token classes \w+ cannot predict (covid-19 -> covid,'-19'; foo@bar.com is
+# ONE email lexeme), so a Python-side split produced prefixes like '19':*
+# that can never match the indexed '-19'. Aggregating quote_literal'd
+# lexemes from to_tsvector makes the query agree with the index for every
+# token class, keeps word-prefix AND semantics, and is injection-proof by
+# construction — the search string only ever travels as a bind parameter
+# into to_tsvector. (Verified against postgres:16-alpine: covid-19, email
+# and hostile-quote inputs all behave; see PR #404.)
+PG_TSQUERY_FROM_SEARCH = (
+    "(SELECT to_tsquery('simple', string_agg(quote_literal(lexeme) || ':*', ' & ')) "
+    "FROM unnest(to_tsvector('simple', :fts_search)))"
+)
 
 
 def install_fts_ddl_listener(metadata) -> None:

--- a/src/db/fts.py
+++ b/src/db/fts.py
@@ -1,0 +1,103 @@
+"""Full-text search plumbing shared by the migration, the adapter and tests.
+
+SQLite gets an external-content FTS5 table over ``messages.text`` kept in
+sync by triggers; PostgreSQL gets a STORED generated tsvector column with a
+GIN index. Both tokenize language-neutrally (``unicode61`` / ``'simple'``) —
+Telegram archives are multilingual, so stemming would help one language and
+hurt the rest. One module owns the SQL so the migration, the capability
+probe and the test fixtures can never drift apart.
+
+Query semantics on both engines: every word of the search is a required
+prefix (``hola mun`` matches a message containing ``hola`` and ``mundo``) —
+the official clients' word-prefix behavior, replacing ILIKE's substring
+scan. Input is reduced to word characters before it reaches either query
+parser, so FTS5 operators and tsquery syntax cannot be injected.
+"""
+
+import re
+
+SQLITE_FTS_TABLE = "messages_fts"
+
+SQLITE_CREATE_FTS = (
+    "CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts USING fts5("
+    "text, content='messages', content_rowid='rowid', "
+    "tokenize='unicode61 remove_diacritics 2'"
+    ")"
+)
+
+# External-content protocol: the index never stores the text itself, so
+# deletes/updates must hand FTS5 the OLD value to un-index.
+SQLITE_TRIGGERS = (
+    """CREATE TRIGGER IF NOT EXISTS messages_fts_ai AFTER INSERT ON messages BEGIN
+  INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
+END""",
+    """CREATE TRIGGER IF NOT EXISTS messages_fts_ad AFTER DELETE ON messages BEGIN
+  INSERT INTO messages_fts(messages_fts, rowid, text) VALUES ('delete', old.rowid, old.text);
+END""",
+    """CREATE TRIGGER IF NOT EXISTS messages_fts_au AFTER UPDATE OF text ON messages BEGIN
+  INSERT INTO messages_fts(messages_fts, rowid, text) VALUES ('delete', old.rowid, old.text);
+  INSERT INTO messages_fts(rowid, text) VALUES (new.rowid, new.text);
+END""",
+)
+
+SQLITE_REBUILD = "INSERT INTO messages_fts(messages_fts) VALUES ('rebuild')"
+
+PG_TSVECTOR_COLUMN = "text_search"
+PG_ADD_COLUMN = (
+    "ALTER TABLE messages ADD COLUMN IF NOT EXISTS text_search tsvector "
+    "GENERATED ALWAYS AS (to_tsvector('simple', coalesce(text, ''))) STORED"
+)
+PG_CREATE_INDEX = "CREATE INDEX IF NOT EXISTS idx_messages_text_search ON messages USING GIN (text_search)"
+
+_WORD_RE = re.compile(r"\w+", re.UNICODE)
+
+
+def fts_match_query(search: str) -> str | None:
+    """FTS5 MATCH string: every word as a quoted prefix term (``"tok"*``).
+
+    Word extraction (``\\w+``) mirrors unicode61's own alnum tokenization
+    ("covid-19" becomes the terms covid and 19 in the index, so it must
+    become two query terms too) and leaves nothing that FTS5's parser could
+    read as an operator. None when no word survives — callers fall back to
+    ILIKE for punctuation-only searches.
+    """
+    tokens = [f'"{word}"*' for word in _WORD_RE.findall(search or "")]
+    return " ".join(tokens) or None
+
+
+def pg_tsquery(search: str) -> str | None:
+    """``to_tsquery('simple', ...)`` input: ``'tok':* & 'tok2':*``.
+
+    Same word extraction as the FTS5 side so both engines agree on what a
+    query means; quoting each lexeme keeps tsquery syntax uninjectable.
+    """
+    tokens = [f"'{word}':*" for word in _WORD_RE.findall(search or "")]
+    return " & ".join(tokens) or None
+
+
+def install_fts_ddl_listener(metadata) -> None:
+    """Make ``create_all()`` produce the same FTS layer migration 028 does.
+
+    The schema has two authors — the ORM (fresh databases) and Alembic
+    (upgrades) — and the parity gate requires them to agree exactly. The
+    layer is not a model (FTS5 is a virtual table; the tsvector column is
+    generated), so the ORM side installs it here, right after its tables
+    are created. Idempotent on both engines; skipped on SQLite builds
+    without FTS5 (the adapter probes and keeps ILIKE there).
+    """
+    from sqlalchemy import event
+
+    @event.listens_for(metadata, "after_create")
+    def _create_fts_layer(target, connection, **kw):
+        if connection.dialect.name == "sqlite":
+            fts5_row = connection.exec_driver_sql(
+                "SELECT 1 FROM pragma_compile_options WHERE compile_options='ENABLE_FTS5'"
+            ).first()
+            if fts5_row is None:
+                return
+            connection.exec_driver_sql(SQLITE_CREATE_FTS)
+            for trigger_sql in SQLITE_TRIGGERS:
+                connection.exec_driver_sql(trigger_sql)
+        elif connection.dialect.name == "postgresql":
+            connection.exec_driver_sql(PG_ADD_COLUMN)
+            connection.exec_driver_sql(PG_CREATE_INDEX)

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -42,6 +42,7 @@ from sqlalchemy import (
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 from ..message_utils import utcnow_naive
+from .fts import install_fts_ddl_listener
 
 # The account every row written before v8.0.0 belongs to. Migration 022 seeds it
 # and backfills every existing row to it, and it is the server-side default of
@@ -80,6 +81,12 @@ class Base(DeclarativeBase):
     """Base class for all models."""
 
     pass
+
+
+# The full-text layer (migration 028) is part of the schema contract but not
+# a model — create_all() databases must produce it too or the ORM and Alembic
+# schema authors diverge (test_schema_parity).
+install_fts_ddl_listener(Base.metadata)
 
 
 class Account(Base):

--- a/tests/test_createall_race.py
+++ b/tests/test_createall_race.py
@@ -194,7 +194,11 @@ async def test_a_genuinely_fresh_database_is_still_built(tmp_path: Path) -> None
 
     await open_with_manager(db_path)
 
-    assert table_names(db_path) == set(Base.metadata.tables)
+    built = table_names(db_path)
+    # create_all also installs the FTS layer (after_create listener) — model
+    # tables must all exist, and the layer must too (never silently absent).
+    assert {t for t in built if not t.startswith("messages_fts")} == set(Base.metadata.tables)
+    assert "messages_fts" in built
 
 
 async def test_an_empty_file_that_already_exists_is_still_built(tmp_path: Path) -> None:
@@ -205,7 +209,11 @@ async def test_an_empty_file_that_already_exists_is_still_built(tmp_path: Path) 
 
     await open_with_manager(db_path)
 
-    assert table_names(db_path) == set(Base.metadata.tables)
+    built = table_names(db_path)
+    # create_all also installs the FTS layer (after_create listener) — model
+    # tables must all exist, and the layer must too (never silently absent).
+    assert {t for t in built if not t.startswith("messages_fts")} == set(Base.metadata.tables)
+    assert "messages_fts" in built
 
 
 async def test_removing_the_guard_puts_the_tables_back(tmp_path: Path) -> None:

--- a/tests/test_full_text_search.py
+++ b/tests/test_full_text_search.py
@@ -25,11 +25,12 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from src.db.adapter import DatabaseAdapter
 from src.db.base import DatabaseManager
 from src.db.fts import (
+    PG_TSQUERY_FROM_SEARCH,
     SQLITE_CREATE_FTS,
     SQLITE_REBUILD,
     SQLITE_TRIGGERS,
     fts_match_query,
-    pg_tsquery,
+    search_has_words,
 )
 from src.db.models import Base, Chat, Message
 
@@ -82,12 +83,20 @@ async def _make_adapter(with_fts: bool) -> DatabaseAdapter:
 
 @pytest_asyncio.fixture
 async def adapter():
-    return await _make_adapter(with_fts=True)
+    instance = await _make_adapter(with_fts=True)
+    try:
+        yield instance
+    finally:
+        await instance.db_manager.engine.dispose()
 
 
 @pytest_asyncio.fixture
 async def adapter_without_fts():
-    return await _make_adapter(with_fts=False)
+    instance = await _make_adapter(with_fts=False)
+    try:
+        yield instance
+    finally:
+        await instance.db_manager.engine.dispose()
 
 
 async def _search_ids(adapter_, query: str) -> list[int]:
@@ -113,6 +122,20 @@ async def test_word_and_prefix_matches(adapter):
 async def test_diacritics_fold(adapter):
     """remove_diacritics 2: searching 'cafe' finds 'Café'."""
     assert await _search_ids(adapter, "cafe") == [2]
+
+
+@pytest.mark.asyncio
+async def test_underscore_separates_like_the_tokenizer(adapter):
+    """unicode61 treats '_' as a separator (it is NOT \\w): 'foo_bar' is
+    indexed as foo,bar, so the query must become two required prefixes —
+    keeping it one quoted term silently narrowed the search to a phrase.
+    """
+    async with adapter.db_manager.async_session_factory() as session:
+        session.add(_msg(7, "prefix foo_bar suffix"))
+        session.add(_msg(8, "foo between bar"))
+        await session.commit()
+    assert await _search_ids(adapter, "foo_bar") == [7, 8]  # word-AND contract
+    assert await _search_ids(adapter, "foo") == [7, 8]
 
 
 @pytest.mark.asyncio
@@ -193,15 +216,42 @@ async def test_punctuation_only_search_falls_back_even_with_the_layer(adapter):
 def test_fts_match_query_shapes():
     assert fts_match_query("hola mundo") == '"hola"* "mundo"*'
     assert fts_match_query("covid-19") == '"covid"* "19"*'
+    assert fts_match_query("foo_bar") == '"foo"* "bar"*'  # '_' separates, like unicode61
     assert fts_match_query('a "b" OR (c)') == '"a"* "b"* "OR"* "c"*'
     assert fts_match_query("$$$") is None
     assert fts_match_query("") is None
 
 
-def test_pg_tsquery_shapes():
-    assert pg_tsquery("hola mundo") == "'hola':* & 'mundo':*"
-    assert pg_tsquery("covid-19") == "'covid':* & '19':*"
-    assert pg_tsquery("!!!") is None
+def test_search_word_gate():
+    assert search_has_words("hola") is True
+    assert search_has_words("covid-19") is True
+    assert search_has_words("___") is False  # underscores alone are not words
+    assert search_has_words("!!!") is False
+    assert search_has_words("") is False
+
+
+@pytest.mark.asyncio
+async def test_pg_predicate_delegates_tokenization_to_the_index_parser():
+    """The PG tsquery is built IN SQL from the index's own lexemes ('simple'
+    keeps token classes a Python split cannot predict: covid-19 indexes as
+    covid,'-19'; foo@bar.com is one email lexeme). The raw search string
+    must travel only as a bind parameter. Behavior was proven against
+    postgres:16-alpine; this locks the wiring.
+    """
+    adapter_ = await _make_adapter(with_fts=True)
+    adapter_.db_manager._is_sqlite = False
+    adapter_._is_sqlite = False
+    adapter_._fts_ready_cache = True
+    async with adapter_.db_manager.async_session_factory() as session:
+        predicate = await adapter_._text_search_predicate(session, "covid-19")
+        assert predicate is not None
+        compiled = str(predicate)
+        assert "to_tsvector('simple', :fts_search)" in compiled
+        assert "quote_literal(lexeme)" in compiled
+        assert predicate.compile().params["fts_search"] == "covid-19"
+        assert await adapter_._text_search_predicate(session, "___") is None
+    assert "to_tsvector('simple', :fts_search)" in PG_TSQUERY_FROM_SEARCH
+    await adapter_.db_manager.engine.dispose()
 
 
 @pytest.mark.asyncio

--- a/tests/test_full_text_search.py
+++ b/tests/test_full_text_search.py
@@ -1,0 +1,225 @@
+"""Full-text search replaces the leading-wildcard ILIKE scan (9t6.11.1).
+
+ILIKE '%q%' cannot use any index, so every search scanned the chat. With
+migration 028 SQLite gets an external-content FTS5 table synced by triggers
+and PostgreSQL a generated tsvector + GIN; the adapter probes for the layer
+once and swaps ONLY the text predicate — pagination, scoping and topic
+filters are untouched, and databases without the layer (or punctuation-only
+searches that tokenize to nothing) keep the old ILIKE substring behavior.
+Semantics on the indexed path are official-app word-prefix AND: every word
+of the query must prefix-match a word of the message.
+"""
+
+import os
+import sys
+from datetime import datetime
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text as sa_text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.fts import (
+    SQLITE_CREATE_FTS,
+    SQLITE_REBUILD,
+    SQLITE_TRIGGERS,
+    fts_match_query,
+    pg_tsquery,
+)
+from src.db.models import Base, Chat, Message
+
+CHAT_ID = -1001
+
+
+def _msg(msg_id: int, msg_text: str) -> Message:
+    return Message(
+        id=msg_id,
+        chat_id=CHAT_ID,
+        sender_id=None,
+        date=datetime(2026, 1, 1, 10, 0, msg_id % 60),
+        text=msg_text,
+        account_id=1,
+    )
+
+
+async def _make_adapter(with_fts: bool) -> DatabaseAdapter:
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        # create_all installs the FTS layer via the models' after_create
+        # listener — the same DDL migration 028 runs on upgraded databases.
+        await conn.run_sync(Base.metadata.create_all)
+        if not with_fts:
+            # A database whose migration has not run yet (e.g. an exotic
+            # SQLite without FTS5): strip the layer to prove the fallback.
+            for trigger_name in ("messages_fts_ai", "messages_fts_ad", "messages_fts_au"):
+                await conn.exec_driver_sql(f"DROP TRIGGER IF EXISTS {trigger_name}")
+            await conn.exec_driver_sql("DROP TABLE IF EXISTS messages_fts")
+
+    db_manager = DatabaseManager.__new__(DatabaseManager)
+    db_manager.engine = engine
+    db_manager.database_url = "sqlite+aiosqlite://"
+    db_manager._is_sqlite = True
+    db_manager.async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with db_manager.async_session_factory() as session:
+        session.add(Chat(id=CHAT_ID, type="channel", title="Chat A"))
+        session.add(_msg(1, "hola mundo cruel"))
+        session.add(_msg(2, "Café con leche"))
+        session.add(_msg(3, "unrelated content entirely"))
+        await session.commit()
+
+    return DatabaseAdapter(db_manager)
+
+
+@pytest_asyncio.fixture
+async def adapter():
+    return await _make_adapter(with_fts=True)
+
+
+@pytest_asyncio.fixture
+async def adapter_without_fts():
+    return await _make_adapter(with_fts=False)
+
+
+async def _search_ids(adapter_, query: str) -> list[int]:
+    rows = await adapter_.get_messages_paginated(CHAT_ID, limit=50, search=query, account_id=1)
+    return sorted(m["id"] for m in rows)
+
+
+# ---------------------------------------------------------------------------
+# Indexed path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_word_and_prefix_matches(adapter):
+    assert await _search_ids(adapter, "mundo") == [1]
+    assert await _search_ids(adapter, "mun") == [1]  # word prefix
+    assert await _search_ids(adapter, "HOLA") == [1]  # case-insensitive
+    assert await _search_ids(adapter, "hola cruel") == [1]  # all words required
+    assert await _search_ids(adapter, "hola unrelated") == []
+
+
+@pytest.mark.asyncio
+async def test_diacritics_fold(adapter):
+    """remove_diacritics 2: searching 'cafe' finds 'Café'."""
+    assert await _search_ids(adapter, "cafe") == [2]
+
+
+@pytest.mark.asyncio
+async def test_prefix_not_substring(adapter):
+    """The indexed path is word-PREFIX, not substring — the official-app trade.
+
+    'undo' is inside 'mundo' but no word starts with it; ILIKE used to match.
+    This is deliberate (the bead's goal is official-client search semantics).
+    """
+    assert await _search_ids(adapter, "undo") == []
+
+
+@pytest.mark.asyncio
+async def test_edits_and_deletes_stay_in_sync(adapter):
+    async with adapter.db_manager.async_session_factory() as session:
+        await session.execute(sa_text("UPDATE messages SET text = 'texto nuevo' WHERE id = 1"))
+        await session.execute(sa_text("DELETE FROM messages WHERE id = 3"))
+        await session.commit()
+    assert await _search_ids(adapter, "hola") == []  # old text un-indexed
+    assert await _search_ids(adapter, "nuevo") == [1]  # new text indexed
+    assert await _search_ids(adapter, "unrelated") == []  # deleted row gone
+
+
+@pytest.mark.asyncio
+async def test_operator_injection_is_inert(adapter):
+    """FTS5 syntax in user input must neither crash nor widen the match."""
+    for hostile in ('mundo" OR "cruel', "mundo OR unrelated", 'x" NEAR y --', "(((", "*"):
+        rows = await adapter.get_messages_paginated(CHAT_ID, limit=50, search=hostile, account_id=1)
+        assert isinstance(rows, list)
+    # OR is a quoted term, not an operator: message must contain a word
+    # starting with "or" — none does.
+    assert await _search_ids(adapter, "mundo OR unrelated") == []
+
+
+@pytest.mark.asyncio
+async def test_query_plan_uses_the_index(adapter):
+    """A check that cannot fail is not a check: the plan must NAME messages_fts."""
+    async with adapter.db_manager.async_session_factory() as session:
+        fts_predicate = await adapter._text_search_predicate(session, "mundo")
+        assert fts_predicate is not None
+        compiled = str(fts_predicate)
+        assert "messages_fts" in compiled and "MATCH" in compiled
+        plan = await session.execute(
+            sa_text(
+                "EXPLAIN QUERY PLAN SELECT id FROM messages WHERE "
+                "messages.rowid IN (SELECT rowid FROM messages_fts WHERE messages_fts MATCH :q)"
+            ).bindparams(q='"mundo"*')
+        )
+        plan_text = " ".join(str(row) for row in plan.fetchall())
+        assert "messages_fts" in plan_text
+
+
+# ---------------------------------------------------------------------------
+# Fallback paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_without_the_layer_search_keeps_substring_semantics(adapter_without_fts):
+    assert await _search_ids(adapter_without_fts, "undo") == [1]  # ILIKE substring
+    assert await _search_ids(adapter_without_fts, "HOLA") == [1]
+    assert adapter_without_fts._fts_ready_cache is False
+
+
+@pytest.mark.asyncio
+async def test_punctuation_only_search_falls_back_even_with_the_layer(adapter):
+    async with adapter.db_manager.async_session_factory() as session:
+        session.add(_msg(9, "signs +++ only"))
+        await session.commit()
+    assert await _search_ids(adapter, "+++") == [9]  # ILIKE literal match
+
+
+# ---------------------------------------------------------------------------
+# Query builders + migration idempotence
+# ---------------------------------------------------------------------------
+
+
+def test_fts_match_query_shapes():
+    assert fts_match_query("hola mundo") == '"hola"* "mundo"*'
+    assert fts_match_query("covid-19") == '"covid"* "19"*'
+    assert fts_match_query('a "b" OR (c)') == '"a"* "b"* "OR"* "c"*'
+    assert fts_match_query("$$$") is None
+    assert fts_match_query("") is None
+
+
+def test_pg_tsquery_shapes():
+    assert pg_tsquery("hola mundo") == "'hola':* & 'mundo':*"
+    assert pg_tsquery("covid-19") == "'covid':* & '19':*"
+    assert pg_tsquery("!!!") is None
+
+
+@pytest.mark.asyncio
+async def test_create_sequence_is_idempotent():
+    """Running migration 028's SQLite sequence twice must be a no-op."""
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+        for _ in range(2):
+            await conn.exec_driver_sql(SQLITE_CREATE_FTS)
+            for trigger_sql in SQLITE_TRIGGERS:
+                await conn.exec_driver_sql(trigger_sql)
+        await conn.exec_driver_sql(SQLITE_REBUILD)
+        triggers = await conn.exec_driver_sql(
+            "SELECT count(*) FROM sqlite_master WHERE type='trigger' AND name LIKE 'messages_fts_%'"
+        )
+        assert triggers.first()[0] == 3

--- a/tests/test_general_topic_messages.py
+++ b/tests/test_general_topic_messages.py
@@ -110,10 +110,16 @@ async def test_topic_zero_returns_empty(forum_adapter):
 async def test_topic_filter_combined_with_search(forum_adapter):
     """topic_id and search filters must both apply — only matching messages returned."""
     adapter, chat_id = forum_adapter
-    # Search within General topic (id=1) — only "pre-forum general #1" matches
-    messages = await adapter.get_messages_paginated(chat_id=chat_id, topic_id=1, search="general #1")
+    # Indexed search is word-prefix AND (official-app semantics since 028):
+    # "general #1" also matches "(explicit 1)", so discriminate with a word
+    # only message 1 carries. Both filters must still apply together.
+    messages = await adapter.get_messages_paginated(chat_id=chat_id, topic_id=1, search="pre-forum general #1")
     ids = sorted(m["id"] for m in messages)
     assert ids == [1]
+    # And the prefix semantics themselves: "1" prefix-matches the "1" token
+    # of message 6 inside the same topic.
+    messages = await adapter.get_messages_paginated(chat_id=chat_id, topic_id=1, search="general #1")
+    assert sorted(m["id"] for m in messages) == [1, 6]
 
     # Search term exists in topic-47 but not in General
     messages = await adapter.get_messages_paginated(chat_id=chat_id, topic_id=1, search="topic-47")


### PR DESCRIPTION
## Problem

Search is `ILIKE '%q%'` — a leading wildcard no index can serve, so every search scans every message row of the chat. Official apps search indexed and return instantly; a 60k-message chat here pays a full table walk per keystroke-submitted search.

## Fix

**Index layer** (shared SQL in `src/db/fts.py` so no copy can drift):
- SQLite: an external-content **FTS5** table over `messages.text` (`unicode61`, diacritics folded — searching `cafe` finds `Café`), kept in sync by three triggers. Builds without FTS5 are detected and skipped — search simply stays on ILIKE there.
- PostgreSQL: a STORED generated **tsvector** column ('simple' config — Telegram archives are multilingual, stemming would privilege one language) with a GIN index.

**Two schema authors, one schema**: upgraded databases get the layer from idempotent migration 028 (FTS rebuild runs only when the table is first created); fresh `create_all()` databases get the identical DDL from an `after_create` listener on the metadata. The schema-parity gate stays strict with its allowlist empty, and the create_all race test now pins the layer's presence.

**Adapter**: probes for the layer once per process and swaps ONLY the text predicate inside `get_messages_paginated` — entitlement scoping, topic filters, and cursor pagination are untouched. No index, or a punctuation-only query that tokenizes to nothing → the existing ILIKE substring path answers, unchanged.

**Semantics**: the indexed path is word-prefix AND (`hola mun` requires a word starting `hola` and one starting `mun`) — official-client behavior, replacing accidental substring hits (`undo` no longer matches `mundo`). User input is reduced to word characters before touching either query parser, so FTS5 operators and tsquery syntax cannot be injected. Tag search deliberately stays on ILIKE: both tokenizers strip the `#`/`$` sigil the tag view discriminates on.

## Evidence

- Real `alembic upgrade head` on a scratch DB: 027→028 ran, table + 3 triggers created, stamped; live insert/edit/delete each proven against the index; second upgrade a no-op.
- 11 new tests: prefix/case/diacritics/AND matching, trigger sync under raw UPDATE/DELETE, operator-injection inertness, EXPLAIN naming `messages_fts`, both fallbacks, builder shapes, DDL idempotence.
- Four mutations (predicate disabled, sanitizer passthrough, update-trigger dropped, probe forced true) each proven to fail a test.
- Full suite 3696 green; lint run exactly as CI runs it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added full-text message search with word-prefix and AND matching.
  - Improved search performance across SQLite and PostgreSQL.
  - Searches now support case- and diacritic-insensitive matching where available.
  - Search indexes stay synchronized when messages are added, edited, or deleted.

- **Bug Fixes**
  - Added safe substring-search fallback when full-text search is unavailable.
  - Improved handling of punctuation-only searches and combined topic/search filters.
  - Strengthened protection against unsafe search input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->