### PR TITLE
Fix(viewer): Windows media path normalization for media thumbnails

### DIFF
--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1484,27 +1484,33 @@ def _url_media_key(message_id: object, media_type: object) -> str | None:
 
 
 def _media_relative_path(file_path: str | None) -> str | None:
-    """Normalize a media row's file_path to a media-root-relative path, or None.
+    """Normalize a media row's file_path to a media-root-relative path.
 
-    Same rules the gallery has always applied before building URLs: absolute
-    paths must live under the media root (older archives stored them absolute),
-    and the result must pass the traversal predicate _checked_media_path
-    enforces — a row whose path cannot be proven to stay inside the root serves
-    nothing.
+    Handles both Unix-style and Windows absolute paths. Absolute paths are
+    accepted only when they resolve inside the configured media root.
+    Relative paths are kept relative, but traversal is rejected.
     """
-    if not file_path:
+    if not file_path or not _media_root:
         return None
-    path = file_path
-    if path.startswith("/"):
-        if not _media_root:
+
+    try:
+        media_root = _media_root.resolve()
+        raw_path = Path(file_path)
+
+        if raw_path.is_absolute():
+            resolved = raw_path.resolve()
+            if not resolved.is_relative_to(media_root):
+                return None
+            path = resolved.relative_to(media_root).as_posix()
+        else:
+            path = file_path.replace("\\", "/")
+
+        if path.startswith("/") or ".." in path.split("/"):
             return None
-        media_root_str = str(_media_root) + "/"
-        if not path.startswith(media_root_str):
-            return None
-        path = path[len(media_root_str) :]
-    if path.startswith("/") or ".." in path.split("/"):
+
+        return path
+    except (OSError, ValueError):
         return None
-    return path
 
 
 def _resolve_media_file(relative_path: str):

--- a/src/web/main.py
+++ b/src/web/main.py
@@ -1483,34 +1483,57 @@ def _url_media_key(message_id: object, media_type: object) -> str | None:
     return f"{message_id}_{media_type}"
 
 
-def _media_relative_path(file_path: str | None) -> str | None:
-    """Normalize a media row's file_path to a media-root-relative path.
+# A drive-qualified Windows path: "C:/x", "C:\\x" or the drive-relative "C:x".
+_WINDOWS_DRIVE_PREFIX = re.compile(r"^[A-Za-z]:")
 
-    Handles both Unix-style and Windows absolute paths. Absolute paths are
-    accepted only when they resolve inside the configured media root.
-    Relative paths are kept relative, but traversal is rejected.
+
+def _media_relative_path(file_path: str | None) -> str | None:
+    """Normalize a media row's file_path to a media-root-relative path, or None.
+
+    Rows hold whatever the writer stored. Modern archives store a relative path;
+    older ones stored an absolute path, with whichever separator the machine that
+    wrote it uses. Three shapes have to end up as the same root-relative tail:
+
+    - a relative path, from either platform;
+    - an absolute path under the CURRENT media root;
+    - an absolute path under a DIFFERENT root, which is an archive that has been
+      moved to another directory or drive (#438). The media directory is always
+      named after the root's own last component (config builds it as
+      ``<BACKUP_PATH>/media``), so whatever follows that component is the tail
+      the current root expects, and a moved archive keeps working without
+      rewriting every row in the database.
+
+    Deliberately lexical: no filesystem call. This runs for every media row of
+    every message list, and the media root is a network or FUSE mount on most
+    installs, where one ``Path.resolve()`` costs ~260 us against ~0.07 us for a
+    string compare — 19 ms on a 50-row page, on an endpoint the viewer polls
+    every three seconds. Nothing here is a security bound: the bound is applied
+    where the bytes are read, by _resolve_media_file and ensure_thumbnail, which
+    both resolve the joined path and re-check it against the root.
     """
     if not file_path or not _media_root:
         return None
 
