### PR TITLE
fix(media): exclude skipped chats from pending retry batch

### DIFF
--- a/src/db/adapter.py
+++ b/src/db/adapter.py
@@ -2635,6 +2635,7 @@ class DatabaseAdapter:
         max_media_size_bytes: int | None = None,
         max_attempts: int | None = None,
         limit: int | None = 1000,
+        exclude_chat_ids: set[int] | None = None,
         *,
         account_id: int,
     ) -> list[dict[str, Any]]:
@@ -2665,6 +2666,8 @@ class DatabaseAdapter:
                 conditions.append(or_(Media.file_size.is_(None), Media.file_size <= max_media_size_bytes))
             if max_attempts is not None:
                 conditions.append(Media.download_attempts < max_attempts)
+            if exclude_chat_ids:
+                conditions.append(~Media.chat_id.in_(exclude_chat_ids))
             where_clause = and_(*conditions)
             stmt = select(Media).where(where_clause).order_by(Media.download_attempts.asc(), Media.id.asc())
             if limit is not None:

--- a/src/telegram_backup.py
+++ b/src/telegram_backup.py
@@ -1909,7 +1909,10 @@ class TelegramBackup:
         are skipped silently.
         """
         pending = await self.db.get_pending_media_downloads(
-            self.config.get_max_media_size_bytes(), self.config.max_media_download_attempts, account_id=self.account_id
+            self.config.get_max_media_size_bytes(),
+            self.config.max_media_download_attempts,
+            exclude_chat_ids=self.config.skip_media_chat_ids,
+            account_id=self.account_id,
         )
         # Surface (don't silently swallow) files given up after hitting the retry cap —
         # the silent-loss failure mode #212 was about. Count only (no chat/file names, PII).

--- a/tests/test_pending_media_skip_exclusion.py
+++ b/tests/test_pending_media_skip_exclusion.py
@@ -1,0 +1,80 @@
+"""SKIP_MEDIA_CHAT_IDS is applied before the retry batch's LIMIT (#442).
+
+The pending-media retry pulled at most ``limit`` rows and only then dropped the
+ones belonging to skipped chats, so a skipped chat holding more pending rows
+than the limit filled the whole batch and every download that could happen
+waited behind it: on a real archive, 974 of 1,000 slots.
+
+Skipped rows are deliberately left at ``downloaded=0``, so taking a chat off the
+skip list makes its media eligible again. These run on both backends through
+``real_adapter``.
+"""
+
+from datetime import datetime
+
+SKIPPED_CHAT = -1001234000001
+NORMAL_CHAT = -1001234000002
+LIMIT = 10
+
+
+async def _seed(adapter, chat_id, message_ids):
+    await adapter.upsert_chat({"id": chat_id, "type": "group", "title": "fixture chat"}, account_id=1)
+    for message_id in message_ids:
+        await adapter.insert_message(
+            {"id": message_id, "chat_id": chat_id, "text": "x", "date": datetime(2026, 9, 1, 12), "raw_data": {}},
+            account_id=1,
+        )
+        await adapter.insert_media(
+            {
+                "id": f"{chat_id}_{message_id}_photo",
+                "message_id": message_id,
+                "chat_id": chat_id,
+                "type": "photo",
+                "file_size": 10,
+                "downloaded": False,
+            },
+            account_id=1,
+        )
+
+
+def _chats(rows):
+    return sorted({row["chat_id"] for row in rows})
+
+
+async def test_skipped_rows_no_longer_fill_the_batch(real_adapter):
+    """More skipped rows than the limit, the shape of the report."""
+    await _seed(real_adapter, SKIPPED_CHAT, range(1, 31))
+    await _seed(real_adapter, NORMAL_CHAT, range(101, 104))
+
+    # The control: without the exclusion this fixture really does starve.
+    unfiltered = await real_adapter.get_pending_media_downloads(None, 5, limit=LIMIT, account_id=1)
+    assert len(unfiltered) == LIMIT
+    assert _chats(unfiltered) == [SKIPPED_CHAT]
+
+    batch = await real_adapter.get_pending_media_downloads(
+        None, 5, limit=LIMIT, exclude_chat_ids={SKIPPED_CHAT}, account_id=1
+    )
+    assert _chats(batch) == [NORMAL_CHAT]
+    assert len(batch) == 3
+
+
+async def test_skipped_rows_stay_pending_and_return_when_unskipped(real_adapter):
+    await _seed(real_adapter, SKIPPED_CHAT, range(1, 4))
+    await _seed(real_adapter, NORMAL_CHAT, range(101, 103))
+
+    excluded = await real_adapter.get_pending_media_downloads(None, 5, exclude_chat_ids={SKIPPED_CHAT}, account_id=1)
+    assert _chats(excluded) == [NORMAL_CHAT]
+
+    unskipped = await real_adapter.get_pending_media_downloads(None, 5, exclude_chat_ids=set(), account_id=1)
+    assert _chats(unskipped) == sorted([SKIPPED_CHAT, NORMAL_CHAT])
+    assert len(unskipped) == 5
+    assert not any(row["downloaded"] for row in unskipped)
+
+
+async def test_no_exclusion_is_the_query_it_always_was(real_adapter):
+    await _seed(real_adapter, SKIPPED_CHAT, range(1, 4))
+    await _seed(real_adapter, NORMAL_CHAT, range(101, 103))
+
+    for nothing in (None, set()):
+        rows = await real_adapter.get_pending_media_downloads(None, 5, exclude_chat_ids=nothing, account_id=1)
+        assert len(rows) == 5

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -3876,7 +3876,7 @@ class TestRetryPendingMediaCap(unittest.TestCase):
     def test_passes_attempt_cap_to_query(self):
         self.backup._process_media = AsyncMock(return_value={"downloaded": True, "id": "f1"})
         _run(self.backup._retry_pending_media_downloads())
-        self.backup.db.get_pending_media_downloads.assert_awaited_once_with(100 * 1024 * 1024, 5, account_id=1)
+        self.backup.db.get_pending_media_downloads.assert_awaited_once_with(100 * 1024 * 1024, 5, exclude_chat_ids=set(), account_id=1)
 
     def test_increment_on_failed_download(self):
         """A download that raises bumps the attempt counter (the #212 name-too-long case)."""

--- a/tests/test_telegram_backup_extended.py
+++ b/tests/test_telegram_backup_extended.py
@@ -3876,7 +3876,9 @@ class TestRetryPendingMediaCap(unittest.TestCase):
     def test_passes_attempt_cap_to_query(self):
         self.backup._process_media = AsyncMock(return_value={"downloaded": True, "id": "f1"})
         _run(self.backup._retry_pending_media_downloads())
-        self.backup.db.get_pending_media_downloads.assert_awaited_once_with(100 * 1024 * 1024, 5, exclude_chat_ids=set(), account_id=1)
+        self.backup.db.get_pending_media_downloads.assert_awaited_once_with(
+            100 * 1024 * 1024, 5, exclude_chat_ids=set(), account_id=1
+        )
 
     def test_increment_on_failed_download(self):
         """A download that raises bumps the attempt counter (the #212 name-too-long case)."""


### PR DESCRIPTION
When `SKIP_MEDIA_CHAT_IDS` is configured, pending media records belonging to those chats remain stored with `downloaded=0`.

This is intentional: skipped media should remain pending so that they can become downloadable again if the chat is later removed from `SKIP_MEDIA_CHAT_IDS`.

However, `_retry_pending_media_downloads()` currently retrieves a maximum of 1000 pending records **before** filtering out skipped chats.

This means skipped records consume slots in the bounded retry batch.

For example:

```text
3703 pending media records
    ↓
first 1000 records selected
    ↓
974 belong to SKIP_MEDIA_CHAT_IDS
    ↓
only 26 actionable downloads
```

The remaining actionable pending media are not considered during that retry pass. On the next run, the same skipped records can be selected again, potentially starving other pending media indefinitely.

### Expected Behavior

`SKIP_MEDIA_CHAT_IDS` should be applied when selecting pending media for the retry queue, before the `limit` is applied.

For example:

```text
3703 pending records
    ↓
exclude SKIP_MEDIA_CHAT_IDS
    ↓
remaining actionable pending records
    ↓
take up to 1000
    ↓
retry downloads
```

Skipped records should **not** be marked as `downloaded=1`.

They should remain `downloaded=0` so that removing a chat from `SKIP_MEDIA_CHAT_IDS` automatically makes its pending media eligible again.

### Observed Behavior

On a real archive:

```text
media retry: processing 1000 of 3703 pending
Retrying 1000 pending media downloads...
Pending media retry: 26 downloaded, 974 skipped, 0 failed
```

This demonstrates that 97.4% of the bounded retry batch was consumed by records that were known to be skipped.

### Proposed Fix

Add an optional exclusion parameter to `get_pending_media_downloads()`:

```python
exclude_chat_ids: set[int] | None = None
```

and add the exclusion to the SQLAlchemy query before applying the existing `limit`:

```python
if exclude_chat_ids:
    conditions.append(~Media.chat_id.in_(exclude_chat_ids))
```

Then pass the configured skip list from `_retry_pending_media_downloads()`:

```python
pending = await self.db.get_pending_media_downloads(
    self.config.get_max_media_size_bytes(),
    self.config.max_media_download_attempts,
    exclude_chat_ids=self.config.skip_media_chat_ids,
    account_id=self.account_id,
)
```

This keeps the existing `downloaded` semantics unchanged and makes the retry limit apply only to actionable pending media.

### Regression Tests

Add database-level coverage for `get_pending_media_downloads()` verifying that:

1. Pending media from a skipped chat are excluded.
2. Pending media from non-skipped chats are returned.
3. The `limit` is applied **after** the chat exclusion.
4. Skipped rows remain `downloaded=0`.
5. Removing the chat from the exclusion set makes those rows pending again.
6. An empty/`None` exclusion set preserves the existing behavior.

A particularly important regression case should contain more skipped rows than the retry limit, for example:

```text
1500 pending records in skipped chats
   +
10 pending records in a normal chat
   ↓
limit=1000
```

Expected result:

```text
10 records returned
```

rather than:

```text
1000 skipped records returned
```

### Scope

The fix should only change pending-media selection.

It should not:

* mark skipped media as downloaded
* delete existing media
* change `SKIP_MEDIA_CHAT_IDS` semantics
* change the retry limit
* change media download behavior for non-skipped chats
* change the meaning of `downloaded=0`


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that causes existing functionality to change)
- [ ] Documentation update
- [ ] Infrastructure/CI change

## Database Changes

- [ ] Schema changes (Alembic migration required)
- [ ] Data migration script added in `scripts/`
- [x] No database changes

## Testing

- [x] Tests pass locally (`python -m pytest tests/ -v`)
- [x] Linting passes (`ruff check .`)
- [ ] Formatting passes (`ruff format --check .`)
- [ ] Manually tested in development environment

## Security Checklist

- [x] No secrets or credentials committed
- [ ] User input properly validated/sanitized
- [ ] Authentication/authorization properly checked


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Pending media retries now skip chats marked for exclusion.
  * Excluded chats no longer consume limited retry slots, allowing other pending media to download.
  * Skipped media remains available for retry when the chat is no longer excluded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->