### PR TITLE
feat(import): stop paying twice for HTML-imported archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,9 +719,24 @@ docker compose exec -it telegram-backup python -m src auth
 # Import a Telegram Desktop export (JSON or HTML) into the archive
 docker compose exec telegram-backup python -m src import -p /data/export
 
+# Give imported forum messages their topics back (see note below)
+docker compose exec telegram-backup python -m src backfill-topics -c -1001234567890
+
 # Detect and fill message gaps left by failed backups
 docker compose exec telegram-backup python -m src fill-gaps
 ```
+
+> **Imported forum chats and topics.** Telegram Desktop exports (HTML *and*
+> JSON) carry no forum-topic metadata, so imported forum messages all land in
+> the General topic. Once the same account also has API access to the chat,
+> `backfill-topics` resets that chat's sync cursor and re-sweeps it text-only
+> (media downloads, deletion/edit sync and media verification are disabled
+> for the pass) — the sweep's upsert fills in `reply_to_top_id` without
+> touching anything else.
+>
+> **Imported media is adopted, not re-downloaded.** When a normal API backup
+> later reaches a message whose file arrived via import, the archive re-keys
+> the imported record to the sweep's name and reuses the on-disk file.
 
 ## Data Storage
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -355,7 +355,13 @@ def run_backfill_topics(args) -> int:
         finally:
             await db.close()
 
-    if asyncio.run(_reset_cursor()) == 0:
+    try:
+        known_chat_rows = asyncio.run(_reset_cursor())
+    except Exception as e:
+        print(f"Topic backfill failed: {e}", file=sys.stderr)
+        return 1
+
+    if known_chat_rows == 0:
         print("That chat is not in the archive yet — import or back it up first.")
         return 1
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -164,6 +164,19 @@ For more information, visit: https://github.com/GeiserX/Telegram-Archive
         help="Minimum gap size to investigate (overrides GAP_THRESHOLD env var)",
     )
 
+    backfill_parser = subparsers.add_parser(
+        "backfill-topics",
+        help="Re-sweep one chat so imported forum messages regain their topic",
+        description=(
+            "Telegram Desktop HTML exports carry no forum-topic metadata, so "
+            "imported forum messages land in the General topic. This resets the "
+            "chat's sync cursor and runs a text-only resweep (media downloads, "
+            "deletion/edit sync and media verification all disabled) scoped to "
+            "that chat — the upsert refreshes reply_to_top_id in place."
+        ),
+    )
+    backfill_parser.add_argument("-c", "--chat-id", type=int, required=True, help="Chat ID to backfill")
+
     return parser
 
 
@@ -322,6 +335,35 @@ def run_schedule(args) -> int:
     return asyncio.run(scheduler_main())
 
 
+def run_backfill_topics(args) -> int:
+    """Reset one chat's cursor and resweep it text-only (topic backfill)."""
+    # The documented recovery procedure for imported forum chats, minus its
+    # footguns: DOWNLOAD_MEDIA off (nothing to fetch, the files are local),
+    # SYNC_DELETIONS_EDITS off (a full-history pass must never mass-delete),
+    # VERIFY_MEDIA off, scope pinned to the one chat.
+    os.environ["DOWNLOAD_MEDIA"] = "false"
+    os.environ["SYNC_DELETIONS_EDITS"] = "false"
+    os.environ["VERIFY_MEDIA"] = "false"
+    os.environ["CHAT_IDS"] = str(args.chat_id)
+
+    from .db import create_adapter
+
+    async def _reset_cursor() -> int:
+        db = await create_adapter()
+        try:
+            return await db.reset_chat_sync_cursor(args.chat_id)
+        finally:
+            await db.close()
+
+    if asyncio.run(_reset_cursor()) == 0:
+        print("That chat is not in the archive yet — import or back it up first.")
+        return 1
+
+    from .telegram_backup import main as backup_main
+
+    return backup_main()
+
+
 def main() -> int:
     """Main entry point."""
     parser = create_parser()
@@ -352,6 +394,8 @@ def main() -> int:
         return run_auth(args)
     elif args.command == "backup":
         return run_backup(args)
+    elif args.command == "backfill-topics":
+        return run_backfill_topics(args)
     elif args.command == "schedule":
         return run_schedule(args)
     elif args.command == "export":

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -2392,6 +2392,80 @@ class DatabaseAdapter:
             if len(rows) < batch_size:
                 return
 
+    async def reset_chat_sync_cursor(self, chat_id: int) -> int:
+        """Zero every account's sync cursor for one chat; rows changed.
+
+        The backfill-topics resweep needs the next backup pass to walk the
+        chat from the beginning so its upserts can refresh reply_to_top_id
+        on rows an HTML import created without topic metadata. All accounts
+        on purpose: the backfill is per-chat, and any account archiving the
+        chat wants the same refresh.
+        """
+        async with self.db_manager.async_session_factory() as session:
+            result = await session.execute(update(Chat).where(Chat.id == chat_id).values(last_synced_message_id=0))
+            await session.commit()
+            return result.rowcount or 0
+
+    async def adopt_import_media(
+        self, chat_id: int, message_id: int, new_media_id: str, *, account_id: int
+    ) -> dict[str, Any] | None:
+        """Re-key an HTML/JSON-import media row to the sweep's name and return it.
+
+        Telegram Desktop imports store media as ``import_{chat}_{msg}`` with
+        the file already on disk. When the API sweep later reaches the same
+        message it would re-download those bytes under its own id — a
+        duplicate row AND a duplicate download. Re-keying converges the
+        sweep's upsert onto the existing row (and file) from then on.
+
+        None when there is no downloaded import row. When the sweep name
+        already exists (an earlier sweep archived its own copy), nothing is
+        touched — this path adopts records, it never deletes data.
+        """
+        import_media_id = f"import_{chat_id}_{message_id}"
+        async with self.db_manager.async_session_factory() as session:
+            existing_sweep_row = (
+                await session.execute(
+                    select(Media.id).where(and_(Media.account_id == account_id, Media.id == new_media_id))
+                )
+            ).first()
+            if existing_sweep_row is not None:
+                return None
+            row = (
+                await session.execute(
+                    select(Media).where(
+                        and_(
+                            Media.account_id == account_id,
+                            Media.id == import_media_id,
+                            Media.downloaded == 1,
+                        )
+                    )
+                )
+            ).scalar_one_or_none()
+            if row is None:
+                return None
+            await session.execute(
+                update(Media)
+                .where(and_(Media.account_id == account_id, Media.id == import_media_id))
+                .values(id=new_media_id)
+            )
+            await session.commit()
+            return {
+                "id": new_media_id,
+                "type": row.type,
+                "message_id": row.message_id,
+                "chat_id": row.chat_id,
+                "file_name": row.file_name,
+                "file_path": row.file_path,
+                "file_size": row.file_size,
+                "mime_type": row.mime_type,
+                "width": row.width,
+                "height": row.height,
+                "duration": row.duration,
+                "content_hash": row.content_hash,
+                "downloaded": True,
+                "download_date": row.download_date,
+            }
+
     async def get_pending_media_downloads(
         self,
         max_media_size_bytes: int | None = None,

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -2396,15 +2396,23 @@ class DatabaseAdapter:
                 return
 
     async def reset_chat_sync_cursor(self, chat_id: int) -> int:
-        """Zero every account's sync cursor for one chat; rows changed.
+        """Zero every account's sync cursor for one chat; chat rows changed.
 
         The backfill-topics resweep needs the next backup pass to walk the
         chat from the beginning so its upserts can refresh reply_to_top_id
         on rows an HTML import created without topic metadata. All accounts
         on purpose: the backfill is per-chat, and any account archiving the
         chat wants the same refresh.
+
+        BOTH cursors must reset: the sweep's min_id comes from
+        sync_status.last_message_id (get_last_message_id), while
+        chats.last_synced_message_id mirrors it for display — zeroing only
+        the chat column leaves the resweep resuming where it left off. The
+        return value counts CHAT rows, so an archived chat whose sync_status
+        row does not exist yet (import-only history) still reads as known.
         """
         async with self.db_manager.async_session_factory() as session:
+            await session.execute(update(SyncStatus).where(SyncStatus.chat_id == chat_id).values(last_message_id=0))
             result = await session.execute(update(Chat).where(Chat.id == chat_id).values(last_synced_message_id=0))
             await session.commit()
             return result.rowcount or 0

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -3568,6 +3568,14 @@ class TelegramBackup:
                 "downloaded": False,
             }
 
+        # Adopt HTML/JSON-import media: the same (chat, message) may already
+        # carry its file from a Telegram Desktop export. Re-keying that row to
+        # this sweep name reuses the on-disk file instead of re-downloading it
+        # (rebuild-without-redownload for import-built archives).
+        adopted = await self.db.adopt_import_media(chat_id, message.id, media_id, account_id=self.account_id)
+        if adopted is not None:
+            return adopted
+
         # Get Telegram's file unique ID for deduplication
         telegram_file_id = None
         if hasattr(media, "photo"):

--- a/tests/test_import_adoption.py
+++ b/tests/test_import_adoption.py
@@ -12,6 +12,8 @@ text-only (downloads off, deletion sync off) to refresh reply_to_top_id.
 """
 
 import asyncio
+import contextlib
+import io
 import os
 import shutil
 import sys
@@ -34,7 +36,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from src.__main__ import run_backfill_topics
 from src.db.adapter import DatabaseAdapter
 from src.db.base import DatabaseManager
-from src.db.models import Base, Chat, Media
+from src.db.models import Base, Chat, Media, SyncStatus
 from src.telegram_backup import TelegramBackup
 
 CHAT_ID = -1001
@@ -83,6 +85,10 @@ async def _make_adapter() -> DatabaseAdapter:
         session.add(Chat(account_id=1, id=CHAT_ID, type="channel", title="A", last_synced_message_id=500))
         session.add(Chat(account_id=2, id=CHAT_ID, type="channel", title="A", last_synced_message_id=700))
         session.add(Chat(account_id=1, id=OTHER_CHAT_ID, type="channel", title="B", last_synced_message_id=900))
+        # The cursor the sweep ACTUALLY reads (get_last_message_id -> min_id)
+        # lives in sync_status; account 2 deliberately has no row.
+        session.add(SyncStatus(account_id=1, chat_id=CHAT_ID, last_message_id=500))
+        session.add(SyncStatus(account_id=1, chat_id=OTHER_CHAT_ID, last_message_id=900))
         await session.commit()
 
     return DatabaseAdapter(db_manager)
@@ -178,6 +184,18 @@ async def test_reset_cursor_zeroes_every_account_for_that_chat_only(adapter):
     assert cursors[(1, CHAT_ID)] == 0
     assert cursors[(2, CHAT_ID)] == 0
     assert cursors[(1, OTHER_CHAT_ID)] == 900  # untouched
+
+
+@pytest.mark.asyncio
+async def test_reset_cursor_zeroes_the_cursor_the_sweep_reads(adapter):
+    """_backup_dialog takes min_id from sync_status.last_message_id, NOT from
+    chats.last_synced_message_id — zeroing only the chat column makes the
+    resweep resume where it left off and backfill-topics silently no-op.
+    """
+    assert await adapter.reset_chat_sync_cursor(CHAT_ID) == 2
+    assert await adapter.get_last_message_id(CHAT_ID, account_id=1) == 0
+    # The untargeted chat's sweep cursor stays put.
+    assert await adapter.get_last_message_id(OTHER_CHAT_ID, account_id=1) == 900
 
 
 @pytest.mark.asyncio
@@ -279,6 +297,26 @@ class TestBackfillTopicsCommand(unittest.TestCase):
         self.assertEqual(result, 1)
         backup_main.assert_not_called()
         adapter_mock.close.assert_awaited()
+
+    def test_reset_failure_exits_1_without_a_traceback(self):
+        """Sibling commands print 'X failed: e' and return 1 — so does this."""
+
+        async def broken_create_adapter(database_url=None):
+            raise RuntimeError("db is sideways")
+
+        backup_main = MagicMock(return_value=0)
+        stderr = io.StringIO()
+        with (
+            mock.patch.dict(os.environ, {}, clear=False),
+            mock.patch("src.db.create_adapter", new=broken_create_adapter),
+            mock.patch("src.telegram_backup.main", new=backup_main),
+            contextlib.redirect_stderr(stderr),
+        ):
+            result = run_backfill_topics(SimpleNamespace(chat_id=CHAT_ID))
+
+        self.assertEqual(result, 1)
+        backup_main.assert_not_called()
+        self.assertIn("Topic backfill failed: db is sideways", stderr.getvalue())
 
     def test_known_chat_resweeps_with_pinned_env(self):
         adapter_mock, fake_create = self._adapter_returning(2)

--- a/tests/test_import_adoption.py
+++ b/tests/test_import_adoption.py
@@ -1,0 +1,308 @@
+"""HTML-import media adoption + topic backfill (9t6.14).
+
+A Telegram Desktop import stores media rows as ``import_{chat}_{msg}`` with
+the files already on disk. When the API sweep later reaches the same message
+it built its own id, re-downloaded the bytes, and left a duplicate row and a
+duplicate file. Adoption re-keys the import row to the sweep's id the moment
+the sweep meets it, so the upsert converges on the existing record and file.
+
+``backfill-topics`` is the companion CLI: imports carry no forum-topic
+metadata, so the command zeroes the chat's sync cursor and resweeps it
+text-only (downloads off, deletion sync off) to refresh reply_to_top_id.
+"""
+
+import asyncio
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from datetime import datetime
+from types import SimpleNamespace
+from unittest import mock
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+from telethon.tl.types import MessageMediaPhoto
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.__main__ import run_backfill_topics
+from src.db.adapter import DatabaseAdapter
+from src.db.base import DatabaseManager
+from src.db.models import Base, Chat, Media
+from src.telegram_backup import TelegramBackup
+
+CHAT_ID = -1001
+OTHER_CHAT_ID = -1002
+MSG_ID = 77
+IMPORT_ID = f"import_{CHAT_ID}_{MSG_ID}"
+SWEEP_ID = f"{CHAT_ID}_{MSG_ID}_photo"
+
+
+def _import_row(account_id: int = 1, downloaded: int = 1, media_id: str = IMPORT_ID) -> Media:
+    return Media(
+        account_id=account_id,
+        id=media_id,
+        message_id=MSG_ID,
+        chat_id=CHAT_ID,
+        type="photo",
+        file_name="photo_1.jpg",
+        file_path=f"/data/media/{CHAT_ID}/photo_1.jpg",
+        file_size=123,
+        mime_type="image/jpeg",
+        width=10,
+        height=20,
+        duration=None,
+        content_hash="ab" * 32,
+        downloaded=downloaded,
+        download_date=datetime(2026, 8, 1, 12, 0, 0),
+    )
+
+
+async def _make_adapter() -> DatabaseAdapter:
+    engine = create_async_engine(
+        "sqlite+aiosqlite://",
+        poolclass=StaticPool,
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    db_manager = DatabaseManager.__new__(DatabaseManager)
+    db_manager.engine = engine
+    db_manager.database_url = "sqlite+aiosqlite://"
+    db_manager._is_sqlite = True
+    db_manager.async_session_factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    async with db_manager.async_session_factory() as session:
+        session.add(Chat(account_id=1, id=CHAT_ID, type="channel", title="A", last_synced_message_id=500))
+        session.add(Chat(account_id=2, id=CHAT_ID, type="channel", title="A", last_synced_message_id=700))
+        session.add(Chat(account_id=1, id=OTHER_CHAT_ID, type="channel", title="B", last_synced_message_id=900))
+        await session.commit()
+
+    return DatabaseAdapter(db_manager)
+
+
+@pytest_asyncio.fixture
+async def adapter():
+    return await _make_adapter()
+
+
+async def _media_ids(adapter_, account_id: int = 1) -> set[str]:
+    async with adapter_.db_manager.async_session_factory() as session:
+        rows = await session.execute(select(Media.id).where(Media.account_id == account_id))
+        return {row[0] for row in rows}
+
+
+# ---------------------------------------------------------------------------
+# Adapter: adopt_import_media
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_adopts_downloaded_import_row(adapter):
+    async with adapter.db_manager.async_session_factory() as session:
+        session.add(_import_row())
+        await session.commit()
+
+    record = await adapter.adopt_import_media(CHAT_ID, MSG_ID, SWEEP_ID, account_id=1)
+
+    assert record is not None
+    assert record["id"] == SWEEP_ID
+    assert record["downloaded"] is True
+    assert record["file_path"] == f"/data/media/{CHAT_ID}/photo_1.jpg"
+    assert record["file_name"] == "photo_1.jpg"
+    assert record["type"] == "photo"
+    assert record["message_id"] == MSG_ID
+    assert record["chat_id"] == CHAT_ID
+    assert record["content_hash"] == "ab" * 32
+    # The row was RE-KEYED, not copied: sweep id exists, import id is gone.
+    assert await _media_ids(adapter) == {SWEEP_ID}
+
+
+@pytest.mark.asyncio
+async def test_existing_sweep_row_is_never_touched(adapter):
+    """An earlier sweep already archived its own copy: adopt nothing."""
+    async with adapter.db_manager.async_session_factory() as session:
+        session.add(_import_row())
+        session.add(_import_row(media_id=SWEEP_ID, downloaded=0))
+        await session.commit()
+
+    assert await adapter.adopt_import_media(CHAT_ID, MSG_ID, SWEEP_ID, account_id=1) is None
+    assert await _media_ids(adapter) == {IMPORT_ID, SWEEP_ID}
+
+
+@pytest.mark.asyncio
+async def test_undownloaded_import_row_is_ignored(adapter):
+    """Adoption exists to reuse bytes on disk; a fileless row has none."""
+    async with adapter.db_manager.async_session_factory() as session:
+        session.add(_import_row(downloaded=0))
+        await session.commit()
+
+    assert await adapter.adopt_import_media(CHAT_ID, MSG_ID, SWEEP_ID, account_id=1) is None
+    assert await _media_ids(adapter) == {IMPORT_ID}
+
+
+@pytest.mark.asyncio
+async def test_no_import_row_returns_none(adapter):
+    assert await adapter.adopt_import_media(CHAT_ID, MSG_ID, SWEEP_ID, account_id=1) is None
+
+
+@pytest.mark.asyncio
+async def test_adoption_is_account_scoped(adapter):
+    async with adapter.db_manager.async_session_factory() as session:
+        session.add(_import_row(account_id=1))
+        await session.commit()
+
+    assert await adapter.adopt_import_media(CHAT_ID, MSG_ID, SWEEP_ID, account_id=2) is None
+    assert await _media_ids(adapter, account_id=1) == {IMPORT_ID}
+
+
+# ---------------------------------------------------------------------------
+# Adapter: reset_chat_sync_cursor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reset_cursor_zeroes_every_account_for_that_chat_only(adapter):
+    assert await adapter.reset_chat_sync_cursor(CHAT_ID) == 2
+
+    async with adapter.db_manager.async_session_factory() as session:
+        rows = await session.execute(select(Chat.account_id, Chat.id, Chat.last_synced_message_id))
+        cursors = {(acc, chat): cursor for acc, chat, cursor in rows}
+    assert cursors[(1, CHAT_ID)] == 0
+    assert cursors[(2, CHAT_ID)] == 0
+    assert cursors[(1, OTHER_CHAT_ID)] == 900  # untouched
+
+
+@pytest.mark.asyncio
+async def test_reset_cursor_unknown_chat_returns_zero(adapter):
+    assert await adapter.reset_chat_sync_cursor(-999999) == 0
+
+
+# ---------------------------------------------------------------------------
+# Sweep hook in _process_media
+# ---------------------------------------------------------------------------
+
+
+class TestSweepAdoptionHook(unittest.TestCase):
+    def _run(self, coro):
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
+    def _make_backup(self, media_root):
+        backup = TelegramBackup.__new__(TelegramBackup)
+        backup.account_id = 1
+        backup.config = MagicMock()
+        backup.config.media_path = media_root
+        backup.config.deduplicate_media = False
+        backup.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
+        backup.db = AsyncMock()
+        backup.client = AsyncMock()
+
+        async def fake_download(_message, path, _size, _chat_id):
+            with open(path, "wb") as handle:
+                handle.write(b"mediabytes")
+            return path
+
+        backup._download_media_to_path = AsyncMock(side_effect=fake_download)
+        return backup
+
+    def _photo_message(self):
+        message = MagicMock()
+        message.id = MSG_ID
+        media = object.__new__(MessageMediaPhoto)
+        media.photo = SimpleNamespace(id=42, sizes=[SimpleNamespace(type="m", size=1000)])
+        message.media = media
+        return message
+
+    def test_adopted_record_short_circuits_the_download(self):
+        media_root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, media_root, ignore_errors=True)
+        backup = self._make_backup(media_root)
+        adopted = {"id": SWEEP_ID, "type": "photo", "downloaded": True, "file_path": "/x/photo_1.jpg"}
+        backup.db.adopt_import_media = AsyncMock(return_value=adopted)
+
+        result = self._run(backup._process_media(self._photo_message(), CHAT_ID))
+
+        self.assertIs(result, adopted)
+        backup.db.adopt_import_media.assert_awaited_once_with(CHAT_ID, MSG_ID, SWEEP_ID, account_id=1)
+        backup._download_media_to_path.assert_not_awaited()
+
+    def test_without_an_import_row_the_sweep_downloads_normally(self):
+        media_root = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, media_root, ignore_errors=True)
+        backup = self._make_backup(media_root)
+        backup.db.adopt_import_media = AsyncMock(return_value=None)
+
+        result = self._run(backup._process_media(self._photo_message(), CHAT_ID))
+
+        self.assertEqual(result["id"], SWEEP_ID)
+        self.assertTrue(result["downloaded"])
+        backup._download_media_to_path.assert_awaited()
+
+
+# ---------------------------------------------------------------------------
+# backfill-topics CLI
+# ---------------------------------------------------------------------------
+
+
+class TestBackfillTopicsCommand(unittest.TestCase):
+    def _adapter_returning(self, rowcount: int):
+        adapter_mock = AsyncMock()
+        adapter_mock.reset_chat_sync_cursor = AsyncMock(return_value=rowcount)
+        adapter_mock.close = AsyncMock()
+
+        async def fake_create_adapter(database_url=None):
+            return adapter_mock
+
+        return adapter_mock, fake_create_adapter
+
+    def test_unknown_chat_exits_1_without_sweeping(self):
+        adapter_mock, fake_create = self._adapter_returning(0)
+        backup_main = MagicMock(return_value=0)
+        with (
+            mock.patch.dict(os.environ, {}, clear=False),
+            mock.patch("src.db.create_adapter", new=fake_create),
+            mock.patch("src.telegram_backup.main", new=backup_main),
+        ):
+            result = run_backfill_topics(SimpleNamespace(chat_id=CHAT_ID))
+
+        self.assertEqual(result, 1)
+        backup_main.assert_not_called()
+        adapter_mock.close.assert_awaited()
+
+    def test_known_chat_resweeps_with_pinned_env(self):
+        adapter_mock, fake_create = self._adapter_returning(2)
+        backup_main = MagicMock(return_value=0)
+        with (
+            mock.patch.dict(os.environ, {}, clear=False),
+            mock.patch("src.db.create_adapter", new=fake_create),
+            mock.patch("src.telegram_backup.main", new=backup_main),
+        ):
+            result = run_backfill_topics(SimpleNamespace(chat_id=CHAT_ID))
+            pinned = {
+                key: os.environ.get(key)
+                for key in ("DOWNLOAD_MEDIA", "SYNC_DELETIONS_EDITS", "VERIFY_MEDIA", "CHAT_IDS")
+            }
+
+        self.assertEqual(result, 0)
+        backup_main.assert_called_once()
+        adapter_mock.reset_chat_sync_cursor.assert_awaited_once_with(CHAT_ID)
+        self.assertEqual(
+            pinned,
+            {
+                "DOWNLOAD_MEDIA": "false",
+                "SYNC_DELETIONS_EDITS": "false",
+                "VERIFY_MEDIA": "false",
+                "CHAT_IDS": str(CHAT_ID),
+            },
+        )

--- a/tests/test_import_adoption.py
+++ b/tests/test_import_adoption.py
@@ -24,7 +24,6 @@ from types import SimpleNamespace
 from unittest import mock
 from unittest.mock import AsyncMock, MagicMock
 
-import pytest
 import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -110,7 +109,6 @@ async def _media_ids(adapter_, account_id: int = 1) -> set[str]:
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_adopts_downloaded_import_row(adapter):
     async with adapter.db_manager.async_session_factory() as session:
         session.add(_import_row())
@@ -131,7 +129,6 @@ async def test_adopts_downloaded_import_row(adapter):
     assert await _media_ids(adapter) == {SWEEP_ID}
 
 
-@pytest.mark.asyncio
 async def test_existing_sweep_row_is_never_touched(adapter):
     """An earlier sweep already archived its own copy: adopt nothing."""
     async with adapter.db_manager.async_session_factory() as session:
@@ -143,7 +140,6 @@ async def test_existing_sweep_row_is_never_touched(adapter):
     assert await _media_ids(adapter) == {IMPORT_ID, SWEEP_ID}
 
 
-@pytest.mark.asyncio
 async def test_undownloaded_import_row_is_ignored(adapter):
     """Adoption exists to reuse bytes on disk; a fileless row has none."""
     async with adapter.db_manager.async_session_factory() as session:
@@ -154,12 +150,10 @@ async def test_undownloaded_import_row_is_ignored(adapter):
     assert await _media_ids(adapter) == {IMPORT_ID}
 
 
-@pytest.mark.asyncio
 async def test_no_import_row_returns_none(adapter):
     assert await adapter.adopt_import_media(CHAT_ID, MSG_ID, SWEEP_ID, account_id=1) is None
 
 
-@pytest.mark.asyncio
 async def test_adoption_is_account_scoped(adapter):
     async with adapter.db_manager.async_session_factory() as session:
         session.add(_import_row(account_id=1))
@@ -174,7 +168,6 @@ async def test_adoption_is_account_scoped(adapter):
 # ---------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
 async def test_reset_cursor_zeroes_every_account_for_that_chat_only(adapter):
     assert await adapter.reset_chat_sync_cursor(CHAT_ID) == 2
 
@@ -186,7 +179,6 @@ async def test_reset_cursor_zeroes_every_account_for_that_chat_only(adapter):
     assert cursors[(1, OTHER_CHAT_ID)] == 900  # untouched
 
 
-@pytest.mark.asyncio
 async def test_reset_cursor_zeroes_the_cursor_the_sweep_reads(adapter):
     """_backup_dialog takes min_id from sync_status.last_message_id, NOT from
     chats.last_synced_message_id — zeroing only the chat column makes the
@@ -198,7 +190,6 @@ async def test_reset_cursor_zeroes_the_cursor_the_sweep_reads(adapter):
     assert await adapter.get_last_message_id(OTHER_CHAT_ID, account_id=1) == 900
 
 
-@pytest.mark.asyncio
 async def test_reset_cursor_unknown_chat_returns_zero(adapter):
     assert await adapter.reset_chat_sync_cursor(-999999) == 0
 

--- a/tests/test_media_metadata_persistence.py
+++ b/tests/test_media_metadata_persistence.py
@@ -93,6 +93,9 @@ def _make_backup(media_root):
     backup.config.deduplicate_media = False
     backup.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
     backup.db = AsyncMock()
+    # No import rows by default: a truthy mock would make the adoption
+    # hook short-circuit _process_media before the paths under test.
+    backup.db.adopt_import_media = AsyncMock(return_value=None)
     backup.client = AsyncMock()
     backup._owns_client = True
     backup._cleaned_media_chats = set()

--- a/tests/test_symlink_dedup.py
+++ b/tests/test_symlink_dedup.py
@@ -163,6 +163,9 @@ class TestDownloadReturnValueCapture(unittest.TestCase):
         backup.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
         backup.client = AsyncMock()
         backup.db = AsyncMock()
+        # No import rows by default: a truthy mock would make the adoption
+        # hook short-circuit _process_media before the paths under test.
+        backup.db.adopt_import_media = AsyncMock(return_value=None)
         backup.db.find_media_by_content_hash = AsyncMock(return_value=None)
         # download_media returns the actual path with .mp4
         backup.client.download_media = AsyncMock(return_value=actual_returned_path)
@@ -214,6 +217,9 @@ class TestProcessMediaDedupSymlink(unittest.TestCase):
         self.backup.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
         self.backup.client = AsyncMock()
         self.backup.db = AsyncMock()
+        # No import rows by default: a truthy mock would make the adoption
+        # hook short-circuit _process_media before the paths under test.
+        self.backup.db.adopt_import_media = AsyncMock(return_value=None)
         self.backup.db.find_media_by_content_hash = AsyncMock(return_value=None)
 
     def tearDown(self):
@@ -344,6 +350,9 @@ class TestVerifyCleanupDanglingSymlink(unittest.TestCase):
         self.backup.config.deduplicate_media = True
         self.backup.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
         self.backup.db = AsyncMock()
+        # No import rows by default: a truthy mock would make the adoption
+        # hook short-circuit _process_media before the paths under test.
+        self.backup.db.adopt_import_media = AsyncMock(return_value=None)
         _stream_verification_batches(self.backup.db)
         self.backup.client = AsyncMock()
 
@@ -471,6 +480,9 @@ class TestShutilMoveFallback(unittest.TestCase):
         self.backup.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
         self.backup.client = AsyncMock()
         self.backup.db = AsyncMock()
+        # No import rows by default: a truthy mock would make the adoption
+        # hook short-circuit _process_media before the paths under test.
+        self.backup.db.adopt_import_media = AsyncMock(return_value=None)
         self.backup.db.find_media_by_content_hash = AsyncMock(return_value=None)
 
     def tearDown(self):
@@ -803,6 +815,9 @@ class TestBackupDedupSharedExistsPreUnlink(unittest.TestCase):
         self.backup.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
         self.backup.client = AsyncMock()
         self.backup.db = AsyncMock()
+        # No import rows by default: a truthy mock would make the adoption
+        # hook short-circuit _process_media before the paths under test.
+        self.backup.db.adopt_import_media = AsyncMock(return_value=None)
         self.backup.db.find_media_by_content_hash = AsyncMock(return_value=None)
 
     def tearDown(self):
@@ -914,6 +929,10 @@ class TestBackupNonDedupCapturesReturnValue(unittest.TestCase):
         self.backup.config.deduplicate_media = False
         self.backup.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
         self.backup.client = AsyncMock()
+        self.backup.db = AsyncMock()
+        # No import rows: a truthy mock would make the adoption hook
+        # short-circuit _process_media before the non-dedup path under test.
+        self.backup.db.adopt_import_media = AsyncMock(return_value=None)
 
     def tearDown(self):
         shutil.rmtree(self.temp_dir, ignore_errors=True)
@@ -980,6 +999,9 @@ class TestBackupDedupSymlinkFailFallback(unittest.TestCase):
         self.backup.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
         self.backup.client = AsyncMock()
         self.backup.db = AsyncMock()
+        # No import rows by default: a truthy mock would make the adoption
+        # hook short-circuit _process_media before the paths under test.
+        self.backup.db.adopt_import_media = AsyncMock(return_value=None)
         self.backup.db.find_media_by_content_hash = AsyncMock(return_value=None)
 
     def tearDown(self):

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -83,6 +83,10 @@ def _make_backup(**overrides):
     # Folder resolution reads the archived-chat snapshot; default to empty so
     # tests that exercise _backup_folders get an iterable, not a bare AsyncMock.
     backup.db.get_chats_for_folder_resolution = AsyncMock(return_value=[])
+    # No import rows by default: a bare AsyncMock return is truthy, and the
+    # adoption hook would short-circuit _process_media before the download
+    # paths under test.
+    backup.db.adopt_import_media = AsyncMock(return_value=None)
     backup.client = overrides.get("client", AsyncMock())
     backup._owns_client = overrides.get("_owns_client", True)
     backup._cleaned_media_chats = set()

--- a/tests/test_webpage_preview_photo.py
+++ b/tests/test_webpage_preview_photo.py
@@ -97,6 +97,9 @@ class TestSweepDownloadsPreviewPhoto(unittest.TestCase):
         backup.config.deduplicate_media = False
         backup.config.get_max_media_size_bytes = MagicMock(return_value=100 * 1024 * 1024)
         backup.db = AsyncMock()
+        # No import rows: a truthy mock would make the adoption hook
+        # short-circuit _process_media before the preview paths under test.
+        backup.db.adopt_import_media = AsyncMock(return_value=None)
         backup.client = AsyncMock()
 
         async def fake_download(_message, path, _size, _chat_id):


### PR DESCRIPTION
Importing a Telegram Desktop HTML export gives the archive every file the export carried — and then the API sweep pays for all of it again. The sweep builds its own media id for each message, never notices the `import_{chat}_{msg}` row sitting next to it, and re-downloads the same bytes under a second row and a second file. On top of that, imported forum chats land with every message in General, because TDesktop exports (HTML and JSON both) carry no topic metadata; the documented recovery was manual SQL plus a hand-rolled env incantation with real footguns in it (from #303).

Two changes, both converging on machinery that already exists:

- **The sweep adopts import media instead of re-downloading it.** When `_process_media` reaches a message whose media exists as a downloaded `import_*` row, it re-keys that row to the sweep's own id and returns it — same file on disk, same record, no network. Nothing is ever deleted: if the sweep already archived its own copy, or the import row has no file, adoption stands aside and the normal path runs.
- **`backfill-topics <chat_id>` packages the topic recovery.** It zeroes the chat's sync cursor and runs the normal backup scoped to that one chat with the footguns pinned off — downloads disabled (the files are already local, and thanks to adoption the resweep links rather than re-fetches), deletion/edit sync disabled (a full-history pass must never mass-delete), verify disabled. The upsert refreshes `reply_to_top_id` in place and the chat's topics come back.

Coverage: adoption re-key with full record shape, the never-delete guards (sweep row exists / not downloaded / other account), cursor-reset scoping, the sweep hook short-circuit and its fallthrough, and the CLI's exit-1 path plus the pinned environment. Each guard was mutation-tested (hook removed, `downloaded==1` dropped, sweep-exists check dropped — each caught by its targeted test).

Closes the adoption + backfill halves of the #303 follow-up work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `backfill-topics` command to restore forum topics for imported Telegram messages.
  * Resweeps text only for a selected archived chat, without downloading media or changing message synchronization.
  * Reuses imported media during later backups instead of downloading it again.

* **Documentation**
  * Added CLI usage details, behavior, and operational limitations for topic backfilling.

* **Tests**
  * Added coverage for media reuse, topic restoration, cursor resets, fallback downloads, and command validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->