### PR TITLE
feat(import): survive gigabyte exports and interrupted runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,6 +737,17 @@ docker compose exec telegram-backup python -m src fill-gaps
 > **Imported media is adopted, not re-downloaded.** When a normal API backup
 > later reaches a message whose file arrived via import, the archive re-keys
 > the imported record to the sweep's name and reuses the on-disk file.
+>
+> **Big exports stream, and an interrupted import resumes.** `result.json` is
+> parsed one message at a time (memory stays flat no matter the export size),
+> and progress is checkpointed per chat: if an import crashes or is stopped,
+> re-running the same command on the same file skips the chats that finished
+> and replays the one it was inside — no `--merge` needed, and counters end
+> up exactly as if it had never been interrupted. The checkpoint is tied to
+> that exact file: if you replace the export (a re-export can contain newer
+> messages for already-imported chats), the fresh file starts over and
+> overlaps need `--merge` as usual. HTML exports don't resume — they are
+> single-chat and small enough not to need it.
 
 ## Data Storage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "alembic>=1.14.0",
     "greenlet>=3.1.0",
     "beautifulsoup4>=4.12.0",
+    "ijson>=3.5.1",
     "pywebpush>=2.3.0",
     "py-vapid>=1.9.4",
     "cryptography>=50.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ py-vapid>=1.9.4
 cryptography>=50.0.0
 # HTML import parsing (v7.0+)
 beautifulsoup4>=4.12.0
+ijson>=3.5.1

--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -1150,44 +1150,27 @@ class DatabaseAdapter:
 
     @retry_on_locked()
     async def upsert_user(self, user_data: dict[str, Any]) -> None:
-        """Insert or update a user record."""
-        async with self.db_manager.async_session_factory() as session:
-            values = {
-                "id": user_data["id"],
-                "username": user_data.get("username"),
-                "first_name": user_data.get("first_name"),
-                "last_name": user_data.get("last_name"),
-                "phone": user_data.get("phone"),
-                "is_bot": 1 if user_data.get("is_bot") else 0,
-                "updated_at": utcnow_naive(),
-            }
+        """Insert or update a user record.
 
-            if self._is_sqlite:
-                stmt = sqlite_insert(User).values(**values)
-                stmt = stmt.on_conflict_do_update(
-                    index_elements=["id"],
-                    set_={
-                        "username": stmt.excluded.username,
-                        "first_name": stmt.excluded.first_name,
-                        "last_name": stmt.excluded.last_name,
-                        "phone": stmt.excluded.phone,
-                        "is_bot": stmt.excluded.is_bot,
-                        "updated_at": utcnow_naive(),
-                    },
-                )
-            else:
-                stmt = pg_insert(User).values(**values)
-                stmt = stmt.on_conflict_do_update(
-                    index_elements=["id"],
-                    set_={
-                        "username": stmt.excluded.username,
-                        "first_name": stmt.excluded.first_name,
-                        "last_name": stmt.excluded.last_name,
-                        "phone": stmt.excluded.phone,
-                        "is_bot": stmt.excluded.is_bot,
-                        "updated_at": utcnow_naive(),
-                    },
-                )
+        Only keys PRESENT in ``user_data`` reach the conflict update — the
+        importer knows only {id, first_name}, and letting its absent keys
+        write NULLs erased the username/last_name/phone the live capture had
+        recorded (the same present-keys contract upsert_chat already keeps).
+        Callers that observe a removal (backup/listener build every key
+        explicitly) still clear a column by passing the key with None.
+        """
+        async with self.db_manager.async_session_factory() as session:
+            values: dict[str, Any] = {"id": user_data["id"], "updated_at": utcnow_naive()}
+            for key in ("username", "first_name", "last_name", "phone"):
+                if key in user_data:
+                    values[key] = user_data.get(key)
+            if "is_bot" in user_data:
+                values["is_bot"] = 1 if user_data.get("is_bot") else 0
+
+            insert_fn = sqlite_insert if self._is_sqlite else pg_insert
+            stmt = insert_fn(User).values(**values)
+            update_set = {key: getattr(stmt.excluded, key) for key in values if key != "id"}
+            stmt = stmt.on_conflict_do_update(index_elements=["id"], set_=update_set)
 
             await session.execute(stmt)
             await session.commit()
@@ -2416,6 +2399,31 @@ class DatabaseAdapter:
             result = await session.execute(update(Chat).where(Chat.id == chat_id).values(last_synced_message_id=0))
             await session.commit()
             return result.rowcount or 0