-    try:
-        media_root = _media_root.resolve()
-        raw_path = Path(file_path)
+    # Whichever separator wrote the row. A stored file NAME never contains a
+    # backslash — sanitize_media_filename collapses them before the name is
+    # written — so a backslash here is always a directory separator.
+    path = file_path.replace("\\", "/")
+    root = _media_root.as_posix()
 
-        if raw_path.is_absolute():
-            resolved = raw_path.resolve()
-            if not resolved.is_relative_to(media_root):
-                return None
-            path = resolved.relative_to(media_root).as_posix()
+    # "/x", "C:/x" and "C:x" are all absolute enough to need the root stripped.
+    if path.startswith("/") or _WINDOWS_DRIVE_PREFIX.match(path):
+        if path.startswith(root + "/"):
+            path = path[len(root) + 1 :]
         else:
-            path = file_path.replace("\\", "/")
+            anchor = "/" + _media_root.name + "/"
+            cut = path.rfind(anchor)
+            if cut < 0:
+                return None
+            path = path[cut + len(anchor) :]
 
-        if path.startswith("/") or ".." in path.split("/"):
-            return None
-
-        return path
-    except (OSError, ValueError):
+    if not path or path.startswith("/") or ".." in path.split("/"):
         return None
+    return path
 
 
 def _resolve_media_file(relative_path: str):

--- a/tests/test_web_main.py
+++ b/tests/test_web_main.py
@@ -1077,6 +1077,94 @@ class TestSecurityHelpers(unittest.TestCase):
             self.assertIsNone(web_main._media_relative_path(None))
             self.assertIsNone(web_main._media_relative_path(""))
 
