### PR TITLE
ci(dependabot): stop shipping Python bumps CI can never resolve

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,12 @@
 version: 2
 updates:
-  - package-ecosystem: pip
+  # uv, not pip: every CI job installs with `uv sync --locked`, so a bump that
+  # rewrites pyproject.toml without relocking dies at resolution before a single
+  # check runs (#410). The pip updater cannot write uv.lock; the uv one does, and
+  # it is already what the security updates in this repo go through.
+  # requirements.txt stays hand-maintained — it is loose `>=` floors kept for
+  # `pip install -r`, not the source of truth the images build from.
+  - package-ecosystem: uv
     directory: /
     schedule:
       interval: weekly
@@ -18,7 +24,7 @@ updates:
         update-types:
           - minor
           - patch
-      pip_security:
+      uv_security:
         applies-to: security-updates
         patterns:
           - '*'


### PR DESCRIPTION
Every Monday Dependabot opens a Python bump, and every one of them arrives dead: the `ruff` and `test` jobs fail in the first ten seconds with

```
error: The lockfile at `uv.lock` needs to be updated, but `--locked` was provided.
```

Nothing is wrong with the dependency. The `pip` updater rewrites `pyproject.toml` and cannot write `uv.lock` — and every CI job installs with `uv sync --locked`, so resolution fails before a single check runs. #410 (ruff 0.15.14 → 0.16.4) is the latest one: two red required checks, both from a stale lockfile, and the bump itself turned out to be clean once the lock caught up.

Dependabot has a first-class `uv` ecosystem that updates `pyproject.toml` and `uv.lock` together. It is already the updater this repo's security bumps go through — #279, #278, #231 all landed green with the lock updated — so the version updates were the only ones still going out through `pip`.

One line, plus the reasoning beside it so nobody flips it back. `requirements.txt` stays hand-maintained; it is loose `>=` floors kept for `pip install -r`, not what the images build from.

Verified against the official Dependabot schema (`check-jsonschema --builtin-schema vendor.dependabot`), including a deliberately invalid ecosystem to confirm the validator actually rejects one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated Python dependency update configuration to use the `uv` ecosystem.
  * Clarified dependency source-of-truth documentation.
  * Renamed the security update grouping for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->