### PR TITLE
fix(viewer): stop sizing the layout root in dvh — it left a dead band on iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ docker run -it --rm \
   -e TELEGRAM_PHONE=+YOUR_PHONE_NUMBER \
   -e SESSION_NAME=telegram_backup \
   -v /path/to/your/session:/data/session \
-  drumsergio/telegram-archive:8.4.0 \
+  drumsergio/telegram-archive:8.4.1 \
   python -m src auth
 ```
 
@@ -166,7 +166,7 @@ docker run -it --rm \
 docker run -it --rm \
   --env-file .env \
   -v ./data:/data \
-  drumsergio/telegram-archive:8.4.0 \
+  drumsergio/telegram-archive:8.4.1 \
   python -m src auth
 
 # Then restart the backup container
@@ -207,7 +207,7 @@ The standalone viewer image (`drumsergio/telegram-archive-viewer`) lets you brow
 # Example: Viewer-only deployment
 services:
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:8.4.0
+    image: drumsergio/telegram-archive-viewer:8.4.1
     ports:
       - "127.0.0.1:8000:8000"
     environment:
@@ -623,9 +623,9 @@ want and run `docker compose up -d`:
 ```yaml
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:8.4.0
+    image: drumsergio/telegram-archive:8.4.1
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:8.4.0
+    image: drumsergio/telegram-archive-viewer:8.4.1
 ```
 
 Check [Releases](https://github.com/GeiserX/Telegram-Archive/releases) for available
@@ -640,8 +640,8 @@ start:
 
 ```bash
 git pull
-docker build -t drumsergio/telegram-archive:8.4.0 .
-docker build -t drumsergio/telegram-archive-viewer:8.4.0 -f Dockerfile.viewer .
+docker build -t drumsergio/telegram-archive:8.4.1 .
+docker build -t drumsergio/telegram-archive-viewer:8.4.1 -f Dockerfile.viewer .
 docker compose up -d
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:8.4.0
+    image: drumsergio/telegram-archive:8.4.1
     container_name: telegram-backup
     restart: unless-stopped
     # A stop during a long sweep needs time to finish in-flight writes and
@@ -187,7 +187,7 @@ services:
     #       memory: 512M
 
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:8.4.0
+    image: drumsergio/telegram-archive-viewer:8.4.1
     container_name: telegram-viewer
     restart: unless-stopped
     # A stop during a long sweep needs time to finish in-flight writes and
@@ -295,7 +295,7 @@ services:
   # Example: Restricted Channel Viewer (optional)
   # Use this to share specific channels publicly with authentication
   # telegram-channel-viewer:
-  #   image: drumsergio/telegram-archive-viewer:8.4.0
+  #   image: drumsergio/telegram-archive-viewer:8.4.1
   #   container_name: telegram-channel-viewer
   #   restart: unless-stopped
   #   ports:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [8.4.1] - 2026-08-26
+
+### Fixed
+
+- **The viewer no longer leaves a dead band below the message list on phones.** 8.4.0 sized the layout root to `100dvh`, meaning to keep bottom-anchored content clear of iOS Safari's retractable toolbar. Combined with the safe-area padding and `overflow: hidden` that `body` already carries, the dynamic unit resolved to less than the visible area, so the app rendered short and the space under the newest message went to waste. The layout root is back to what it was before 8.4.0. The scroll-to-latest button, whose clipping 8.4.0 also addressed, stays fixed — that was a separate cause and a separate fix.
+
 ## [8.4.0] - 2026-08-26
 
 The viewer's colors are yours now, and two capture bugs are gone.

--- a/docs/VIEWER-THEMES.md
+++ b/docs/VIEWER-THEMES.md
@@ -88,12 +88,17 @@ causes, fixed independently of the themes:
    live browser: `x: -20` before, `x: 436` (bottom-right, 20px margins) after. The utility came in
    with the unseen-count badge, which needs a positioned parent — `position: absolute` already is
    one, so it is simply dropped.
-2. The app sized itself to `100vh`, which on phones includes the strip behind the retractable
-   browser toolbar, so anything anchored to the layout's bottom edge sat partly behind browser
-   chrome. The app now sizes to `100dvh` (which tracks the toolbar), with `100vh` kept as the
-   fallback for engines without it.
+2. ~~The app sized itself to `100vh`…~~ **Reverted in 8.4.1.** The same change also switched the
+   layout root to `100dvh`, on the theory that `100vh` hides bottom-anchored content behind iOS
+   Safari's retractable toolbar. That half was reasoning, not measurement — it cannot be
+   reproduced in headless Chrome, which has no retractable toolbar — and on a real iPhone it did
+   the opposite of what was intended: the app rendered short, leaving a large dead band under the
+   message list. `body` also carries the safe-area padding and `overflow: hidden`, and in that
+   combination the dynamic unit resolves to less than the visible area. The layout root is back on
+   `h-screen`, and a test now fails if a dvh override is re-added.
 
