### PR TITLE
fix(viewer): show the tile's own icon when a thumbnail cannot be made

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ docker run -it --rm \
   -e TELEGRAM_PHONE=+YOUR_PHONE_NUMBER \
   -e SESSION_NAME=telegram_backup \
   -v /path/to/your/session:/data/session \
-  drumsergio/telegram-archive:8.9.1 \
+  drumsergio/telegram-archive:8.9.2 \
   python -m src auth
 ```
 
@@ -166,7 +166,7 @@ docker run -it --rm \
 docker run -it --rm \
   --env-file .env \
   -v ./data:/data \
-  drumsergio/telegram-archive:8.9.1 \
+  drumsergio/telegram-archive:8.9.2 \
   python -m src auth
 
 # Then restart the backup container
@@ -207,7 +207,7 @@ The standalone viewer image (`drumsergio/telegram-archive-viewer`) lets you brow
 # Example: Viewer-only deployment
 services:
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:8.9.1
+    image: drumsergio/telegram-archive-viewer:8.9.2
     ports:
       - "127.0.0.1:8000:8000"
     environment:
@@ -627,9 +627,9 @@ want and run `docker compose up -d`:
 ```yaml
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:8.9.1
+    image: drumsergio/telegram-archive:8.9.2
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:8.9.1
+    image: drumsergio/telegram-archive-viewer:8.9.2
 ```
 
 Check [Releases](https://github.com/GeiserX/Telegram-Archive/releases) for available
@@ -644,8 +644,8 @@ start:
 
 ```bash
 git pull
-docker build -t drumsergio/telegram-archive:8.9.1 .
-docker build -t drumsergio/telegram-archive-viewer:8.9.1 -f Dockerfile.viewer .
+docker build -t drumsergio/telegram-archive:8.9.2 .
+docker build -t drumsergio/telegram-archive-viewer:8.9.2 -f Dockerfile.viewer .
 docker compose up -d
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   telegram-backup:
-    image: drumsergio/telegram-archive:8.9.1
+    image: drumsergio/telegram-archive:8.9.2
     container_name: telegram-backup
     restart: unless-stopped
     # A stop during a long sweep needs time to finish in-flight writes and
@@ -188,7 +188,7 @@ services:
     #       memory: 512M
 
   telegram-viewer:
-    image: drumsergio/telegram-archive-viewer:8.9.1
+    image: drumsergio/telegram-archive-viewer:8.9.2
     container_name: telegram-viewer
     restart: unless-stopped
     # A stop during a long sweep needs time to finish in-flight writes and
@@ -308,7 +308,7 @@ services:
   # Example: Restricted Channel Viewer (optional)
   # Use this to share specific channels publicly with authentication
   # telegram-channel-viewer:
