### PR TITLE
feat(listener): let a first message from a never-tracked chat match CHAT_TYPES

### DIFF
--- a/src/listener.py
+++ b/src/listener.py
@@ -1240,7 +1240,16 @@ class TelegramListener:
                 # backup adds it to _tracked_chat_ids. Otherwise a first message
                 # from someone we've never chatted with is invisible to the
                 # listener (see _should_process_chat).
+                #
+                # Telethon's event.is_channel is True for BOTH broadcast channels
+                # and megagroups (any PeerChannel), while event.is_group is True
+                # for megagroups too - so a megagroup would otherwise set both
+                # flags and could match a channels-only CHAT_TYPES filter it
+                # should be excluded from. _get_chat_type() already treats a
+                # megagroup as "group", never "channel"; mirror that here.
                 is_user, is_group, is_channel = event.is_private, event.is_group, event.is_channel
+                if is_channel and is_group:
+                    is_channel = False
 
                 # Add to tracked chats if we should be backing up this chat
                 if chat_id not in self._tracked_chat_ids:

--- a/src/listener.py
+++ b/src/listener.py
@@ -744,23 +744,27 @@ class TelegramListener:
         MODE 2 - Type-based Mode:
             Process if:
             - Chat is in our tracked list (backed up at least once), OR
-            - Chat matches our backup filters (include lists), OR
             - The caller already knows the chat's type (is_user/is_group/