-Both carry regression tests; the first was watched go red against the reverted markup.
+The clipped button was fully explained by cause 1 on its own. Both the fix and the revert carry
+regression tests, each watched go red against the code it guards against.
 
 ![Jump button before and after](images/themes/jump-button-before-after.png)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "8.4.0"
+version = "8.4.1"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/migrate-sqlite-to-postgres.py
+++ b/scripts/migrate-sqlite-to-postgres.py
@@ -20,14 +20,14 @@ Usage:
         -e POSTGRES_USER=telegram \
         -e POSTGRES_PASSWORD=your-password \
         -e POSTGRES_DB=telegram_backup \
-        drumsergio/telegram-archive:8.4.0 \
+        drumsergio/telegram-archive:8.4.1 \
         python scripts/migrate-sqlite-to-postgres.py
 
     # Or with explicit paths
     docker run --rm -it \
         -v /path/to/sqlite/telegram_backup.db:/sqlite.db:ro \
         -e DATABASE_URL=postgresql+asyncpg://user:pass@host:5432/dbname \
-        drumsergio/telegram-archive:8.4.0 \
+        drumsergio/telegram-archive:8.4.1 \
         python scripts/migrate-sqlite-to-postgres.py --sqlite /sqlite.db
 
 Environment Variables:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "8.4.0"
+__version__ = "8.4.1"

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -272,30 +272,6 @@
             background-color: rgb(var(--tg-bg));
         }
 
