### PR TITLE
fix(compose): use multi-arch 8.3.2 images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:8.1.0
+    image: drumsergio/telegram-archive:8.3.2
     container_name: telegram-backup
     restart: unless-stopped
     # A stop during a long sweep needs time to finish in-flight writes and
@@ -187,7 +187,7 @@ services:
     #       memory: 512M
 
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:8.1.0
+    image: drumsergio/telegram-archive-viewer:8.3.2
     container_name: telegram-viewer
     restart: unless-stopped
     # A stop during a long sweep needs time to finish in-flight writes and
@@ -292,7 +292,7 @@ services:
   # Example: Restricted Channel Viewer (optional)
   # Use this to share specific channels publicly with authentication
   # telegram-channel-viewer:
-  #   image: drumsergio/telegram-archive-viewer:8.1.0
+  #   image: drumsergio/telegram-archive-viewer:8.3.2
   #   container_name: telegram-channel-viewer
   #   restart: unless-stopped
   #   ports:


### PR DESCRIPTION
- Update the backup and viewer image pins from 8.1.0 to 8.3.2.
- Update the restricted-viewer example to use the same release.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Telegram backup, viewer, and example viewer containers to version 8.3.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->