### PR TITLE
chore(release): 8.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ docker run -it --rm \
   -e TELEGRAM_PHONE=+YOUR_PHONE_NUMBER \
   -e SESSION_NAME=telegram_backup \
   -v /path/to/your/session:/data/session \
-  drumsergio/telegram-archive:8.3.2 \
+  drumsergio/telegram-archive:8.4.0 \
   python -m src auth
 ```
 
@@ -166,7 +166,7 @@ docker run -it --rm \
 docker run -it --rm \
   --env-file .env \
   -v ./data:/data \
-  drumsergio/telegram-archive:8.3.2 \
+  drumsergio/telegram-archive:8.4.0 \
   python -m src auth
 
 # Then restart the backup container
@@ -207,7 +207,7 @@ The standalone viewer image (`drumsergio/telegram-archive-viewer`) lets you brow
 # Example: Viewer-only deployment
 services:
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:8.3.2
+    image: drumsergio/telegram-archive-viewer:8.4.0
     ports:
       - "127.0.0.1:8000:8000"
     environment:
@@ -623,9 +623,9 @@ want and run `docker compose up -d`:
 ```yaml
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:8.3.2
+    image: drumsergio/telegram-archive:8.4.0
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:8.3.2
+    image: drumsergio/telegram-archive-viewer:8.4.0
 ```
 
 Check [Releases](https://github.com/GeiserX/Telegram-Archive/releases) for available
@@ -640,8 +640,8 @@ start:
 
 ```bash
 git pull
-docker build -t drumsergio/telegram-archive:8.3.2 .
-docker build -t drumsergio/telegram-archive-viewer:8.3.2 -f Dockerfile.viewer .
+docker build -t drumsergio/telegram-archive:8.4.0 .
+docker build -t drumsergio/telegram-archive-viewer:8.4.0 -f Dockerfile.viewer .
 docker compose up -d
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:8.3.2
+    image: drumsergio/telegram-archive:8.4.0
     container_name: telegram-backup
     restart: unless-stopped
     # A stop during a long sweep needs time to finish in-flight writes and
@@ -187,7 +187,7 @@ services:
     #       memory: 512M
 
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:8.3.2
+    image: drumsergio/telegram-archive-viewer:8.4.0
     container_name: telegram-viewer
     restart: unless-stopped
     # A stop during a long sweep needs time to finish in-flight writes and
@@ -295,7 +295,7 @@ services:
   # Example: Restricted Channel Viewer (optional)
   # Use this to share specific channels publicly with authentication
   # telegram-channel-viewer:
-  #   image: drumsergio/telegram-archive-viewer:8.3.2
+  #   image: drumsergio/telegram-archive-viewer:8.4.0
   #   container_name: telegram-channel-viewer
   #   restart: unless-stopped
   #   ports:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [8.4.0] - 2026-08-26
+
+The viewer's colors are yours now, and two capture bugs are gone.
+
+### Added
+
+- **Seven color themes, picked from the sidebar header.** Slate (the palette the viewer has always had) stays the default; Telegram Night, AMOLED, Forest and Aubergine join it, plus two light modes — Day and Paper. The choice is remembered per browser, applied before the page paints, and shareable as a `?theme=` link. See [docs/VIEWER-THEMES.md](VIEWER-THEMES.md). ([#420](https://github.com/GeiserX/Telegram-Archive/pull/420))
+- **`VIEWER_DEFAULT_THEME`** picks the palette a deployment hands to browsers that have not chosen one. A viewer's own choice always wins over it. ([#420](https://github.com/GeiserX/Telegram-Archive/pull/420))
+
+### Fixed
+
+- **The listener no longer misses the first message from a chat it has never backed up.** A new DM from someone you had never spoken to, or a group you had just joined, stayed invisible until the next scheduled sweep discovered it. The listener now reads the chat's type straight off the event — no extra network call — and applies exactly the decision the scheduled backup would. Chats your exclude lists or include-whitelists keep out of the archive are still never captured. Thanks to [@jordanfelle](https://github.com/jordanfelle). ([#416](https://github.com/GeiserX/Telegram-Archive/issues/415))
+- **The scroll-to-latest button is whole again on phones.** It was rendering half off the bottom-left edge — a `relative` utility on the button was overriding its own positioning — and the app sized itself to `100vh`, which on phones includes the strip behind the retractable browser toolbar. ([#419](https://github.com/GeiserX/Telegram-Archive/pull/419))
+- The example `docker-compose.yml` pinned 8.1.0, the last release that shipped amd64-only images, so anyone copying it onto an ARM machine got a version that could not run there. Thanks to [@skywinder](https://github.com/skywinder). ([#417](https://github.com/GeiserX/Telegram-Archive/pull/417))
+
+### Internal
+
+- A release can no longer ship stale pins or half its architectures. The image pins in `docker-compose.yml`, the README and the migration helper must name the version being released, and both publish workflows now read each pushed tag's manifest back from the registry and fail unless amd64 and arm64 are both in it. ([#418](https://github.com/GeiserX/Telegram-Archive/pull/418))
+
 ## [8.3.2] - 2026-08-25
 
 Dependency maintenance. Nothing about how the archive behaves changes.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "8.3.2"
+version = "8.4.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/migrate-sqlite-to-postgres.py
+++ b/scripts/migrate-sqlite-to-postgres.py
@@ -20,14 +20,14 @@ Usage:
         -e POSTGRES_USER=telegram \
         -e POSTGRES_PASSWORD=your-password \
         -e POSTGRES_DB=telegram_backup \
-        drumsergio/telegram-archive:8.3.2 \
+        drumsergio/telegram-archive:8.4.0 \
         python scripts/migrate-sqlite-to-postgres.py
 
     # Or with explicit paths
     docker run --rm -it \
         -v /path/to/sqlite/telegram_backup.db:/sqlite.db:ro \
         -e DATABASE_URL=postgresql+asyncpg://user:pass@host:5432/dbname \
-        drumsergio/telegram-archive:8.3.2 \
+        drumsergio/telegram-archive:8.4.0 \
         python scripts/migrate-sqlite-to-postgres.py --sqlite /sqlite.db
 
 Environment Variables:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "8.3.2"
+__version__ = "8.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1224,7 +1224,7 @@ wheels = [
 
 [[package]]
 name = "telegram-archive"
-version = "8.3.2"
+version = "8.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Ships the viewer color themes (seven palettes, two of them light, picked from the sidebar header and settable per deployment with `VIEWER_DEFAULT_THEME`), the mobile scroll-to-latest button fix, and the listener no longer missing the first message from a chat it has never backed up.

Full notes in [docs/CHANGELOG.md](https://github.com/GeiserX/Telegram-Archive/blob/ai/release-8.4.0/docs/CHANGELOG.md); the theme design is in [docs/VIEWER-THEMES.md](https://github.com/GeiserX/Telegram-Archive/blob/main/docs/VIEWER-THEMES.md).

Version declarations, the lockfile and every shipped image pin move together — `tests/test_release_pins.py` (new in #418) held this PR red until the compose, README and migration-helper pins named 8.4.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added seven selectable viewer color themes with browser persistence.
  - Added shareable theme links using `?theme=` and a configurable default theme for deployments.

- **Bug Fixes**
  - Improved first-message capture.
  - Fixed mobile scroll-to-latest behavior and viewport sizing.
  - Updated deployment images to version 8.4.0, including ARM-compatible Compose configuration.

- **Documentation**
  - Updated setup, upgrade, migration, and build examples for version 8.4.0.
  - Added release notes covering the new themes and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->