### PR TITLE
ci(release): a release can no longer ship stale pins or half its architectures

### DIFF
--- a/.github/scripts/check_manifest_arches.py
+++ b/.github/scripts/check_manifest_arches.py
@@ -1,0 +1,38 @@
+"""Fail unless a pushed manifest list carries every promised architecture.
+
+Reads the raw OCI index / Docker manifest list JSON on stdin (what
+`docker buildx imagetools inspect --raw <tag>` prints) and exits nonzero
+unless linux/amd64 and linux/arm64 are both present. 8.1.0 and everything
+before it shipped amd64-only while the workflows stayed green - QEMU was
+set up, `platforms:` was not (#337). Green must mean "both architectures
+are actually in the registry", so the publish workflows read the manifest
+back and gate on it.
+
+Usage: docker buildx imagetools inspect --raw "$tag" | python3 check_manifest_arches.py "$tag"
+"""
+
+import json
+import sys
+
+REQUIRED = {"linux/amd64", "linux/arm64"}
+
+
+def main() -> int:
+    tag = sys.argv[1] if len(sys.argv) > 1 else "<image>"
+    data = json.load(sys.stdin)
+    archs = set()
+    for m in data.get("manifests", []):
+        p = m.get("platform") or {}
+        # Provenance/SBOM attestations ride along as unknown/unknown.
+        if p.get("os", "unknown") != "unknown":
+            archs.add(p.get("os", "") + "/" + p.get("architecture", ""))
+    print(tag + ": " + (", ".join(sorted(archs)) or "no platform manifests"))
+    missing = sorted(REQUIRED - archs)
+    if missing:
+        print("::error::" + tag + " is missing " + ", ".join(missing))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/docker-publish-viewer.yml
+++ b/.github/workflows/docker-publish-viewer.yml
@@ -181,3 +181,17 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Green must mean "both architectures are actually in the registry".
+      # 8.1.0 and everything before it shipped amd64-only while this
+      # workflow stayed green: QEMU was set up, platforms: was not (#337).
+      # Read every tag just pushed back from the registry and gate on it.
+      - name: Verify pushed tags ship amd64 and arm64
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -eu
+          for tag in $TAGS; do
+            docker buildx imagetools inspect --raw "$tag" \
+              | python3 .github/scripts/check_manifest_arches.py "$tag"
+          done

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -183,3 +183,17 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      # Green must mean "both architectures are actually in the registry".
+      # 8.1.0 and everything before it shipped amd64-only while this
+      # workflow stayed green: QEMU was set up, platforms: was not (#337).
+      # Read every tag just pushed back from the registry and gate on it.
+      - name: Verify pushed tags ship amd64 and arm64
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -eu
+          for tag in $TAGS; do
+            docker buildx imagetools inspect --raw "$tag" \
+              | python3 .github/scripts/check_manifest_arches.py "$tag"
+          done

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,7 +185,7 @@ Use: pytest, pytest-asyncio, pytest-cov
 
 ### Version Files
 
-Both `pyproject.toml` AND `src/__init__.py` must be updated together when bumping versions.
+Both `pyproject.toml` AND `src/__init__.py` must be updated together when bumping versions — plus `uv.lock` and the image pins in `docker-compose.yml`, `README.md` and `scripts/migrate-sqlite-to-postgres.py` (`tests/test_release_pins.py` fails the release PR until every pin names the new version).
 
 ### Release Workflow
 

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ docker run -it --rm \
   -e TELEGRAM_PHONE=+YOUR_PHONE_NUMBER \
   -e SESSION_NAME=telegram_backup \
   -v /path/to/your/session:/data/session \
-  drumsergio/telegram-archive:7.33.6 \
+  drumsergio/telegram-archive:8.3.2 \
   python -m src auth
 ```
 
@@ -166,7 +166,7 @@ docker run -it --rm \
 docker run -it --rm \
   --env-file .env \
   -v ./data:/data \
-  drumsergio/telegram-archive:7.33.6 \
+  drumsergio/telegram-archive:8.3.2 \
   python -m src auth
 
 # Then restart the backup container
@@ -207,7 +207,7 @@ The standalone viewer image (`drumsergio/telegram-archive-viewer`) lets you brow
 # Example: Viewer-only deployment
 services:
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:7.33.6
+    image: drumsergio/telegram-archive-viewer:8.3.2
     ports:
       - "127.0.0.1:8000:8000"
     environment:
@@ -622,9 +622,9 @@ want and run `docker compose up -d`:
 ```yaml
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:7.33.6
+    image: drumsergio/telegram-archive:8.3.2
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:7.33.6
+    image: drumsergio/telegram-archive-viewer:8.3.2
 ```
 
 Check [Releases](https://github.com/GeiserX/Telegram-Archive/releases) for available
@@ -639,8 +639,8 @@ start:
 
 ```bash
 git pull
