### PR TITLE
feat(viewer): round videos are circles, not grey file rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ docker run -it --rm \
   -e TELEGRAM_PHONE=+YOUR_PHONE_NUMBER \
   -e SESSION_NAME=telegram_backup \
   -v /path/to/your/session:/data/session \
-  drumsergio/telegram-archive:8.4.2 \
+  drumsergio/telegram-archive:8.5.0 \
   python -m src auth
 ```
 
@@ -166,7 +166,7 @@ docker run -it --rm \
 docker run -it --rm \
   --env-file .env \
   -v ./data:/data \
-  drumsergio/telegram-archive:8.4.2 \
+  drumsergio/telegram-archive:8.5.0 \
   python -m src auth
 
 # Then restart the backup container
@@ -207,7 +207,7 @@ The standalone viewer image (`drumsergio/telegram-archive-viewer`) lets you brow
 # Example: Viewer-only deployment
 services:
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:8.4.2
+    image: drumsergio/telegram-archive-viewer:8.5.0
     ports:
       - "127.0.0.1:8000:8000"
     environment:
@@ -623,9 +623,9 @@ want and run `docker compose up -d`:
 ```yaml
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:8.4.2
+    image: drumsergio/telegram-archive:8.5.0
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:8.4.2
+    image: drumsergio/telegram-archive-viewer:8.5.0
 ```
 
 Check [Releases](https://github.com/GeiserX/Telegram-Archive/releases) for available
@@ -640,8 +640,8 @@ start:
 
 ```bash
 git pull
-docker build -t drumsergio/telegram-archive:8.4.2 .
-docker build -t drumsergio/telegram-archive-viewer:8.4.2 -f Dockerfile.viewer .
+docker build -t drumsergio/telegram-archive:8.5.0 .
+docker build -t drumsergio/telegram-archive-viewer:8.5.0 -f Dockerfile.viewer .
 docker compose up -d
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:8.4.2
+    image: drumsergio/telegram-archive:8.5.0
     container_name: telegram-backup
     restart: unless-stopped
     # A stop during a long sweep needs time to finish in-flight writes and
@@ -187,7 +187,7 @@ services:
     #       memory: 512M
 
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:8.4.2
+    image: drumsergio/telegram-archive-viewer:8.5.0
     container_name: telegram-viewer
     restart: unless-stopped
     # A stop during a long sweep needs time to finish in-flight writes and
@@ -295,7 +295,7 @@ services:
   # Example: Restricted Channel Viewer (optional)
   # Use this to share specific channels publicly with authentication
   # telegram-channel-viewer:
-  #   image: drumsergio/telegram-archive-viewer:8.4.2
+  #   image: drumsergio/telegram-archive-viewer:8.5.0
   #   container_name: telegram-channel-viewer
   #   restart: unless-stopped
   #   ports:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,9 +4,14 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
-## [8.4.2] - 2026-08-30
+## [8.5.0] - 2026-08-30
 
-Media brought in from a Telegram Desktop export works like every other file now.
+Round videos are circles, and media brought in from a Telegram Desktop export works like every other file.
+
+### Added
+
+- **Round videos are recognised and shown as circles.** Telegram's circular video messages were archived as ordinary videos, because neither the scheduled backup nor the live listener ever looked at the flag that marks one. They are now typed `video_note`, and the viewer plays them in place as a circle that autoplays while it is on screen, the way every official client does. Click one to toggle its sound. Archives built from a Telegram Desktop export already held round videos under this type and showed them as a grey file row; those are fixed by the same change, with no re-import needed.
+- **One media classifier instead of two.** The backup and the listener each carried their own copy of the rules that decide what a piece of media is, which is how round videos ended up unimplemented in both at once. There is now one, and a test fails if it is ever forked again.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "8.4.2"
+version = "8.5.0"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/migrate-sqlite-to-postgres.py
+++ b/scripts/migrate-sqlite-to-postgres.py
@@ -20,14 +20,14 @@ Usage:
         -e POSTGRES_USER=telegram \
         -e POSTGRES_PASSWORD=your-password \
         -e POSTGRES_DB=telegram_backup \
-        drumsergio/telegram-archive:8.4.2 \
+        drumsergio/telegram-archive:8.5.0 \
         python scripts/migrate-sqlite-to-postgres.py
 
     # Or with explicit paths
     docker run --rm -it \
         -v /path/to/sqlite/telegram_backup.db:/sqlite.db:ro \
         -e DATABASE_URL=postgresql+asyncpg://user:pass@host:5432/dbname \
-        drumsergio/telegram-archive:8.4.2 \
+        drumsergio/telegram-archive:8.5.0 \
         python scripts/migrate-sqlite-to-postgres.py --sqlite /sqlite.db
 
 Environment Variables:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "8.4.2"
+__version__ = "8.5.0"