-              is_channel) and it matches CHAT_TYPES
+              is_channel) and the full scheduled-backup decision
+              (config.should_backup_chat: excludes first, include lists as
+              whitelists, then CHAT_TYPES) accepts it, OR
+            - Without type info: chat is in an explicit include list
 
         The is_user/is_group/is_channel kwargs let a caller that already has
         cheap, no-network type info (e.g. NewMessage.Event.is_private/
         is_group/is_channel, derived from the update's peer) evaluate a
-        brand-new, never-tracked chat against CHAT_TYPES immediately -
-        without them, a chat we've never backed up falls through to
-        "conservative: only explicit include lists match", i.e. first
-        contact from someone we've never chatted with is invisible to the
-        listener until the next scheduled backup discovers it. Bots can't
-        be distinguished from regular users this way (that needs the sender
-        entity, which isn't synchronously available), so is_user=True is
-        passed for both - a first DM from a bot is evaluated against
-        CHAT_TYPES' "private" bucket rather than "bots" until the next
-        scheduled backup reclassifies it.
+        brand-new, never-tracked chat immediately - without them, a chat
+        we've never backed up falls through to "conservative: only explicit
+        include lists match", i.e. first contact from someone we've never
+        chatted with is invisible to the listener until the next scheduled
+        backup discovers it. With them, the decision is should_backup_chat()
+        - the same one the scheduled backup applies - so a chat the exclude
+        lists or an include-whitelist would keep out of the archive is never
+        live-captured either. Bots can't be distinguished from regular users
+        this way (that needs the sender entity, which isn't synchronously
+        available), so is_user=True is passed for both - a first DM from a
+        bot is evaluated against CHAT_TYPES' "private" bucket rather than
+        "bots" until the next scheduled backup reclassifies it.
         """
         # MODE 1: Whitelist Mode - CHAT_IDS takes absolute priority. Followed
         # migrations are added explicitly (not via _tracked_chat_ids, which
@@ -773,7 +777,16 @@ class TelegramListener:
         if chat_id in self._tracked_chat_ids:
             return True
 
-        # If not tracked yet, check if it would be backed up based on config
+        # With type info in hand, an untracked chat gets exactly the
+        # scheduled backup's decision - excludes first, include lists as
+        # whitelists, then CHAT_TYPES. Never the bare type filter: a chat
+        # the exclude lists (or an include-whitelist) keep out of the
+        # archive must not be live-captured either.
+        if is_user is not None or is_group is not None or is_channel is not None:
+            return self.config.should_backup_chat(chat_id, bool(is_user), bool(is_group), bool(is_channel))
+
+        # Without type info (edits/deletions/pins/reactions), stay
+        # conservative: only explicit include-list membership matches.
         if chat_id in self.config.global_include_ids:
             return True
         if chat_id in self.config.private_include_ids:
@@ -782,12 +795,6 @@ class TelegramListener:
             return True
         if chat_id in self.config.channels_include_ids:
             return True
-
-        # First-contact fallback: only take this path when the caller
-        # supplied real type info; otherwise stay conservative and return
-        # False rather than guess.
-        if is_user is not None or is_group is not None or is_channel is not None:
-            return self.config.should_backup_chat_type(bool(is_user), bool(is_group), bool(is_channel))
 
         return False
 
@@ -1248,7 +1255,14 @@ class TelegramListener:
                 # should be excluded from. _get_chat_type() already treats a
                 # megagroup as "group", never "channel"; mirror that here.
                 is_user, is_group, is_channel = event.is_private, event.is_group, event.is_channel
-                if is_channel and is_group:
+                if is_channel and is_group is None:
+                    # Telethon's is_group is None for a PeerChannel whose
+                    # broadcast flag it can't see (chat entity absent from
+                    # the update). Megagroup vs broadcast is unknowable
+                    # here, so don't guess: drop the hints and take the
+                    # conservative no-hint path for this message.
+                    is_user = is_group = is_channel = None
+                elif is_channel and is_group:
                     is_channel = False
 
                 # Add to tracked chats if we should be backing up this chat

--- a/src/listener.py
+++ b/src/listener.py
@@ -724,7 +724,14 @@ class TelegramListener:
                 media_type=prior.get("media_type"),
             )
 
-    def _should_process_chat(self, chat_id: int) -> bool:
+    def _should_process_chat(
+        self,
+        chat_id: int,
+        *,
+        is_user: bool | None = None,
+        is_group: bool | None = None,
+        is_channel: bool | None = None,
+    ) -> bool:
         """
         Check if we should process events for this chat.
 
@@ -737,7 +744,23 @@ class TelegramListener:
         MODE 2 - Type-based Mode:
             Process if:
             - Chat is in our tracked list (backed up at least once), OR
-            - Chat matches our backup filters (include lists)
+            - Chat matches our backup filters (include lists), OR
+            - The caller already knows the chat's type (is_user/is_group/
+              is_channel) and it matches CHAT_TYPES
+
+        The is_user/is_group/is_channel kwargs let a caller that already has
+        cheap, no-network type info (e.g. NewMessage.Event.is_private/
+        is_group/is_channel, derived from the update's peer) evaluate a
+        brand-new, never-tracked chat against CHAT_TYPES immediately -
+        without them, a chat we've never backed up falls through to
+        "conservative: only explicit include lists match", i.e. first
+        contact from someone we've never chatted with is invisible to the
+        listener until the next scheduled backup discovers it. Bots can't
+        be distinguished from regular users this way (that needs the sender
+        entity, which isn't synchronously available), so is_user=True is
+        passed for both - a first DM from a bot is evaluated against
+        CHAT_TYPES' "private" bucket rather than "bots" until the next
+        scheduled backup reclassifies it.
         """
         # MODE 1: Whitelist Mode - CHAT_IDS takes absolute priority. Followed
         # migrations are added explicitly (not via _tracked_chat_ids, which
@@ -751,8 +774,6 @@ class TelegramListener:
             return True
 
         # If not tracked yet, check if it would be backed up based on config
-        # We can't determine chat type without fetching the entity, so be conservative
-        # and only process if it's in an explicit include list
         if chat_id in self.config.global_include_ids:
             return True
         if chat_id in self.config.private_include_ids:
@@ -761,6 +782,12 @@ class TelegramListener:
             return True
         if chat_id in self.config.channels_include_ids:
             return True
+
+        # First-contact fallback: only take this path when the caller
+        # supplied real type info; otherwise stay conservative and return
+        # False rather than guess.
+        if is_user is not None or is_group is not None or is_channel is not None:
+            return self.config.should_backup_chat_type(bool(is_user), bool(is_group), bool(is_channel))
 
         return False
 
@@ -1206,14 +1233,23 @@ class TelegramListener:
             try:
                 chat_id = self._get_marked_id(event.chat_id)
 
+                # NewMessage carries its peer type (PeerUser/PeerChat/PeerChannel)
+                # synchronously via _chat_peer - no entity fetch needed - so a chat
+                # we've never backed up before can be matched against CHAT_TYPES
+                # right now instead of being dropped until the next scheduled
+                # backup adds it to _tracked_chat_ids. Otherwise a first message
+                # from someone we've never chatted with is invisible to the
+                # listener (see _should_process_chat).
+                is_user, is_group, is_channel = event.is_private, event.is_group, event.is_channel
+
                 # Add to tracked chats if we should be backing up this chat
                 if chat_id not in self._tracked_chat_ids:
-                    if self._should_process_chat(chat_id):
+                    if self._should_process_chat(chat_id, is_user=is_user, is_group=is_group, is_channel=is_channel):
                         self._tracked_chat_ids.add(chat_id)
                         logger.debug("Added chat to tracking list")
 
                 # Skip if not in tracked chats
-                if not self._should_process_chat(chat_id):
+                if not self._should_process_chat(chat_id, is_user=is_user, is_group=is_group, is_channel=is_channel):
                     return
 
                 # Save the message to database

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -628,6 +628,39 @@ class TestEventHandlers:
         assert new_chat_id not in listener._tracked_chat_ids
         listener.db.insert_message.assert_not_called()
 
+    def test_on_new_message_first_contact_megagroup_not_treated_as_channel(self, listener_with_handlers, full_config):
+        """A megagroup's first message sets both is_group and is_channel on the
+        Telethon event; CHAT_TYPES=channels alone must not match it (#415 review
+        fix - _get_chat_type() already treats a megagroup as "group", never
+        "channel", so the type hint passed to should_backup_chat_type must too)."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.NewMessage]
+
+        # CHAT_TYPES=channels only: a real "channels" chat would match, but a
+        # megagroup (is_group=True *and* is_channel=True on the raw event) must not.
+        full_config.should_backup_chat_type = MagicMock(
+            side_effect=lambda is_user, is_group, is_channel: is_channel and not is_group
+        )
+
+        new_chat_id = -1005555555
+        listener._tracked_chat_ids = set()
+
+        event = MagicMock()
+        event.chat_id = new_chat_id
+        event.is_private = False
+        event.is_group = True  # Telethon: True for a megagroup
+        event.is_channel = True  # Telethon: also True for a megagroup (any PeerChannel)
+        msg = MagicMock()
+        msg.reply_to = None
+        event.message = msg
+
+        asyncio.run(handler(event))
+
+        for call in full_config.should_backup_chat_type.call_args_list:
+            assert call.args == (False, True, False)
+        assert new_chat_id not in listener._tracked_chat_ids
+        listener.db.insert_message.assert_not_called()
+
     def test_on_new_message_increments_error_on_exception(self, listener_with_handlers):
         """Test error counter increments when handler raises an exception."""
         listener, handlers = listener_with_handlers

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -31,9 +31,10 @@ class TestTelegramListener:
         # CHAT_IDS whitelist mode (v6.0.0)
         config.whitelist_mode = False
         config.chat_ids = set()
-        # First-contact CHAT_TYPES fallback (default: no match, same as the
-        # pre-fallback conservative behavior) unless a test opts in.
-        config.should_backup_chat_type = MagicMock(return_value=False)
+        # First-contact fallback (default: no match, same as the pre-hint
+        # conservative behavior) unless a test opts in. The listener consults
+        # the full should_backup_chat decision, never the bare type filter.
+        config.should_backup_chat = MagicMock(return_value=False)
         # Mass operation protection settings
         config.listen_edits = True
         config.listen_deletions = False
@@ -97,22 +98,22 @@ class TestTelegramListener:
         listener._tracked_chat_ids = set()
 
         assert listener._should_process_chat(555) is False
-        mock_config.should_backup_chat_type.assert_not_called()
+        mock_config.should_backup_chat.assert_not_called()
 
     def test_should_process_chat_type_hint_first_contact(self, mock_config, mock_db):
         """A type hint lets a never-before-seen chat match CHAT_TYPES (#415)."""
         listener = TelegramListener(mock_config, mock_db, account_id=1)
         listener._tracked_chat_ids = set()
-        mock_config.should_backup_chat_type = MagicMock(return_value=True)
+        mock_config.should_backup_chat = MagicMock(return_value=True)
 
         assert listener._should_process_chat(555, is_user=True, is_group=False, is_channel=False) is True
-        mock_config.should_backup_chat_type.assert_called_once_with(True, False, False)
+        mock_config.should_backup_chat.assert_called_once_with(555, True, False, False)
 
     def test_should_process_chat_type_hint_no_match(self, mock_config, mock_db):
         """A type hint that CHAT_TYPES rejects still returns False."""
         listener = TelegramListener(mock_config, mock_db, account_id=1)
         listener._tracked_chat_ids = set()
-        mock_config.should_backup_chat_type = MagicMock(return_value=False)
+        mock_config.should_backup_chat = MagicMock(return_value=False)
 
         assert listener._should_process_chat(555, is_user=True, is_group=False, is_channel=False) is False
 
@@ -120,11 +121,25 @@ class TestTelegramListener:
         """CHAT_IDS whitelist mode takes priority over any type hint."""
         mock_config.whitelist_mode = True
         mock_config.chat_ids = {-1002222222}
-        mock_config.should_backup_chat_type = MagicMock(return_value=True)
+        mock_config.should_backup_chat = MagicMock(return_value=True)
         listener = TelegramListener(mock_config, mock_db, account_id=1)
         listener._tracked_chat_ids = set()
 
         assert listener._should_process_chat(555, is_user=True, is_group=False, is_channel=False) is False
+        mock_config.should_backup_chat.assert_not_called()
+
+    def test_should_process_chat_type_hint_uses_full_decision_not_bare_type_filter(self, mock_config, mock_db):
+        """The hinted path consults should_backup_chat (excludes first, include
+        lists as whitelists, then CHAT_TYPES) - never the bare type filter,
+        which would live-capture chats the exclude lists keep out of the
+        archive (#416 review)."""
+        listener = TelegramListener(mock_config, mock_db, account_id=1)
+        listener._tracked_chat_ids = set()
+        mock_config.should_backup_chat = MagicMock(return_value=False)
+        mock_config.should_backup_chat_type = MagicMock(return_value=True)
+
+        assert listener._should_process_chat(555, is_user=True, is_group=False, is_channel=False) is False
+        mock_config.should_backup_chat.assert_called_once_with(555, True, False, False)
         mock_config.should_backup_chat_type.assert_not_called()
 
     def test_get_marked_id(self, mock_config, mock_db):
@@ -298,9 +313,10 @@ class TestEventHandlers:
         config.mass_operation_window_seconds = 30
         config.mass_operation_buffer_delay = 2.0
         config.should_download_media_for_chat = MagicMock(return_value=False)
-        # First-contact CHAT_TYPES fallback (default: no match, same as the
-        # pre-fallback conservative behavior) unless a test opts in.
-        config.should_backup_chat_type = MagicMock(return_value=False)
+        # First-contact fallback (default: no match, same as the pre-hint
+        # conservative behavior) unless a test opts in. The listener consults
+        # the full should_backup_chat decision, never the bare type filter.
+        config.should_backup_chat = MagicMock(return_value=False)
         return config
 
     @pytest.fixture
@@ -537,17 +553,28 @@ class TestEventHandlers:
         assert saved["raw_data"]["entities"] == [{"type": "bold", "offset": 0, "length": 4}]
 
     def test_on_new_message_adds_untracked_chat_to_tracking(self, listener_with_handlers, full_config):
-        """Test new message from untracked-but-included chat gets added to tracking."""
+        """Test new message from untracked-but-included chat gets added to tracking.
+
+        With type hints on the event (every real NewMessage has them), the
+        include decision is should_backup_chat's - mock it with the real
+        semantics: global include membership wins.
+        """
         listener, handlers = listener_with_handlers
         handler = handlers[events.NewMessage]
 
         # Chat not in tracked set, but in global include list
         new_chat_id = -1009999999
         full_config.global_include_ids = {new_chat_id}
+        full_config.should_backup_chat = MagicMock(
+            side_effect=lambda chat_id, is_user, is_group, is_channel: chat_id in full_config.global_include_ids
+        )
         listener._tracked_chat_ids = set()  # Empty
 
         event = MagicMock()
         event.chat_id = new_chat_id
+        event.is_private = False
+        event.is_group = False
+        event.is_channel = True
         msg = MagicMock()
         msg.reply_to = None
         msg.id = 1
@@ -573,7 +600,7 @@ class TestEventHandlers:
         listener, handlers = listener_with_handlers
         handler = handlers[events.NewMessage]
 
-        full_config.should_backup_chat_type = MagicMock(return_value=True)
+        full_config.should_backup_chat = MagicMock(return_value=True)
 
         new_chat_id = 424242424  # Never backed up, not in any include list
         listener._tracked_chat_ids = set()
@@ -601,7 +628,7 @@ class TestEventHandlers:
         asyncio.run(handler(event))
 
         assert new_chat_id in listener._tracked_chat_ids
-        full_config.should_backup_chat_type.assert_called_once_with(True, False, False)
+        full_config.should_backup_chat.assert_called_once_with(424242424, True, False, False)
         listener.db.insert_message.assert_called_once()
 
     def test_on_new_message_first_contact_no_chat_types_match(self, listener_with_handlers, full_config):
@@ -609,7 +636,7 @@ class TestEventHandlers:
         listener, handlers = listener_with_handlers
         handler = handlers[events.NewMessage]
 
-        full_config.should_backup_chat_type = MagicMock(return_value=False)
+        full_config.should_backup_chat = MagicMock(return_value=False)
 
         new_chat_id = 424242425
         listener._tracked_chat_ids = set()
@@ -632,14 +659,14 @@ class TestEventHandlers:
         """A megagroup's first message sets both is_group and is_channel on the
         Telethon event; CHAT_TYPES=channels alone must not match it (#415 review
         fix - _get_chat_type() already treats a megagroup as "group", never
-        "channel", so the type hint passed to should_backup_chat_type must too)."""
+        "channel", so the type hint passed to should_backup_chat must too)."""
         listener, handlers = listener_with_handlers
         handler = handlers[events.NewMessage]
 
         # CHAT_TYPES=channels only: a real "channels" chat would match, but a
         # megagroup (is_group=True *and* is_channel=True on the raw event) must not.
-        full_config.should_backup_chat_type = MagicMock(
-            side_effect=lambda is_user, is_group, is_channel: is_channel and not is_group
+        full_config.should_backup_chat = MagicMock(
+            side_effect=lambda chat_id, is_user, is_group, is_channel: is_channel and not is_group
         )
 
         new_chat_id = -1005555555
@@ -656,9 +683,37 @@ class TestEventHandlers:
 
         asyncio.run(handler(event))
 
-        for call in full_config.should_backup_chat_type.call_args_list:
-            assert call.args == (False, True, False)
+        for call in full_config.should_backup_chat.call_args_list:
+            assert call.args[1:] == (False, True, False)
         assert new_chat_id not in listener._tracked_chat_ids
+        listener.db.insert_message.assert_not_called()
+
+    def test_on_new_message_channel_unknown_broadcast_stays_conservative(self, listener_with_handlers, full_config):
+        """A PeerChannel whose broadcast flag Telethon can't see yields
+        is_group=None; megagroup vs broadcast is unknowable there, so no hints
+        are passed and the pre-hint conservative behavior applies (#416
+        review) rather than guessing "channel"."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.NewMessage]
+
+        full_config.should_backup_chat = MagicMock(return_value=True)
+
+        new_chat_id = -1006666666
+        listener._tracked_chat_ids = set()
+
+        event = MagicMock()
+        event.chat_id = new_chat_id
+        event.is_private = False
+        event.is_group = None  # Telethon: broadcast status unknown
+        event.is_channel = True
+        msg = MagicMock()
+        msg.reply_to = None
+        event.message = msg
+
+        asyncio.run(handler(event))
+
+        assert new_chat_id not in listener._tracked_chat_ids
+        full_config.should_backup_chat.assert_not_called()
         listener.db.insert_message.assert_not_called()
 
     def test_on_new_message_increments_error_on_exception(self, listener_with_handlers):
@@ -979,9 +1034,10 @@ class TestStatsTracking:
         config.mass_operation_window_seconds = 30
         config.mass_operation_buffer_delay = 2.0
         config.should_download_media_for_chat = MagicMock(return_value=False)
-        # First-contact CHAT_TYPES fallback (default: no match, same as the
-        # pre-fallback conservative behavior) unless a test opts in.
-        config.should_backup_chat_type = MagicMock(return_value=False)
+        # First-contact fallback (default: no match, same as the pre-hint
+        # conservative behavior) unless a test opts in. The listener consults
+        # the full should_backup_chat decision, never the bare type filter.
+        config.should_backup_chat = MagicMock(return_value=False)
         return config
 
     @pytest.fixture
@@ -1209,9 +1265,10 @@ class TestListenerEventHandling:
         # CHAT_IDS whitelist mode (v6.0.0)
         config.whitelist_mode = False
         config.chat_ids = set()
-        # First-contact CHAT_TYPES fallback (default: no match, same as the
-        # pre-fallback conservative behavior) unless a test opts in.
-        config.should_backup_chat_type = MagicMock(return_value=False)
+        # First-contact fallback (default: no match, same as the pre-hint
+        # conservative behavior) unless a test opts in. The listener consults
+        # the full should_backup_chat decision, never the bare type filter.
+        config.should_backup_chat = MagicMock(return_value=False)
         # Mass operation protection settings
         config.listen_edits = True
         config.listen_deletions = False

--- a/tests/test_listener.py
+++ b/tests/test_listener.py
@@ -31,6 +31,9 @@ class TestTelegramListener:
         # CHAT_IDS whitelist mode (v6.0.0)
         config.whitelist_mode = False
         config.chat_ids = set()
+        # First-contact CHAT_TYPES fallback (default: no match, same as the
+        # pre-fallback conservative behavior) unless a test opts in.
+        config.should_backup_chat_type = MagicMock(return_value=False)
         # Mass operation protection settings
         config.listen_edits = True
         config.listen_deletions = False
@@ -87,6 +90,42 @@ class TestTelegramListener:
 
         assert listener._should_process_chat(-1009999999) is True
         assert listener._should_process_chat(-1008888888) is False
+
+    def test_should_process_chat_no_hint_stays_conservative(self, mock_config, mock_db):
+        """Without a type hint, an untracked/unlisted chat is still rejected (#415 regression guard)."""
+        listener = TelegramListener(mock_config, mock_db, account_id=1)
+        listener._tracked_chat_ids = set()
+
+        assert listener._should_process_chat(555) is False
+        mock_config.should_backup_chat_type.assert_not_called()
+
+    def test_should_process_chat_type_hint_first_contact(self, mock_config, mock_db):
+        """A type hint lets a never-before-seen chat match CHAT_TYPES (#415)."""
+        listener = TelegramListener(mock_config, mock_db, account_id=1)
+        listener._tracked_chat_ids = set()
+        mock_config.should_backup_chat_type = MagicMock(return_value=True)
+
+        assert listener._should_process_chat(555, is_user=True, is_group=False, is_channel=False) is True
+        mock_config.should_backup_chat_type.assert_called_once_with(True, False, False)
+
+    def test_should_process_chat_type_hint_no_match(self, mock_config, mock_db):
+        """A type hint that CHAT_TYPES rejects still returns False."""
+        listener = TelegramListener(mock_config, mock_db, account_id=1)
+        listener._tracked_chat_ids = set()
+        mock_config.should_backup_chat_type = MagicMock(return_value=False)
+
+        assert listener._should_process_chat(555, is_user=True, is_group=False, is_channel=False) is False
+
+    def test_should_process_chat_type_hint_ignored_in_whitelist_mode(self, mock_config, mock_db):
+        """CHAT_IDS whitelist mode takes priority over any type hint."""
+        mock_config.whitelist_mode = True
+        mock_config.chat_ids = {-1002222222}
+        mock_config.should_backup_chat_type = MagicMock(return_value=True)
+        listener = TelegramListener(mock_config, mock_db, account_id=1)
+        listener._tracked_chat_ids = set()
+
+        assert listener._should_process_chat(555, is_user=True, is_group=False, is_channel=False) is False
+        mock_config.should_backup_chat_type.assert_not_called()
 
     def test_get_marked_id(self, mock_config, mock_db):
         """Test _get_marked_id handles various inputs."""
@@ -259,6 +298,9 @@ class TestEventHandlers:
         config.mass_operation_window_seconds = 30
         config.mass_operation_buffer_delay = 2.0
         config.should_download_media_for_chat = MagicMock(return_value=False)
+        # First-contact CHAT_TYPES fallback (default: no match, same as the
+        # pre-fallback conservative behavior) unless a test opts in.
+        config.should_backup_chat_type = MagicMock(return_value=False)
         return config
 
     @pytest.fixture
@@ -524,6 +566,67 @@ class TestEventHandlers:
         asyncio.run(handler(event))
 
         assert new_chat_id in listener._tracked_chat_ids
+
+    def test_on_new_message_first_contact_matches_chat_types(self, listener_with_handlers, full_config):
+        """A message from a brand-new private chat (never tracked, no include list
+        match) is captured live when its CHAT_TYPES-derived type hint matches (#415)."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.NewMessage]
+
+        full_config.should_backup_chat_type = MagicMock(return_value=True)
+
+        new_chat_id = 424242424  # Never backed up, not in any include list
+        listener._tracked_chat_ids = set()
+
+        event = MagicMock()
+        event.chat_id = new_chat_id
+        event.is_private = True
+        event.is_group = False
+        event.is_channel = False
+        msg = MagicMock()
+        msg.reply_to = None
+        msg.id = 1
+        msg.sender_id = 111
+        msg.date = MagicMock()
+        msg.text = "hi, first message"
+        msg.reply_to_msg_id = None
+        msg.edit_date = None
+        msg.out = False
+        msg.grouped_id = None
+        msg.media = None
+        msg.sender = None
+        event.message = msg
+        event.get_chat = AsyncMock(return_value=MagicMock())
+
+        asyncio.run(handler(event))
+
+        assert new_chat_id in listener._tracked_chat_ids
+        full_config.should_backup_chat_type.assert_called_once_with(True, False, False)
+        listener.db.insert_message.assert_called_once()
+
+    def test_on_new_message_first_contact_no_chat_types_match(self, listener_with_handlers, full_config):
+        """A brand-new chat whose type doesn't match CHAT_TYPES stays untracked."""
+        listener, handlers = listener_with_handlers
+        handler = handlers[events.NewMessage]
+
+        full_config.should_backup_chat_type = MagicMock(return_value=False)
+
+        new_chat_id = 424242425
+        listener._tracked_chat_ids = set()
+
+        event = MagicMock()
+        event.chat_id = new_chat_id
+        event.is_private = False
+        event.is_group = True
+        event.is_channel = False
+        msg = MagicMock()
+        msg.reply_to = None
+        event.message = msg
+
+        asyncio.run(handler(event))
+
+        assert new_chat_id not in listener._tracked_chat_ids
+        listener.db.insert_message.assert_not_called()
 
     def test_on_new_message_increments_error_on_exception(self, listener_with_handlers):
         """Test error counter increments when handler raises an exception."""
@@ -843,6 +946,9 @@ class TestStatsTracking:
         config.mass_operation_window_seconds = 30
         config.mass_operation_buffer_delay = 2.0
         config.should_download_media_for_chat = MagicMock(return_value=False)
+        # First-contact CHAT_TYPES fallback (default: no match, same as the
+        # pre-fallback conservative behavior) unless a test opts in.
+        config.should_backup_chat_type = MagicMock(return_value=False)
         return config
 
     @pytest.fixture
@@ -1070,6 +1176,9 @@ class TestListenerEventHandling:
         # CHAT_IDS whitelist mode (v6.0.0)
         config.whitelist_mode = False
         config.chat_ids = set()
+        # First-contact CHAT_TYPES fallback (default: no match, same as the
+        # pre-fallback conservative behavior) unless a test opts in.
+        config.should_backup_chat_type = MagicMock(return_value=False)
         # Mass operation protection settings
         config.listen_edits = True
         config.listen_deletions = False

--- a/tests/test_listener_reactions.py
+++ b/tests/test_listener_reactions.py
@@ -265,7 +265,7 @@ def _new_message_event(msg_id=77, reactions=None):
         grouped_id=None,
         reply_to_msg_id=None,
     )
-    event = SimpleNamespace(chat_id=TRACKED, message=message)
+    event = SimpleNamespace(chat_id=TRACKED, message=message, is_private=True, is_group=False, is_channel=False)
     event.get_chat = AsyncMock(return_value=None)
     return event
 


### PR DESCRIPTION
## Summary

- Fixes #415: `ENABLE_LISTENER=true` currently drops the very first message from a chat you've never backed up before (a new DM from someone you've never chatted with, or a group/channel you just joined), because `_should_process_chat()` can't cheaply tell a bare `chat_id`'s type and conservatively only matches already-tracked chats or explicit `*_INCLUDE_CHAT_IDS` entries. First contact only appears once the next *scheduled* backup discovers the chat via `get_dialogs()`.
- `events.NewMessage.Event` already exposes `is_private`/`is_group`/`is_channel` synchronously (from the update's own peer, no entity fetch/network round-trip), so `on_new_message` now passes those through as optional hints to `_should_process_chat()`, which falls back to `Config.should_backup_chat_type()` for a chat that's neither tracked nor in an include list.
- Scope: only `on_new_message` supplies the hint. Every other handler (edits, deletions, pins, reactions, chat actions) is untouched — those events only ever matter for a chat a `NewMessage` has already made known, so they can't hit the "never seen before" case this PR addresses.
- Whitelist mode (`CHAT_IDS` set) is unaffected — it's checked first and returns before the hint is ever consulted.
- Known limitation (documented in the docstring): a first DM from a bot is evaluated against CHAT_TYPES' `"private"` bucket rather than `"bots"`, since telling the two apart needs the sender entity, which isn't available synchronously off the event. The next scheduled backup reclassifies the chat correctly either way, so this only affects the very first live-captured message in that edge case.

## Test plan

- [x] `ruff check .` / `ruff format --check .` clean
- [x] `python -m pytest tests/ -v` — 3765 passed, 138 skipped (same skip count as `main`), 0 failed
- [x] Added unit tests for `_should_process_chat`'s new hint kwargs (no-hint stays conservative, hint match/no-match, whitelist mode ignores the hint) in `tests/test_listener.py`
- [x] Added `on_new_message` end-to-end tests for a genuinely first-contact chat: one where the CHAT_TYPES hint matches (message captured, chat tracked) and one where it doesn't (message dropped, chat stays untracked)
- [x] Fixed two other test fixtures/builders (`test_listener.py`'s `mock_config`/`full_config`, `test_listener_reactions.py`'s `_new_message_event`) that previously left `should_backup_chat_type`/`is_private`/`is_group`/`is_channel` unset — those now default to the pre-PR conservative behavior explicitly rather than relying on `MagicMock()`'s default truthiness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scheduled-backup decisions for new and untracked chats, including exclusions and include-list rules.
  - Chat ID allowlists now correctly work alongside chat-type settings.
  - Megagroups are classified as groups, while chats with unknown channel status are handled conservatively.
  - First-contact messages are processed according to the complete backup configuration.

- **Tests**
  - Expanded coverage for backup precedence, chat classification, allowlists, and ambiguous channel events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->