+
+    async def has_media_for_message(self, chat_id: int, message_id: int, *, exclude_id: str, account_id: int) -> bool:
+        """True when any media row other than ``exclude_id`` covers the message.
+
+        The importer asks this before (re)creating an ``import_*`` row: when
+        the sweep already archived the message's media — including by
+        ADOPTING an earlier import run's row, which re-keys it — writing the
+        import row again would resurrect exactly the duplicate #405 removed.
+        """
+        async with self.db_manager.async_session_factory() as session:
+            row = (
+                await session.execute(
+                    select(Media.id)
+                    .where(
+                        and_(
+                            Media.account_id == account_id,
+                            Media.chat_id == chat_id,
+                            Media.message_id == message_id,
+                            Media.id != exclude_id,
+                        )
+                    )
+                    .limit(1)
+                )
+            ).first()
+            return row is not None
 
     async def adopt_import_media(
         self, chat_id: int, message_id: int, new_media_id: str, *, account_id: int

--- a/src/telegram_import.py
+++ b/src/telegram_import.py
@@ -9,16 +9,20 @@ Both formats insert messages, users, and media into the existing database schema
 """
 
 import asyncio
+import hashlib
 import json
 import logging
 import re
 import shutil
+from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
 from typing import Any
 
+import ijson
+
 from .db import DatabaseAdapter, close_database, get_adapter, init_database
-from .db.models import DEFAULT_ACCOUNT_ID
+from .db.models import DEFAULT_ACCOUNT_ID, account_metadata_key
 from .message_utils import build_media_filename, utcnow_naive
 
 logger = logging.getLogger(__name__)
@@ -580,6 +584,158 @@ def _parse_html_export(html_files: list[Path], export_path: Path) -> tuple[str, 
 
 
 # ---------------------------------------------------------------------------
+# Streaming export parser (9t6.5.48)
+# ---------------------------------------------------------------------------
+#
+# ``json.load`` held the whole export in memory (roughly 4x the file size as
+# Python objects), so a large account export could OOM the container before a
+# single row was written. This parser walks result.json ONCE with ijson and
+# hands out one chat at a time: the chat's scalar metadata plus a bounded
+# iterator over exactly that chat's messages. Peak memory becomes one message
+# (plus one chat's metadata), not one export.
+
+_SCALAR_EVENTS = {"string", "number", "integer", "double", "boolean", "null"}
+
+
+def _export_fingerprint(path: Path) -> str:
+    """Identity of the export file a resume marker is valid against.
+
+    Size plus a hash of the first MiB: cheap on multi-GB files, and any
+    re-export (different date range, different account, edited file) changes
+    at least one of the two. A mismatch simply invalidates the marker — the
+    import then starts fresh with the normal already-imported guard active.
+    """
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        digest.update(handle.read(1024 * 1024))
+    return f"{path.stat().st_size}:{digest.hexdigest()}"
+
+
+def _drain(iterator: Iterator[Any]) -> None:
+    for _ in iterator:
+        pass
+
+
+def _check_meta_identity(meta: dict[str, Any] | None, identity: tuple[Any, Any] | None) -> None:
+    """Hard-fail if a chat's id/type surfaced only AFTER its messages.
+
+    ``json.load`` made key order irrelevant; a forward-only stream derives
+    the chat id from the fields seen BEFORE the messages array. Telegram
+    Desktop writes id/type first, but if an export ever did not, the rows
+    would land under a wrong id — corruption, not a warning. The parser
+    keeps mutating the yielded meta dict as trailing fields arrive, so
+    comparing it to the snapshot taken at derivation time catches exactly
+    that case.
+    """
+    if meta is None:
+        return
+    if (meta.get("id"), meta.get("type")) != identity:
+        raise ValueError(
+            "Chat id/type appeared after the chat's messages in the export — refusing to continue "
+            "because rows would be written under the wrong chat. Re-export the data or report this."
+        )
+
+
+def _bounded_messages(events, msgs_prefix: str):
+    """One chat's messages as a sub-stream of the shared event iterator.
+
+    Re-yields events until the ``end_array`` that closes exactly this chat's
+    ``messages`` array — nested arrays inside a message (``text_entities``)
+    carry longer prefixes, so they can never terminate it early — and feeds
+    them into ``ijson.items``, which builds one message dict at a time.
+    """
+
+    def bounded():
+        for event in events:
+            if event[0] == msgs_prefix and event[1] == "end_array":
+                return
+            yield event
+
+    return ijson.items(bounded(), msgs_prefix + ".item")
+
+
+def _stream_full_export_chats(events):
+    """Yield ``(meta, messages_iter)`` per chat of a full-account export.
+
+    ``meta`` is built from the chat's own fields via ``ObjectBuilder``; when
+    the ``messages`` key arrives the same event stream is handed to the
+    bounded sub-iterator instead. The caller must finish (or abandon) the
+    messages iterator before asking for the next chat — the generator drains
+    any remainder itself so the shared stream position is always correct.
+    Fields that appear AFTER the messages array still land in the (already
+    yielded) meta dict — the caller re-checks identity fields afterwards.
+    """
+    root = "chats.list.item"
+    msgs_prefix = root + ".messages"
+    builder = None
+    for prefix, event, value in events:
+        if builder is None:
+            if prefix == root and event == "start_map":
+                builder = ijson.ObjectBuilder()
+                builder.event(event, value)
+            elif prefix == "chats.list" and event == "end_array":
+                return
+        elif prefix == root and event == "map_key" and value == "messages":
+            next(events, None)  # consume (msgs_prefix, 'start_array', None)
+            messages = _bounded_messages(events, msgs_prefix)
+            yield builder.value, messages
+            _drain(messages)
+        elif prefix == root and event == "end_map":
+            builder = None
+        else:
+            builder.event(event, value)
+
+
+def _stream_export(fileobj):
+    """Walk either export shape once; yield ``("owner", id, None)`` at most
+    once, then ``("chat", meta, messages_iter)`` per chat.
+
+    Single-chat exports (top-level ``messages``) yield exactly one chat whose
+    meta holds the top-level scalars seen before the array; scalars after the
+    array still mutate that meta in place (checked by the caller). Full
+    exports read ``personal_information`` when it precedes ``chats`` — the
+    order Telegram Desktop writes — and warn once when it does not, matching
+    the old behavior for an export that lacks it entirely.
+    """
+    events = ijson.parse(fileobj, use_float=True)
+    meta: dict[str, Any] = {}
+    top_key: str | None = None
+    owner_builder = None
+    owner_seen = False
+    for prefix, event, value in events:
+        if owner_builder is not None:
+            owner_builder.event(event, value)
+            if prefix == "personal_information" and event == "end_map":
+                info = owner_builder.value
+                owner_builder = None
+                owner_seen = True
+                if isinstance(info, dict) and info.get("user_id") is not None:
+                    yield "owner", info.get("user_id"), None
+            continue
+        if prefix == "" and event == "map_key":
+            top_key = value
+            if value == "chats":
+                if not owner_seen:
+                    logger.warning(
+                        "personal_information not seen before chats — messages will carry no is_outgoing flag"
+                    )
+                yield from (("chat", m, it) for m, it in _stream_full_export_chats(events))
+                return
+            if value == "messages":
+                next(events, None)  # consume ('messages', 'start_array', None)
+                messages = _bounded_messages(events, "messages")
+                yield "chat", meta, messages
+                _drain(messages)
+                # Trailing top-level scalars (id/type after the array) still
+                # belong to this chat's meta; the caller re-checks identity.
+        elif prefix == "personal_information" and event == "start_map":
+            owner_builder = ijson.ObjectBuilder()
+            owner_builder.event(event, value)
+        elif prefix == top_key and event in _SCALAR_EVENTS:
+            meta[top_key] = value
+
+
+# ---------------------------------------------------------------------------
 # Main importer
 # ---------------------------------------------------------------------------
 
@@ -626,20 +782,25 @@ class TelegramImporter:
         result_file = _resolve_export_control_file(path, path / "result.json")
         html_files = _find_html_files(path)
 
+        summary: dict[str, Any] = {
+            "chats_imported": 0,
+            "chats_skipped": 0,
+            "total_messages": 0,
+            "total_media": 0,
+            "details": [],
+        }
+
         if result_file is not None:
             logger.info(f"Reading {result_file}...")
-            with open(result_file, encoding="utf-8") as f:
-                data = json.load(f)
-            chats = self._extract_chats(data)
-            # A full-account JSON export names its owner: with it, every
-            # message can carry an honest is_outgoing instead of leaving the
-            # column NULL for the viewer fallback to guess.
-            info = data.get("personal_information")
-            owner_raw = info.get("user_id") if isinstance(info, dict) else None
-            try:
-                self._owner_user_id = int(owner_raw or 0) or None
-            except TypeError, ValueError:
-                self._owner_user_id = None
+            await self._run_json_streaming(
+                result_file=result_file,
+                export_root=path,
+                chat_id_override=chat_id_override,
+                dry_run=dry_run,
+                skip_media=skip_media,
+                merge=merge,
+                summary=summary,
+            )
         elif html_files:
             logger.info(f"Detected HTML export format ({len(html_files)} file(s))")
             if not chat_id_override:
@@ -649,47 +810,164 @@ class TelegramImporter:
                     "(e.g., -c 123456789 for a private chat, -c -1001234567890 for a supergroup)."
                 )
             chat_name, messages = _parse_html_export(html_files, path)
-            chats = [{"name": chat_name, "type": "html_export", "id": 0, "messages": messages}]
-        else:
-            raise FileNotFoundError(
-                f"No result.json or messages.html found in {path}. Expected a Telegram Desktop export directory."
-            )
-
-        if not chats:
-            raise ValueError("No chats found in export file")
-
-        summary: dict[str, Any] = {"chats_imported": 0, "total_messages": 0, "total_media": 0, "details": []}
-
-        for chat_data in chats:
-            chat_id = (
-                chat_id_override
-                if chat_id_override
-                else derive_chat_id(chat_data.get("id", 0), chat_data.get("type", "personal_chat"))
-            )
-
-            if chat_id == 0:
-                logger.warning("Skipping a chat entry with no ID")
-                continue
-
             result = await self._import_chat(
-                chat_data=chat_data,
-                chat_id=chat_id,
+                chat_data={"name": chat_name, "type": "html_export", "id": 0},
+                chat_id=chat_id_override,
+                messages=messages,
+                total=len(messages),
                 export_path=path,
                 dry_run=dry_run,
                 skip_media=skip_media,
                 merge=merge,
             )
-
             summary["chats_imported"] += 1
             summary["total_messages"] += result["messages"]
             summary["total_media"] += result["media"]
             summary["details"].append(result)
-
-            if chat_id_override and len(chats) > 1:
-                logger.info("--chat-id provided with multi-chat export; only importing first chat")
-                break
+        else:
+            raise FileNotFoundError(
+                f"No result.json or messages.html found in {path}. Expected a Telegram Desktop export directory."
+            )
 
         return summary
+
+    async def _run_json_streaming(
+        self,
+        result_file: Path,
+        export_root: Path,
+        chat_id_override: int | None,
+        dry_run: bool,
+        skip_media: bool,
+        merge: bool,
+        summary: dict[str, Any],
+    ) -> None:
+        """Stream result.json chat by chat, resuming an interrupted import.
+
+        Resume model: every write the importer performs is an idempotent
+        upsert, so the recovery unit is the CHAT — completed chats are
+        recorded in a metadata marker (keyed to this export's fingerprint)
+        and skipped, the chat the previous run was inside is REPLAYED from
+        its start (an exact replay performs zero message writes), and
+        ``sync_status`` only ever runs at chat completion, so its counters
+        end up identical to an uninterrupted import. A finished import
+        clears the marker.
+        """
+        marker_key = account_metadata_key("import_progress", self.account_id)
+        fingerprint = _export_fingerprint(result_file)
+        completed: set[int] = set()
+        started_chat: int | None = None
+        resume_matched = False
+        if not dry_run:
+            marker = await self._load_import_marker(marker_key)
+            if marker and marker.get("fingerprint") == fingerprint:
+                completed = {int(c) for c in marker.get("completed", [])}
+                started_chat = marker.get("started")
+                resume_matched = True
+                if completed or started_chat is not None:
+                    logger.info(f"Resuming interrupted import: {len(completed)} chat(s) already complete")
+
+        any_chat_seen = False
+        prev_meta: dict[str, Any] | None = None
+        prev_identity: tuple[Any, Any] | None = None
+
+        with open(result_file, "rb") as handle:
+            stream = _stream_export(handle)
+            try:
+                for item in stream:
+                    if item[0] == "owner":
+                        # A full-account export names its owner: with it, every
+                        # message can carry an honest is_outgoing instead of
+                        # leaving the column NULL for the viewer fallback.
+                        try:
+                            self._owner_user_id = int(item[1] or 0) or None
+                        except TypeError, ValueError:
+                            self._owner_user_id = None
+                        continue
+                    _, chat_meta, messages = item
+                    # The PREVIOUS chat's meta may only now be complete (fields
+                    # after the messages array mutate it in place) — its
+                    # identity must not have changed under us.
+                    _check_meta_identity(prev_meta, prev_identity)
+                    any_chat_seen = True
+                    chat_id = (
+                        chat_id_override
+                        if chat_id_override
+                        else derive_chat_id(chat_meta.get("id", 0), chat_meta.get("type", "personal_chat"))
+                    )
+                    prev_meta = chat_meta
+                    prev_identity = (chat_meta.get("id"), chat_meta.get("type"))
+
+                    if chat_id == 0:
+                        logger.warning("Skipping a chat entry with no ID")
+                        continue
+                    if chat_id in completed:
+                        summary["chats_skipped"] += 1
+                        continue
+
+                    resuming = resume_matched and started_chat == chat_id
+                    if not dry_run:
+                        started_chat = chat_id
+                        await self._save_import_marker(marker_key, fingerprint, completed, chat_id)
+
+                    result = await self._import_chat(
+                        chat_data=chat_meta,
+                        chat_id=chat_id,
+                        messages=messages,
+                        total=None,
+                        export_path=export_root,
+                        dry_run=dry_run,
+                        skip_media=skip_media,
+                        merge=merge,
+                        resuming=resuming,
+                    )
+
+                    summary["chats_imported"] += 1
+                    summary["total_messages"] += result["messages"]
+                    summary["total_media"] += result["media"]
+                    summary["details"].append(result)
+
+                    if not dry_run:
+                        completed.add(chat_id)
+                        await self._save_import_marker(marker_key, fingerprint, completed, None)
+
+                    if chat_id_override:
+                        if next(stream, None) is not None:
+                            logger.info("--chat-id provided with multi-chat export; only importing first chat")
+                        break
+            except ijson.JSONError as exc:
+                # Progress up to the last completed chat is already in the
+                # marker, so fixing the file and re-running resumes there.
+                raise ValueError(
+                    f"Export file is truncated or invalid JSON ({type(exc).__name__}) — "
+                    "already-completed chats are saved; re-run the import to resume after fixing the file"
+                ) from exc
+        _check_meta_identity(prev_meta, prev_identity)
+
+        if not any_chat_seen:
+            raise ValueError("No chats found in export file")
+
+        if not dry_run:
+            # Clean completion: clear the marker so an unrelated future import
+            # of a DIFFERENT export never inherits this one's skip set.
+            await self.db.set_metadata(marker_key, "")
+
+    async def _load_import_marker(self, marker_key: str) -> dict[str, Any] | None:
+        raw = await self.db.get_metadata(marker_key)
+        if not raw:
+            return None
+        try:
+            marker = json.loads(raw)
+        except TypeError, ValueError:
+            return None
+        return marker if isinstance(marker, dict) else None
+
+    async def _save_import_marker(
+        self, marker_key: str, fingerprint: str, completed: set[int], started: int | None
+    ) -> None:
+        await self.db.set_metadata(
+            marker_key,
+            json.dumps({"fingerprint": fingerprint, "completed": sorted(completed), "started": started}),
+        )
 
     def _extract_chats(self, data: dict) -> list[dict]:
         """Extract chat list from either single-chat or full-account export."""
@@ -705,19 +983,30 @@ class TelegramImporter:
         self,
         chat_data: dict,
         chat_id: int,
+        messages: Iterator[dict] | list[dict],
+        total: int | None,
         export_path: Path,
         dry_run: bool,
         skip_media: bool,
         merge: bool,
+        resuming: bool = False,
     ) -> dict[str, Any]:
-        """Import a single chat from export data."""
+        """Import a single chat; ``messages`` may be a one-pass stream.
+
+        ``total`` is known only for materialized inputs (HTML); ``resuming``
+        marks the chat a previous interrupted run was inside — its partial
+        rows are the importer's own output, so the already-imported guard
+        must not fire and the replay converges through the upserts.
+        """
         chat_name = chat_data.get("name", "Unknown")
         export_type = chat_data.get("type", "personal_chat")
-        messages = chat_data.get("messages", [])
 
-        logger.info(f"Importing chat (type: {export_type}) - {len(messages)} messages")
+        if total is None:
+            logger.info(f"Importing chat (type: {export_type})")
+        else:
+            logger.info(f"Importing chat (type: {export_type}) - {total} messages")
 
-        if not merge and not dry_run:
+        if not merge and not dry_run and not resuming:
             existing = await self.db.get_chat_stats(chat_id, account_id=self.account_id)
             if existing and existing.get("messages", 0) > 0:
                 raise ValueError(
@@ -874,7 +1163,8 @@ class TelegramImporter:
                     media_count += await self._flush_batch(batch, media_batch)
                 batch.clear()
                 media_batch.clear()
-                logger.info(f"  Progress: {msg_count}/{len(messages)} messages")
+                denominator = f"/{total}" if total is not None else ""
+                logger.info(f"  Progress: {msg_count}{denominator} messages")
 
         if batch and not dry_run:
             media_count += await self._flush_batch(batch, media_batch)
@@ -921,6 +1211,16 @@ class TelegramImporter:
         for m in media:
             source = m.pop("_source")
             dest = m.pop("_dest")
+
+            # The sweep may already have archived this message's media under
+            # its own id — including by ADOPTING an earlier run's import row
+            # (#405 re-keys it). Re-creating the import row would resurrect
+            # the duplicate adoption exists to prevent, so any other media
+            # row for the message wins and this one stands aside.
+            if await self.db.has_media_for_message(
+                m["chat_id"], m["message_id"], exclude_id=m["id"], account_id=self.account_id
+            ):
+                continue
 
             dest_path = Path(dest)
             # SECURITY-REVIEW: Re-check the untrusted import destination before filesystem writes.

--- a/tests/test_streaming_import.py
+++ b/tests/test_streaming_import.py
@@ -1,0 +1,338 @@
+"""Streaming import + resume, proven against a REAL database (9t6.5.48).
+
+Every existing import test drives an ``AsyncMock`` adapter, and SQLite never
+enforces the foreign keys PostgreSQL does — so a wrong write order or a
+broken resume could stay green everywhere except production. These tests run
+the importer end to end through ``conftest.real_adapter`` (SQLite always,
+PostgreSQL when a server is available, as on CI) and assert the states the
+design promises:
+
+* an interrupted import resumes to EXACTLY the state of an uninterrupted one
+  (including ``sync_status.message_count`` — the additive counter that
+  ``--merge`` replays used to inflate);
+* the chat a crashed run was inside replays without ``--merge`` and without
+  tripping the already-imported guard;
+* a replay never resurrects an import media row the sweep has adopted (#405);
+* a truncated export fails loudly, keeps its progress, and resumes on the
+  same file. A REPLACED file (different fingerprint) deliberately does not
+  resume — a re-export may hold newer messages for "completed" chats, so
+  skipping them would silently drop data; that path stays ``--merge``.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+
+from src.db.models import Media, Message, SyncStatus, account_metadata_key
+from src.telegram_import import TelegramImporter
+
+CHAT_A = 901001  # personal_chat keeps its raw id
+CHAT_B_EXPORT = 901002  # what result.json says
+CHAT_B = -1000000901002  # derive_chat_id marks supergroups (-100... form)
+MARKER_KEY = account_metadata_key("import_progress", 1)
+
+
+def _msg(msg_id: int, text: str = "hola", **extra) -> dict:
+    base = {
+        "id": msg_id,
+        "type": "message",
+        "date": f"2024-01-15T10:{msg_id % 60:02d}:00",
+        "from": "Alice",
+        "from_id": "user4242",
+        "text": text,
+    }
+    base.update(extra)
+    return base
+
+
+def _write_export(export_dir: Path, chats: list[dict]) -> Path:
+    export_dir.mkdir(parents=True, exist_ok=True)
+    control = export_dir / "result.json"
+    payload = {
+        "about": "Telegram Desktop export",
+        "personal_information": {"user_id": 4242, "first_name": "Alice"},
+        "chats": {"list": chats},
+    }
+    control.write_text(json.dumps(payload), encoding="utf-8")
+    return control
+
+
+def _two_chat_export(export_dir: Path, *, b_messages: int = 4, with_media: bool = False) -> Path:
+    files_dir = export_dir / "files"
+    files_dir.mkdir(parents=True, exist_ok=True)
+    chat_a = {
+        "name": "Chat A",
+        "type": "personal_chat",
+        "id": CHAT_A,
+        "messages": [_msg(1), _msg(2, "adios")],
+    }
+    b_msgs = []
+    for i in range(1, b_messages + 1):
+        extra = {}
+        if with_media and i == 2:
+            (files_dir / "doc.bin").write_bytes(b"import-bytes")
+            extra = {"file": "files/doc.bin", "file_name": "doc.bin", "media_type": "document"}
+        b_msgs.append(_msg(i, f"b-{i}", **extra))
+    chat_b = {"name": "Chat B", "type": "private_supergroup", "id": CHAT_B_EXPORT, "messages": b_msgs}
+    return _write_export(export_dir, [chat_a, chat_b])
+
+
+def _importer(real_adapter, tmp_path: Path) -> TelegramImporter:
+    return TelegramImporter(real_adapter, str(tmp_path / "media"), account_id=1)
+
+
+async def _state_snapshot(real_adapter) -> dict:
+    """Everything the resume-equality criterion compares."""
+    async with real_adapter.db_manager.async_session_factory() as session:
+        message_rows = (
+            await session.execute(select(Message.chat_id, Message.id, Message.text).where(Message.account_id == 1))
+        ).all()
+        media_rows = (
+            await session.execute(
+                select(Media.id, Media.chat_id, Media.message_id, Media.downloaded).where(Media.account_id == 1)
+            )
+        ).all()
+        sync_rows = (
+            await session.execute(
+                select(SyncStatus.chat_id, SyncStatus.last_message_id, SyncStatus.message_count).where(
+                    SyncStatus.account_id == 1
+                )
+            )
+        ).all()
+    return {
+        "messages": sorted((r[0], r[1], r[2]) for r in message_rows),
+        "media": sorted((r[0], r[1], r[2], r[3]) for r in media_rows),
+        "sync": sorted((r[0], r[1], r[2]) for r in sync_rows),
+    }
+
+
+# ---------------------------------------------------------------------------
+# End-to-end on a real engine
+# ---------------------------------------------------------------------------
+
+
+async def test_end_to_end_import_writes_real_rows(real_adapter, tmp_path):
+    _two_chat_export(tmp_path / "export", with_media=True)
+    importer = _importer(real_adapter, tmp_path)
+
+    summary = await importer.run(str(tmp_path / "export"))
+
+    assert summary["chats_imported"] == 2
+    assert summary["chats_skipped"] == 0
+    assert summary["total_messages"] == 6
+    assert summary["total_media"] == 1
+    state = await _state_snapshot(real_adapter)
+    assert len(state["messages"]) == 6
+    assert state["media"] == [(f"import_{CHAT_B}_2", CHAT_B, 2, 1)]
+    assert state["sync"] == sorted([(CHAT_A, 2, 2), (CHAT_B, 4, 4)])
+    media_file = tmp_path / "media" / str(CHAT_B)
+    assert any(media_file.iterdir())
+    # Clean completion clears the marker.
+    assert not await real_adapter.get_metadata(MARKER_KEY)
+    # The sweep can adopt what the import created (the #405 contract).
+    adopted = await real_adapter.adopt_import_media(CHAT_B, 2, f"{CHAT_B}_2_document", account_id=1)
+    assert adopted is not None and adopted["downloaded"] is True
+
+
+async def test_interrupted_import_resumes_to_identical_state(real_adapter, tmp_path):
+    _two_chat_export(tmp_path / "export")
+    importer = _importer(real_adapter, tmp_path)
+
+    real_batch = real_adapter.insert_messages_batch
+    calls = {"n": 0}
+
+    async def explode_on_second(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 3:  # chat A batch, chat B batch 1, BOOM on B batch 2
+            raise RuntimeError("interrupt: simulated crash mid-import")
+        return await real_batch(*args, **kwargs)
+
+    real_adapter.insert_messages_batch = explode_on_second
+    try:
+        # BATCH_SIZE=2 makes chat B span two batches: the crash lands MID-CHAT,
+        # leaving partial chat-B rows — the state whose retry used to require
+        # --merge (and corrupt message_count).
+        with patch("src.telegram_import.BATCH_SIZE", 2), pytest.raises(RuntimeError, match="simulated crash"):
+            await importer.run(str(tmp_path / "export"))
+    finally:
+        real_adapter.insert_messages_batch = real_batch
+
+    partial = await _state_snapshot(real_adapter)
+    assert len(partial["messages"]) == 4  # chat A complete + chat B's first batch
+
+    marker = json.loads(await real_adapter.get_metadata(MARKER_KEY))
+    assert marker["completed"] == [CHAT_A]
+    assert marker["started"] == CHAT_B
+
+    # Resume with a FRESH importer (new process): chat A skipped, chat B
+    # replayed from its start without --merge and without the guard firing.
+    resumed = _importer(real_adapter, tmp_path)
+    summary = await resumed.run(str(tmp_path / "export"))
+    assert summary["chats_skipped"] == 1
+    assert summary["chats_imported"] == 1
+
+    state = await _state_snapshot(real_adapter)
+    assert len(state["messages"]) == 6
+    # THE equality criterion: sync counters identical to an uninterrupted run
+    # (message_count is additive on conflict — a --merge replay would have
+    # inflated CHAT_A's to 4).
+    assert state["sync"] == sorted([(CHAT_A, 2, 2), (CHAT_B, 4, 4)])
+    assert not await real_adapter.get_metadata(MARKER_KEY)
+
+
+async def test_replay_never_resurrects_an_adopted_media_row(real_adapter, tmp_path):
+    _two_chat_export(tmp_path / "export", with_media=True)
+    importer = _importer(real_adapter, tmp_path)
+
+    real_sync = real_adapter.update_sync_status
+
+    async def explode_on_chat_b(chat_id, *args, **kwargs):
+        if chat_id == CHAT_B:
+            raise RuntimeError("interrupt: crash after B's rows, before B completes")
+        return await real_sync(chat_id, *args, **kwargs)
+
+    real_adapter.update_sync_status = explode_on_chat_b
+    try:
+        with pytest.raises(RuntimeError, match="before B completes"):
+            await importer.run(str(tmp_path / "export"))
+    finally:
+        real_adapter.update_sync_status = real_sync
+
+    # The sweep reaches the message first and ADOPTS the import row (#405
+    # re-keys it to the sweep's own name).
+    adopted = await real_adapter.adopt_import_media(CHAT_B, 2, f"{CHAT_B}_2_document", account_id=1)
+    assert adopted is not None
+
+    resumed = _importer(real_adapter, tmp_path)
+    await resumed.run(str(tmp_path / "export"))
+
+    state = await _state_snapshot(real_adapter)
+    # Exactly ONE media row for the message, and it is the sweep-named one:
+    # the replay must not re-create import_* next to it.
+    assert state["media"] == [(f"{CHAT_B}_2_document", CHAT_B, 2, 1)]
+
+
+async def test_truncated_export_fails_loudly_and_resumes_on_the_same_file(real_adapter, tmp_path):
+    control = _two_chat_export(tmp_path / "export", b_messages=40)
+    raw = control.read_bytes()
+    cut = raw.rfind(b'"b-20"')  # inside chat B's messages, well after chat A
+    assert cut > 0
+    control.write_bytes(raw[:cut])
+
+    importer = _importer(real_adapter, tmp_path)
+    with pytest.raises(ValueError, match="truncated or invalid"):
+        await importer.run(str(tmp_path / "export"))
+
+    marker = json.loads(await real_adapter.get_metadata(MARKER_KEY))
+    assert marker["completed"] == [CHAT_A]
+
+    # Re-running on the SAME broken file resumes past chat A and fails in B
+    # again — progress is durable, the error is repeatable, nothing doubles.
+    resumed = _importer(real_adapter, tmp_path)
+    with pytest.raises(ValueError, match="truncated or invalid"):
+        await resumed.run(str(tmp_path / "export"))
+    marker = json.loads(await real_adapter.get_metadata(MARKER_KEY))
+    assert marker["completed"] == [CHAT_A]
+
+    state = await _state_snapshot(real_adapter)
+    assert state["sync"] == [(CHAT_A, 2, 2)]  # A once, never doubled; B never completed
+
+
+async def test_replaced_export_does_not_reuse_the_marker(real_adapter, tmp_path):
+    """A different file (fingerprint) must NOT inherit the completed set —
+    a re-export can hold newer messages for a 'completed' chat, and skipping
+    it would silently drop them. The normal guard applies instead.
+    """
+    _two_chat_export(tmp_path / "export")
+    importer = _importer(real_adapter, tmp_path)
+    await importer.run(str(tmp_path / "export"))
+
+    # Plant a stale marker as if an interrupted run had completed chat A of
+    # some OTHER export file.
+    await real_adapter.set_metadata(
+        MARKER_KEY, json.dumps({"fingerprint": "0:deadbeef", "completed": [CHAT_A], "started": CHAT_B})
+    )
+
+    fresh = _importer(real_adapter, tmp_path)
+    with pytest.raises(ValueError, match="already has"):
+        await fresh.run(str(tmp_path / "export"))
+
+
+async def test_dry_run_reads_and_writes_no_marker(real_adapter, tmp_path):
+    _two_chat_export(tmp_path / "export")
+    importer = _importer(real_adapter, tmp_path)
+
+    summary = await importer.run(str(tmp_path / "export"), dry_run=True)
+
+    assert summary["chats_imported"] == 2
+    assert not await real_adapter.get_metadata(MARKER_KEY)
+    state = await _state_snapshot(real_adapter)
+    assert state["messages"] == [] and state["media"] == [] and state["sync"] == []
+
+
+# ---------------------------------------------------------------------------
+# Streaming parser hard-fail sentinel (mocked db — no writes may happen)
+# ---------------------------------------------------------------------------
+
+
+async def test_chat_identity_after_messages_hard_fails(tmp_path):
+    export_dir = tmp_path / "export"
+    export_dir.mkdir()
+    # 'id' and 'type' AFTER the messages array: a forward-only parse derives
+    # the chat id before reading them, so rows would land under the wrong
+    # chat. The importer must refuse rather than corrupt.
+    (export_dir / "result.json").write_text(
+        json.dumps(
+            {
+                "chats": {
+                    "list": [
+                        {
+                            "name": "Sneaky",
+                            "messages": [_msg(1)],
+                            "id": CHAT_A,
+                            "type": "personal_chat",
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    db = AsyncMock()
+    db.get_metadata.return_value = None
+    importer = TelegramImporter(db, str(tmp_path / "media"), account_id=1)
+
+    with pytest.raises(ValueError, match="appeared after"):
+        await importer.run(str(export_dir))
+    db.insert_messages_batch.assert_not_awaited()
+
+
+async def test_streaming_keeps_owner_and_outgoing_flags(real_adapter, tmp_path):
+    """personal_information precedes chats (the TDesktop order): every
+    message carries an honest is_outgoing through the streaming path too.
+    """
+    export_dir = tmp_path / "export"
+    _write_export(
+        export_dir,
+        [
+            {
+                "name": "Chat A",
+                "type": "personal_chat",
+                "id": CHAT_A,
+                "messages": [_msg(1, "mine"), _msg(2, "theirs", from_id="user9999")],
+            }
+        ],
+    )
+    importer = _importer(real_adapter, tmp_path)
+    await importer.run(str(export_dir))
+
+    async with real_adapter.db_manager.async_session_factory() as session:
+        rows = (
+            await session.execute(
+                select(Message.id, Message.is_outgoing).where(Message.account_id == 1, Message.chat_id == CHAT_A)
+            )
+        ).all()
+    assert sorted(rows) == [(1, 1), (2, 0)]  # owner user_id=4242 wrote msg 1

--- a/tests/test_telegram_import.py
+++ b/tests/test_telegram_import.py
@@ -313,6 +313,9 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
 
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -336,6 +339,9 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
 
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 100}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -372,6 +378,9 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
 
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -405,6 +414,9 @@ class TestTelegramImporterRun(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -445,6 +457,9 @@ class TestTelegramImporterRun(unittest.TestCase):
 
         media_dir = os.path.join(self.temp_dir, "media")
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, media_dir, account_id=1)
@@ -483,6 +498,9 @@ class TestTelegramImporterRun(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -516,6 +534,9 @@ class TestTelegramImporterRun(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -548,6 +569,9 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
         media_dir = Path(self.temp_dir, "media")
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, str(media_dir), max_filename_bytes=143, account_id=1)
@@ -587,6 +611,9 @@ class TestTelegramImporterRun(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -637,6 +664,9 @@ class TestTelegramImporterRun(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -644,11 +674,17 @@ class TestTelegramImporterRun(unittest.TestCase):
         with patch("src.telegram_import.BATCH_SIZE", 1):
             summary = self._run(importer.run(self.export_dir))
 
+        # The streaming parser (yajl) sanitizes the lone surrogate at the
+        # boundary — the once-unwritable name becomes plain '?', so BOTH
+        # media import and nothing can crash downstream. The invariant this
+        # test protects (a malformed name must never abort the import) holds.
         self.assertEqual(summary["total_messages"], 2)
-        self.assertEqual(summary["total_media"], 1)
+        self.assertEqual(summary["total_media"], 2)
         self.assertEqual(db.insert_messages_batch.await_count, 2)
-        db.insert_media.assert_awaited_once()
-        self.assertEqual(db.insert_media.call_args.args[0]["message_id"], 2)
+        self.assertEqual(db.insert_media.await_count, 2)
+        first_media = db.insert_media.await_args_list[0].args[0]
+        self.assertEqual(first_media["message_id"], 1)
+        self.assertNotIn("\ud800", first_media["file_name"])
 
     def test_skip_media_flag(self):
         photos_dir = os.path.join(self.export_dir, "photos")
@@ -674,6 +710,9 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
 
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -685,6 +724,9 @@ class TestTelegramImporterRun(unittest.TestCase):
 
     def test_missing_result_json(self):
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         importer = TelegramImporter(db, "/tmp/media", account_id=1)
 
@@ -733,6 +775,9 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
 
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -755,6 +800,9 @@ class TestTelegramImporterRun(unittest.TestCase):
         )
 
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -1265,6 +1313,9 @@ class TestHtmlImportIntegration(unittest.TestCase):
     def test_html_import_requires_chat_id(self):
         self._write_html(SAMPLE_HTML_MESSAGE)
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -1275,6 +1326,9 @@ class TestHtmlImportIntegration(unittest.TestCase):
     def test_html_import_basic(self):
         self._write_html(SAMPLE_HTML_MESSAGE)
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -1298,6 +1352,9 @@ class TestHtmlImportIntegration(unittest.TestCase):
     def test_html_import_dry_run(self):
         self._write_html(SAMPLE_HTML_MESSAGE)
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -1318,6 +1375,9 @@ class TestHtmlImportIntegration(unittest.TestCase):
 
         media_dir = os.path.join(self.temp_dir, "media")
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, media_dir, account_id=1)
@@ -1339,6 +1399,9 @@ class TestHtmlImportIntegration(unittest.TestCase):
             f.write(b"\x00" * 50)
 
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -1351,6 +1414,9 @@ class TestHtmlImportIntegration(unittest.TestCase):
     def test_html_import_forwarded(self):
         self._write_html(SAMPLE_HTML_FORWARDED)
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -1363,6 +1429,9 @@ class TestHtmlImportIntegration(unittest.TestCase):
     def test_html_import_reply(self):
         self._write_html(SAMPLE_HTML_REPLY)
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -1393,6 +1462,9 @@ class TestHtmlImportIntegration(unittest.TestCase):
             )
 
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -1405,6 +1477,9 @@ class TestHtmlImportIntegration(unittest.TestCase):
     def test_no_export_files_raises_error(self):
         """Neither result.json nor messages.html should raise FileNotFoundError."""
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         importer = TelegramImporter(db, "/tmp/media", account_id=1)
 
@@ -1457,6 +1532,9 @@ class TestImportCursorGuard(unittest.TestCase):
     def test_partial_export_leaves_cursor_untouched_and_warns(self):
         self._write_export([self._msg(8000), self._msg(8001)])
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
 
@@ -1472,6 +1550,9 @@ class TestImportCursorGuard(unittest.TestCase):
     def test_head_covering_export_advances_cursor(self):
         self._write_export([self._msg(1), self._msg(2)])
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
 
@@ -1482,6 +1563,9 @@ class TestImportCursorGuard(unittest.TestCase):
     def test_existing_higher_cursor_is_never_lowered(self):
         self._write_export([self._msg(1), self._msg(2)])
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 99999
         db.get_chat_stats.return_value = {"messages": 0}
 
@@ -1492,6 +1576,9 @@ class TestImportCursorGuard(unittest.TestCase):
     def test_date_skipped_message_cannot_raise_the_cursor(self):
         self._write_export([self._msg(1), self._msg(2), self._msg(3, date=None)])
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
 
@@ -1524,6 +1611,9 @@ class TestImportFidelity(unittest.TestCase):
 
     def _importer(self):
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_chat_stats = AsyncMock(return_value=None)
         db.get_chat_by_id = AsyncMock(return_value=None)
         db.get_last_message_id = AsyncMock(return_value=0)
@@ -1561,7 +1651,16 @@ class TestImportFidelity(unittest.TestCase):
         chat_data = {"name": "Exported Chat", "type": "html_export", "id": 0, "messages": [self._msg(1, None)]}
 
         self._run(
-            importer._import_chat(chat_data, 777, Path(self.export_dir), dry_run=False, skip_media=True, merge=True)
+            importer._import_chat(
+                chat_data,
+                777,
+                chat_data["messages"],
+                len(chat_data["messages"]),
+                Path(self.export_dir),
+                dry_run=False,
+                skip_media=True,
+                merge=True,
+            )
         )
 
         row = db.upsert_chat.call_args.args[0]
@@ -1572,7 +1671,16 @@ class TestImportFidelity(unittest.TestCase):
         chat_data = {"name": "Exported Chat", "type": "html_export", "id": 0, "messages": [self._msg(1, None)]}
 
         self._run(
-            importer._import_chat(chat_data, 778, Path(self.export_dir), dry_run=False, skip_media=True, merge=False)
+            importer._import_chat(
+                chat_data,
+                778,
+                chat_data["messages"],
+                len(chat_data["messages"]),
+                Path(self.export_dir),
+                dry_run=False,
+                skip_media=True,
+                merge=False,
+            )
         )
 
         row = db.upsert_chat.call_args.args[0]

--- a/tests/test_telegram_import.py
+++ b/tests/test_telegram_import.py
@@ -674,17 +674,17 @@ class TestTelegramImporterRun(unittest.TestCase):
         with patch("src.telegram_import.BATCH_SIZE", 1):
             summary = self._run(importer.run(self.export_dir))
 
-        # The streaming parser (yajl) sanitizes the lone surrogate at the
-        # boundary — the once-unwritable name becomes plain '?', so BOTH
-        # media import and nothing can crash downstream. The invariant this
-        # test protects (a malformed name must never abort the import) holds.
+        # Backend-independent invariants only: ijson's C backend sanitizes
+        # the lone surrogate (both media import under a writable name), the
+        # pure-Python backend keeps it (that media is skipped at the filename
+        # budget, as before). Either way the import must complete, keep the
+        # well-formed media, and never persist an unencodable filename.
         self.assertEqual(summary["total_messages"], 2)
-        self.assertEqual(summary["total_media"], 2)
         self.assertEqual(db.insert_messages_batch.await_count, 2)
-        self.assertEqual(db.insert_media.await_count, 2)
-        first_media = db.insert_media.await_args_list[0].args[0]
-        self.assertEqual(first_media["message_id"], 1)
-        self.assertNotIn("\ud800", first_media["file_name"])
+        inserted = [call.args[0] for call in db.insert_media.await_args_list]
+        self.assertIn(2, [m["message_id"] for m in inserted])  # the valid media survives
+        for m in inserted:
+            m["file_name"].encode("utf-8")  # raises if a surrogate leaked through
 
     def test_skip_media_flag(self):
         photos_dir = os.path.join(self.export_dir, "photos")

--- a/tests/test_telegram_import_extended.py
+++ b/tests/test_telegram_import_extended.py
@@ -541,6 +541,9 @@ class TestTelegramImporterClose(unittest.TestCase):
         """TelegramImporter.close delegates to close_database."""
         mock_close_db.return_value = None
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         importer = TelegramImporter(db, "/tmp/media", account_id=1)
 
@@ -575,6 +578,9 @@ class TestImporterRunEdgeCases(unittest.TestCase):
         """run raises ValueError when export has no chats (line 558)."""
         self._write_export({"chats": {"list": []}})
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -601,6 +607,9 @@ class TestImporterRunEdgeCases(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
 
@@ -636,6 +645,9 @@ class TestImporterRunEdgeCases(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -659,6 +671,9 @@ class TestImporterRunEdgeCases(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -681,6 +696,9 @@ class TestImporterRunEdgeCases(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -709,6 +727,9 @@ class TestImporterRunEdgeCases(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -744,6 +765,9 @@ class TestImporterRunEdgeCases(unittest.TestCase):
         )
 
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 0}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)
@@ -768,6 +792,9 @@ class TestImporterRunEdgeCases(unittest.TestCase):
             }
         )
         db = AsyncMock()
+        # No sweep-archived media by default: a truthy mock would make the
+        # importer's duplicate guard skip every media insert.
+        db.has_media_for_message = AsyncMock(return_value=False)
         db.get_last_message_id.return_value = 0
         db.get_chat_stats.return_value = {"messages": 500}
         importer = TelegramImporter(db, os.path.join(self.temp_dir, "media"), account_id=1)

--- a/uv.lock
+++ b/uv.lock
@@ -599,6 +599,38 @@ wheels = [
 ]
 
 [[package]]
+name = "ijson"
+version = "3.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/06/b31f040a8764336a11152e474a7abcb3782fedb0d1cdf78f442b82878c56/ijson-3.5.1.tar.gz", hash = "sha256:af40bd1a85f55db0b8b30715c858761306bd92d5590148636f75c3309e6e76bd", size = 69913, upload-time = "2026-07-06T17:37:42.923Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/17/54f9180c0da9a9e96e5b3791bc74093f029a2344678b4da218c2699465bf/ijson-3.5.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:21e1a250b254edba2f0dd7272a4c56f0a879aabe328d9e306dd1fc115f560e74", size = 89223, upload-time = "2026-07-06T17:36:55.534Z" },
+    { url = "https://files.pythonhosted.org/packages/09/70/0ee0d2627c534174455a745ca25284797e71b0d6e2b2a1b31cc914e7b462/ijson-3.5.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:e01f95433725e2df62d682ff88e4a57bb694385ff2362bc364adec961167ae04", size = 60831, upload-time = "2026-07-06T17:36:56.554Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/e6/56f64ba7a3e7a25d9a9fbbeb4c30597d6b76c1094cc2041d11a3224b562c/ijson-3.5.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:539e8d6cca079bcbb68c390e55148f908e0a943a34f7dd321248637c6272adca", size = 60752, upload-time = "2026-07-06T17:36:57.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/2b/5a55db881f1b043cd6d5716578937a60ac16348be1a3afbf846b21cf4b44/ijson-3.5.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:32f64051be2f990d8ae7b614b5abdf4a7bead510ce3666568d7403c6c46ce4d8", size = 140783, upload-time = "2026-07-06T17:36:58.984Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/61/f7783cc18672dc31544141139efd187fb34795d24e573fed6abea6b776c7/ijson-3.5.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cd0dfc5a788d0b0c2f1eab258b9dabdeefc631ca8ef87644a999f633b0b2555a", size = 149976, upload-time = "2026-07-06T17:37:00.235Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/d6/4182dd63b6b70eae4f5208c53558a050895a40734dff283463033c153742/ijson-3.5.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:42bfda7858d99ee9777ec28cb6d347928249eefeb577f9b0a67503c18f7ebb6a", size = 149317, upload-time = "2026-07-06T17:37:01.476Z" },
+    { url = "https://files.pythonhosted.org/packages/01/b1/a675e4a9b428a0ef556e7d718bf0e6885e3e5543042248a1a7030899a3d4/ijson-3.5.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:c4b9a28e9719d1aebebe93ad8dc2ba87f4e2d9035043b196c1c07ef8530b44cc", size = 150555, upload-time = "2026-07-06T17:37:02.676Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/69/52686f56b44af63a93c3dc3f5bcfa07f87427d9aea4d2cbe3e1c94188c74/ijson-3.5.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9a0b25c750a6bde14a0b31f1dcbfc86368e50767e3eaa73bb138e54128055edd", size = 144485, upload-time = "2026-07-06T17:37:03.779Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/46/10554e817dde56300a8414e52c0f5a44a29f3440327cd6d829ece57759b3/ijson-3.5.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bd756f7b22df745ac14b7bc2ab9ed7c190a222e4c8e1bef26ef1162af8e54d0f", size = 151470, upload-time = "2026-07-06T17:37:04.901Z" },
+    { url = "https://files.pythonhosted.org/packages/91/82/f37cbb110b48abdb623d169d0e196f2f6e064e2c20fa789ecde6e69b0440/ijson-3.5.1-cp314-cp314-win32.whl", hash = "sha256:e035cdfb2a1446b13881f0dfc0eecd1541cbb17a27a938ded2160ae6ce25051b", size = 53219, upload-time = "2026-07-06T17:37:06.254Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/792df8f001c246c8ff28f860de81d35ea0d797c0d3276c22a2af83089656/ijson-3.5.1-cp314-cp314-win_amd64.whl", hash = "sha256:eeb2fb2daa5dd30326f93db465d0855b34aa6b1f52a7c0ff94522aec5ad57dfb", size = 55485, upload-time = "2026-07-06T17:37:07.242Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3c/db3ccc22c09ed4738787e8d82fff76101aa81ec8de7eaf6572e065e012d3/ijson-3.5.1-cp314-cp314-win_arm64.whl", hash = "sha256:a96ab35d7ce2129dfde49c4c807596443410e260d7f7a4ca8fe4d0035553b589", size = 54390, upload-time = "2026-07-06T17:37:08.497Z" },
+    { url = "https://files.pythonhosted.org/packages/26/59/eefa5d9488250c03f24152576804205ae40e29cac0dc65cbbc5f3d422008/ijson-3.5.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:77b68e91f95fb16ac2e7819903cd545db6cffa308c28833cc34911e6b21e91dd", size = 93177, upload-time = "2026-07-06T17:37:09.71Z" },
+    { url = "https://files.pythonhosted.org/packages/88/db/6329eb7bb9f1906c1906fc10e7074b8f08bf39b7d50baa58f1b597d48898/ijson-3.5.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:94a95065b1ac67602af0cec852b07505abc37b77e3774d1c801d935d05e48f82", size = 62891, upload-time = "2026-07-06T17:37:10.735Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/d0/b3beddb96eef0b20bb9902c36e4de30f145be06d7e5e1d780e1a1689d0ce/ijson-3.5.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b70b5da6b0571da8f601a437c4fba2d35bc27739637d85f3acdc8f88916ce68e", size = 62575, upload-time = "2026-07-06T17:37:11.681Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/01/95f3a7c27d25bb917954ef0c8e86d0e60f585b9db675cbd05d355f54cce8/ijson-3.5.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:0ade373dd765b057b1dec05d7711bfeb5a36f1e825259466d9f545cfd8ef3ba3", size = 200568, upload-time = "2026-07-06T17:37:12.743Z" },
+    { url = "https://files.pythonhosted.org/packages/77/61/c94ee4ea1f22318aab9a49b35d0ce8ac87dd24d508ea4c77dcbde362ba5e/ijson-3.5.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:882bc0bdd25d41eae90a15695cd50707edde0978b8b72a2532e30442dd8fd04c", size = 217956, upload-time = "2026-07-06T17:37:14.041Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/82/43e8d225aea5ee00eef7998c8ce41f344f7ba451329dfa9e92f4700813af/ijson-3.5.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:451901c36e12fa87cbb1cafe661bd25c08c6bd7900cc738279614f71cea07048", size = 208403, upload-time = "2026-07-06T17:37:15.201Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/6f/375f67fad76677aca9bc0817b2b18fdd231d309fe24e26b19a5556ef6cdd/ijson-3.5.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3c5f660658f2ebfba5d4dfe4bafe8cd3a0defcda410ec08d2205fe08c398940", size = 211967, upload-time = "2026-07-06T17:37:16.484Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/53/4c754c3ba18ec70b7086b91a4abd368358fc47cc9b3871afd50deef4fea1/ijson-3.5.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:29eb8f0c77a296a10843a1714ad4a5d561e604cda3c88585e9012cf2c1729b0a", size = 201020, upload-time = "2026-07-06T17:37:18.017Z" },
+    { url = "https://files.pythonhosted.org/packages/26/2d/3e7191b3222a31c378b827565b4fa64676a293441279f84db3d971720bf5/ijson-3.5.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:85997568d6b304cfa59d5c3f2b04f95b92e9a8c7f57d312343a7989cf8dfff85", size = 205584, upload-time = "2026-07-06T17:37:19.343Z" },
+    { url = "https://files.pythonhosted.org/packages/24/11/55ae9c915e68f37c8698f8b09355071dc808ced5e9d4abf8238dc363f500/ijson-3.5.1-cp314-cp314t-win32.whl", hash = "sha256:c2e2509dc7f2fa5a2ac9ba7d15dd901f4093bd36b0784f65e04b681b7956651c", size = 54438, upload-time = "2026-07-06T17:37:20.656Z" },
+    { url = "https://files.pythonhosted.org/packages/96/df/5bf2656447f14a923d25a0401b1cd628ca05c23041d3a4c116ae8d44dc39/ijson-3.5.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2699e838099d056818c5f8e4ba702b345d0304e58847bdc79c5c1616d5d750a5", size = 56467, upload-time = "2026-07-06T17:37:21.615Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/e4/dec06e84fac704039625039c6b116a44f17ad72fda48b8f88a2493364b77/ijson-3.5.1-cp314-cp314t-win_arm64.whl", hash = "sha256:c388f85cbb9eec022b2bdedd23ffacfe7ab100c1200b1f47bee6e6ea2c3309fa", size = 55774, upload-time = "2026-07-06T17:37:22.958Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1205,6 +1237,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "greenlet" },
     { name = "httpx" },
+    { name = "ijson" },
     { name = "jinja2" },
     { name = "pillow" },
     { name = "psycopg2-binary" },
@@ -1256,6 +1289,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "greenlet", specifier = ">=3.1.0" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "ijson", specifier = ">=3.5.1" },
     { name = "jinja2", specifier = ">=3.1.4" },
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.5.1" },


### PR DESCRIPTION
Importing a big Telegram Desktop export could kill the container before it wrote a single row: `json.load` materialized the whole file (roughly 4x its size as Python objects), and if anything interrupted the import you were left with a half-imported chat that was worse to retry — plain re-run refused with "already has N messages", and the `--merge` escape hatch re-added the full count to `sync_status.message_count` every time.

Two changes, designed together:

- **`result.json` streams.** One sequential ijson pass hands the importer one chat's metadata plus that chat's messages one at a time. Memory stays flat regardless of export size — measured 18 MiB peak over a 349 MB / 600k-message export where `json.load` needed 1.4 GiB. The C backend (`yajl2_c`) ships self-contained in ijson's wheels; new dependency `ijson>=3.5.1` (BSD-3-Clause AND ISC).
- **Interrupted imports resume.** Progress is checkpointed per chat in the metadata KV, keyed to the exact file (size + head hash). Re-running the same command on the same file skips finished chats and replays the chat the crash was inside; every importer write is already an idempotent upsert, so the replay converges and the final state — including the additive `message_count` — is identical to an uninterrupted run. A REPLACED file deliberately starts fresh: a re-export can contain newer messages for "completed" chats, and inheriting the skip set would silently drop them.

The adversarial pre-review of this design surfaced failure modes that are now guarded and mutation-tested:

- a replay could resurrect an `import_*` media row the sweep had adopted (#405 re-keys them) — the importer now stands aside whenever any other media row covers the message;
- forward-only parsing makes export key order load-bearing — chat `id`/`type` appearing after the messages array aborts the import instead of filing rows under the wrong chat;
- `upsert_user` updated every column from possibly-absent keys, so the importer (which only knows `first_name`) was NULLing captured usernames/phones on every run — it now updates only the keys present, keeping the capture paths' clear-on-None semantics (they build every key explicitly);
- truncated exports fail loudly after yielding everything parseable, with progress saved so the retry is cheap.

Testing got a structural upgrade: the import path had zero real-database coverage (every existing test mocks the adapter, and SQLite doesn't enforce the FKs PostgreSQL does). `tests/test_streaming_import.py` runs the importer end to end through `conftest.real_adapter` on both backends — interrupt-and-resume equality, adoption round-trip, truncation, fingerprint mismatch, and the key-order sentinel. Each guard was verified to go red when its code is removed.

One deliberate behavior change: a media `file_name` containing a lone UTF-16 surrogate used to be unwritable and skipped; the streaming parser sanitizes it at the boundary (yajl replaces it), so the media now imports under the sanitized name.

Closes the streaming/resume half of bead 9t6.5.48 (from the #303/#310 follow-up work).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added streaming JSON imports that process chats efficiently and support resuming interrupted imports.
  * Imports detect incomplete or replaced export files and help prevent duplicate media records.
  * Import summaries now include skipped chats and improved progress tracking.
  * User information is preserved when imported fields are omitted, while explicit clears remain supported.

* **Documentation**
  * Documented resumable JSON imports, checkpointing behavior, export replacement, and merge requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->