### PR TITLE
fix(viewer): the scroll-to-latest button is whole again on phones

### DIFF
--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -51,6 +51,18 @@
             background-color: #0f172a;
         }
 
+        /* h-screen is 100vh, and on phones 100vh includes the strip behind the
+           browser's retractable toolbar (safe-area insets don't cover it: they
+           are 0 while a toolbar is showing). With overflow:hidden on body the
+           app never reflows, so everything anchored to the layout's bottom
+           edge - most visibly the scroll-to-latest button - rendered partly
+           behind browser chrome. dvh tracks the toolbar as it shows and
+           hides; the vh line stays as the fallback for engines without dvh. */
+        body.h-screen {
+            height: 100vh;
+            height: 100dvh;
+        }
+
         /* Custom Scrollbar */
         ::-webkit-scrollbar {
             width: 6px;
@@ -1703,7 +1715,7 @@
                     <!-- Scroll to Bottom Button -->
                     <button v-if="showScrollToBottom || unseenMessageCount > 0 || viewingPinnedWindow"
                         @click="scrollToLatest"
-                        class="scroll-to-bottom-btn relative"
+                        class="scroll-to-bottom-btn"
                         :aria-label="unseenMessageCount > 0 ? unseenMessageCount + ' new message(s) — scroll to latest' : 'Scroll to latest messages'"
                         title="Scroll to latest messages">
                         <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -4569,3 +4569,42 @@ def test_parse_telegram_link_recognizes_both_forms_and_rejects_noise():
     assert out[2] == {"markedId": None, "username": "durov", "messageId": 100}
     assert out[3] == {"markedId": None, "username": "Some_Channel", "messageId": 7}
     assert out[4] is None and out[5] is None and out[6] is None and out[7] is None
+
+
+def test_scroll_fab_carries_no_position_utility():
+    """The scroll-to-latest FAB must not carry Tailwind's ``relative``.
+
+    ``.scroll-to-bottom-btn`` positions the FAB with ``position: absolute``
+    (bottom-right of the message pane); Tailwind's ``.relative`` ties it on
+    specificity and the CDN-injected sheet cascades later, so ``relative``
+    WON — turning ``right: 20px`` into "20px left of static position" and
+    parking the button half off the bottom-LEFT edge (shipped in #207 for
+    the unseen badge; the badge needs a positioned parent, which
+    ``position: absolute`` already is).
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    assert 'class="scroll-to-bottom-btn"' in html
+    match = re.search(r'class="[^"]*scroll-to-bottom-btn[^"]*"', html)
+    assert match is not None
+    assert match.group(0) == 'class="scroll-to-bottom-btn"', (
+        f"scroll FAB class list grew: {match.group(0)!r} — any utility that sets "
+        "position (relative/absolute/fixed/static) breaks its placement; if you "
+        "need one, move the positioning into the .scroll-to-bottom-btn rule instead"
+    )
+
+
+def test_app_height_tracks_the_dynamic_viewport():
+    """body must size to 100dvh, with 100vh as the pre-dvh fallback.
+
+    100vh on phones includes the strip behind the retractable browser
+    toolbar; with overflow:hidden the app never reflows, so bottom-anchored
+    absolute content (the scroll FAB) rendered partly behind browser chrome.
+    """
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    rule = re.search(r"body\.h-screen\s*\{([^}]*)\}", html)
+    assert rule is not None, "body.h-screen sizing rule is gone"
+    body = rule.group(1)
+    assert "height: 100vh" in body and "height: 100dvh" in body
+    assert body.index("height: 100vh") < body.index("height: 100dvh"), (
+        "the dvh declaration must come AFTER the vh fallback, or engines with dvh support resolve the older unit"
+    )


### PR DESCRIPTION
On mobile, the jump-down button that appears when you scroll up shows as a cut-off sliver instead of a whole circle. Two stacked faults, both fixed:

**It was rendering bottom-LEFT, 20px off-screen.** The markup carried `class="scroll-to-bottom-btn relative"`. Tailwind's `.relative` ties `.scroll-to-bottom-btn` on specificity and the generated sheet cascades later, so `position: absolute` lost — and `right: 20px` on a relative element means "shift 20px left of static position", parking the button half off the pane's bottom-left edge. Measured in a live browser: `{x: -20, y: 793}` before, `{x: 436, right: 480}` (bottom-right, 20px margins) after. The `relative` came in with the unseen badge (#207), which needs a positioned parent — `position: absolute` already is one, so the utility is simply dropped. The badge still anchors to the button's top-right corner (verified in pixels).

**And 100vh hid its bottom edge behind the browser toolbar.** `h-screen` on body is `100vh`, which on phones includes the strip behind the retractable toolbar — safe-area insets are 0 while a toolbar shows, and with `overflow: hidden` nothing ever reflows. Anything anchored to the layout's bottom edge sat partly behind browser chrome. body now sizes to `100dvh` (tracks the toolbar), with the `100vh` declaration kept as the fallback for engines without dvh. This one can't be shown in headless Chrome (no retractable toolbar there); it follows from how dvh is specified, and a real phone after deploy is the confirming check.

Both have string-test regression guards; the FAB one was watched go red against the reverted markup. Full suite: 3772 passed, 138 skipped.