--- a/src/listener.py
+++ b/src/listener.py
@@ -22,11 +22,6 @@ from typing import Any
 
 from telethon import TelegramClient, events
 from telethon.tl.types import (
-    MessageMediaContact,
-    MessageMediaDocument,
-    MessageMediaGeo,
-    MessageMediaPhoto,
-    MessageMediaPoll,
     UpdateMessageReactions,
     UpdatePinnedChannelMessages,
     UpdatePinnedMessages,
@@ -43,7 +38,7 @@ from .message_utils import (
     METADATA_ONLY_MEDIA_TYPES,
     _photo_size_bytes,
     build_media_filename,
-    classify_extended_media,
+    classify_media_type,
     compute_file_hash_async,
     describe_exception,
     download_and_shard_media,
@@ -843,52 +838,13 @@ class TelegramListener:
             logger.warning(f"Failed to download avatar: {describe_exception(e)}")
 
     def _get_media_type(self, media) -> str | None:
-        """Get media type as string."""
-        if isinstance(media, MessageMediaPhoto):
-            return "photo"
-        elif isinstance(media, MessageMediaDocument):
-            # Check document attributes to determine specific type
-            if hasattr(media, "document") and media.document:
-                # DocumentEmpty is truthy but carries no .attributes at all. Its reference
-                # is unusable, so treat it exactly like a missing document rather than
-                # classifying it as a real one and sending it down the download path.
-                attributes = getattr(media.document, "attributes", None)
-                if attributes is None:
-                    return None
-                is_animated = False
-                for attr in attributes:
-                    attr_type = type(attr).__name__
-                    if "Animated" in attr_type:
-                        is_animated = True
-                    if "Video" in attr_type:
-                        return "animation" if is_animated else "video"
-                    elif "Audio" in attr_type:
-                        if hasattr(attr, "voice") and attr.voice:
-                            return "voice"
-                        return "audio"
-                    elif "Sticker" in attr_type:
-                        return "sticker"
-                if is_animated:
-                    return "animation"
-                return "document"
-            return None  # document reference unavailable (e.g., forwarded from private channel)
-        elif isinstance(media, MessageMediaContact):
-            return "contact"
-        elif isinstance(media, MessageMediaGeo):
-            return "geo"
-        elif isinstance(media, MessageMediaPoll):
-            return "poll"
-        # The nine kinds this ladder used to flatten to None (venue, dice,
-        # invoice, story, giveaways, live location, game, unsupported):
-        # metadata-only types with a typed viewer chip, never downloaded.
-        if type(media).__name__ == "MessageMediaWebPage":
-            webpage = getattr(media, "webpage", None)
-            if type(webpage).__name__ == "WebPage" and (
-                getattr(webpage, "photo", None) is not None or getattr(webpage, "document", None) is not None
-            ):
-                return "webpage"
-            return None  # card-only preview (raw_data.webpage): nothing to download
-        return classify_extended_media(media)
+        """Get media type as string.
+
+        Delegates to the shared classifier: this used to be a byte-identical
+        copy in each capture lane, which is how ``video_note`` ended up
+        unimplemented in both at once.
+        """
+        return classify_media_type(media)
 
     def _get_media_filename(self, message, media_type: str, telegram_file_id: str | None = None) -> str:
         """Generate a filename for media."""

--- a/src/message_utils.py
+++ b/src/message_utils.py
@@ -194,6 +194,7 @@ def build_media_filename(file_id: str, original_name: str, name_max_bytes: int) 
 _FALLBACK_MEDIA_EXTENSIONS = {
     "photo": "jpg",
     "video": "mp4",
+    "video_note": "mp4",
     "animation": "mp4",
     "voice": "ogg",
     "audio": "mp3",
@@ -566,6 +567,93 @@ def _photo_size_bytes(size: object) -> int:
         if candidates:
             return max(candidates)
     return 0
+
+
+def classify_media_type(media: object) -> str | None:
+    """The archive's name for a Telegram media object, or None when there is
+    nothing to record.
+
+    THE single classifier, for the same reason ``extract_media_attributes``
+    below is the single extractor: the scheduled sweep and the realtime
+    listener each carried their own byte-identical copy of this ladder, and a
+    copy only one of them updates is how a message ends up classified
+    differently depending on which lane captured it. Round videos were exactly
+    that -- the Telegram Desktop importer has always written ``video_note`` and
+    neither capture lane ever did, because neither ladder looked at
+    ``round_message``.
+
+    Dispatch is on the type NAME, not isinstance, which is what lets this live
+    in a module the viewer image imports: that image installs no telethon (see
+    Dockerfile.viewer and the viewer-runtime group), so a module-level
+    ``from telethon.tl.types import ...`` here would break it. The two forms are
+    equivalent for these types -- none of them has a subclass, and
+    MessageMediaGeoLive is a sibling of MessageMediaGeo rather than a subclass,
+    so it still falls through to classify_extended_media as "geo_live".
+    """
+    # ``__class__``, not ``type()``: that is the attribute isinstance consults, so
+    # this keeps the exact semantics of the isinstance ladder it replaces --
+    # including for the spec'd mocks the tests classify.
+    kind = media.__class__.__name__
+    if kind == "MessageMediaPhoto":
+        return "photo"
+    if kind == "MessageMediaDocument":
+        # DocumentEmpty is truthy but carries no .attributes at all. Its reference
+        # is unusable, so treat it exactly like a missing document rather than
+        # classifying it as a real one and sending it down the download path.
+        document = getattr(media, "document", None)
+        if not document:
+            return None  # document reference unavailable (e.g., forwarded from private channel)
+        attributes = getattr(document, "attributes", None)
+        if attributes is None:
+            return None
+        is_animated = False
+        for attr in attributes:
+            attr_type = type(attr).__name__
+            if "Animated" in attr_type:
+                is_animated = True
+            if "Video" in attr_type:
+                # A round message is the circular "video note" every official
+                # client renders as a circle. It is a Video attribute like any
+                # other, distinguished only by this flag -- the same shape as the
+                # voice/audio split one branch below.
+                # ``is True``, not truthiness: Telethon's parser sets a real bool
+                # (``_round_message = bool(flags & 1)``), while a bare MagicMock
+                # answers truthy to every getattr -- so a test fixture that never
+                # mentions the flag would silently become a round video. Same
+                # reasoning, and the same wording, as the strict check at
+                # telegram_backup.py's config gate.
+                if getattr(attr, "round_message", False) is True:
+                    return "video_note"
+                # If animated, it's a GIF
+                return "animation" if is_animated else "video"
+            elif "Audio" in attr_type:
+                # Voice notes have .voice=True on DocumentAttributeAudio
+                if getattr(attr, "voice", False):
+                    return "voice"
+                return "audio"
+            elif "Sticker" in attr_type:
+                return "sticker"
+        # If animated but no video attribute, still an animation
+        if is_animated:
+            return "animation"
+        return "document"
+    if kind == "MessageMediaContact":
+        return "contact"
+    if kind == "MessageMediaGeo":
+        return "geo"
+    if kind == "MessageMediaPoll":
+        return "poll"
+    # The nine kinds this ladder used to flatten to None (venue, dice,
+    # invoice, story, giveaways, live location, game, unsupported):
+    # metadata-only types with a typed viewer chip, never downloaded.
+    if kind == "MessageMediaWebPage":
+        webpage = getattr(media, "webpage", None)
+        if type(webpage).__name__ == "WebPage" and (
+            getattr(webpage, "photo", None) is not None or getattr(webpage, "document", None) is not None
+        ):
+            return "webpage"
+        return None  # card-only preview (raw_data.webpage): nothing to download
+    return classify_extended_media(media)
 
 
 def extract_media_attributes(media: object) -> dict[str, Any]:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -36,10 +36,6 @@ from telethon.tl.types import (
     Message,
     MessageActionChannelMigrateFrom,
     MessageActionChatMigrateTo,
-    MessageMediaContact,
-    MessageMediaDocument,
-    MessageMediaGeo,
-    MessageMediaPhoto,
     MessageMediaPoll,
     PeerChannel,
     PeerChat,
@@ -58,7 +54,7 @@ from .message_utils import (
     METADATA_ONLY_MEDIA_TYPES,
     _photo_size_bytes,
     build_media_filename,
-    classify_extended_media,
+    classify_media_type,
     compute_file_hash_async,
     describe_exception,
     download_and_shard_media,
@@ -3824,55 +3820,13 @@ class TelegramBackup:
         return getattr(media, "size", 0)
 
     def _get_media_type(self, media) -> str | None:
-        """Get media type as string."""
-        if isinstance(media, MessageMediaPhoto):
-            return "photo"
-        elif isinstance(media, MessageMediaDocument):
-            # Check document attributes to determine specific type
-            if hasattr(media, "document") and media.document:
-                # DocumentEmpty is truthy but carries no .attributes at all. Its reference
-                # is unusable, so treat it exactly like a missing document rather than
-                # classifying it as a real one and sending it down the download path.
-                attributes = getattr(media.document, "attributes", None)
-                if attributes is None:
-                    return None
-                is_animated = False
-                for attr in attributes:
-                    attr_type = type(attr).__name__
-                    if "Animated" in attr_type:
-                        is_animated = True
-                    if "Video" in attr_type:
-                        # If animated, it's a GIF
-                        return "animation" if is_animated else "video"
-                    elif "Audio" in attr_type:
-                        # Voice notes have .voice=True on DocumentAttributeAudio
-                        if hasattr(attr, "voice") and attr.voice:
-                            return "voice"
-                        return "audio"
-                    elif "Sticker" in attr_type:
-                        return "sticker"
-                # If animated but no video attribute, still an animation
-                if is_animated:
-                    return "animation"
-                return "document"
-            return None  # document reference unavailable (e.g., forwarded from private channel)
-        elif isinstance(media, MessageMediaContact):
-            return "contact"
-        elif isinstance(media, MessageMediaGeo):
-            return "geo"
-        elif isinstance(media, MessageMediaPoll):
-            return "poll"
-        # The nine kinds this ladder used to flatten to None (venue, dice,
-        # invoice, story, giveaways, live location, game, unsupported):
-        # metadata-only types with a typed viewer chip, never downloaded.
-        if type(media).__name__ == "MessageMediaWebPage":
-            webpage = getattr(media, "webpage", None)
-            if type(webpage).__name__ == "WebPage" and (
-                getattr(webpage, "photo", None) is not None or getattr(webpage, "document", None) is not None
-            ):
-                return "webpage"
-            return None  # card-only preview (raw_data.webpage): nothing to download
-        return classify_extended_media(media)
+        """Get media type as string.
+
+        Delegates to the shared classifier: this used to be a byte-identical
+        copy in each capture lane, which is how ``video_note`` ended up
+        unimplemented in both at once.
+        """
+        return classify_media_type(media)
 
     def _get_media_filename(self, message: Message, media_type: str, telegram_file_id: str = None) -> str:
         """

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1832,6 +1832,9 @@
                                              it when it leaves. Muted like every official client;
                                              a click toggles the sound. -->
                                         <div v-else-if="msg.media?.type === 'video_note'">
+                                            <!-- The player carries no native controls, so the sound
+                                                 toggle needs its own affordance: focusable, named, and
+                                                 reachable with Enter or Space, not click alone. -->
                                             <div v-if="msg.mediaLoadFailed"
                                                 class="flex items-center gap-2 text-tg-n400 text-sm py-2">
                                                 <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1840,9 +1843,6 @@
                                                 </svg>
                                                 <span>Media not found</span>
                                             </div>
-                                            <!-- The element carries no native controls, so the sound
-                                                 toggle needs its own affordance: focusable, named, and
-                                                 reachable with Enter or Space, not click alone. -->
                                             <video v-else
                                                 :data-src="getMediaUrl(msg)"
                                                 class="round-video gif-video cursor-pointer"

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1840,12 +1840,19 @@
                                                 </svg>
                                                 <span>Media not found</span>
                                             </div>
+                                            <!-- The element carries no native controls, so the sound
+                                                 toggle needs its own affordance: focusable, named, and
+                                                 reachable with Enter or Space, not click alone. -->
                                             <video v-else
                                                 :data-src="getMediaUrl(msg)"
                                                 class="round-video gif-video cursor-pointer"
                                                 loop muted playsinline
+                                                tabindex="0" role="button"
+                                                :aria-label="roundVideoHint"
                                                 :title="roundVideoHint"
                                                 @click="toggleRoundVideoSound($event)"
+                                                @keydown.enter.prevent="toggleRoundVideoSound($event)"
+                                                @keydown.space.prevent="toggleRoundVideoSound($event)"
                                                 @error="handleMediaError($event, msg)">
                                             </video>
                                         </div>

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -370,6 +370,27 @@
             height: auto;
         }
 
+        /* A round video (a "video note") is the circular clip every official
+           Telegram client renders as a circle in the message list. This arm is
+           (0,2,1) so it outranks `.message-bubble video` directly above, which
+           is (0,1,1) and would otherwise stretch the circle to the bubble's
+           full width -- the same specificity trap the comment above documents
+           for Tailwind utilities.
+
+           ONE custom property drives both axes on purpose. Capping only the
+           width leaves `height: auto` from that rule in play, and the circle
+           becomes an ellipse as soon as the viewport is narrower than the cap. */
+        .message-bubble .round-video {
+            --round-video-size: min(240px, 60vw);
+            width: var(--round-video-size);
+            height: var(--round-video-size);
+            max-width: var(--round-video-size);
+            border-radius: 50%;
+            object-fit: cover;
+            display: block;
+            background: rgb(var(--tg-bg) / 1);
+        }
+
 
         /* Date Separator — floats/sticks at the top of the scroll pane while
            that day's messages are in view, like the native apps. Works in the
@@ -1450,11 +1471,11 @@
                                         <img v-if="item.thumb_url" :src="item.thumb_url" :alt="item.file_name"
                                             class="w-full h-full object-cover" loading="lazy" decoding="async">
                                         <div v-else class="w-full h-full bg-tg-n700 flex items-center justify-center">
-                                            <i class="fas fa-play-circle text-2xl text-tg-n400" v-if="item.type === 'video' || item.type === 'animation'"></i>
+                                            <i class="fas fa-play-circle text-2xl text-tg-n400" v-if="item.type === 'video' || item.type === 'animation' || item.type === 'video_note'"></i>
                                             <i class="fas fa-image text-2xl text-tg-n400" v-else></i>
                                         </div>
                                         <!-- Video overlay -->
-                                        <div v-if="item.type === 'video' || item.type === 'animation'"
+                                        <div v-if="item.type === 'video' || item.type === 'animation' || item.type === 'video_note'"
                                             class="absolute bottom-1 left-1 bg-black/70 text-tg-ink text-xs px-1 rounded">
                                             <i class="fas fa-play text-[10px] mr-0.5"></i>
                                             {{ formatDuration(item.duration) }}
@@ -1802,6 +1823,32 @@
                                             class="rounded-lg max-h-64 w-auto max-w-full gif-video" loop muted
                                             playsinline @click="openMedia(msg)">
                                         </video>
+
+                                        <!-- Round videos ("video notes") - Telegram plays these
+                                             in place as a circle; they never open fullscreen, so
+                                             there is deliberately no lightbox branch for them.
+                                             `gif-video` opts into the existing IntersectionObserver
+                                             that autoplays a clip while it is on screen and pauses
+                                             it when it leaves. Muted like every official client;
+                                             a click toggles the sound. -->
+                                        <div v-else-if="msg.media?.type === 'video_note'">
+                                            <div v-if="msg.mediaLoadFailed"
+                                                class="flex items-center gap-2 text-tg-n400 text-sm py-2">
+                                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                                        d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                                                </svg>
+                                                <span>Media not found</span>
+                                            </div>
+                                            <video v-else
+                                                :data-src="getMediaUrl(msg)"
+                                                class="round-video gif-video cursor-pointer"
+                                                loop muted playsinline
+                                                :title="roundVideoHint"
+                                                @click="toggleRoundVideoSound($event)"
+                                                @error="handleMediaError($event, msg)">
+                                            </video>
+                                        </div>
 
                                         <!-- Videos - click to open in lightbox -->
                                         <div v-else-if="msg.media?.type === 'video'"
@@ -3189,6 +3236,11 @@
                 }
 
                 // Check if media should show as video in lightbox
+                // Deliberately NOT video_note: round videos play in place in the
+                // message list and never open fullscreen, in this viewer as in every
+                // official client. Adding one to a lightbox ENTRY POINT without also
+                // adding an arm here renders a black modal, because the overlay is
+                // `<img v-if>` / `<video v-else-if>` with no `v-else`.
                 const isLightboxVideo = (msg) => {
                     return msg.media?.type === 'video' || msg.media?.type === 'animation'
                 }
@@ -4599,6 +4651,22 @@
                 }
 
                 // Setup Intersection Observer for GIF autoplay
+                // A video note autoplays muted, like every official client, and a
+                // click toggles its sound rather than opening a lightbox -- Telegram
+                // has no fullscreen view for round videos, so there is nothing to
+                // open. Restarting on unmute matches the clients too: you clicked
+                // because you want to HEAR it, and it is at most a minute long.
+                const roundVideoHint = 'Click to toggle sound'
+                const toggleRoundVideoSound = (event) => {
+                    const video = event.currentTarget
+                    if (!video) return
+                    video.muted = !video.muted
+                    if (!video.muted) {
+                        video.currentTime = 0
+                        video.play().catch(() => { })
+                    }
+                }
+
                 const setupGifObserver = () => {
                     if (gifObserver) {
                         gifObserver.disconnect()
@@ -4791,7 +4859,7 @@
                             const data = await res.json()
                             if (selectedChat.value?.ref !== requestChatRef) return
                             mediaGalleryCounts.value = {
-                                photos: (data.photo || 0) + (data.video || 0) + (data.animation || 0),
+                                photos: (data.photo || 0) + (data.video || 0) + (data.animation || 0) + (data.video_note || 0),  // must mirror typeMap.photos above
                                 voice: (data.voice || 0) + (data.audio || 0),
                                 files: data.document || 0,
                             }
@@ -4813,6 +4881,13 @@
                 }
 
                 const openMediaItem = (item) => {
+                    // A round video has no fullscreen form, so the tile goes where the
+                    // voice tab's tiles go: to the message it belongs to. Before this
+                    // the click did nothing at all.
+                    if (item.type === 'video_note') {
+                        jumpToMessage(item)
+                        return
+                    }
                     if (item.type === 'photo' || item.type === 'video' || item.type === 'animation') {
                         const mediaList = mediaGalleryItems.value.filter(m =>
                             m.type === 'photo' || m.type === 'video' || m.type === 'animation'
@@ -6018,6 +6093,7 @@
                 const replyMediaLabels = {
                     photo: 'Photo',
                     video: 'Video',
+                    video_note: 'Video message',
                     voice: 'Voice message',
                     audio: 'Audio',
                     animation: 'GIF',
@@ -8250,6 +8326,8 @@
                 }
 
                 return {
+                    roundVideoHint,
+                    toggleRoundVideoSound,
                     toastMessage,
                     showToast,
                     chats,

--- a/tests/test_listener_extended.py
+++ b/tests/test_listener_extended.py
@@ -378,6 +378,7 @@ class TestGetMediaType:
         media = MagicMock(spec=MessageMediaDocument)
         attr = MagicMock()
         type(attr).__name__ = "DocumentAttributeVideo"
+        attr.round_message = False
         media.document = MagicMock()
         media.document.attributes = [attr]
         assert listener._get_media_type(media) == "video"
@@ -392,6 +393,7 @@ class TestGetMediaType:
         type(anim_attr).__name__ = "DocumentAttributeAnimated"
         video_attr = MagicMock()
         type(video_attr).__name__ = "DocumentAttributeVideo"
+        video_attr.round_message = False
         media.document = MagicMock()
         media.document.attributes = [anim_attr, video_attr]
         assert listener._get_media_type(media) == "animation"

--- a/tests/test_round_video_classification.py
+++ b/tests/test_round_video_classification.py
@@ -139,8 +139,17 @@ INDEX_HTML = pathlib.Path(__file__).resolve().parent.parent / "src" / "web" / "t
 
 class TestViewerRendersRoundVideos:
     @pytest.fixture(scope="class")
-    def html(self):
+    def html(self) -> str:
         return INDEX_HTML.read_text(encoding="utf-8")
+
+    def test_the_sound_toggle_is_reachable_without_a_mouse(self, html: str) -> None:
+        """A bare <video> with no native controls has no focus target and no key
+        handler, so the toggle was mouse-only."""
+        block = html[html.index('class="round-video gif-video cursor-pointer"') :][:700]
+        assert 'tabindex="0"' in block
+        assert ':aria-label="roundVideoHint"' in block
+        assert "@keydown.enter.prevent" in block
+        assert "@keydown.space.prevent" in block
 
     def test_the_bubble_has_a_branch_for_video_note(self, html):
         assert "msg.media?.type === 'video_note'" in html

--- a/tests/test_round_video_classification.py
+++ b/tests/test_round_video_classification.py
@@ -1,0 +1,216 @@
+"""Round videos ("video notes") are classified as video_note by both capture lanes.
+
+Telegram's circular video messages are ordinary documents carrying a
+``DocumentAttributeVideo`` whose ``round_message`` flag is set. Neither the
+scheduled sweep nor the realtime listener ever looked at that flag, so every
+round video was archived as a plain ``video`` — while the Telegram Desktop
+importer has always written ``video_note`` (src/telegram_import.py). The same
+message therefore got a different type depending on which lane captured it.
+
+The ladder lived twice, byte-identically, in src/telegram_backup.py and
+src/listener.py, which is how it stayed unimplemented in both at once. It now
+lives once in src/message_utils.py next to extract_media_attributes, which was
+made the single extractor for the same reason after the same class of bug.
+"""
+
+import os
+import sys
+
+import pytest
+from telethon.tl.types import (
+    DocumentAttributeAudio,
+    DocumentAttributeVideo,
+    MessageMediaDocument,
+    MessageMediaPhoto,
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from src.message_utils import classify_media_type
+
+
+def _document(*attributes):
+    """A MessageMediaDocument carrying real Telethon attribute objects.
+
+    Real objects, not mocks, on purpose: ``getattr`` on a bare ``MagicMock``
+    answers truthy for EVERY name, so a mocked video attribute that never sets
+    ``round_message`` reads as a round video and the test proves nothing.
+    """
+    doc = MessageMediaDocument(
+        document=type("Doc", (), {"attributes": list(attributes)})(),
+    )
+    return doc
+
+
+class TestRoundVideoClassification:
+    def test_a_round_message_is_a_video_note(self):
+        media = _document(DocumentAttributeVideo(duration=7, w=384, h=384, round_message=True))
+        assert classify_media_type(media) == "video_note"
+
+    def test_control_an_ordinary_video_is_still_a_video(self):
+        """The control that gives the test above its meaning: same attribute,
+        same square dimensions, flag off."""
+        media = _document(DocumentAttributeVideo(duration=7, w=384, h=384, round_message=False))
+        assert classify_media_type(media) == "video"
+
+    def test_control_an_unset_flag_is_not_a_round_video(self):
+        """Telethon leaves the flag None when absent, which must read as false."""
+        media = _document(DocumentAttributeVideo(duration=12, w=640, h=360))
+        assert media.document.attributes[0].round_message in (None, False)
+        assert classify_media_type(media) == "video"
+
+    def test_a_round_video_is_never_mistaken_for_a_gif(self):
+        """An animated round video is a contradiction Telegram does not produce,
+        but the animation branch sits directly above and must not swallow it."""
+        animated = type("DocumentAttributeAnimated", (), {})()
+        media = _document(animated, DocumentAttributeVideo(duration=3, w=384, h=384, round_message=True))
+        assert classify_media_type(media) == "video_note"
+
+    def test_the_voice_split_still_works(self):
+        """The round split is modelled on this one; changing either must not
+        disturb the other."""
+        assert classify_media_type(_document(DocumentAttributeAudio(duration=5, voice=True))) == "voice"
+        assert classify_media_type(_document(DocumentAttributeAudio(duration=5, voice=False))) == "audio"
+
+    def test_an_under_specified_mock_is_not_a_round_video(self):
+        """A bare MagicMock answers truthy to EVERY getattr, so a fixture that
+        never mentions round_message would silently classify as a round video.
+        The check is ``is True`` for exactly this reason: Telethon's parser sets
+        a real bool (``bool(flags & 1)``), so nothing on the wire is affected."""
+        from unittest.mock import MagicMock
+
+        attr = MagicMock()
+        type(attr).__name__ = "DocumentAttributeVideo"
+        media = MagicMock(spec=MessageMediaDocument)
+        media.document = MagicMock()
+        media.document.attributes = [attr]
+
+        assert classify_media_type(media) == "video"
+
+    def test_a_photo_is_still_a_photo(self):
+        """Dispatch moved from isinstance to __class__.__name__ so the classifier
+        could live in a module the telethon-free viewer image imports. This is
+        the control that the move preserved ordinary classification."""
+        assert classify_media_type(MessageMediaPhoto(photo=None)) == "photo"
+
+
+class TestBothCaptureLanesAgree:
+    """The bug was one ladder in two files. There is now one, and these two
+    tests are what fail if anyone forks it again."""
+
+    def test_the_sweep_and_the_listener_share_one_classifier(self):
+        import src.listener as listener_mod
+        import src.telegram_backup as backup_mod
+
+        assert backup_mod.classify_media_type is listener_mod.classify_media_type
+        assert backup_mod.classify_media_type is classify_media_type
+
+    @pytest.mark.parametrize(
+        "attributes,expected",
+        [
+            ((DocumentAttributeVideo(duration=7, w=384, h=384, round_message=True),), "video_note"),
+            ((DocumentAttributeVideo(duration=7, w=640, h=360),), "video"),
+            ((DocumentAttributeAudio(duration=5, voice=True),), "voice"),
+        ],
+    )
+    def test_both_lanes_return_the_same_type(self, attributes, expected):
+        from src.listener import TelegramListener
+        from src.telegram_backup import TelegramBackup
+
+        media = _document(*attributes)
+        sweep = TelegramBackup.__new__(TelegramBackup)
+        listener = TelegramListener.__new__(TelegramListener)
+
+        assert sweep._get_media_type(media) == expected
+        assert listener._get_media_type(media) == expected
+
+
+# ============================================================ the viewer half
+# Classification without rendering is a REGRESSION, not a partial win: a round
+# video reclassified from `video` to `video_note` stops matching the bubble's
+# video branch and falls through to the generic file-download row. These pin the
+# branch that keeps that from happening.
+
+import pathlib  # noqa: E402
+import re  # noqa: E402
+
+INDEX_HTML = pathlib.Path(__file__).resolve().parent.parent / "src" / "web" / "templates" / "index.html"
+
+
+class TestViewerRendersRoundVideos:
+    @pytest.fixture(scope="class")
+    def html(self):
+        return INDEX_HTML.read_text(encoding="utf-8")
+
+    def test_the_bubble_has_a_branch_for_video_note(self, html):
+        assert "msg.media?.type === 'video_note'" in html
+        assert 'class="round-video gif-video cursor-pointer"' in html
+
+    def test_the_branch_precedes_the_generic_file_fallback(self, html):
+        """v-else-if order decides everything here: a branch after the generic
+        `<a v-else>` row would never be reached."""
+        branch = html.index("msg.media?.type === 'video_note'")
+        fallback = html.index("<!-- Other documents / files -->")
+        assert branch < fallback
+
+    def test_it_opts_into_the_existing_autoplay_observer(self, html):
+        """`gif-video` is the selector setupGifObserver watches, so visibility
+        playback needs no new code — and if that class is dropped, this fails."""
+        assert "gif-video" in html[html.index("msg.media?.type === 'video_note'") :][:1400]
+        assert "document.querySelectorAll('.gif-video')" in html
+
+    def test_the_circle_outranks_the_bubble_video_rule(self, html):
+        """`.message-bubble video` is (0,1,1) and would stretch the circle to the
+        bubble's width. The round rule must be scoped to the bubble too, at
+        (0,2,1) — measured in a real browser as 240x240 against 520x150 for a
+        plain video in the same bubble."""
+        assert ".message-bubble .round-video {" in html
+        assert ".round-video {" not in html.replace(".message-bubble .round-video {", "")
+
+    def test_both_axes_ride_one_custom_property(self, html):
+        """Capping only the width leaves height:auto in play and the circle
+        becomes an ellipse on narrow screens."""
+        block = html[html.index(".message-bubble .round-video {") :][:420]
+        assert "--round-video-size: min(240px, 60vw);" in block
+        assert "width: var(--round-video-size);" in block
+        assert "height: var(--round-video-size);" in block
+        assert "border-radius: 50%;" in block
+
+    def test_the_gallery_badge_counts_what_the_gallery_fetches(self, html):
+        """These two lists must agree or the tab badge disagrees with its own
+        grid. #424 added video_note to the filter and not to the count."""
+        types = re.search(r"photos: '([^']+)'", html).group(1).split(",")
+        counts = re.search(r"photos: \((.*?)\),", html).group(1)
+        for t in types:
+            assert f"data.{t}" in counts, f"{t} is fetched but never counted"
+
+    def test_a_round_video_is_not_a_dead_gallery_tile(self, html):
+        """openMediaItem had no branch for it, so the tile was a silent no-op.
+        It jumps to the message, like the voice tab's tiles do."""
+        block = html[html.index("const openMediaItem = (item) =>") :][:900]
+        assert "item.type === 'video_note'" in block
+        assert "jumpToMessage(item)" in block
+
+    def test_a_round_video_never_reaches_the_lightbox(self, html):
+        """The overlay is `<img v-if>` / `<video v-else-if>` with NO `v-else`, so
+        routing a type it cannot render into it produces a black modal with
+        chrome and no media. Round videos have no fullscreen form in any official
+        client, so both the predicate and the navigation list exclude them —
+        and the gallery entry point above sends them elsewhere entirely."""
+        predicate = html[html.index("const isLightboxVideo = (msg) => {") :][:300]
+        assert "video_note" not in predicate
+        nav = html[html.index("const mediaMessages = computed(") :][:500]
+        assert "video_note" not in nav
+
+    def test_a_broken_round_video_says_so(self, html):
+        """Without a failure arm a 404 renders a blank circle, which reads as
+        data loss rather than a broken link. The rescan can cause exactly that
+        for a tab left open across it."""
+        block = html[html.index("msg.media?.type === 'video_note'") :][:1400]
+        assert 'v-if="msg.mediaLoadFailed"' in block
+        assert "Media not found" in block
+
+    def test_the_reply_quote_has_a_human_label(self, html):
+        """Without an entry the raw column value 'video_note' is shown to users."""
+        labels = html[html.index("const replyMediaLabels = {") :][:400]
+        assert "video_note: 'Video message'," in labels

--- a/tests/test_telegram_backup.py
+++ b/tests/test_telegram_backup.py
@@ -1291,6 +1291,7 @@ class TestGetMediaType(unittest.TestCase):
         media.document = MagicMock()
         video_attr = MagicMock()
         type(video_attr).__name__ = "DocumentAttributeVideo"
+        video_attr.round_message = False
         media.document.attributes = [video_attr]
         self.assertEqual(self.backup._get_media_type(media), "video")
 
@@ -1302,6 +1303,7 @@ class TestGetMediaType(unittest.TestCase):
         type(anim_attr).__name__ = "DocumentAttributeAnimated"
         video_attr = MagicMock()
         type(video_attr).__name__ = "DocumentAttributeVideo"
+        video_attr.round_message = False
         media.document.attributes = [anim_attr, video_attr]
         self.assertEqual(self.backup._get_media_type(media), "animation")
 

--- a/uv.lock
+++ b/uv.lock
@@ -1224,7 +1224,7 @@ wheels = [
 
 [[package]]
 name = "telegram-archive"
-version = "8.4.2"
+version = "8.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Telegram's round videos — the circular ones — have never worked in this archive, and on an archive built from a Telegram Desktop export they are visibly broken **on main today**: they render as a grey `video_note file` download row.

## Why

A round video is an ordinary document whose `DocumentAttributeVideo` carries `round_message`. Neither capture lane ever looked at that flag, so both typed it `video`. The Desktop importer, meanwhile, has always written `video_note` (`telegram_import.py:46`). The same message therefore got a different type depending on which lane captured it — and the viewer had no branch for `video_note` at all, so it fell off the end of the media chain into the generic file row.

The classifier lived **twice, byte-identically**, in `telegram_backup.py` and `listener.py`. That is precisely how it stayed unimplemented in both at once.

## What this does

**One classifier.** `classify_media_type` now lives in `message_utils.py`, beside `extract_media_attributes` — which was made the single extractor after this same class of bug caused a listener/sweep divergence. Both lanes delegate, and a test fails if anyone forks it again.

Two details in that move are load-bearing and easy to "simplify" back:

- Dispatch is on `media.__class__.__name__`, not `isinstance`. That is what lets the classifier live in a module the **viewer image imports** — that image installs no telethon, so a module-level telethon import would break it. `__class__` rather than `type()` because `__class__` is the attribute `isinstance` consults, so spec'd mocks classify exactly as before. Verified: `type(MagicMock(spec=MessageMediaPhoto)).__name__` is `'MagicMock'`, `.__class__.__name__` is `'MessageMediaPhoto'`.
- The round check is `is True`, not bare truthiness — the reason the config gate at `telegram_backup.py` already documents. Telethon's parser sets a real bool (`_round_message = bool(flags & 1)`), but a bare `MagicMock` answers truthy to *every* `getattr`, so any fixture that never mentions the flag would silently become a round video. There is a regression test for exactly that.

**Rendering follows the official clients.** A circle capped at `min(240px, 60vw)`, autoplaying muted while on screen through the observer GIFs already use, click to toggle sound. No fullscreen: video notes do not open in a lightbox in any Telegram client (I checked Web-A's `MediaViewerContent` — zero round handling), so the gallery tile **jumps to the message** instead, exactly like the voice tab's tiles. Before this it was a dead click.

The CSS was measured, not reasoned about, because this is the same trap that bit the scroll-to-latest button: `.message-bubble video` is specificity (0,1,1) and would stretch the circle to the bubble's width. Measured in a real browser:

```
round video : 240 x 240   border-radius 50%   object-fit cover
plain video : 520 x 150   (same bubble, for contrast)
narrow      : 150 x 150   still square
```

One custom property drives both axes on purpose — capping only the width leaves `height: auto` in play and the circle becomes an ellipse on narrow screens.

## Also fixed, all live on main for imported archives

- The gallery badge counted `photo+video+animation` while the grid **fetched** `video_note` too, so the count disagreed with its own tiles. That one is mine: #424 added it to one list and not the other.
- A reply quoting a round video printed the raw database string `video_note`.
- A mime-less round video would have been named `.bin`, which silently disables *both* the thumbnail lane and inline playback.
- A round video with a broken URL rendered a blank circle; it now says "Media not found" like every other media type.

## Evidence

- **3825 passed, 145 skipped, 0 failed.**
- Red-before/green-after, measured on merged main: round video → `'video'` in both lanes, and the two lanes held **separate** classifier objects. Now → `'video_note'`, one shared object. Plain video unchanged in both, as the control.
- End to end against a real Telegram Desktop export through the real import CLI and the real viewer: the round video gets `/media/{ref}/1455_video_note`, serves its exact bytes, and the counts endpoint returns `{"photo":1,"video":1,"video_note":1}`.

## Known limitation, deliberately not fixed here

Archives captured **before** this still hold their round videos as `video`; correcting them needs a rescan, which is the next PR (it can ask Telegram directly with `InputMessagesFilterRoundVideo`, so no square-and-short guessing).

And one narrow interim issue, worth naming rather than hiding: a round video sitting at `downloaded=0` will now have its retry insert a row under the new type while the old row stays pending. `VERIFY_MEDIA` and `FILL_GAPS` both default off and the sweep is incremental, so a default deployment duplicates nothing for already-downloaded media. The following PR makes a media row identified by its message rather than by a string that spells its type, which closes it properly — along with a VERIFY path that can currently delete the only copy of an imported file.

## Version

Rolls the unreleased 8.4.2 into **8.5.0**. 8.4.2 was never tagged, so nobody has it, and this adds a feature.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Round video messages are now recognized and displayed as circular, autoplaying video notes.
  * Videos start muted and toggle sound when clicked or activated with Enter/Space.
  * Video notes appear correctly in shared-media galleries and are labeled “Video message.”
  * Importing round videos from Telegram Desktop now preserves this behavior.
  * Video notes remain excluded from the lightbox.

* **Documentation**
  * Updated Docker, deployment, and migration examples for version 8.5.0.
  * Added release notes for the video note experience.

* **Release**
  * Updated the application version to 8.5.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->