### PR TITLE
release: 8.3.2 - Telegram connections that stop timing out and spinning

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [8.3.2] - 2026-08-25
+
+Dependency maintenance. Nothing about how the archive behaves changes.
+
+### Changed
+
+- **Telethon 1.44.0** (scheme layer 227). Two of its fixes land on exactly this workload: it no longer times out handling server salts, and no longer burns CPU when Telegram closes a connection from its end. ([#412](https://github.com/GeiserX/Telegram-Archive/pull/412))
+- FastAPI, Uvicorn, websockets, Alembic, BeautifulSoup, ijson and pywebpush each move up a minor or two; ruff, pytest and pre-commit follow on the development side. ([#412](https://github.com/GeiserX/Telegram-Archive/pull/412), [#410](https://github.com/GeiserX/Telegram-Archive/pull/410))
+- Dependency updates now arrive with `uv.lock` already updated. They had been proposed against `pyproject.toml` alone, which CI refuses to resolve because it installs with `uv sync --locked` — so every one of them arrived with red checks that had nothing to do with the dependency. ([#411](https://github.com/GeiserX/Telegram-Archive/pull/411))
+
 ## [8.3.1] - 2026-08-24
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "8.3.1"
+version = "8.3.2"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "8.3.1"
+__version__ = "8.3.2"

--- a/uv.lock
+++ b/uv.lock
@@ -1224,7 +1224,7 @@ wheels = [
 
 [[package]]
 name = "telegram-archive"
-version = "8.3.1"
+version = "8.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Dependency maintenance on top of 8.3.1. Nothing about how the archive behaves changes, but three of the bumps are worth naming.

**Telethon 1.44.0** (scheme layer 227) fixes two things a long-running capture container actually hits: timeouts while handling server salts, and high CPU when Telegram closes a connection from its end. FastAPI, Uvicorn, websockets, Alembic, BeautifulSoup, ijson and pywebpush each move up a minor or two; ruff, pytest and pre-commit follow on the development side.

Dependency updates now also arrive with `uv.lock` already updated. They had been proposed against `pyproject.toml` alone, which CI refuses to resolve — it installs with `uv sync --locked` — so every bump arrived with two red checks that had nothing to do with the dependency.

Verified before merging the bumps: full suite green on both backends, both multi-arch images built from the new lock, and the viewer started for real on the new FastAPI/Uvicorn/websockets set — serving at 200 with the websocket upgrade correctly refused for an unauthenticated socket. The test client never starts Uvicorn, so that jump was otherwise unexercised.

Ships #410, #411, #412 and #413.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Released version 8.3.2 with updated dependency versions.
  * Improved connection stability and reduced CPU usage when closing connections.
* **Documentation**
  * Added changelog details for the 8.3.2 release.
* **Maintenance**
  * Dependency updates now include a synchronized lockfile for more reliable installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->