### PR TITLE
fix(viewer): stop the shared media grid from starving the viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ docker run -it --rm \
   -e TELEGRAM_PHONE=+YOUR_PHONE_NUMBER \
   -e SESSION_NAME=telegram_backup \
   -v /path/to/your/session:/data/session \
-  drumsergio/telegram-archive:8.9.0 \
+  drumsergio/telegram-archive:8.9.1 \
   python -m src auth
 ```
 
@@ -166,7 +166,7 @@ docker run -it --rm \
 docker run -it --rm \
   --env-file .env \
   -v ./data:/data \
-  drumsergio/telegram-archive:8.9.0 \
+  drumsergio/telegram-archive:8.9.1 \
   python -m src auth
 
 # Then restart the backup container
@@ -207,7 +207,7 @@ The standalone viewer image (`drumsergio/telegram-archive-viewer`) lets you brow
 # Example: Viewer-only deployment
 services:
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:8.9.0
+    image: drumsergio/telegram-archive-viewer:8.9.1
     ports:
       - "127.0.0.1:8000:8000"
     environment:
@@ -627,9 +627,9 @@ want and run `docker compose up -d`:
 ```yaml
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:8.9.0
+    image: drumsergio/telegram-archive:8.9.1
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:8.9.0
+    image: drumsergio/telegram-archive-viewer:8.9.1
 ```
 
 Check [Releases](https://github.com/GeiserX/Telegram-Archive/releases) for available
@@ -644,8 +644,8 @@ start:
 
 ```bash
 git pull
-docker build -t drumsergio/telegram-archive:8.9.0 .
-docker build -t drumsergio/telegram-archive-viewer:8.9.0 -f Dockerfile.viewer .
+docker build -t drumsergio/telegram-archive:8.9.1 .
+docker build -t drumsergio/telegram-archive-viewer:8.9.1 -f Dockerfile.viewer .
 docker compose up -d
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:8.9.0
+    image: drumsergio/telegram-archive:8.9.1
     container_name: telegram-backup
     restart: unless-stopped
     # A stop during a long sweep needs time to finish in-flight writes and
@@ -188,7 +188,7 @@ services:
     #       memory: 512M
 
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:8.9.0
+    image: drumsergio/telegram-archive-viewer:8.9.1
     container_name: telegram-viewer
     restart: unless-stopped
     # A stop during a long sweep needs time to finish in-flight writes and
@@ -308,7 +308,7 @@ services:
   # Example: Restricted Channel Viewer (optional)
   # Use this to share specific channels publicly with authentication
   # telegram-channel-viewer:
-  #   image: drumsergio/telegram-archive-viewer:8.9.0
+  #   image: drumsergio/telegram-archive-viewer:8.9.1
   #   container_name: telegram-channel-viewer
   #   restart: unless-stopped
   #   ports:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [8.9.1] - 2026-09-08
+
+The shared media grid stops flooding the viewer.
+
+### Fixed
+
+- **Opening shared media no longer knocks out the rest of the viewer.** A tile in that grid does not fetch a picture, it asks the viewer to make one, and for a video that means running ffmpeg. Fifty tiles asked at once, so on a chat with thousands of photos and videos the requests behind them, including the message list and the gallery's own file list, waited half a minute and were dropped: the pane then showed "Failed to load media" over an empty grid while the tab still counted the files. Tiles are now admitted a few at a time in the order they appear, and each one that finishes lets the next start, so the grid fills steadily instead of all at once.
+- **A tile that never answers no longer blocks the ones behind it.** If an image neither loads nor fails, its place is released after twenty seconds.
+
+### Note
+
+If your viewer mounts the archive read-only, set `THUMBNAIL_CACHE_DIR` to a writable volume. Without it the cache falls back to a directory inside the container, which is discarded whenever the container is recreated, so the first gallery after every update pays to generate everything again.
+
 ## [8.9.0] - 2026-09-08
 
 A chat info panel in the viewer, the way the apps have one.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "8.9.0"