-        /* h-screen is 100vh, and on phones 100vh includes the strip behind the
-           browser's retractable toolbar (safe-area insets don't cover it: they
-           are 0 while a toolbar is showing). With overflow:hidden on body the
-           app never reflows, so everything anchored to the layout's bottom
-           edge - most visibly the scroll-to-latest button - rendered partly
-           behind browser chrome. dvh tracks the toolbar as it shows and
-           hides; the vh line stays as the fallback for engines without dvh. */
-        body.h-screen {
-            height: 100vh;
-            height: 100dvh;
-        }
-
-        /* h-screen is 100vh, and on phones 100vh includes the strip behind the
-           browser's retractable toolbar (safe-area insets don't cover it: they
-           are 0 while a toolbar is showing). With overflow:hidden on body the
-           app never reflows, so everything anchored to the layout's bottom
-           edge - most visibly the scroll-to-latest button - rendered partly
-           behind browser chrome. dvh tracks the toolbar as it shows and
-           hides; the vh line stays as the fallback for engines without dvh. */
-        body.h-screen {
-            height: 100vh;
-            height: 100dvh;
-        }
-
         /* Custom Scrollbar */
         ::-webkit-scrollbar {
             width: 6px;

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -4614,9 +4614,26 @@ def test_body_height_is_not_overridden_with_a_dynamic_viewport_unit():
     and is scoped to that element, not the layout root.
     """
     html = INDEX_HTML.read_text(encoding="utf-8")
-    assert re.search(r"body\.h-screen\s*\{", html) is None, (
-        "body.h-screen override is back; sizing the layout root in dvh left a "
-        "dead band at the bottom on iOS (8.4.0 regression)"
+    style = html[html.index("<style>") : html.index("</style>")]
+
+    # A layout-root compound selector: html / body / #app plus its own
+    # classes, ids, attributes or pseudos - but no descendant, so a rule
+    # like `body .modal` or `.date-picker-dialog` is correctly not a root.
+    root = re.compile(r"^(?:html|body|#app)(?:[.#:\[][^\s>+~,]*)*$")
+    offenders = []
+    for selector, decls in re.findall(r"([^{}]+)\{([^{}]*)\}", style):
+        selector = selector.strip()
+        if selector.startswith("@"):
+            continue
+        parts = [p.strip() for p in selector.split(",")]
+        if not any(root.match(p) for p in parts):
+            continue
+        for prop, value in re.findall(r"([a-z-]*height)\s*:\s*([^;]+)", decls):
+            if "dvh" in value or "svh" in value:
+                offenders.append(f"{selector} {{ {prop}: {value.strip()} }}")
+    assert not offenders, (
+        "the layout root is sized with a dynamic viewport unit again; that left "
+        f"a dead band at the bottom on iOS (8.4.0 regression): {offenders}"
     )
     assert 'class="bg-tg-bg text-tg-ink h-screen overflow-hidden"' in html, (
         "body must keep h-screen: it is what gives the app its height"

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -4619,7 +4619,11 @@ def test_body_height_is_not_overridden_with_a_dynamic_viewport_unit():
     # A layout-root compound selector: html / body / #app plus its own
     # classes, ids, attributes or pseudos - but no descendant, so a rule
     # like `body .modal` or `.date-picker-dialog` is correctly not a root.
-    root = re.compile(r"^(?:html|body|#app)(?:[.#:\[][^\s>+~,]*)*$")
+    # The qualifier group is optional, never repeated: its trailing class
+    # already swallows further qualifiers, so one pass matches the same
+    # selectors without the nested quantifier that lets `html####...`
+    # backtrack exponentially (CodeQL py/redos).
+    root = re.compile(r"^(?:html|body|#app)(?:[.#:\[][^\s>+~,]*)?$")
     offenders = []
     for selector, decls in re.findall(r"([^{}]+)\{([^{}]*)\}", style):
         selector = selector.strip()

--- a/tests/test_frontend_bootstrap.py
+++ b/tests/test_frontend_bootstrap.py
@@ -4595,20 +4595,31 @@ def test_scroll_fab_carries_no_position_utility():
     )
 
 
-def test_app_height_tracks_the_dynamic_viewport():
-    """body must size to 100dvh, with 100vh as the pre-dvh fallback.
+def test_body_height_is_not_overridden_with_a_dynamic_viewport_unit():
+    """body keeps Tailwind's h-screen (100vh). Do not re-add a dvh override.
 
-    100vh on phones includes the strip behind the retractable browser
-    toolbar; with overflow:hidden the app never reflows, so bottom-anchored
-    absolute content (the scroll FAB) rendered partly behind browser chrome.
+    8.4.0 sized body to 100dvh on the theory that 100vh hides bottom-anchored
+    content behind iOS Safari's retractable toolbar. On a real iPhone it did
+    the opposite: the app rendered SHORT, leaving a large dead band below the
+    message list. body also carries the safe-area padding and overflow:hidden,
+    and in that combination the dynamic unit resolves to less than the visible
+    area. Reverted in 8.4.1.
+
+    The scroll-to-latest button being clipped - the bug the dvh change was
+    bundled with - was fully explained and fixed by removing the `relative`
+    utility (see test_scroll_fab_carries_no_position_utility), which was
+    measured in a browser; the dvh half never was.
+
+    The one legitimate dvh use is a modal's max-height, which predates this
+    and is scoped to that element, not the layout root.
     """
     html = INDEX_HTML.read_text(encoding="utf-8")
-    rule = re.search(r"body\.h-screen\s*\{([^}]*)\}", html)
-    assert rule is not None, "body.h-screen sizing rule is gone"
-    body = rule.group(1)
-    assert "height: 100vh" in body and "height: 100dvh" in body
-    assert body.index("height: 100vh") < body.index("height: 100dvh"), (
-        "the dvh declaration must come AFTER the vh fallback, or engines with dvh support resolve the older unit"
+    assert re.search(r"body\.h-screen\s*\{", html) is None, (
+        "body.h-screen override is back; sizing the layout root in dvh left a "
+        "dead band at the bottom on iOS (8.4.0 regression)"
+    )
+    assert 'class="bg-tg-bg text-tg-ink h-screen overflow-hidden"' in html, (
+        "body must keep h-screen: it is what gives the app its height"
     )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1224,7 +1224,7 @@ wheels = [
 
 [[package]]
 name = "telegram-archive"
-version = "8.4.0"
+version = "8.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
8.4.0 wasted a large strip of screen under the message list on iPhone.

**Cause.** 8.4.0 changed the layout root from `h-screen` (`100vh`) to `100dvh`, meaning to keep bottom-anchored content clear of iOS Safari's retractable toolbar. But `body` also carries the safe-area padding and `overflow: hidden`, and in that combination the dynamic unit resolves to *less* than the visible area — so the app rendered short and the space below the newest message went dead.

**Honest note on how this shipped.** That half of #419 was reasoning, not measurement, and the PR said so: headless Chrome has no retractable toolbar, so it can reproduce neither the original problem nor this regression. It should not have gone out on a theory.

The other half of #419 — the clipped scroll-to-latest button — was measured in a real browser (the button's box moved from `x: -20` to `x: 436`) and was fully explained by a stray `relative` utility overriding the button's absolute positioning. **That fix stays; only the dvh half is reverted.**

The rule had also been duplicated verbatim by the merge that brought #419 into the themes branch — both copies are gone.

A test now fails if a dvh override on the layout root comes back, watched red against a re-added rule. The modal `max-height: calc(100dvh - 2rem)` is untouched: it predates all of this and is scoped to one element, not the layout root.

Releases 8.4.1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed excess blank space beneath messages in the mobile viewer, particularly on iPhones.
  - Preserved the separate fix preventing the jump-to-latest button from being clipped.

- **Release**
  - Updated the application and Docker images to version 8.4.1.

- **Documentation**
  - Updated upgrade, deployment, build, migration, and mobile viewer documentation for version 8.4.1.
  - Added release notes describing the mobile layout correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->