-docker build -t drumsergio/telegram-archive:7.33.6 .
-docker build -t drumsergio/telegram-archive-viewer:7.33.6 -f Dockerfile.viewer .
+docker build -t drumsergio/telegram-archive:8.3.2 .
+docker build -t drumsergio/telegram-archive-viewer:8.3.2 -f Dockerfile.viewer .
 docker compose up -d
 ```
 

--- a/scripts/migrate-sqlite-to-postgres.py
+++ b/scripts/migrate-sqlite-to-postgres.py
@@ -20,14 +20,14 @@ Usage:
         -e POSTGRES_USER=telegram \
         -e POSTGRES_PASSWORD=your-password \
         -e POSTGRES_DB=telegram_backup \
-        drumsergio/telegram-archive:latest \
+        drumsergio/telegram-archive:8.3.2 \
         python scripts/migrate-sqlite-to-postgres.py
 
     # Or with explicit paths
     docker run --rm -it \
         -v /path/to/sqlite/telegram_backup.db:/sqlite.db:ro \
         -e DATABASE_URL=postgresql+asyncpg://user:pass@host:5432/dbname \
-        drumsergio/telegram-archive:latest \
+        drumsergio/telegram-archive:8.3.2 \
         python scripts/migrate-sqlite-to-postgres.py --sqlite /sqlite.db
 
 Environment Variables:

--- a/tests/test_release_pins.py
+++ b/tests/test_release_pins.py
@@ -1,0 +1,52 @@
+"""Every user-facing image pin must name the version being released.
+
+docker-compose.yml sat on 8.1.0 - the last amd64-only release - while main
+was three releases ahead (#417): nothing made the pins move with a release,
+so they drifted until an arm64 user hit the one tag that could not run on
+his machine. A release bumps src/__init__.py; these assertions make the
+same commit move every shipped pin with it, so the release PR goes red
+until compose, README and the migration helper all point at the release.
+
+docs/UPGRADING-8.0.md is deliberately not covered: it documents the one-off
+7.x -> 8.0 migration and its 8.0.1 pins are the point.
+"""
+
+import re
+from pathlib import Path
+
+from src import __version__
+
+REPO = Path(__file__).resolve().parent.parent
+
+# A drumsergio/telegram-archive[-viewer] reference immediately followed by a
+# tag. Bare-name references (Docker Hub URLs, badge links, image tables)
+# carry no ":" and are exempt by construction; every tagged reference in the
+# covered files is whitespace-delimited.
+PIN = re.compile(r"drumsergio/telegram-archive(?:-viewer)?:(\S+)")
+
+PINNED_FILES = (
+    "docker-compose.yml",
+    "README.md",
+    "scripts/migrate-sqlite-to-postgres.py",
+)
+
+
+def _pins(name: str) -> list[tuple[str, int, str]]:
+    text = (REPO / name).read_text(encoding="utf-8")
+    return [
+        (name, lineno, match.group(1))
+        for lineno, line in enumerate(text.splitlines(), start=1)
+        for match in PIN.finditer(line)
+    ]
+
+
+def test_every_pinned_file_actually_contains_pins():
+    """Guard the guard: a rename or rewrite that drops every reference would
+    otherwise turn the version assertion into vacuous green."""
+    for name in PINNED_FILES:
+        assert _pins(name), f"{name} no longer pins any image; update PINNED_FILES"
+
+
+def test_shipped_image_pins_match_the_released_version():
+    stale = [pin for name in PINNED_FILES for pin in _pins(name) if pin[2] != __version__]
+    assert not stale, f"image pins must equal src.__version__ ({__version__}); stale (file, line, tag): {stale}"


### PR DESCRIPTION
Multi-arch images shouldn't depend on anyone remembering anything: a release must move everything together, and CI must prove it did. Two ways that wasn't true, both now enforced.

**The pins didn't move with releases.** docker-compose.yml shipped `8.1.0` — the last amd64-only release — three releases after main had moved on, and README still said `7.33.6` (#417 fixed the compose file by hand). `tests/test_release_pins.py` now fails any PR where a shipped image pin (compose, README, the sqlite→postgres helper) disagrees with `src.__version__`, so a release PR goes red until every pin moves with it. The helper's `:latest` examples become real pins for the same reason. `docs/UPGRADING-8.0.md` is deliberately exempt: it documents the one-off 7.x→8.0 migration and its 8.0.1 pins are the point.

**A half-arch publish stayed green.** Before #337 the publish workflows set up QEMU but never passed `platforms:`, and every tag shipped amd64-only with green checks. Both publish workflows now read every pushed tag's manifest list back from the registry after the push and fail unless `linux/amd64` and `linux/arm64` are both present (`.github/scripts/check_manifest_arches.py`; attestation manifests are ignored).

The checker was proven against real registry data before it was trusted: red on the actual `8.1.0` manifest (amd64-only), green on `8.3.2`. The pins test was watched failing on the stale README before the bumps landed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Published Docker images are now verified to support both AMD64 and ARM64 platforms.
  - Invalid or incomplete image manifests prevent publication from completing.

- **Documentation**
  - Updated Docker image references to version 8.3.2 across setup, deployment, and migration guidance.
  - Version update instructions now cover all relevant release files and image references.

- **Quality Improvements**
  - Added automated checks to keep shipped image versions synchronized across documentation and deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->