+version = "8.9.1"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/migrate-sqlite-to-postgres.py
+++ b/scripts/migrate-sqlite-to-postgres.py
@@ -20,14 +20,14 @@ Usage:
         -e POSTGRES_USER=telegram \
         -e POSTGRES_PASSWORD=your-password \
         -e POSTGRES_DB=telegram_backup \
-        drumsergio/telegram-archive:8.9.0 \
+        drumsergio/telegram-archive:8.9.1 \
         python scripts/migrate-sqlite-to-postgres.py
 
     # Or with explicit paths
     docker run --rm -it \
         -v /path/to/sqlite/telegram_backup.db:/sqlite.db:ro \
         -e DATABASE_URL=postgresql+asyncpg://user:pass@host:5432/dbname \
-        drumsergio/telegram-archive:8.9.0 \
+        drumsergio/telegram-archive:8.9.1 \
         python scripts/migrate-sqlite-to-postgres.py --sqlite /sqlite.db
 
 Environment Variables:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "8.9.0"
+__version__ = "8.9.1"

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1637,8 +1637,12 @@
                                     <div v-for="item in mediaGalleryItems" :key="item.id"
                                         @click="openMediaItem(item)"
                                         class="aspect-square relative cursor-pointer group overflow-hidden rounded">
-                                        <img v-if="item.thumb_url" :src="item.thumb_url" :alt="item.file_name"
-                                            class="w-full h-full object-cover" loading="lazy" decoding="async">
+                                        <!-- No loading="lazy" here: a deferred image never fires
+                                             load, so it would hold its admission slot until the
+                                             timeout. The queue is the throttle now. -->
+                                        <img v-if="item.thumb_url && isThumbAdmitted(item.id)" :src="item.thumb_url"
+                                            :alt="item.file_name" class="w-full h-full object-cover" decoding="async"
+                                            @load="settleThumb(item.id)" @error="settleThumb(item.id)">
                                         <div v-else class="w-full h-full bg-tg-n700 flex items-center justify-center">
                                             <i class="fas fa-play-circle text-2xl text-tg-n400" v-if="item.type === 'video' || item.type === 'animation' || item.type === 'video_note'"></i>
                                             <i class="fas fa-image text-2xl text-tg-n400" v-else></i>
@@ -3452,6 +3456,74 @@
                 const mediaGalleryLoading = ref(false)
                 const mediaGalleryHasMore = ref(true)
                 const mediaGalleryCounts = ref({})