+    def test_media_relative_path_reads_rows_written_on_windows(self):
+        """A row written by a Windows install carries backslashes and a drive.
+
+        The thumbnail route splits the tail on "/" (folder, _, filename =
+        relative.rpartition("/")), so a path that keeps its backslashes yields an
+        empty folder and no thumbnail is ever generated — the bug in #436.
+        """
+        from pathlib import Path
+
+        with patch.object(web_main, "_media_root", Path("/srv/media")):
+            self.assertEqual(web_main._media_relative_path("123\\file.jpg"), "123/file.jpg")
+            self.assertEqual(web_main._media_relative_path("_shared\\14\\file.jpg"), "_shared/14/file.jpg")
+
+        with patch.object(web_main, "_media_root", Path("D:/TelegramArchive/data/backups/media")):
+            self.assertEqual(
+                web_main._media_relative_path("D:\\TelegramArchive\\data\\backups\\media\\_shared\\14\\f.jpg"),
+                "_shared/14/f.jpg",
+            )
+
+    def test_media_relative_path_follows_a_moved_archive(self):
+        """#438: the media directory moved to another drive and the rows still
+        name the old one. The tail below the media directory is what the current
+        root expects, so the file is found without rewriting the database."""
+        from pathlib import Path
+
+        with patch.object(web_main, "_media_root", Path("D:/TelegramArchive/data/backups/media")):
+            self.assertEqual(
+                web_main._media_relative_path("E:\\TelegramArchive\\data\\backups\\media\\_shared\\14\\f.jpg"),
+                "_shared/14/f.jpg",
+            )
+        # Same on a POSIX install whose backup directory was moved.
+        with patch.object(web_main, "_media_root", Path("/mnt/big/backups/media")):
+            self.assertEqual(
+                web_main._media_relative_path("/old/disk/backups/media/-1001/f.jpg"),
+                "-1001/f.jpg",
+            )
+        # An absolute path with no media directory in it cannot be anchored.
+        with patch.object(web_main, "_media_root", Path("/srv/media")):
+            self.assertIsNone(web_main._media_relative_path("/etc/passwd"))
+            self.assertIsNone(web_main._media_relative_path("/srv/media"))
+
+    def test_media_relative_path_rejects_traversal_in_either_separator(self):
+        """A backslash row must not smuggle "..": splitting on "/" alone would
+        see one opaque component and pass it through."""
+        from pathlib import Path
+
+        with patch.object(web_main, "_media_root", Path("/srv/media")):
+            for row in (
+                "..\\..\\etc\\passwd",
+                "../../etc/passwd",
+                "123\\..\\..\\etc\\passwd",
+                "/srv/media/../../etc/passwd",
+                "/old/backups/media/../../../etc/passwd",
+            ):
+                with self.subTest(row=row):
+                    self.assertIsNone(web_main._media_relative_path(row))
+
+    def test_media_relative_path_answers_the_same_on_every_platform(self):
+        """The helper reads rows written anywhere, so its answer must not depend
+        on the platform it runs on. Path.is_absolute() is False for "C:\\x" on
+        POSIX and True on Windows, which is why this is done lexically."""
+        from pathlib import Path
+
+        with patch.object(web_main, "_media_root", Path("/srv/media")):
+            self.assertEqual(web_main._media_relative_path("/srv/media/1/a.jpg"), "1/a.jpg")
+            self.assertEqual(web_main._media_relative_path("C:/old/media/1/a.jpg"), "1/a.jpg")
+            self.assertIsNone(web_main._media_relative_path("C:/old/pics/1/a.jpg"))
+
+    def test_media_relative_path_never_touches_the_filesystem(self):
+        """It runs for every media row of every message list, and the media root
+        is a network or FUSE mount on most installs: one Path.resolve() there
+        measured ~260 us against ~0.07 us for a string compare, which is ~19 ms
+        added to a 50-row page on an endpoint the viewer polls every 3 seconds.
+        Containment is enforced where the bytes are read, not here."""
+        from pathlib import Path
+
+        def explode(*args, **kwargs):
+            raise AssertionError("_media_relative_path must not call the filesystem")
+
+        with (
+            patch.object(web_main, "_media_root", Path("/srv/media")),
+            patch.object(Path, "resolve", explode),
+            patch("os.path.realpath", explode),
+        ):
+            self.assertEqual(web_main._media_relative_path("/srv/media/123/file.jpg"), "123/file.jpg")
+            self.assertEqual(web_main._media_relative_path("/old/backups/media/123/file.jpg"), "123/file.jpg")
+            self.assertIsNone(web_main._media_relative_path("/etc/passwd"))
+
     def test_strip_original_media_paths_handles_media_items(self):
         """No-download sessions strip both legacy media and multi-media item paths."""
         messages = [


### PR DESCRIPTION
## Summary

Fix Windows media path normalization

- Normalize absolute Windows media paths relative to the configured media root before serving thumbnails and media files.

This fixes thumbnail requests for media entries whose database file_path contains an absolute Windows path. The fix also normalizes Windows path separators and rejects paths outside the configured media root or containing traversal components.

No changes to the media URL/API format are required.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change

## Database Changes

- [ ] Schema changes (Alembic migration required)
- [ ] Data migration script added in `scripts/`
- [x] No database changes

## Data Consistency Checklist

<!-- Required when modifying database code (see AGENTS.md) -->

- [ ] All `chat_id` values use marked format (via `_get_marked_id()`)
- [ ] All datetime values pass through `_strip_tz()` before DB operations
- [ ] INSERT and UPDATE operations handle the same fields identically

## Testing

- [x] Tests pass locally (`python -m pytest tests/ -v`)
- [x] Linting passes (`ruff check .`)
- [ ] Formatting passes (`ruff format --check .`)
- [x] Manually tested in development environment

## Security Checklist

- [x] No secrets or credentials committed
- [ ] User input properly validated/sanitized
- [ ] Authentication/authorization properly checked



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media path handling across operating systems, including Windows-style paths.
  * Ensured media continues to resolve correctly when an archive is moved to another directory or drive.
  * Prevented traversal and other invalid paths from being accepted.
  * Ensured media paths outside the configured media directory are rejected.
  * Standardized valid media paths into a consistent relative format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->