### PR TITLE
test(linkify): compare the visible host whole instead of prefix-matching the URL

### DIFF
--- a/tests/test_linkify_escaping.py
+++ b/tests/test_linkify_escaping.py
@@ -15,6 +15,7 @@ rather than source text.
 """
 
 import json
+import re
 import shutil
 import subprocess
 import tempfile
@@ -79,6 +80,18 @@ PAYLOADS = {
 # The four characters that cannot sit raw inside href="..." and are therefore
 # percent-encoded on the way in. Everything else must reach the href untouched.
 HREF_PERCENT_ENCODED = {"<": "%3C", ">": "%3E", '"': "%22", "'": "%27"}
+
+
+# The host a reader takes from a link's visible text: the hostname run right
+# after the scheme. Parsed and compared whole, never prefix-matched — a
+# ``startswith("https://good.example")`` premise would also accept
+# ``https://good.example.evil.example/``.
+_VISIBLE_HOST = re.compile(r"^https?://([A-Za-z0-9.-]+)")
+
+
+def _visible_host(link_text: str) -> str | None:
+    match = _VISIBLE_HOST.match(link_text)
+    return match.group(1) if match else None
 
 
 def _expected_href(link_text: str) -> str:
@@ -227,7 +240,7 @@ def test_entity_smuggling_cannot_retarget_a_link(name: str) -> None:
     attributes, link_text = _only_anchor(name)
     href = attributes["href"] or ""
 
-    assert link_text.startswith("https://good.example")
+    assert _visible_host(link_text) == "good.example"
     assert urlsplit(href).hostname != "evil.example", href
 
 

--- a/tests/test_linkify_escaping.py
+++ b/tests/test_linkify_escaping.py
@@ -244,6 +244,15 @@ def test_entity_smuggling_cannot_retarget_a_link(name: str) -> None:
     assert urlsplit(href).hostname != "evil.example", href
 
 
+def test_visible_host_reads_the_whole_hostname() -> None:
+    """The premise helper must reject a lookalike that merely starts with the host."""
+    assert _visible_host("https://good.example/x") == "good.example"
+    assert _visible_host("https://good.example.evil.example/") == "good.example.evil.example"
+    assert _visible_host("https://good.example&#x40;evil.example/") == "good.example"
+    assert _visible_host("https://good.example@evil.example/") == "good.example"
+    assert _visible_host("not a link") is None
+
+
 @pytest.mark.parametrize("name", sorted(PAYLOADS))
 def test_payloads_render_as_an_inert_anchor(name: str) -> None:
     """Nothing but the anchor itself may survive into the DOM."""


### PR DESCRIPTION
CodeQL alert #50 (py/incomplete-url-substring-sanitization) points at the premise check in `test_entity_smuggling_cannot_retarget_a_link`: `link_text.startswith("https://good.example")`. That prefix also passes a visible text of `https://good.example.evil.example/`, which is the lookalike these payloads are about.

The check now parses the hostname run after the scheme and compares it whole (`_visible_host(link_text) == "good.example"`). Every payload still satisfies it whether the smuggled entity renders decoded (`@`, newline) or literal (`&#x40;`), because both stop the hostname run at the same character.

Verified: 121 linkify tests pass; flipping the expected host to `evil.example` fails the seven parametrized cases, so the assertion is live. No production code touched.

Closes https://github.com/GeiserX/Telegram-Archive/security/code-scanning/50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Strengthened link-safety test coverage by requiring exact hostname matching, preventing deceptive hosts that merely begin with an approved domain from passing validation.
  * Added coverage for complete hostnames, userinfo formats, and non-URL text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->