### PR TITLE
chore(release): 8.3.1 — the viewer is usable again

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [8.3.1] - 2026-08-24
+
+### Fixed
+
+- **The viewer rendered raw template over the whole UI.** 8.3.0's template lost the export modal's closing tags (a modal was spliced in mid-element); browsers recovered by force-closing open elements, which pushed every later modal outside Vue's mount target — they showed as un-compiled `{{ }}` overlays with dead buttons, covering the app on every browser. The structure is restored, and a new structural test makes the whole class unshippable: the template must parse perfectly balanced, with every modal inside the mount target. ([#408](https://github.com/GeiserX/Telegram-Archive/pull/408))
+
 ## [8.3.0] - 2026-08-23
 
 Fidelity and scale: the archive now keeps what official clients show — formatting, forward origins, link previews, the media kinds that used to vanish — searches it through a real text index, and survives gigabyte imports. Every change shipped through its own reviewed PR.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "8.3.0"
+version = "8.3.1"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "8.3.0"
+__version__ = "8.3.1"

--- a/uv.lock
+++ b/uv.lock
@@ -1224,7 +1224,7 @@ wheels = [
 
 [[package]]
 name = "telegram-archive"
-version = "8.3.0"
+version = "8.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Hotfix release for the 8.3.0 viewer lock-out (#408): raw template rendered over the whole UI because the export modal's closing tags were lost and parser recovery ejected every later modal out of `#app`. Version bump + changelog; tag v8.3.1 follows the merge.