-  #   image: drumsergio/telegram-archive-viewer:8.9.1
+  #   image: drumsergio/telegram-archive-viewer:8.9.2
   #   container_name: telegram-channel-viewer
   #   restart: unless-stopped
   #   ports:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented here.
 
 For upgrade instructions, see [Upgrading](#upgrading) at the bottom.
 
+## [8.9.2] - 2026-09-08
+
+### Fixed
+
+- **A file the viewer cannot make a thumbnail for now shows its own icon instead of a broken picture.** Some videos cannot be decoded, or take longer than the viewer is willing to wait, and the shared media grid painted the browser's broken-image glyph and the file name across the tile. The tile already has a picture for that case, a play symbol for video and a picture symbol for anything else, and that is what it shows now. The grid forgets these when you switch tab or chat, so a file that failed once is tried again the next time you look.
+
 ## [8.9.1] - 2026-09-08
 
 The shared media grid stops flooding the viewer.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "telegram-archive"
-version = "8.9.1"
+version = "8.9.2"
 description = "Automated Telegram backup with Docker. Performs incremental backups of messages and media on a configurable schedule."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/scripts/migrate-sqlite-to-postgres.py
+++ b/scripts/migrate-sqlite-to-postgres.py
@@ -20,14 +20,14 @@ Usage:
         -e POSTGRES_USER=telegram \
         -e POSTGRES_PASSWORD=your-password \
         -e POSTGRES_DB=telegram_backup \
-        drumsergio/telegram-archive:8.9.1 \
+        drumsergio/telegram-archive:8.9.2 \
         python scripts/migrate-sqlite-to-postgres.py
 
     # Or with explicit paths
     docker run --rm -it \
         -v /path/to/sqlite/telegram_backup.db:/sqlite.db:ro \
         -e DATABASE_URL=postgresql+asyncpg://user:pass@host:5432/dbname \
-        drumsergio/telegram-archive:8.9.1 \
+        drumsergio/telegram-archive:8.9.2 \
         python scripts/migrate-sqlite-to-postgres.py --sqlite /sqlite.db
 
 Environment Variables:

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -2,4 +2,4 @@
 Telegram Backup Automation - Main Package
 """
 
-__version__ = "8.9.1"
+__version__ = "8.9.2"

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -1640,9 +1640,10 @@
                                         <!-- No loading="lazy" here: a deferred image never fires
                                              load, so it would hold its admission slot until the
                                              timeout. The queue is the throttle now. -->
-                                        <img v-if="item.thumb_url && isThumbAdmitted(item.id)" :src="item.thumb_url"
-                                            :alt="item.file_name" class="w-full h-full object-cover" decoding="async"
-                                            @load="settleThumb(item.id)" @error="settleThumb(item.id)">
+                                        <img v-if="item.thumb_url && isThumbAdmitted(item.id) && !thumbFailed(item.id)"
+                                            :src="item.thumb_url" :alt="item.file_name"
+                                            class="w-full h-full object-cover" decoding="async"
+                                            @load="settleThumb(item.id)" @error="failThumb(item.id)">
                                         <div v-else class="w-full h-full bg-tg-n700 flex items-center justify-center">
                                             <i class="fas fa-play-circle text-2xl text-tg-n400" v-if="item.type === 'video' || item.type === 'animation' || item.type === 'video_note'"></i>
                                             <i class="fas fa-image text-2xl text-tg-n400" v-else></i>
@@ -3470,12 +3471,25 @@
                 // slot for the rest of the session.
                 const THUMB_SETTLE_TIMEOUT_MS = 20000
                 const admittedThumbs = ref(new Set())
+                // A thumbnail the server cannot make (an undecodable video, an ffmpeg
+                // timeout) answers 404, and an <img> that 404s paints the browser's broken
+                // -image glyph plus its alt text. The tile has a placeholder for exactly this
+                // -- a play or picture icon -- so a failed tile drops its <img> and shows it.
+                const failedThumbs = ref(new Set())
                 const queuedThumbs = new Set()
                 let thumbQueue = []
                 let thumbsInFlight = 0
                 const thumbTimers = new Map()
 
                 const isThumbAdmitted = (id) => admittedThumbs.value.has(id)
+                const thumbFailed = (id) => failedThumbs.value.has(id)
+
+                // The tile's error handler: record the failure, then free the slot the same
+                // way a successful load does.
+                const failThumb = (id) => {
+                    failedThumbs.value = new Set([...failedThumbs.value, id])
+                    settleThumb(id)
+                }
 
                 const pumpThumbs = () => {
                     while (thumbsInFlight < THUMB_CONCURRENCY && thumbQueue.length) {
@@ -3504,6 +3518,7 @@
                     thumbQueue = []
                     thumbsInFlight = 0
                     admittedThumbs.value = new Set()
+                    failedThumbs.value = new Set()
                 }
 
                 const queueThumbs = (items) => {
@@ -9508,7 +9523,9 @@
                     mediaGalleryHasMore,
                     mediaGalleryCounts,
                     isThumbAdmitted,
+                    thumbFailed,
                     settleThumb,
+                    failThumb,
                     mediaTabs,
                     loadMediaGallery,
                     loadMediaCounts,

--- a/tests/test_gallery_thumb_batching.py
+++ b/tests/test_gallery_thumb_batching.py
@@ -35,6 +35,7 @@ const fire = id => { const t = timers.get(id); assert.ok(t, 'no such timer'); ti
 const oldestTimer = () => { assert.ok(timers.size, 'no pending timer'); return [...timers.keys()][0] };
 const items = n => Array.from({ length: n }, (_, i) => ({ id: `${i + 1}_photo`, thumb_url: `/media/thumb/200/ref/${i + 1}_photo` }));
 const admitted = () => [...admittedThumbs.value];
+const failed = () => [...failedThumbs.value];
 const setItems = list => { mediaGalleryItems.value = list; watchers[0].fn(list) };
 """
 
@@ -148,13 +149,45 @@ assert.deepEqual(admitted(), ['c_photo', 'd_photo'], 'only tiles that would fetc
     )
 
 
+def test_a_thumbnail_the_server_cannot_make_gives_way_to_the_tile_icon() -> None:
+    _run_node(
+        _script("""
+setItems(items(6));
+assert.deepEqual(admitted(), ['1_photo', '2_photo', '3_photo', '4_photo']);
+
+// An undecodable video answers 404, which fires error, not load.
+failThumb('2_photo');
+assert.deepEqual(failed(), ['2_photo'], 'the tile is remembered as unrenderable');
+assert.equal(isThumbAdmitted('2_photo'), true, 'it stays admitted, so the queue does not re-issue it');
+assert.deepEqual(admitted().slice(-1), ['5_photo'], 'and it frees its slot like any other outcome');
+
+// A load after the failure must not resurrect the broken <img>.
+settleThumb('2_photo');
+assert.deepEqual(failed(), ['2_photo']);
+assert.equal(admitted().length, 5, 'and must not open a second slot');
+
+// The next view starts clean: the same id can render again elsewhere.
+setItems([]);
+assert.deepEqual(failed(), [], 'failures do not outlive the view that produced them');
+setItems([{ id: '2_photo', thumb_url: '/x/2' }]);
+assert.equal(isThumbAdmitted('2_photo'), true);
+assert.equal(failed().length, 0);
+""")
+    )
+
+
 def test_the_grid_is_wired_to_the_queue() -> None:
     html = INDEX_HTML.read_text(encoding="utf-8")
     start = html.index("<template v-if=\"mediaGalleryTab === 'photos'\">")
     grid = html[start : html.index("</template>", start)]
-    assert 'v-if="item.thumb_url && isThumbAdmitted(item.id)"' in grid, "the tile waits to be admitted"
-    assert '@load="settleThumb(item.id)"' in grid and '@error="settleThumb(item.id)"' in grid
+    assert 'v-if="item.thumb_url && isThumbAdmitted(item.id) && !thumbFailed(item.id)"' in grid, (
+        "the tile waits to be admitted, and steps aside once it is known to be unrenderable"
+    )
+    assert '@load="settleThumb(item.id)"' in grid and '@error="failThumb(item.id)"' in grid
+    # The v-else branch is the fallback: a play icon for video, a picture icon otherwise.
+    assert "fa-play-circle" in grid and "fa-image" in grid
     # A deferred image never fires load, so it would hold its slot until the timeout.
     img = grid[grid.index("<img") : grid.index(">", grid.index("<img"))]
     assert 'loading="lazy"' not in img, "the queue is the throttle; native lazy loading would stall it"
-    assert re.search(r"isThumbAdmitted,\s*\n\s*settleThumb,", html), "both are returned from setup"
+    for name in ("isThumbAdmitted,", "thumbFailed,", "settleThumb,", "failThumb,"):
+        assert re.search(rf"^\s+{re.escape(name)}$", html, re.M), f"{name} is returned from setup"

--- a/uv.lock
+++ b/uv.lock
@@ -1224,7 +1224,7 @@ wheels = [
 
 [[package]]
 name = "telegram-archive"
-version = "8.9.1"
+version = "8.9.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
One tile in the shared media grid came up as the browser's broken-image glyph with a filename printed across it.

That happens when the viewer cannot produce a thumbnail at all: the video is undecodable, or ffmpeg takes longer than the 15 seconds it is given, so the request answers 404 and the `<img>` has nothing to draw.

The tile already has a picture for exactly that situation. While it waits its turn in the queue it shows a play symbol for video and a picture symbol for anything else, and that is what it now keeps when the thumbnail fails. The failure is remembered only for the current view, so switching tab or chat clears it and the file is tried again next time.

## Testing

- `tests/test_gallery_thumb_batching.py` gains a case that runs the real queue: an errored tile is recorded, stays admitted so the queue does not re-issue it, frees its slot exactly like a successful load, cannot be resurrected by a later load event, and does not survive a view change.
- Three mutations each turn it red: routing the error handler back to `settleThumb`, dropping `!thumbFailed(item.id)` from the tile, and leaving the failure set uncleared on reset.
- Full suite: 3932 passed, 168 skipped. `ruff check` and `ruff format --check` clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Media gallery tiles now display file or video icons when thumbnail generation fails or times out, instead of broken-image placeholders.
  * Failed thumbnail states are cleared when switching views, allowing thumbnails to be retried.

* **Documentation**
  * Updated Docker image references, build commands, migration examples, and project version information to 8.9.2.
  * Added changelog details for the improved thumbnail fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->