+
+                // ---- Thumbnail admission ----
+                // A tile does not fetch a picture, it asks the server to MAKE one, and for a
+                // video that is an ffmpeg run (two at a time server-side, 15s each). A grid
+                // that shows fifty tiles at once therefore queued dozens of generations and
+                // starved the requests behind them: on a cold cache the message list and the
+                // gallery's own item request timed out and the pane read "Failed to load
+                // media". So a tile gets its src only when the queue admits it, a few at a
+                // time, in the order the grid renders; each one that finishes admits the next.
+                const THUMB_CONCURRENCY = 4
+                // A tile that neither loads nor errors (a stalled connection) must not hold a
+                // slot for the rest of the session.
+                const THUMB_SETTLE_TIMEOUT_MS = 20000
+                const admittedThumbs = ref(new Set())
+                const queuedThumbs = new Set()
+                let thumbQueue = []
+                let thumbsInFlight = 0
+                const thumbTimers = new Map()
+
+                const isThumbAdmitted = (id) => admittedThumbs.value.has(id)
+
+                const pumpThumbs = () => {
+                    while (thumbsInFlight < THUMB_CONCURRENCY && thumbQueue.length) {
+                        const id = thumbQueue.shift()
+                        thumbsInFlight++
+                        // Replaced, not mutated: a Set mutated in place is not a reactive read.
+                        admittedThumbs.value = new Set([...admittedThumbs.value, id])
+                        thumbTimers.set(id, setTimeout(() => settleThumb(id), THUMB_SETTLE_TIMEOUT_MS))
+                    }
+                }
+
+                // Called by the tile's own load AND error handlers: a 404 frees the slot too.
+                const settleThumb = (id) => {
+                    const timer = thumbTimers.get(id)
+                    if (timer === undefined) return
+                    clearTimeout(timer)
+                    thumbTimers.delete(id)
+                    thumbsInFlight = Math.max(0, thumbsInFlight - 1)
+                    pumpThumbs()
+                }
+
+                const resetThumbQueue = () => {
+                    thumbTimers.forEach(clearTimeout)
+                    thumbTimers.clear()
+                    queuedThumbs.clear()
+                    thumbQueue = []
+                    thumbsInFlight = 0
+                    admittedThumbs.value = new Set()
+                }
+
+                const queueThumbs = (items) => {
+                    for (const item of items) {
+                        if (!item || !item.thumb_url || queuedThumbs.has(item.id)) continue
+                        queuedThumbs.add(item.id)
+                        thumbQueue.push(item.id)
+                    }
+                    pumpThumbs()
+                }
+
+                // The list is replaced on every tab switch and cleared when the gallery opens,
+                // so an empty list is the signal to forget the previous view entirely.
+                watch(mediaGalleryItems, (items) => {
+                    if (!items || !items.length) {
+                        resetThumbQueue()
+                        return
+                    }
+                    queueThumbs(items)
+                })
 
                 const mediaTabs = [
                     { id: 'photos', label: 'Photos & Videos' },
@@ -9435,6 +9507,8 @@
                     mediaGalleryLoading,
                     mediaGalleryHasMore,
                     mediaGalleryCounts,
+                    isThumbAdmitted,
+                    settleThumb,
                     mediaTabs,
                     loadMediaGallery,
                     loadMediaCounts,

--- a/tests/test_gallery_thumb_batching.py
+++ b/tests/test_gallery_thumb_batching.py
@@ -1,0 +1,160 @@
+"""The shared-media grid admits thumbnails a few at a time, executed.
+
+A tile does not fetch a picture, it asks the server to make one, and a video
+costs an ffmpeg run (two at a time server-side, 15 s each). A grid that showed
+fifty tiles at once queued dozens of generations and starved everything behind
+them: on a cold cache the message list and the gallery's own item request sat
+for 7 to 39 seconds and were reset, so the pane read "Failed to load media"
+while the tab badges said there were 1,701 files.
+
+These lift the real admission queue out of the template and run it under node,
+so they pin the behaviour rather than the source text.
+"""
+
+import re
+
+from test_frontend_audit_fixes import INDEX_HTML, _run_node
+
+BLOCK_START = "                const THUMB_CONCURRENCY = 4\n"
+BLOCK_END = "                const mediaTabs = [\n"
+
+PRELUDE = """
+"use strict";
+const assert = require('node:assert/strict');
+const ref = value => ({ value });
+const watchers = [];
+const watch = (source, fn) => watchers.push({ source, fn });
+const mediaGalleryItems = ref([]);
+// Timers are driven by hand so the test never sleeps.
+const timers = new Map();
+let nextTimer = 1;
+const setTimeout = (fn, ms) => { const id = nextTimer++; timers.set(id, { fn, ms }); return id };
+const clearTimeout = id => timers.delete(id);
+const fire = id => { const t = timers.get(id); assert.ok(t, 'no such timer'); timers.delete(id); t.fn() };
+// Insertion-ordered, so the first key is the oldest tile still in flight.
+const oldestTimer = () => { assert.ok(timers.size, 'no pending timer'); return [...timers.keys()][0] };
+const items = n => Array.from({ length: n }, (_, i) => ({ id: `${i + 1}_photo`, thumb_url: `/media/thumb/200/ref/${i + 1}_photo` }));
+const admitted = () => [...admittedThumbs.value];
+const setItems = list => { mediaGalleryItems.value = list; watchers[0].fn(list) };
+"""
+
+
+def _queue_block(html: str) -> str:
+    start = html.index(BLOCK_START)
+    return html[start : html.index(BLOCK_END, start)]
+
+
+def _script(body: str) -> str:
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    return "\n".join([PRELUDE, _queue_block(html), body])
+
+
+def test_only_a_few_tiles_are_admitted_and_each_one_that_settles_admits_the_next() -> None:
+    _run_node(
+        _script("""
+setItems(items(10));
+assert.deepEqual(admitted(), ['1_photo', '2_photo', '3_photo', '4_photo'], 'four at a time, in grid order');
+assert.equal(timers.size, 4, 'each admitted tile carries a stall timer');
+
+// A tile that loads frees its slot for exactly one more.
+settleThumb('1_photo');
+assert.deepEqual(admitted().slice(-1), ['5_photo']);
+assert.equal(admitted().length, 5);
+assert.equal(timers.size, 4);
+
+// A 404 settles the same way a load does.
+settleThumb('2_photo');
+assert.deepEqual(admitted().slice(-1), ['6_photo']);
+
+// Settling the same tile twice must not open a second slot.
+settleThumb('2_photo');
+assert.equal(admitted().length, 6, 'a duplicate settle admits nothing');
+// ...and neither does settling a tile that was never admitted.
+settleThumb('9_photo');
+assert.equal(admitted().length, 6);
+
+for (const id of ['3_photo', '4_photo', '5_photo', '6_photo']) settleThumb(id);
+assert.equal(admitted().length, 10, 'the queue drains to the end');
+assert.equal(timers.size, 4, 'the last four are still in flight, each with its own stall timer');
+for (const id of ['7_photo', '8_photo', '9_photo', '10_photo']) settleThumb(id);
+assert.equal(timers.size, 0, 'and nothing is left pending once they finish');
+""")
+    )
+
+
+def test_a_tile_that_never_loads_releases_its_slot_on_the_timeout() -> None:
+    _run_node(
+        _script("""
+setItems(items(5));
+assert.equal(admitted().length, 4);
+settleThumb('1_photo');
+assert.equal(admitted().length, 5, 'the fifth is admitted, so four tiles are in flight');
+assert.equal(timers.size, 4);
+
+// Tile 2 never fires load or error. Only its timer can free that slot.
+const stalled = oldestTimer();
+setItems(items(5).concat([{ id: '6_photo', thumb_url: '/media/thumb/200/ref/6_photo' }]));
+assert.equal(admitted().length, 5, 'a full queue admits nothing new');
+fire(stalled);
+assert.deepEqual(admitted().slice(-1), ['6_photo'], 'the stalled tile released its slot');
+assert.equal(timers.size, 4, 'the released slot is immediately reused, not leaked');
+""")
+    )
+
+
+def test_appending_a_page_queues_only_the_new_tiles() -> None:
+    _run_node(
+        _script("""
+const first = items(4);
+setItems(first);
+assert.equal(admitted().length, 4);
+// "Load more" appends; the already-admitted ids must not be queued a second time.
+setItems(first.concat([{ id: '5_photo', thumb_url: '/x/5' }, { id: '6_photo', thumb_url: '/x/6' }]));
+assert.equal(admitted().length, 4, 'the new page waits its turn');
+settleThumb('1_photo');
+assert.deepEqual(admitted().slice(-1), ['5_photo']);
+settleThumb('1_photo');
+assert.equal(admitted().length, 5, 'a settled tile cannot be settled again by a re-render');
+""")
+    )
+
+
+def test_a_tab_switch_forgets_the_previous_view_entirely() -> None:
+    _run_node(
+        _script("""
+setItems(items(10));
+assert.equal(admitted().length, 4);
+// Every tab switch and every gallery open clears the list first.
+setItems([]);
+assert.deepEqual(admitted(), [], 'nothing stays admitted');
+assert.equal(timers.size, 0, 'and no stall timer survives to fire into the new view');
+setItems([{ id: '1_photo', thumb_url: '/x/1' }]);
+assert.deepEqual(admitted(), ['1_photo'], 'the same id is admitted again in the new view');
+""")
+    )
+
+
+def test_items_without_a_thumbnail_never_take_a_slot() -> None:
+    _run_node(
+        _script("""
+setItems([
+  { id: 'a_document' },                                   // files tab: no thumbnail at all
+  { id: 'b_photo', thumb_url: null },                     // no-download session
+  { id: 'c_photo', thumb_url: '/x/c' },
+  { id: 'd_photo', thumb_url: '/x/d' },
+]);
+assert.deepEqual(admitted(), ['c_photo', 'd_photo'], 'only tiles that would fetch something');
+""")
+    )
+
+
+def test_the_grid_is_wired_to_the_queue() -> None:
+    html = INDEX_HTML.read_text(encoding="utf-8")
+    start = html.index("<template v-if=\"mediaGalleryTab === 'photos'\">")
+    grid = html[start : html.index("</template>", start)]
+    assert 'v-if="item.thumb_url && isThumbAdmitted(item.id)"' in grid, "the tile waits to be admitted"
+    assert '@load="settleThumb(item.id)"' in grid and '@error="settleThumb(item.id)"' in grid
+    # A deferred image never fires load, so it would hold its slot until the timeout.
+    img = grid[grid.index("<img") : grid.index(">", grid.index("<img"))]
+    assert 'loading="lazy"' not in img, "the queue is the throttle; native lazy loading would stall it"
+    assert re.search(r"isThumbAdmitted,\s*\n\s*settleThumb,", html), "both are returned from setup"

--- a/uv.lock
+++ b/uv.lock
@@ -1224,7 +1224,7 @@ wheels = [
 
 [[package]]
 name = "telegram-archive"
-version = "8.9.0"
+version = "8.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Opening **Shared Media** on a big chat killed the rest of the viewer. The grid came up empty with a "Failed to load media" toast, while the tab beside it cheerfully said there were 1,701 files. Reloading did not help, and the same requests answered in under a second from the command line.

## What was happening

A tile in that grid does not fetch a picture. It asks the viewer to **make** one, and for a video that means running ffmpeg, which the server already limits to two at a time with a 15 second timeout each. The grid asked for fifty of them the moment it opened.

Everything queued behind that. Caddy's access log for the failing minute:

```
502  read tcp ...:8000: read: connection reset by peer   /api/chats/<ref>/media     8.5s
502  read tcp ...:8000: read: connection reset by peer   /api/chats/<ref>/media     7.2s
502  read tcp ...:8000: read: connection reset by peer   /api/chats/<ref>/messages 10.4s
502  read tcp ...:8000: read: connection reset by peer   /api/chats/<ref>/messages 38.8s
```

and the viewer's own log at the same second: ~50 `/media/thumb/200/...` at once, then `Video thumbnail generation failed: TimeoutExpired`. So the gallery's own file list and the message list were casualties of the gallery's thumbnails.

## The fix

Tiles are admitted four at a time, in the order the grid renders them, and each one that loads or fails lets the next one start. A tile that never answers releases its place after twenty seconds, so one stalled image cannot park a slot for the session. `loading="lazy"` comes off the tile: a deferred image never fires `load`, so it would hold its slot until that timeout.

The grid now fills steadily instead of all at once, and nothing else in the viewer waits on it.

## Note for read-only deployments

If the viewer mounts the archive read-only, the thumbnail cache silently falls back to a directory **inside the container** and is discarded on every recreate, so the first gallery after each update regenerates everything. Set `THUMBNAIL_CACHE_DIR` to a writable volume. That is deployment config, not code, so it is not in this PR.

## Testing

- `tests/test_gallery_thumb_batching.py` lifts the real admission queue out of the template and runs it under node: four at a time in order, a load and a 404 both free exactly one slot, a duplicate settle frees none, a stalled tile is released by its timer, appending a page queues only the new ids, a tab switch forgets everything, and tiles with no thumbnail never take a slot.
- Both mutations go red: raising the limit to 50 fails five of the six, and dropping the `@load` handler fails all six.
- Full suite: 3931 passed, 168 skipped. `ruff check` and `ruff format --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shared media galleries by limiting concurrent thumbnail loading, preventing request floods.
  * Added recovery for stalled thumbnail requests so subsequent images continue loading.
  * Improved gallery and pagination behavior to avoid duplicate thumbnail requests.

* **Documentation**
  * Added guidance for configuring a writable thumbnail cache when using read-only archive mounts.
  * Updated Docker usage examples and deployment configuration to version 8.9.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->